### PR TITLE
Fix reverse read existence check

### DIFF
--- a/src/reference-databases.jl
+++ b/src/reference-databases.jl
@@ -909,7 +909,7 @@ function fasterq_dump(;outdir=pwd(), srr_identifier="")
     end
     return (
         forward_reads = isfile(forward_reads_gz) ? forward_reads_gz : missing,
-        reverse_reads = isfile(forward_reads_gz) ? reverse_reads_gz : missing,
+        reverse_reads = isfile(reverse_reads_gz) ? reverse_reads_gz : missing,
         unpaired_reads = isfile(unpaired_reads_gz) ? unpaired_reads_gz : missing
     )
 end


### PR DESCRIPTION
## Summary
- fix `fasterq_dump` return value to check for reverse reads

## Testing
- `julia --project=. -e 'using Pkg; Pkg.test()'` *(fails: julia not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686f95f5a4e08325aac51edd2ae38ad4