### PR TITLE
Add negative regex examples

### DIFF
--- a/test/2_preprocessing_qc/constants.jl
+++ b/test/2_preprocessing_qc/constants.jl
@@ -9,6 +9,14 @@
             @test occursin(Mycelia.FASTQ_REGEX, hypothethical_fastq_file)
             @test occursin(Mycelia.FASTQ_REGEX, hypothethical_fastq_file * ".gz")
         end
+        invalid_fastq_files = [
+            "sample.fast",
+            "sample.fastq1",
+            "notfastq.txt",
+        ]
+        for invalid_fastq_file in invalid_fastq_files
+            @test !occursin(Mycelia.FASTQ_REGEX, invalid_fastq_file)
+        end
     end
     @testset "FASTA regex" begin
         hypothethical_fasta_files = [
@@ -25,6 +33,14 @@
             @test occursin(Mycelia.FASTA_REGEX, hypothethical_fasta_file)
             @test occursin(Mycelia.FASTA_REGEX, hypothethical_fasta_file * ".gz")
         end
+        invalid_fasta_files = [
+            "genome.fasta1",
+            "file.fasta.txt",
+            "notfasta.fa.gz.old",
+        ]
+        for invalid_fasta_file in invalid_fasta_files
+            @test !occursin(Mycelia.FASTA_REGEX, invalid_fasta_file)
+        end
     end
     @testset "VCF regex" begin
         hypothethical_vcf_files = [
@@ -33,6 +49,14 @@
         ]
         for hypothethical_vcf_file in hypothethical_vcf_files
             @test occursin(Mycelia.VCF_REGEX, hypothethical_vcf_file)
+        end
+        invalid_vcf_files = [
+            "variants.vcf1",
+            "vcf_variants.txt",
+            "sample.vcf.gz.old",
+        ]
+        for invalid_vcf_file in invalid_vcf_files
+            @test !occursin(Mycelia.VCF_REGEX, invalid_vcf_file)
         end
     end
     @testset "XAM regex" begin
@@ -44,6 +68,14 @@
         ]
         for hypothetical_xam_file in hypothetical_xam_files
             @test occursin(Mycelia.XAM_REGEX, hypothetical_xam_file)
+        end
+        invalid_xam_files = [
+            "alignment.sam1",
+            "alignment.bam.gz",
+            "xam_alignment.txt",
+        ]
+        for invalid_xam_file in invalid_xam_files
+            @test !occursin(Mycelia.XAM_REGEX, invalid_xam_file)
         end
     end
 end


### PR DESCRIPTION
## Summary
- expand tests for FASTQ, FASTA, VCF, and XAM filename regexes
- check invalid filenames with `!occursin`

## Testing
- `julia --project -e 'using Pkg; Pkg.test()'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f95fa2aec8325874a23b6e1ca9144