### PR TITLE
Fix comment typo near Merqury QV function

### DIFF
--- a/src/kmer-analysis.jl
+++ b/src/kmer-analysis.jl
@@ -486,7 +486,7 @@ function kmer_counts_to_merqury_qv(;raw_data_counts::AbstractDict{Kmers.DNAKmer{
     Ktotal = length(keys(assembly_counts))
     # Kshared = # of shared kmers between assembly and readset
     Kshared = length(intersect(keys(raw_data_counts), keys(assembly_counts)))
-    # probabilitiy_base_in_assembly_correct
+    # probability_base_in_assembly_correct
     P = (Kshared/Ktotal)^(1/k)
     # # Error rate
     E = 1-P


### PR DESCRIPTION
## Summary
- fix typo in comment near `kmer_counts_to_merqury_qv` in kmer-analysis

## Testing
- `julia --project -e 'using Pkg; Pkg.test()'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f95f9d0948325b215431f4ed235af