### PR TITLE
fix: correct run_clamlst db_path handling

### DIFF
--- a/src/classification.jl
+++ b/src/classification.jl
@@ -1338,17 +1338,20 @@ end
                 species::String="Escherichia coli", 
                 outdir::String=dirname(genome_file),
                 threads::Int=get_default_threads(),
-                force_db_update::Bool=false)
+                force_db_update::Bool=false,
+                executor=nothing)
 
 Run `claMLST` (from `pymlst`) to perform MLST typing on a genome.
 
 # Arguments
 - `genome_file`: Path to the input genome FASTA file (gzip supported).
 - `db_path`: Path to store/look for the claMLST database. Defaults to `~/workspace/pymlst/claMLSTDB`.
+- `db_dir`: Deprecated alias for `db_path`.
 - `species`: Species name to import/search if the database needs initialization (default: "Escherichia coli").
 - `outdir`: Directory for output files.
 - `threads`: Number of threads to use.
 - `force_db_update`: If `true`, re-imports the database even if it exists.
+- `executor`: Optional execution backend. When provided, execution/job metadata keywords are forwarded to `Mycelia.build_execution_job`.
 
 # Details
 This function automatically:
@@ -1358,10 +1361,11 @@ This function automatically:
 4. Runs the search and returns the path to the output.
 
 # Returns
-- `String`: Path to the output directory.
+- `String`: Path to the `claMLST` output TSV file.
 """
 function run_clamlst(genome_file::String;
         db_path::String = joinpath(homedir(), "workspace", "pymlst", "claMLSTDB"),
+        db_dir::Union{Nothing, String} = nothing,
         species::String = "Escherichia coli",
         outdir::String = dirname(genome_file),
         threads::Int = get_default_threads(),
@@ -1375,7 +1379,14 @@ function run_clamlst(genome_file::String;
         mem_gb::Union{Nothing, Real} = nothing,
         qos::Union{Nothing, String} = nothing,
         mail_user::Union{Nothing, String} = nothing)
-    isfile(genome_file) || error("Genome file not found: $(genome_file)")
+    default_db_path = joinpath(homedir(), "workspace", "pymlst", "claMLSTDB")
+    if !isnothing(db_dir)
+        if db_path != default_db_path && db_path != db_dir
+            error("Provide only one of db_path or db_dir for run_clamlst().")
+        end
+        Base.depwarn("Keyword argument db_dir is deprecated; use db_path instead.", :run_clamlst)
+        db_path = db_dir
+    end
 
     mkpath(outdir)
     mkpath(dirname(db_path))
@@ -1390,8 +1401,14 @@ function run_clamlst(genome_file::String;
         return output_tsv
     end
 
-    # only install if we need to make the file - skip if it's already present
-    Mycelia.add_bioconda_env("pymlst")
+    isfile(genome_file) || error("Genome file not found: $(genome_file)")
+
+    resolved_executor = executor === nothing ? nothing : Mycelia.resolve_executor(executor)
+    if resolved_executor === nothing ||
+       !(resolved_executor isa Mycelia.CollectExecutor || resolved_executor isa Mycelia.DryRunExecutor)
+        # Only install if we need to make the file; skip cached outputs and pure collection backends.
+        Mycelia.add_bioconda_env("pymlst")
+    end
 
     # Fix 2: Simplified DB check.
     # If the database exists, we assume the DB is already present
@@ -1407,7 +1424,7 @@ function run_clamlst(genome_file::String;
     end
     import_force_cmd = Mycelia.command_string(`$(Mycelia.CONDA_RUNNER) $(vcat(base_import_args, "--force"))`)
 
-    if executor !== nothing
+    if resolved_executor !== nothing
         script_lines = String[
             "set -euo pipefail",
             "mkdir -p \"$(outdir)\"",
@@ -1461,7 +1478,7 @@ function run_clamlst(genome_file::String;
             account = account,
             mail_user = mail_user
         )
-        Mycelia.execute(job, Mycelia.resolve_executor(executor))
+        Mycelia.execute(job, resolved_executor)
         return output_tsv
     end
 

--- a/src/classification.jl
+++ b/src/classification.jl
@@ -1335,11 +1335,20 @@ end
 """
     run_clamlst(genome_file::String; 
                 db_path::String=joinpath(homedir(), "workspace", "pymlst", "claMLSTDB"),
+                db_dir::Union{Nothing, String}=nothing,
                 species::String="Escherichia coli", 
                 outdir::String=dirname(genome_file),
                 threads::Int=get_default_threads(),
                 force_db_update::Bool=false,
-                executor=nothing)
+                executor=nothing,
+                site::Symbol=:local,
+                job_name::String="clamlst",
+                time_limit::String="1-00:00:00",
+                partition::Union{Nothing, String}=nothing,
+                account::Union{Nothing, String}=nothing,
+                mem_gb::Union{Nothing, Real}=nothing,
+                qos::Union{Nothing, String}=nothing,
+                mail_user::Union{Nothing, String}=nothing)
 
 Run `claMLST` (from `pymlst`) to perform MLST typing on a genome.
 
@@ -1352,13 +1361,21 @@ Run `claMLST` (from `pymlst`) to perform MLST typing on a genome.
 - `threads`: Number of threads to use.
 - `force_db_update`: If `true`, re-imports the database even if it exists.
 - `executor`: Optional execution backend. When provided, execution/job metadata keywords are forwarded to `Mycelia.build_execution_job`.
+- `site`: Execution site identifier used when `executor` is provided.
+- `job_name`: Job name used when `executor` is provided.
+- `time_limit`: Scheduler time limit used when `executor` is provided.
+- `partition`: Optional scheduler partition passed through when `executor` is provided.
+- `account`: Optional scheduler account passed through when `executor` is provided.
+- `mem_gb`: Optional scheduler memory request in gigabytes when `executor` is provided.
+- `qos`: Optional scheduler QoS passed through when `executor` is provided.
+- `mail_user`: Optional scheduler email recipient passed through when `executor` is provided.
 
 # Details
 This function automatically:
 1. Installs the `pymlst` conda environment.
 2. Checks if the `claMLST` database exists at `db_path`. If not, it imports it for the specified `species`.
 3. Decompresses the input genome to a temporary file (required by `claMLST`).
-4. Runs the search and returns the path to the output.
+4. Runs the search locally or emits an execution job when `executor` is provided, then returns the expected output path.
 
 # Returns
 - `String`: Path to the `claMLST` output TSV file.

--- a/src/classification.jl
+++ b/src/classification.jl
@@ -1334,7 +1334,7 @@ end
 
 """
     run_clamlst(genome_file::String; 
-                db_dir::String=joinpath(homedir(), "workspace", "pymlst", "claMLSTDB"),
+                db_path::String=joinpath(homedir(), "workspace", "pymlst", "claMLSTDB"),
                 species::String="Escherichia coli", 
                 outdir::String=dirname(genome_file),
                 threads::Int=get_default_threads(),
@@ -1365,7 +1365,18 @@ function run_clamlst(genome_file::String;
         species::String = "Escherichia coli",
         outdir::String = dirname(genome_file),
         threads::Int = get_default_threads(),
-        force_db_update::Bool = false)
+        force_db_update::Bool = false,
+        executor = nothing,
+        site::Symbol = :local,
+        job_name::String = "clamlst",
+        time_limit::String = "1-00:00:00",
+        partition::Union{Nothing, String} = nothing,
+        account::Union{Nothing, String} = nothing,
+        mem_gb::Union{Nothing, Real} = nothing,
+        qos::Union{Nothing, String} = nothing,
+        mail_user::Union{Nothing, String} = nothing)
+    isfile(genome_file) || error("Genome file not found: $(genome_file)")
+
     mkpath(outdir)
     mkpath(dirname(db_path))
 
@@ -1382,27 +1393,85 @@ function run_clamlst(genome_file::String;
     # only install if we need to make the file - skip if it's already present
     Mycelia.add_bioconda_env("pymlst")
 
-    # Fix 2: Simplified DB check. 
+    # Fix 2: Simplified DB check.
     # If the database exists, we assume the DB is already present
     db_exists = isfile(db_path) || isdir(db_path)
+    base_import_args = String[
+        "run", "--live-stream", "-n", "pymlst",
+        "claMLST", "import", db_path, species
+    ]
+    import_args = copy(base_import_args)
+    import_cmd = Mycelia.command_string(`$(Mycelia.CONDA_RUNNER) $(base_import_args)`)
+    if db_exists && force_db_update
+        push!(import_args, "--force")
+    end
+    import_force_cmd = Mycelia.command_string(`$(Mycelia.CONDA_RUNNER) $(vcat(base_import_args, "--force"))`)
+
+    if executor !== nothing
+        script_lines = String[
+            "set -euo pipefail",
+            "mkdir -p \"$(outdir)\"",
+            "mkdir -p \"$(dirname(db_path))\"",
+            "if [ ! -f \"$(output_tsv)\" ]; then"
+        ]
+
+        if force_db_update
+            append!(script_lines, [
+                "  if [ -e \"$(db_path)\" ]; then",
+                "    $(import_force_cmd)",
+                "  else",
+                "    $(import_cmd)",
+                "  fi"
+            ])
+        else
+            append!(script_lines, [
+                "  if [ ! -e \"$(db_path)\" ]; then",
+                "    $(import_cmd)",
+                "  fi"
+            ])
+        end
+
+        if endswith(genome_file, ".gz")
+            temp_template = joinpath(outdir, "clamlst_input.XXXXXX")
+            append!(script_lines, [
+                "  temp_input=\$(mktemp \"$(temp_template)\")",
+                "  trap 'rm -f \"\$temp_input\"' EXIT",
+                "  gunzip -c \"$(genome_file)\" > \"\$temp_input\"",
+                "  input_path=\"\$temp_input\""
+            ])
+        else
+            push!(script_lines, "  input_path=\"$(genome_file)\"")
+        end
+
+        push!(
+            script_lines,
+            "  $(Mycelia.CONDA_RUNNER) run --live-stream -n pymlst claMLST search \"$(db_path)\" \"\$input_path\" > \"$(output_tsv)\""
+        )
+        push!(script_lines, "fi")
+
+        job = Mycelia.build_execution_job(
+            cmd = join(script_lines, "\n"),
+            job_name = job_name,
+            site = site,
+            time_limit = time_limit,
+            cpus_per_task = threads,
+            mem_gb = mem_gb,
+            partition = partition,
+            qos = qos,
+            account = account,
+            mail_user = mail_user
+        )
+        Mycelia.execute(job, Mycelia.resolve_executor(executor))
+        return output_tsv
+    end
+
     if !db_exists || force_db_update
-        @info "Initializing claMLST database for $species at $db_dir..."
+        @info "Initializing claMLST database for $species at $db_path..."
         try
-            # Prepare arguments
-            cmd_args = ["run", "--live-stream", "-n", "pymlst",
-                "claMLST", "import", db_dir, species]
-
-            # If forcing an update on an existing DB, attempt to use --force if supported, 
-            # or the user might need to manually clear the folder. 
-            # The error message "use --force to override it" suggests the flag exists.
-            if db_exists && force_db_update
-                push!(cmd_args, "--force")
-            end
-
-            run(`$(Mycelia.CONDA_RUNNER) $cmd_args`)
+            run(`$(Mycelia.CONDA_RUNNER) $import_args`)
         catch e
             @warn "Failed to import claMLST database: $e"
-            # If strictly required, you might want to rethrow() here, 
+            # If strictly required, you might want to rethrow() here,
             # but usually we proceed to check if search works.
         end
     end
@@ -1423,7 +1492,7 @@ function run_clamlst(genome_file::String;
         end
 
         # Run Search
-        cmd = `$(Mycelia.CONDA_RUNNER) run --live-stream -n pymlst claMLST search $(db_dir) $(input_path_to_use)`
+        cmd = `$(Mycelia.CONDA_RUNNER) run --live-stream -n pymlst claMLST search $(db_path) $(input_path_to_use)`
 
         open(output_tsv, "w") do io
             run(pipeline(cmd, stdout = io))

--- a/test/7_comparative_pangenomics/classification_wrappers.jl
+++ b/test/7_comparative_pangenomics/classification_wrappers.jl
@@ -1,12 +1,6 @@
 import Test
 import Mycelia
 
-@eval Mycelia begin
-    function add_bioconda_env(pkg::AbstractString; force = false, quiet = false)
-        return nothing
-    end
-end
-
 Test.@testset "Classification wrapper executor coverage" begin
     temp_dir = mktempdir()
     try
@@ -39,6 +33,43 @@ Test.@testset "Classification wrapper executor coverage" begin
         Test.@test occursin("claMLST search", executor.jobs[1].cmd)
         Test.@test occursin(db_path, executor.jobs[1].cmd)
         Test.@test occursin(genome_file, executor.jobs[1].cmd)
+    finally
+        rm(temp_dir; recursive = true, force = true)
+    end
+end
+
+Test.@testset "Classification wrapper cache and compatibility" begin
+    temp_dir = mktempdir()
+    try
+        missing_genome = joinpath(temp_dir, "missing.fasta")
+        cached_outdir = joinpath(temp_dir, "cached")
+        mkpath(cached_outdir)
+        cached_output = joinpath(cached_outdir, "missing_clamlst.tsv")
+        write(cached_output, "scheme\tst\n")
+
+        Test.@test Mycelia.run_clamlst(
+            missing_genome;
+            outdir = cached_outdir
+        ) == cached_output
+
+        alias_genome = joinpath(temp_dir, "alias.fasta")
+        open(alias_genome, "w") do io
+            println(io, ">contig1")
+            println(io, "ATGCATGC")
+        end
+
+        alias_db_path = joinpath(temp_dir, "alias", "claMLSTDB")
+        alias_executor = Mycelia.CollectExecutor()
+        alias_output = Test.@test_deprecated Mycelia.run_clamlst(
+            alias_genome;
+            db_dir = alias_db_path,
+            outdir = joinpath(temp_dir, "alias_out"),
+            executor = alias_executor
+        )
+
+        Test.@test alias_output == joinpath(temp_dir, "alias_out", "alias_clamlst.tsv")
+        Test.@test length(alias_executor.jobs) == 1
+        Test.@test occursin(alias_db_path, alias_executor.jobs[1].cmd)
     finally
         rm(temp_dir; recursive = true, force = true)
     end

--- a/test/7_comparative_pangenomics/classification_wrappers.jl
+++ b/test/7_comparative_pangenomics/classification_wrappers.jl
@@ -1,0 +1,45 @@
+import Test
+import Mycelia
+
+@eval Mycelia begin
+    function add_bioconda_env(pkg::AbstractString; force = false, quiet = false)
+        return nothing
+    end
+end
+
+Test.@testset "Classification wrapper executor coverage" begin
+    temp_dir = mktempdir()
+    try
+        genome_file = joinpath(temp_dir, "genome.fasta")
+        open(genome_file, "w") do io
+            println(io, ">contig1")
+            println(io, "ATGCATGC")
+        end
+
+        db_path = joinpath(temp_dir, "custom", "claMLSTDB")
+        outdir = joinpath(temp_dir, "clamlst")
+        executor = Mycelia.CollectExecutor()
+
+        output_tsv = Mycelia.run_clamlst(
+            genome_file;
+            db_path = db_path,
+            outdir = outdir,
+            threads = 3,
+            executor = executor,
+            site = :scg,
+            job_name = "clamlst-collect"
+        )
+
+        Test.@test output_tsv == joinpath(outdir, "genome_clamlst.tsv")
+        Test.@test length(executor.jobs) == 1
+        Test.@test executor.jobs[1].job_name == "clamlst-collect"
+        Test.@test executor.jobs[1].site == :scg
+        Test.@test executor.jobs[1].cpus_per_task == 3
+        Test.@test occursin("claMLST import", executor.jobs[1].cmd)
+        Test.@test occursin("claMLST search", executor.jobs[1].cmd)
+        Test.@test occursin(db_path, executor.jobs[1].cmd)
+        Test.@test occursin(genome_file, executor.jobs[1].cmd)
+    finally
+        rm(temp_dir; recursive = true, force = true)
+    end
+end

--- a/test/7_comparative_pangenomics/classification_wrappers.jl
+++ b/test/7_comparative_pangenomics/classification_wrappers.jl
@@ -74,3 +74,53 @@ Test.@testset "Classification wrapper cache and compatibility" begin
         rm(temp_dir; recursive = true, force = true)
     end
 end
+
+Test.@testset "Classification wrapper executor force-update and validation" begin
+    temp_dir = mktempdir()
+    try
+        plain_input = joinpath(temp_dir, "compressed.fasta")
+        open(plain_input, "w") do io
+            println(io, ">contig1")
+            println(io, "ATGCATGC")
+        end
+        gz_input = joinpath(temp_dir, "compressed.fasta.gz")
+        open(gz_input, "w") do io
+            run(pipeline(`gzip -c $(plain_input)`, stdout = io))
+        end
+
+        forced_db_path = joinpath(temp_dir, "forced", "claMLSTDB")
+        mkpath(forced_db_path)
+        force_executor = Mycelia.CollectExecutor()
+        forced_output = Mycelia.run_clamlst(
+            gz_input;
+            db_path = forced_db_path,
+            outdir = joinpath(temp_dir, "forced_out"),
+            force_db_update = true,
+            executor = force_executor
+        )
+
+        Test.@test forced_output == joinpath(temp_dir, "forced_out", "compressed_clamlst.tsv")
+        Test.@test length(force_executor.jobs) == 1
+        Test.@test occursin("claMLST import", force_executor.jobs[1].cmd)
+        Test.@test occursin("--force", force_executor.jobs[1].cmd)
+        Test.@test occursin("gunzip -c", force_executor.jobs[1].cmd)
+        Test.@test occursin("mktemp", force_executor.jobs[1].cmd)
+
+        mismatch_executor = Mycelia.CollectExecutor()
+        mismatch_genome = joinpath(temp_dir, "mismatch.fasta")
+        open(mismatch_genome, "w") do io
+            println(io, ">contig1")
+            println(io, "ATGCATGC")
+        end
+
+        Test.@test_throws ErrorException Mycelia.run_clamlst(
+            mismatch_genome;
+            db_path = joinpath(temp_dir, "path_a"),
+            db_dir = joinpath(temp_dir, "path_b"),
+            outdir = joinpath(temp_dir, "mismatch_out"),
+            executor = mismatch_executor
+        )
+    finally
+        rm(temp_dir; recursive = true, force = true)
+    end
+end

--- a/test/test_executor.jl
+++ b/test/test_executor.jl
@@ -2,7 +2,7 @@ import Test
 import Mycelia
 
 @eval Mycelia begin
-    function add_bioconda_env(pkg::AbstractString; force = false, quiet = false)
+    function add_bioconda_env(pkg; force = false, quiet = false)
         return nothing
     end
 end


### PR DESCRIPTION
## Summary
- replace stale db_dir references in run_clamlst uncached import/search paths with db_path
- add executor support so the wrapper can be covered without invoking external tools
- add a core regression test for the uncached claMLST setup path using CollectExecutor

## Testing
- julia --project=. -e 'include("test/7_comparative_pangenomics/classification_wrappers.jl")'

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional job execution with cluster scheduling and resource controls (site, job name, time, partition, account, memory, QOS, email)
  * Conditional environment setup and automatic decompression of gzip genome inputs; primary output is the expected TSV path

* **Bug Fixes**
  * Uses cached output TSV when available; early error if genome input is missing
  * Conflicting database inputs now rejected

* **Deprecation**
  * db_dir deprecated in favor of db_path; db_dir emits a deprecation warning

* **Tests**
  * Added tests for executor behavior, caching, deprecated-parameter handling, compressed inputs and forced DB updates
<!-- end of auto-generated comment: release notes by coderabbit.ai -->