### PR TITLE
add: expand slurm-sbatch wrapper coverage

### DIFF
--- a/test/8_tool_integration/slurm_template_system.jl
+++ b/test/8_tool_integration/slurm_template_system.jl
@@ -39,11 +39,16 @@ end
 
 function _with_git_email(f::Function, email::AbstractString)
     mktempdir() do repo_dir
-        run(`git -C $repo_dir init --quiet`)
-        run(`git -C $repo_dir config user.name TestUser`)
-        run(`git -C $repo_dir config user.email $email`)
-        cd(repo_dir) do
-            return f()
+        _with_env(Dict(
+            "GIT_AUTHOR_EMAIL" => nothing,
+            "GIT_COMMITTER_EMAIL" => nothing
+        )) do
+            run(`git -C $repo_dir init --quiet`)
+            run(`git -C $repo_dir config user.name TestUser`)
+            run(`git -C $repo_dir config user.email $email`)
+            cd(repo_dir) do
+                return f()
+            end
         end
     end
 end

--- a/test/8_tool_integration/slurm_template_system.jl
+++ b/test/8_tool_integration/slurm_template_system.jl
@@ -90,6 +90,41 @@ function _with_fake_lawrencium_associations(f::Function)
     end
 end
 
+function _with_collector_logdir(f::Function)
+    mktempdir() do logdir
+        collector = Mycelia.CollectExecutor()
+        return f(logdir, collector)
+    end
+end
+
+function _assert_submit_result(
+    result;
+    backend::Symbol = :sbatch,
+    site::Symbol,
+    artifact_contains::Union{Nothing, AbstractString} = nothing,
+    submit_contains::Union{Nothing, AbstractString} = nothing
+)
+    Test.@test result isa Mycelia.SubmitResult
+    if !(result isa Mycelia.SubmitResult)
+        return nothing
+    end
+
+    Test.@test result.ok
+    Test.@test result.dry_run
+    Test.@test result.backend == backend
+    Test.@test result.site == site
+
+    if !isnothing(artifact_contains)
+        Test.@test occursin(artifact_contains, something(result.artifact_text, ""))
+    end
+
+    if !isnothing(submit_contains)
+        Test.@test occursin(submit_contains, something(result.submit_command, ""))
+    end
+
+    return nothing
+end
+
 Test.@testset "JobSpec JSON roundtrip" begin
     job = Mycelia.JobSpec(
         job_name = "json-roundtrip",
@@ -302,12 +337,11 @@ end
 
 Test.@testset "SLURM wrapper entrypoints" begin
     Test.@testset "lawrencium_sbatch uses env fallbacks with collect executor" begin
-        mktempdir() do logdir
+        _with_collector_logdir() do logdir, collector
             _with_env(Dict(
                 "LRC_ACCOUNT" => "pc_example",
                 "SLURM_MAIL_USER" => "slurm@example.org"
             )) do
-                collector = Mycelia.CollectExecutor()
                 outcome = Mycelia.lawrencium_sbatch(
                     job_name = "lawrencium-wrapper",
                     cmd = "echo hello",
@@ -331,13 +365,12 @@ Test.@testset "SLURM wrapper entrypoints" begin
     end
 
     Test.@testset "lawrencium_sbatch falls back to git email" begin
-        mktempdir() do logdir
+        _with_collector_logdir() do logdir, collector
             _with_env(Dict(
                 "LRC_ACCOUNT" => "pc_git",
                 "SLURM_MAIL_USER" => nothing
             )) do
                 _with_git_email("git-lawrencium@example.org") do
-                    collector = Mycelia.CollectExecutor()
                     outcome = Mycelia.lawrencium_sbatch(
                         job_name = "lawrencium-git-fallback",
                         cmd = "echo hello",
@@ -387,12 +420,11 @@ Test.@testset "SLURM wrapper entrypoints" begin
                 executor = :slurm
             )
 
-            Test.@test result isa Mycelia.SubmitResult
-            Test.@test result.ok
-            Test.@test result.dry_run
-            Test.@test result.backend == :sbatch
-            Test.@test result.site == :lawrencium
-            Test.@test occursin("#SBATCH --partition=lr6", something(result.artifact_text, ""))
+            _assert_submit_result(
+                result;
+                site = :lawrencium,
+                artifact_contains = "#SBATCH --partition=lr6"
+            )
         end
     end
 
@@ -426,8 +458,7 @@ Test.@testset "SLURM wrapper entrypoints" begin
     end
 
     Test.@testset "scg_sbatch keeps explicit overrides" begin
-        mktempdir() do logdir
-            collector = Mycelia.CollectExecutor()
+        _with_collector_logdir() do logdir, collector
             outcome = Mycelia.scg_sbatch(
                 job_name = "scg-wrapper",
                 mail_user = "override@example.org",
@@ -454,10 +485,9 @@ Test.@testset "SLURM wrapper entrypoints" begin
     end
 
     Test.@testset "scg_sbatch falls back to git email" begin
-        mktempdir() do logdir
+        _with_collector_logdir() do logdir, collector
             _with_env(Dict("SLURM_MAIL_USER" => nothing)) do
                 _with_git_email("git-scg@example.org") do
-                    collector = Mycelia.CollectExecutor()
                     outcome = Mycelia.scg_sbatch(
                         job_name = "scg-git-fallback",
                         account = "PI_GIT",
@@ -485,13 +515,12 @@ Test.@testset "SLURM wrapper entrypoints" begin
                 executor = :slurm
             )
 
-            Test.@test result isa Mycelia.SubmitResult
-            Test.@test result.ok
-            Test.@test result.dry_run
-            Test.@test result.backend == :sbatch
-            Test.@test result.site == :scg
-            Test.@test occursin("sbatch", something(result.submit_command, ""))
-            Test.@test occursin("#SBATCH --partition=nih_s10", something(result.artifact_text, ""))
+            _assert_submit_result(
+                result;
+                site = :scg,
+                submit_contains = "sbatch",
+                artifact_contains = "#SBATCH --partition=nih_s10"
+            )
         end
     end
 
@@ -557,9 +586,8 @@ Test.@testset "SLURM wrapper entrypoints" begin
             )
         end
 
-        mktempdir() do logdir
+        _with_collector_logdir() do logdir, collector
             _with_env(Dict("NERSC_ACCOUNT" => "m1234")) do
-                collector = Mycelia.CollectExecutor()
                 outcome = Mycelia.nersc_sbatch_shared(
                     job_name = "nersc-shared-wrapper",
                     mail_user = "user@example.org",
@@ -578,9 +606,8 @@ Test.@testset "SLURM wrapper entrypoints" begin
             end
         end
 
-        mktempdir() do logdir
+        _with_collector_logdir() do logdir, collector
             mktempdir() do scriptdir
-                collector = Mycelia.CollectExecutor()
                 outcome = Mycelia.nersc_sbatch(
                     job_name = "nersc-command-block",
                     mail_user = "user@example.org",
@@ -615,12 +642,11 @@ Test.@testset "SLURM wrapper entrypoints" begin
                 executor = :slurm
             )
 
-            Test.@test result isa Mycelia.SubmitResult
-            Test.@test result.ok
-            Test.@test result.dry_run
-            Test.@test result.backend == :sbatch
-            Test.@test result.site == :nersc
-            Test.@test occursin("#SBATCH --constraint=cpu", something(result.artifact_text, ""))
+            _assert_submit_result(
+                result;
+                site = :nersc,
+                artifact_contains = "#SBATCH --constraint=cpu"
+            )
         end
     end
 
@@ -694,12 +720,11 @@ Test.@testset "SLURM wrapper entrypoints" begin
     end
 
     Test.@testset "submit_job routes to configured backend" begin
-        mktempdir() do logdir
+        _with_collector_logdir() do logdir, collector
             _with_env(Dict(
                 "LRC_ACCOUNT" => "pc_submit",
                 "SLURM_MAIL_USER" => "route@example.org"
             )) do
-                collector = Mycelia.CollectExecutor()
                 outcome = Mycelia.submit_job(
                     site = "lawrencium",
                     job_name = "submit-lawrencium",
@@ -713,8 +738,7 @@ Test.@testset "SLURM wrapper entrypoints" begin
             end
         end
 
-        mktempdir() do logdir
-            collector = Mycelia.CollectExecutor()
+        _with_collector_logdir() do logdir, collector
             outcome = Mycelia.submit_job(
                 site = "SCG",
                 job_name = "submit-route",
@@ -729,8 +753,7 @@ Test.@testset "SLURM wrapper entrypoints" begin
             Test.@test only(collector.jobs).site == :scg
         end
 
-        mktempdir() do logdir
-            collector = Mycelia.CollectExecutor()
+        _with_collector_logdir() do logdir, collector
             outcome = Mycelia.submit_job(
                 site = "nersc",
                 job_name = "submit-nersc",

--- a/test/8_tool_integration/slurm_template_system.jl
+++ b/test/8_tool_integration/slurm_template_system.jl
@@ -2,8 +2,7 @@ import Test
 import Mycelia
 
 const LEGACY_FIXTURE_LOGDIR = "/Users/cameronprybol/workspace/slurmlogs"
-const FAKE_LAWRENCIUM_ASSOCIATIONS =
-    "Account|User|Partition|QOS|\npc_test|user|lr6|lr_normal|\n"
+const FAKE_LAWRENCIUM_ASSOCIATIONS = "Account|User|Partition|QOS|\npc_test|user|lr6|lr_normal|\n"
 
 function _has_message(messages::Vector{String}, needle::String)
     return any(msg -> occursin(needle, msg), messages)
@@ -342,7 +341,8 @@ Test.@testset "SLURM wrapper entrypoints" begin
                     )
 
                     Test.@test outcome == 1
-                    Test.@test only(collector.jobs).mail_user == "git-lawrencium@example.org"
+                    Test.@test only(collector.jobs).mail_user ==
+                               "git-lawrencium@example.org"
                 end
             end
         end
@@ -353,12 +353,19 @@ Test.@testset "SLURM wrapper entrypoints" begin
             _with_env(Dict(
                 "SLURM_MAIL_USER" => nothing
             )) do
-                Test.@test_throws ErrorException Mycelia.lawrencium_sbatch(
-                    job_name = "lawrencium-missing-mail",
-                    account = "pc_nomail",
-                    cmd = "echo fail before submit",
-                    executor = Mycelia.CollectExecutor()
-                )
+                err = try
+                    Mycelia.lawrencium_sbatch(
+                        job_name = "lawrencium-missing-mail",
+                        account = "pc_nomail",
+                        cmd = "echo fail before submit",
+                        executor = Mycelia.CollectExecutor()
+                    )
+                    nothing
+                catch e
+                    e
+                end
+                Test.@test err isa ErrorException
+                Test.@test occursin("mail", lowercase(err.msg))
             end
         end
     end
@@ -514,12 +521,19 @@ Test.@testset "SLURM wrapper entrypoints" begin
             _with_env(Dict(
                 "SLURM_MAIL_USER" => nothing
             )) do
-                Test.@test_throws ErrorException Mycelia.scg_sbatch(
-                    job_name = "scg-missing-mail",
-                    account = "PI_FAIL",
-                    cmd = "echo fail before submit",
-                    executor = Mycelia.CollectExecutor()
-                )
+                err = try
+                    Mycelia.scg_sbatch(
+                        job_name = "scg-missing-mail",
+                        account = "PI_FAIL",
+                        cmd = "echo fail before submit",
+                        executor = Mycelia.CollectExecutor()
+                    )
+                    nothing
+                catch e
+                    e
+                end
+                Test.@test err isa ErrorException
+                Test.@test occursin("mail", lowercase(err.msg))
             end
         end
     end
@@ -656,7 +670,8 @@ Test.@testset "SLURM wrapper entrypoints" begin
             err_files = filter(name -> endswith(name, ".err"), readdir(logdir))
             Test.@test length(out_files) == 1
             Test.@test length(err_files) == 1
-            Test.@test read(joinpath(logdir, only(out_files)), String) == "hello from lovelace"
+            Test.@test read(joinpath(logdir, only(out_files)), String) ==
+                       "hello from lovelace"
             Test.@test isempty(read(joinpath(logdir, only(err_files)), String))
         end
 

--- a/test/8_tool_integration/slurm_template_system.jl
+++ b/test/8_tool_integration/slurm_template_system.jl
@@ -1,6 +1,16 @@
 import Test
 import Mycelia
 
+@eval Mycelia begin
+    function sleep(seconds::Real)
+        return nothing
+    end
+
+    function list_lawrencium_associations(; execute::Bool = true)::String
+        return "Account|User|Partition|QOS|\npc_test|user|lr6|lr_normal|\n"
+    end
+end
+
 function _has_message(messages::Vector{String}, needle::String)
     return any(msg -> occursin(needle, msg), messages)
 end
@@ -42,6 +52,25 @@ function _with_git_email(f::Function, email::AbstractString)
         run(`git -C $repo_dir config user.email $email`)
         cd(repo_dir) do
             return f()
+        end
+    end
+end
+
+function _without_git_email(f::Function)
+    mktempdir() do repo_dir
+        run(`git -C $repo_dir init --quiet`)
+        empty_config = joinpath(repo_dir, "empty.gitconfig")
+        write(empty_config, "")
+
+        _with_env(Dict(
+            "HOME" => repo_dir,
+            "XDG_CONFIG_HOME" => joinpath(repo_dir, ".config"),
+            "GIT_CONFIG_GLOBAL" => empty_config,
+            "GIT_CONFIG_NOSYSTEM" => "1"
+        )) do
+            cd(repo_dir) do
+                return f()
+            end
         end
     end
 end
@@ -308,6 +337,21 @@ Test.@testset "SLURM wrapper entrypoints" begin
         end
     end
 
+    Test.@testset "lawrencium_sbatch errors when no mail source is available" begin
+        _without_git_email() do
+            _with_env(Dict(
+                "SLURM_MAIL_USER" => nothing
+            )) do
+                Test.@test_throws ErrorException Mycelia.lawrencium_sbatch(
+                    job_name = "lawrencium-missing-mail",
+                    account = "pc_nomail",
+                    cmd = "echo fail before submit",
+                    executor = Mycelia.CollectExecutor()
+                )
+            end
+        end
+    end
+
     Test.@testset "lawrencium_sbatch dry_run delegates to slurm submit executor" begin
         mktempdir() do logdir
             result = Mycelia.lawrencium_sbatch(
@@ -326,6 +370,31 @@ Test.@testset "SLURM wrapper entrypoints" begin
             Test.@test result.backend == :sbatch
             Test.@test result.site == :lawrencium
             Test.@test occursin("#SBATCH --partition=lr6", something(result.artifact_text, ""))
+        end
+    end
+
+    Test.@testset "lawrencium_sbatch direct dry_run succeeds and validation failures return false" begin
+        mktempdir() do logdir
+            Test.@test Mycelia.lawrencium_sbatch(
+                job_name = "lawrencium-direct-dry-run",
+                mail_user = "explicit@example.org",
+                account = "pc_direct",
+                cmd = "echo direct dry-run",
+                logdir = logdir,
+                dry_run = true
+            )
+        end
+
+        mktempdir() do logdir
+            Test.@test !Mycelia.lawrencium_sbatch(
+                job_name = "lawrencium-invalid",
+                mail_user = "explicit@example.org",
+                account = "pc_invalid",
+                cpus_per_task = 0,
+                cmd = "echo should fail validation",
+                logdir = logdir,
+                dry_run = true
+            )
         end
     end
 
@@ -396,6 +465,35 @@ Test.@testset "SLURM wrapper entrypoints" begin
             Test.@test result.site == :scg
             Test.@test occursin("sbatch", something(result.submit_command, ""))
             Test.@test occursin("#SBATCH --partition=nih_s10", something(result.artifact_text, ""))
+        end
+    end
+
+    Test.@testset "scg_sbatch direct dry_run covers env fallback and missing mail sources" begin
+        mktempdir() do logdir
+            _with_env(Dict(
+                "SCG_ACCOUNT" => "PI_ENV",
+                "SLURM_MAIL_USER" => "env-scg@example.org"
+            )) do
+                Test.@test Mycelia.scg_sbatch(
+                    job_name = "scg-direct-dry-run",
+                    cmd = "echo direct dry-run",
+                    logdir = logdir,
+                    dry_run = true
+                )
+            end
+        end
+
+        _without_git_email() do
+            _with_env(Dict(
+                "SLURM_MAIL_USER" => nothing
+            )) do
+                Test.@test_throws ErrorException Mycelia.scg_sbatch(
+                    job_name = "scg-missing-mail",
+                    account = "PI_FAIL",
+                    cmd = "echo fail before submit",
+                    executor = Mycelia.CollectExecutor()
+                )
+            end
         end
     end
 
@@ -477,6 +575,30 @@ Test.@testset "SLURM wrapper entrypoints" begin
             Test.@test result.backend == :sbatch
             Test.@test result.site == :nersc
             Test.@test occursin("#SBATCH --constraint=cpu", something(result.artifact_text, ""))
+        end
+    end
+
+    Test.@testset "nersc_sbatch direct dry_run returns true" begin
+        mktempdir() do logdir
+            mktempdir() do scriptdir
+                Test.@test Mycelia.nersc_sbatch(
+                    job_name = "nersc-direct-dry-run",
+                    mail_user = "user@example.org",
+                    account = "m2468",
+                    cmd = "echo direct dry-run",
+                    logdir = logdir,
+                    scriptdir = scriptdir,
+                    dry_run = true
+                )
+            end
+        end
+
+        _with_env(Dict("NERSC_ACCOUNT" => nothing)) do
+            Test.@test_throws ErrorException Mycelia.nersc_sbatch(
+                job_name = "nersc-direct-missing-account",
+                mail_user = "user@example.org",
+                cmd = "echo fail"
+            )
         end
     end
 

--- a/test/8_tool_integration/slurm_template_system.jl
+++ b/test/8_tool_integration/slurm_template_system.jl
@@ -1,15 +1,9 @@
 import Test
 import Mycelia
 
-@eval Mycelia begin
-    function sleep(seconds::Real)
-        return nothing
-    end
-
-    function list_lawrencium_associations(; execute::Bool = true)::String
-        return "Account|User|Partition|QOS|\npc_test|user|lr6|lr_normal|\n"
-    end
-end
+const LEGACY_FIXTURE_LOGDIR = "/Users/cameronprybol/workspace/slurmlogs"
+const FAKE_LAWRENCIUM_ASSOCIATIONS =
+    "Account|User|Partition|QOS|\npc_test|user|lr6|lr_normal|\n"
 
 function _has_message(messages::Vector{String}, needle::String)
     return any(msg -> occursin(needle, msg), messages)
@@ -41,8 +35,7 @@ function _with_env(f::Function, overrides::AbstractDict)
 end
 
 function _normalize_fixture_logdir(text::AbstractString)
-    legacy_logdir = "/Users/cameronprybol/workspace/slurmlogs"
-    return replace(String(text), legacy_logdir => Mycelia.DEFAULT_SLURM_LOGDIR)
+    return replace(String(text), LEGACY_FIXTURE_LOGDIR => Mycelia.DEFAULT_SLURM_LOGDIR)
 end
 
 function _with_git_email(f::Function, email::AbstractString)
@@ -63,14 +56,32 @@ function _without_git_email(f::Function)
         write(empty_config, "")
 
         _with_env(Dict(
-            "HOME" => repo_dir,
-            "XDG_CONFIG_HOME" => joinpath(repo_dir, ".config"),
             "GIT_CONFIG_GLOBAL" => empty_config,
-            "GIT_CONFIG_NOSYSTEM" => "1"
+            "GIT_CONFIG_NOSYSTEM" => "1",
+            "GIT_AUTHOR_EMAIL" => nothing,
+            "GIT_COMMITTER_EMAIL" => nothing
         )) do
             cd(repo_dir) do
                 return f()
             end
+        end
+    end
+end
+
+function _with_fake_lawrencium_associations(f::Function)
+    mktempdir() do bindir
+        sacctmgr_path = joinpath(bindir, "sacctmgr")
+        write(
+            sacctmgr_path,
+            "#!/bin/sh\ncat <<'EOF'\n$(FAKE_LAWRENCIUM_ASSOCIATIONS)EOF\n")
+        chmod(sacctmgr_path, 0o755)
+
+        path_entries = filter(!isempty, [bindir, get(ENV, "PATH", "")])
+        _with_env(Dict(
+            "PATH" => join(path_entries, ":"),
+            "USER" => "user"
+        )) do
+            return f()
         end
     end
 end
@@ -375,26 +386,30 @@ Test.@testset "SLURM wrapper entrypoints" begin
 
     Test.@testset "lawrencium_sbatch direct dry_run succeeds and validation failures return false" begin
         mktempdir() do logdir
-            Test.@test Mycelia.lawrencium_sbatch(
-                job_name = "lawrencium-direct-dry-run",
-                mail_user = "explicit@example.org",
-                account = "pc_direct",
-                cmd = "echo direct dry-run",
-                logdir = logdir,
-                dry_run = true
-            )
+            _with_fake_lawrencium_associations() do
+                Test.@test Mycelia.lawrencium_sbatch(
+                    job_name = "lawrencium-direct-dry-run",
+                    mail_user = "explicit@example.org",
+                    account = "pc_test",
+                    cmd = "echo direct dry-run",
+                    logdir = logdir,
+                    dry_run = true
+                )
+            end
         end
 
         mktempdir() do logdir
-            Test.@test !Mycelia.lawrencium_sbatch(
-                job_name = "lawrencium-invalid",
-                mail_user = "explicit@example.org",
-                account = "pc_invalid",
-                cpus_per_task = 0,
-                cmd = "echo should fail validation",
-                logdir = logdir,
-                dry_run = true
-            )
+            _with_fake_lawrencium_associations() do
+                Test.@test !Mycelia.lawrencium_sbatch(
+                    job_name = "lawrencium-invalid",
+                    mail_user = "explicit@example.org",
+                    account = "pc_test",
+                    cpus_per_task = 0,
+                    cmd = "echo should fail validation",
+                    logdir = logdir,
+                    dry_run = true
+                )
+            end
         end
     end
 
@@ -481,6 +496,18 @@ Test.@testset "SLURM wrapper entrypoints" begin
                     dry_run = true
                 )
             end
+        end
+
+        mktempdir() do logdir
+            Test.@test !Mycelia.scg_sbatch(
+                job_name = "scg-direct-invalid",
+                mail_user = "env-scg@example.org",
+                account = "PI_ENV",
+                cpus_per_task = 0,
+                cmd = "echo invalid scg direct dry-run",
+                logdir = logdir,
+                dry_run = true
+            )
         end
 
         _without_git_email() do
@@ -578,7 +605,7 @@ Test.@testset "SLURM wrapper entrypoints" begin
         end
     end
 
-    Test.@testset "nersc_sbatch direct dry_run returns true" begin
+    Test.@testset "nersc_sbatch direct dry_run returns true and false on validation failure" begin
         mktempdir() do logdir
             mktempdir() do scriptdir
                 Test.@test Mycelia.nersc_sbatch(
@@ -586,6 +613,21 @@ Test.@testset "SLURM wrapper entrypoints" begin
                     mail_user = "user@example.org",
                     account = "m2468",
                     cmd = "echo direct dry-run",
+                    logdir = logdir,
+                    scriptdir = scriptdir,
+                    dry_run = true
+                )
+            end
+        end
+
+        mktempdir() do logdir
+            mktempdir() do scriptdir
+                Test.@test !Mycelia.nersc_sbatch(
+                    job_name = "nersc-direct-invalid",
+                    mail_user = "user@example.org",
+                    account = "m2468",
+                    cpus_per_task = 0,
+                    cmd = "echo invalid nersc direct dry-run",
                     logdir = logdir,
                     scriptdir = scriptdir,
                     dry_run = true


### PR DESCRIPTION
## Summary
- expand `slurm_template_system` coverage for direct wrapper submit paths in `slurm-sbatch.jl`
- add missing mail-source error tests for Lawrencium and SCG wrappers
- add direct dry-run and missing-account coverage for NERSC wrappers

## Verification
- `MYCELIA_RUN_ALL=true MYCELIA_RUN_EXTERNAL=true julia --project=. --code-coverage=user test/8_tool_integration/slurm_template_system.jl`
- latest `src/slurm-sbatch.jl.*.cov`: `exec=98 zero=4 coverage=95.92%`

## Notes
- `coderabbit review --plain --type uncommitted --base master` could not run because CodeRabbit auth is not configured in this environment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added test-only constants and utilities to normalize legacy log paths, simulate git email presence/absence, stub external association tooling, create isolated collector/logdir environments, and centralize submit-result assertions.
  * Reworked SLURM integration tests to use helpers, reduce boilerplate, and add error/dry-run coverage across backends, mail/account fallbacks, validation, and output-format expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->