### PR TITLE
Add assembly function tests

### DIFF
--- a/test/4_assembly/assembly_merging.jl
+++ b/test/4_assembly/assembly_merging.jl
@@ -1,6 +1,32 @@
 # Assembly Merging tests
 @testset "Assembly Merging" begin
     @testset "Contig Merging" begin
-        @test true  # placeholder
+        lines = [
+            "H\tVN:Z:1.0",
+            "S\t1\tACGT\t*\tDP:i:1",
+            "S\t2\tCGTA\t*\tDP:i:1",
+            "L\t1\t+\t2\t+\t3M",
+        ]
+        gfa = joinpath(tempdir(), "simple.gfa")
+        open(gfa, "w") do io
+            for l in lines
+                println(io, l)
+            end
+        end
+
+        g = Mycelia.parse_gfa(gfa)
+        @test Graphs.nv(g) == 2
+        @test Graphs.ne(g) == 1
+        @test length(MetaGraphs.get_prop(g, :records)) == 2
+
+        result = Mycelia.gfa_to_structure_table(gfa)
+        @test size(result.contig_table, 1) == 1
+        row = result.contig_table[1, :]
+        @test row.connected_component == 1
+        @test row.contigs == "1,2"
+        @test row.is_circular == false
+        @test row.is_closed == false
+        @test row.lengths == "4,4"
+        @test length(result.records) == 2
     end
 end

--- a/test/4_assembly/assembly_modules.jl
+++ b/test/4_assembly/assembly_modules.jl
@@ -5,6 +5,22 @@
     @testset "2. k‑mer Analysis" begin
     end
     @testset "3. Hybrid Assembly (Mutual Support Strategy)" begin
+        mktempdir() do dir
+            fastq = joinpath(dir, "reads.fq")
+            open(fastq, "w") do io
+                println(io, "@r1")
+                println(io, "ACGT")
+                println(io, "+")
+                println(io, "!!!!")
+            end
+            outdir = joinpath(dir, "asm")
+            mkpath(outdir)
+            prefix = joinpath(outdir, basename(fastq) * ".hifiasm")
+            touch(prefix * ".dummy")
+            result = Mycelia.run_hifiasm(fastq=fastq, outdir=outdir)
+            @test result.outdir == outdir
+            @test result.hifiasm_outprefix == prefix
+        end
     end
     @testset "4. Assembly merging" begin
     end

--- a/test/4_assembly/hybrid_assembly.jl
+++ b/test/4_assembly/hybrid_assembly.jl
@@ -1,9 +1,17 @@
 # Hybrid Assembly tests
 @testset "Hybrid Assembly" begin
     @testset "Assembly Core" begin
-        @test true  # placeholder
+        kmers = [BioSequences.LongDNA{2}("AAA"), BioSequences.LongDNA{2}("AAT"), BioSequences.LongDNA{2}("ATG")]
+        index = Mycelia.get_kmer_index(kmers, kmers[2])
+        @test index == 2
+        seq = Mycelia.kmer_path_to_sequence(kmers)
+        @test String(seq) == "AAATG"
     end
     @testset "Contig Overlap Graph Integrity" begin
-        @test true  # placeholder
+        obs = Mycelia.ngrams("ACGT", 2)
+        @test obs == ["AC", "CG", "GT"]
+        g = Mycelia.string_to_ngram_graph(s="ACGT", n=2)
+        @test Graphs.nv(g) == 3
+        @test Graphs.ne(g) == 2
     end
 end

--- a/test/4_assembly/polishing.jl
+++ b/test/4_assembly/polishing.jl
@@ -1,6 +1,12 @@
 # Assembly Polishing tests
 @testset "Assembly Polishing" begin
     @testset "Error Correction" begin
-        @test true  # placeholder
+        solidity = Bool[true, false, false, true, false, true]
+        branchpoints = [1, 4, 6]
+        stretches = Mycelia.find_resampling_stretches(
+            record_kmer_solidity=solidity,
+            solid_branching_kmer_indices=branchpoints,
+        )
+        @test stretches == [1:4, 4:6]
     end
 end

--- a/test/4_assembly/strain_resolution.jl
+++ b/test/4_assembly/strain_resolution.jl
@@ -1,6 +1,6 @@
 # Strain Resolution tests
 @testset "Strain Resolution" begin
     @testset "Strain-aware Reassembly" begin
-        @test true  # placeholder
+        @test Mycelia.ks(min=5, max=7) == [5, 7]
     end
 end


### PR DESCRIPTION
## Summary
- expand assembly merging tests with `parse_gfa` and `gfa_to_structure_table`
- add hybrid assembly tests for kmer helpers and ngram graphs
- test polishing utilities and ks sequence
- test run_hifiasm logic in assembly modules

## Testing
- `julia --project=test -e 'using Pkg; Pkg.test()'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fb4c0568c83259585ca1d8bba031d