### PR TITLE
chore(ci): trigger CI and docs workflows for branch-protection

### DIFF
--- a/.github/TRIGGER.md
+++ b/.github/TRIGGER.md
@@ -1,0 +1,1 @@
+Trigger workflows for branch protection


### PR DESCRIPTION
This PR adds a tiny trigger file so CI and documentation workflows run once and expose their job-level status checks (CI / test and Documentation / build) in branch protection settings. This PR can be closed and the branch deleted after verification.