### PR TITLE
fix: cover dense temp-file and sparse k-mer edge cases

### DIFF
--- a/src/kmer-analysis.jl
+++ b/src/kmer-analysis.jl
@@ -2024,7 +2024,7 @@ function fasta_list_to_dense_kmer_counts(;
     progress1 = show_progress ?
                 ProgressMeter.Progress(num_files; desc = "Counting: ",
         barglyphs = ProgressMeter.BarGlyphs("[=> ]"), color = :cyan) : nothing
-    lock = use_threading ? Base.ReentrantLock() : nothing
+    lock = Base.ReentrantLock()
     error_log = Vector{Tuple{Int, String}}()
     successful_indices = Vector{Int}()
     max_observed_count_ref = Ref{Int}(0)
@@ -2695,7 +2695,8 @@ function multi_scale_kmer_analysis(sequences::Vector{BioSequences.LongDNA{4}};
         # Select consensus k-mers (high-frequency, high-quality)
         sorted_kmers = sort(collect(kmer_counts), by = x->x[2], rev = true)
         consensus_threshold = max(3, Int(ceil(0.1 * length(sorted_kmers))))
-        consensus_kmers[k] = [kmer for (kmer, count) in sorted_kmers[1:consensus_threshold]]
+        consensus_limit = min(consensus_threshold, length(sorted_kmers))
+        consensus_kmers[k] = [kmer for (kmer, count) in sorted_kmers[1:consensus_limit]]
 
         # Estimate coverage
         if !isempty(kmer_counts)

--- a/src/kmer-analysis.jl
+++ b/src/kmer-analysis.jl
@@ -93,8 +93,25 @@ function load_kmer_results(filename::AbstractString)
             if loaded_alphabet isa Symbol
                 metadata["alphabet"] = loaded_alphabet
             elseif loaded_alphabet isa AbstractString
-                metadata["alphabet"] = Symbol(loaded_alphabet)
+                try
+                    metadata["alphabet"] = Symbol(loaded_alphabet)
+                catch error
+                    @warn(
+                        "Could not convert loaded alphabet back to Symbol. Preserving original value.",
+                        key = "metadata/alphabet",
+                        loaded_alphabet = loaded_alphabet,
+                        alphabet_type = typeof(loaded_alphabet),
+                        error = error
+                    )
+                    metadata["alphabet"] = loaded_alphabet
+                end
             else
+                @warn(
+                    "Unexpected loaded alphabet metadata type. Preserving original value.",
+                    key = "metadata/alphabet",
+                    loaded_alphabet = loaded_alphabet,
+                    alphabet_type = typeof(loaded_alphabet)
+                )
                 metadata["alphabet"] = loaded_alphabet
             end
         end

--- a/src/kmer-analysis.jl
+++ b/src/kmer-analysis.jl
@@ -89,12 +89,13 @@ function load_kmer_results(filename::AbstractString)
             metadata["k"] = loaded_data["metadata/k"]
         end
         if haskey(loaded_data, "metadata/alphabet")
-            # Attempt to convert back to Symbol, fallback to string if error
-            try
-                metadata["alphabet"] = Symbol(loaded_data["metadata/alphabet"])
-            catch
-                @warn "Could not convert loaded alphabet '$(loaded_data["metadata/alphabet"])' back to Symbol. Storing as String."
-                metadata["alphabet"] = loaded_data["metadata/alphabet"]
+            loaded_alphabet = loaded_data["metadata/alphabet"]
+            if loaded_alphabet isa Symbol
+                metadata["alphabet"] = loaded_alphabet
+            elseif loaded_alphabet isa AbstractString
+                metadata["alphabet"] = Symbol(loaded_alphabet)
+            else
+                metadata["alphabet"] = loaded_alphabet
             end
         end
         # Add other metadata fields if they exist

--- a/test/3_feature_extraction_kmer/kmer_analysis_additional_coverage_test.jl
+++ b/test/3_feature_extraction_kmer/kmer_analysis_additional_coverage_test.jl
@@ -816,5 +816,259 @@ Test.@testset "K-mer Analysis Additional Coverage" begin
                 k = 2
             )
         end
+
+        Test.@testset "Sparse generation and fallback branches" begin
+            dna_sparse_fasta = joinpath(temp_dir, "sparse_generation_dna.fasta")
+            rna_sparse_fasta = joinpath(temp_dir, "sparse_generation_rna.fasta")
+            aa_sparse_fasta = joinpath(temp_dir, "sparse_generation_aa.fasta")
+
+            Mycelia.write_fasta(
+                outfile = dna_sparse_fasta,
+                records = [FASTX.FASTA.Record("dna_sparse", "ATGCATGCATGC")],
+                gzip = false,
+                show_progress = false
+            )
+            Mycelia.write_fasta(
+                outfile = rna_sparse_fasta,
+                records = [FASTX.FASTA.Record("rna_sparse", "AUGCAUGCAUGC")],
+                gzip = false,
+                show_progress = false
+            )
+            Mycelia.write_fasta(
+                outfile = aa_sparse_fasta,
+                records = [FASTX.FASTA.Record("aa_sparse", "ACDEFGHIK")],
+                gzip = false,
+                show_progress = false
+            )
+
+            auto_generated = Mycelia.generate_and_save_kmer_counts(
+                alphabet = :DNA,
+                fastas = [dna_sparse_fasta],
+                k = 10,
+                output_dir = temp_dir
+            )
+            Test.@test isfile(auto_generated)
+            Test.@test occursin(".dna10mers.jld2", Base.Filesystem.basename(auto_generated))
+            auto_loaded = Mycelia.load_kmer_results(auto_generated)
+            Test.@test auto_loaded !== nothing
+            Test.@test auto_loaded.metadata["alphabet"] == :DNA
+            Test.@test auto_loaded.metadata["k"] == 10
+
+            rna_sparse_generated = Mycelia.generate_and_save_kmer_counts(
+                alphabet = :RNA,
+                fastas = [rna_sparse_fasta],
+                k = 10,
+                output_dir = temp_dir,
+                filename = "generated_rna_sparse.jld2"
+            )
+            Test.@test isfile(rna_sparse_generated)
+            rna_loaded = Mycelia.load_kmer_results(rna_sparse_generated)
+            Test.@test rna_loaded !== nothing
+            Test.@test rna_loaded.metadata["alphabet"] == :RNA
+
+            aa_sparse_generated = Mycelia.generate_and_save_kmer_counts(
+                alphabet = :AA,
+                fastas = [aa_sparse_fasta],
+                k = 4,
+                output_dir = temp_dir,
+                filename = "generated_aa_sparse.jld2"
+            )
+            Test.@test isfile(aa_sparse_generated)
+            aa_loaded = Mycelia.load_kmer_results(aa_sparse_generated)
+            Test.@test aa_loaded !== nothing
+            Test.@test aa_loaded.metadata["alphabet"] == :AA
+
+            rarefaction_cache = joinpath(temp_dir, "force_sparse_cache.jld2")
+            Mycelia.fasta_list_to_sparse_kmer_counts(
+                fasta_list = [dna_sparse_fasta],
+                k = 3,
+                alphabet = :DNA,
+                result_file = rarefaction_cache,
+                skip_rarefaction_plot = true,
+                skip_rarefaction_data = true,
+                force_threading = false,
+                force_temp_files = true,
+                force_progress_bars = false
+            )
+            Test.@test isfile(rarefaction_cache)
+
+            rarefaction_outdir = joinpath(temp_dir, "forced_rarefaction")
+            forced_sparse = Mycelia.fasta_list_to_sparse_kmer_counts(
+                fasta_list = [dna_sparse_fasta],
+                k = 3,
+                alphabet = :DNA,
+                result_file = rarefaction_cache,
+                out_dir = rarefaction_outdir,
+                rarefaction_data_filename = "forced_rarefaction.tsv",
+                rarefaction_plot_basename = "forced_rarefaction",
+                show_rarefaction_plot = false,
+                skip_rarefaction_plot = false,
+                skip_rarefaction_data = false,
+                force = true,
+                force_threading = false,
+                force_temp_files = true,
+                force_progress_bars = true
+            )
+            Test.@test forced_sparse.rarefaction_data_path ==
+                       joinpath(rarefaction_outdir, "forced_rarefaction.tsv")
+            Test.@test isfile(forced_sparse.rarefaction_data_path)
+
+            threaded_dense_bad_dir = joinpath(temp_dir, "missing_dense_dir", "threaded.jld2")
+            threaded_sorted_kmers = sort(Mycelia.generate_all_possible_canonical_kmers(
+                3, Mycelia.DNA_ALPHABET))
+            threaded_dense = Mycelia._dense_kmer_counts_in_memory(
+                [dna_sparse_fasta, rna_sparse_fasta],
+                threaded_sorted_kmers,
+                Kmers.DNAKmer{3},
+                Mycelia.count_canonical_kmers,
+                true,
+                true,
+                UInt16,
+                threaded_dense_bad_dir
+            )
+            Test.@test size(threaded_dense.counts) == (length(threaded_sorted_kmers), 2)
+            Test.@test sum(threaded_dense.counts[:, 1]) == 10
+            Test.@test sum(threaded_dense.counts[:, 2]) == 0
+            Test.@test !isfile(threaded_dense_bad_dir)
+
+            dense_temp_fail = Mycelia.fasta_list_to_dense_kmer_counts(
+                fasta_list = [rna_sparse_fasta],
+                k = 3,
+                alphabet = :DNA,
+                force_threading = false,
+                force_temp_files = true,
+                force_progress_bars = true
+            )
+            Test.@test isempty(dense_temp_fail.successful_fasta_list)
+            Test.@test length(dense_temp_fail.error_log) == 1
+            Test.@test size(dense_temp_fail.counts, 2) == 0
+
+            aa_record_estimate = Mycelia.estimate_genome_size_from_kmers(
+                [FASTX.FASTA.Record("aa_record", "ACDEFG")],
+                2
+            )
+            Test.@test aa_record_estimate["num_records"] == 1
+            Test.@test aa_record_estimate["actual_size"] == 6
+
+            Test.@test_throws ErrorException Mycelia.generate_all_possible_canonical_kmers(2, [1, 2])
+        end
+
+        Test.@testset "Count element type and serial fallback branches" begin
+            dense_ok_fasta = joinpath(temp_dir, "dense_ok.fasta")
+            dense_bad_fasta = joinpath(temp_dir, "dense_bad.fasta")
+            sparse_uint16_fasta = joinpath(temp_dir, "sparse_uint16.fasta")
+            sparse_uint32_fasta = joinpath(temp_dir, "sparse_uint32.fasta")
+
+            Mycelia.write_fasta(
+                outfile = dense_ok_fasta,
+                records = [FASTX.FASTA.Record("dense_ok", repeat("A", 10))],
+                gzip = false,
+                show_progress = false
+            )
+            Mycelia.write_fasta(
+                outfile = dense_bad_fasta,
+                records = [FASTX.FASTA.Record("dense_bad", repeat("U", 8))],
+                gzip = false,
+                show_progress = false
+            )
+            Mycelia.write_fasta(
+                outfile = sparse_uint16_fasta,
+                records = [FASTX.FASTA.Record("sparse_uint16", repeat("A", 300))],
+                gzip = false,
+                show_progress = false
+            )
+            Mycelia.write_fasta(
+                outfile = sparse_uint32_fasta,
+                records = [FASTX.FASTA.Record("sparse_uint32", repeat("A", 70000))],
+                gzip = false,
+                show_progress = false
+            )
+
+            serial_sorted_kmers = sort(Mycelia.generate_all_possible_canonical_kmers(
+                1, Mycelia.DNA_ALPHABET))
+            serial_dense = Mycelia._dense_kmer_counts_in_memory(
+                [dense_ok_fasta, dense_bad_fasta],
+                serial_sorted_kmers,
+                Kmers.DNAKmer{1},
+                Mycelia.count_canonical_kmers,
+                false,
+                true,
+                nothing,
+                nothing
+            )
+            Test.@test size(serial_dense.counts) == (length(serial_sorted_kmers), 2)
+            Test.@test sum(serial_dense.counts[:, 1]) == 10
+            Test.@test sum(serial_dense.counts[:, 2]) == 0
+
+            Test.@test_throws InexactError Mycelia._dense_kmer_counts_in_memory(
+                [sparse_uint16_fasta],
+                serial_sorted_kmers,
+                Kmers.DNAKmer{1},
+                Mycelia.count_canonical_kmers,
+                false,
+                false,
+                UInt8,
+                nothing
+            )
+
+            sparse_uint16 = Mycelia.fasta_list_to_sparse_kmer_counts(
+                fasta_list = [sparse_uint16_fasta],
+                k = 1,
+                alphabet = :DNA,
+                skip_rarefaction_plot = true,
+                skip_rarefaction_data = true,
+                force_threading = false,
+                force_temp_files = true,
+                force_progress_bars = false
+            )
+            Test.@test eltype(sparse_uint16.counts) == UInt16
+            Test.@test sum(sparse_uint16.counts) == 300
+
+            sparse_uint32 = Mycelia.fasta_list_to_sparse_kmer_counts(
+                fasta_list = [sparse_uint32_fasta],
+                k = 1,
+                alphabet = :DNA,
+                skip_rarefaction_plot = true,
+                skip_rarefaction_data = true,
+                force_threading = false,
+                force_temp_files = true,
+                force_progress_bars = false
+            )
+            Test.@test eltype(sparse_uint32.counts) == UInt32
+            Test.@test sum(sparse_uint32.counts) == 70000
+
+            sparse_missing_result = joinpath(temp_dir, "missing_sparse_dir", "sparse_result.jld2")
+            sparse_custom_type = Mycelia.fasta_list_to_sparse_kmer_counts(
+                fasta_list = [sparse_uint16_fasta],
+                k = 1,
+                alphabet = :DNA,
+                result_file = sparse_missing_result,
+                count_element_type = UInt16,
+                skip_rarefaction_plot = true,
+                skip_rarefaction_data = true,
+                force_threading = false,
+                force_temp_files = true,
+                force_progress_bars = false
+            )
+            Test.@test eltype(sparse_custom_type.counts) == UInt16
+            Test.@test !isfile(sparse_missing_result)
+
+            dense_missing_result = joinpath(temp_dir, "missing_dense_temp", "dense_result.jld2")
+            dense_temp_overflow = Mycelia.fasta_list_to_dense_kmer_counts(
+                fasta_list = [sparse_uint16_fasta],
+                k = 1,
+                alphabet = :DNA,
+                count_element_type = UInt8,
+                result_file = dense_missing_result,
+                force_threading = false,
+                force_temp_files = true,
+                force_progress_bars = true
+            )
+            Test.@test dense_temp_overflow.successful_fasta_list == [sparse_uint16_fasta]
+            Test.@test isempty(dense_temp_overflow.error_log)
+            Test.@test size(dense_temp_overflow.counts, 2) == 1
+            Test.@test sum(dense_temp_overflow.counts[:, 1]) == 0
+            Test.@test !isfile(dense_missing_result)
+        end
     end
 end

--- a/test/3_feature_extraction_kmer/kmer_analysis_additional_coverage_test.jl
+++ b/test/3_feature_extraction_kmer/kmer_analysis_additional_coverage_test.jl
@@ -118,7 +118,23 @@ Test.@testset "K-mer Analysis Additional Coverage" begin
             loaded = Mycelia.load_kmer_results(weird_metadata_path)
             Test.@test loaded !== nothing
             Test.@test loaded.metadata["k"] == 3
-            Test.@test loaded.metadata["alphabet"] == Symbol("123")
+            Test.@test loaded.metadata["alphabet"] == 123
+
+            symbol_metadata_path = joinpath(temp_dir, "symbol_metadata.jld2")
+            JLD2.jldopen(symbol_metadata_path, "w") do file
+                file["kmers"] = [Kmers.DNAKmer{3}("AAA")]
+                file["counts"] = reshape(UInt16[4, 2], 1, 2)
+                file["fasta_list"] = ["a.fasta", "b.fasta"]
+                file["metadata/k"] = 3
+                file["metadata/alphabet"] = :DNA
+            end
+            symbol_loaded = Mycelia.load_kmer_results(symbol_metadata_path)
+            Test.@test symbol_loaded !== nothing
+            Test.@test symbol_loaded.metadata["alphabet"] == :DNA
+
+            corrupt_path = joinpath(temp_dir, "corrupt_results.jld2")
+            write(corrupt_path, "not a jld2 file")
+            Test.@test isnothing(Mycelia.load_kmer_results(corrupt_path))
         end
 
         Test.@testset "Additional helper coverage" begin
@@ -133,6 +149,7 @@ Test.@testset "K-mer Analysis Additional Coverage" begin
             Test.@test length(Mycelia._collect_kmers(dna_kmer, 2)) == 3
             Test.@test length(Mycelia._collect_kmers(rna_kmer, 2)) == 3
             Test.@test length(Mycelia._collect_kmers(aa_kmer, 2)) == 2
+            Test.@test_throws ErrorException Mycelia._collect_kmers("ATGC", 2)
 
             rna_result = Mycelia.estimate_genome_size_from_kmers(
                 BioSequences.LongRNA{4}("ACGUAC"),
@@ -149,6 +166,11 @@ Test.@testset "K-mer Analysis Additional Coverage" begin
             Test.@test aa_result["actual_size"] == 4
             Test.@test aa_result["total_kmers"] == 3
             Test.@test aa_result["estimated_genome_size"] == 2
+
+            dna_string_result = Mycelia.estimate_genome_size_from_kmers("ATGCAT", 2)
+            Test.@test dna_string_result["actual_size"] == 6
+            Test.@test dna_string_result["total_kmers"] == 5
+            Test.@test dna_string_result["estimated_genome_size"] == 4
 
             fallback = Mycelia.adaptive_kmer_selection((
                 coverage_estimates = Dict(3 => 1.0, 5 => 2.0, 7 => 3.0),
@@ -259,8 +281,11 @@ Test.@testset "K-mer Analysis Additional Coverage" begin
             Test.@test full_probe.unique_kmer_counts[1] == 0
             Test.@test issorted(full_probe.sampling_points)
 
+            saturation_outdir = joinpath(temp_dir, "saturation_outputs")
+            mkpath(saturation_outdir)
             chosen_k = Mycelia.assess_dnamer_saturation(
                 fasta;
+                outdir = saturation_outdir,
                 power = 2,
                 min_k = 3,
                 max_k = 5,
@@ -268,6 +293,8 @@ Test.@testset "K-mer Analysis Additional Coverage" begin
                 kmers_to_assess = 16
             )
             Test.@test chosen_k in (3, 5)
+            Test.@test isfile(joinpath(saturation_outdir, "chosen_k.txt"))
+            Test.@test isfile(joinpath(saturation_outdir, "$(chosen_k).svg"))
         end
 
         Test.@testset "K-mer spectra analysis" begin
@@ -379,9 +406,27 @@ Test.@testset "K-mer Analysis Additional Coverage" begin
             Test.@test same_loaded !== nothing
             Test.@test same_loaded.kmers == kmers
 
+            Test.@test_throws Exception Mycelia.save_kmer_results(
+                filename = joinpath(temp_dir, "missing_dir", "write_fail.jld2"),
+                kmers = kmers,
+                counts = counts,
+                fasta_list = ["a.fasta", "b.fasta"],
+                k = 3,
+                alphabet = :DNA
+            )
+
             no_peak = Mycelia.coverage_peak_from_hist(Dict(1 => 4); min_coverage = 2)
             Test.@test ismissing(no_peak.coverage)
             Test.@test no_peak.kmers == 0
+
+            dict_analysis = Mycelia.analyze_kmer_frequency_spectrum(Dict(
+                Kmers.DNAKmer{2}("AT") => 3,
+                Kmers.DNAKmer{2}("TG") => 1
+            ); min_coverage = 2)
+            Test.@test dict_analysis.total_kmers == 4
+            Test.@test dict_analysis.unique_kmers == 2
+            Test.@test dict_analysis.peak.coverage == 3
+            Test.@test dict_analysis.peak.kmers == 1
 
             vector_analysis = Mycelia.analyze_kmer_frequency_spectrum([1, 1, 2, 4];
                 min_coverage = 3)
@@ -400,6 +445,12 @@ Test.@testset "K-mer Analysis Additional Coverage" begin
             Test.@test_throws ErrorException Mycelia.canonical_minimizers(
                 dna_sequence, 3, 0)
             Test.@test isempty(Mycelia.canonical_minimizers(dna_sequence, 3, 10))
+            minimizers = Mycelia.canonical_minimizers(dna_sequence, 3, 2)
+            Test.@test minimizers == [
+                BioSequences.canonical(Kmers.DNAKmer{3}("ATG")),
+                BioSequences.canonical(Kmers.DNAKmer{3}("GCA")),
+                BioSequences.canonical(Kmers.DNAKmer{3}("ATG"))
+            ]
 
             canonical_syncmers = Mycelia.open_syncmers(
                 dna_sequence, 3, 2, 1; canonical = true)
@@ -486,9 +537,23 @@ Test.@testset "K-mer Analysis Additional Coverage" begin
 
         Test.@testset "Dense and sparse file count helpers" begin
             fasta = joinpath(temp_dir, "matrix_input.fasta")
+            rna_fasta = joinpath(temp_dir, "matrix_input_rna.fasta")
+            aa_fasta = joinpath(temp_dir, "matrix_input_aa.fasta")
             Mycelia.write_fasta(
                 outfile = fasta,
                 records = [FASTX.FASTA.Record("matrix", "ATGCATGC")],
+                gzip = false,
+                show_progress = false
+            )
+            Mycelia.write_fasta(
+                outfile = rna_fasta,
+                records = [FASTX.FASTA.Record("matrix_rna", "AUGCAUGC")],
+                gzip = false,
+                show_progress = false
+            )
+            Mycelia.write_fasta(
+                outfile = aa_fasta,
+                records = [FASTX.FASTA.Record("matrix_aa", "ACDEFG")],
                 gzip = false,
                 show_progress = false
             )
@@ -513,6 +578,30 @@ Test.@testset "K-mer Analysis Additional Coverage" begin
                 result_file = dense_cache
             )
             Test.@test dense_cached == dense_result
+
+            dense_rna_result = Mycelia.fasta_list_to_dense_kmer_counts(
+                fasta_list = [rna_fasta],
+                k = 2,
+                alphabet = :RNA,
+                force_threading = true,
+                force_temp_files = true,
+                force_progress_bars = true
+            )
+            Test.@test size(dense_rna_result.counts, 2) == 1
+            Test.@test all(kmer -> kmer isa Kmers.RNAKmer{2}, dense_rna_result.kmers)
+            Test.@test dense_rna_result.successful_fasta_list == [rna_fasta]
+
+            dense_aa_result = Mycelia.fasta_list_to_dense_kmer_counts(
+                fasta_list = [aa_fasta],
+                k = 2,
+                alphabet = :AA,
+                force_threading = true,
+                force_temp_files = true,
+                force_progress_bars = true
+            )
+            Test.@test size(dense_aa_result.counts, 2) == 1
+            Test.@test all(kmer -> kmer isa Kmers.AAKmer{2}, dense_aa_result.kmers)
+            Test.@test dense_aa_result.successful_fasta_list == [aa_fasta]
 
             sparse_cache = joinpath(temp_dir, "sparse_cache.jld2")
             sparse_result = Mycelia.fasta_list_to_sparse_kmer_counts(
@@ -539,6 +628,64 @@ Test.@testset "K-mer Analysis Additional Coverage" begin
             )
             Test.@test sparse_cached == sparse_result
 
+            sparse_outdir = joinpath(temp_dir, "sparse_outputs")
+            sparse_invalid_cache = joinpath(temp_dir, "sparse_invalid_cache.jld2")
+            JLD2.save_object(sparse_invalid_cache, Dict(:counts => 1))
+            sparse_recomputed = Mycelia.fasta_list_to_sparse_kmer_counts(
+                fasta_list = [fasta],
+                k = 3,
+                alphabet = :DNA,
+                result_file = sparse_invalid_cache,
+                out_dir = sparse_outdir,
+                rarefaction_data_filename = "curve.tsv",
+                skip_rarefaction_plot = true,
+                force_threading = false,
+                force_temp_files = true,
+                force_progress_bars = false
+            )
+            Test.@test sparse_recomputed.rarefaction_data_path ==
+                       joinpath(sparse_outdir, "curve.tsv")
+
+            sparse_force_cache = joinpath(temp_dir, "nested_sparse", "forced_sparse.jld2")
+            sparse_forced = Mycelia.fasta_list_to_sparse_kmer_counts(
+                fasta_list = [fasta],
+                k = 3,
+                alphabet = :DNA,
+                result_file = sparse_force_cache,
+                rarefaction_data_filename = "forced.tsv",
+                skip_rarefaction_plot = true,
+                force = true,
+                force_threading = false,
+                force_temp_files = true,
+                force_progress_bars = false
+            )
+            Test.@test sparse_forced.rarefaction_data_path ==
+                       joinpath(dirname(sparse_force_cache), "forced.tsv")
+
+            sparse_rna_result = Mycelia.fasta_list_to_sparse_kmer_counts(
+                fasta_list = [rna_fasta],
+                k = 2,
+                alphabet = :RNA,
+                skip_rarefaction_plot = true,
+                skip_rarefaction_data = true,
+                force_threading = false,
+                force_temp_files = true,
+                force_progress_bars = false
+            )
+            Test.@test all(kmer -> kmer isa Kmers.RNAKmer{2}, sparse_rna_result.kmers)
+
+            sparse_aa_result = Mycelia.fasta_list_to_sparse_kmer_counts(
+                fasta_list = [aa_fasta],
+                k = 2,
+                alphabet = :AA,
+                skip_rarefaction_plot = true,
+                skip_rarefaction_data = true,
+                force_threading = false,
+                force_temp_files = true,
+                force_progress_bars = false
+            )
+            Test.@test all(kmer -> kmer isa Kmers.AAKmer{2}, sparse_aa_result.kmers)
+
             Test.@test_throws ErrorException Mycelia.fasta_list_to_dense_kmer_counts(
                 fasta_list = String[],
                 k = 3,
@@ -548,6 +695,21 @@ Test.@testset "K-mer Analysis Additional Coverage" begin
                 fasta_list = [joinpath(temp_dir, "missing.fasta")],
                 k = 3,
                 alphabet = :DNA
+            )
+            Test.@test_throws ErrorException Mycelia.fasta_list_to_dense_kmer_counts(
+                fasta_list = [fasta],
+                k = 3,
+                alphabet = :INVALID
+            )
+            Test.@test_throws ErrorException Mycelia.fasta_list_to_dense_kmer_counts(
+                fasta_list = [aa_fasta],
+                k = 6,
+                alphabet = :AA
+            )
+            Test.@test_throws ErrorException Mycelia.fasta_list_to_dense_kmer_counts(
+                fasta_list = [rna_fasta],
+                k = 12,
+                alphabet = :RNA
             )
             Test.@test_throws ErrorException Mycelia.fasta_list_to_sparse_kmer_counts(
                 fasta_list = String[],
@@ -649,6 +811,10 @@ Test.@testset "K-mer Analysis Additional Coverage" begin
             Test.@test isempty(empty_sparse.kmers)
             Test.@test size(empty_sparse.counts) == (0, 1)
             Test.@test isfile(empty_sparse_cache)
+            Test.@test_throws ErrorException Mycelia.biosequences_to_dense_counts_table(
+                biosequences = ["ATGC"],
+                k = 2
+            )
         end
     end
 end

--- a/test/3_feature_extraction_kmer/kmer_analysis_additional_coverage_test.jl
+++ b/test/3_feature_extraction_kmer/kmer_analysis_additional_coverage_test.jl
@@ -533,6 +533,16 @@ Test.@testset "K-mer Analysis Additional Coverage" begin
             Test.@test all(k -> haskey(multi_k.consensus_kmers, k), [3, 5])
             Test.@test all(k -> !isempty(multi_k.quality_profiles[k]), [3, 5])
             Test.@test all(v -> v >= 0.0, values(multi_k.coverage_estimates))
+
+            sparse_multi_k = Mycelia.multi_scale_kmer_analysis(
+                [BioSequences.LongDNA{4}("ATGC")];
+                prime_ks = [7],
+                window_size = 3,
+                step_size = 1
+            )
+            Test.@test sparse_multi_k.coverage_estimates[7] == 0.0
+            Test.@test isempty(sparse_multi_k.consensus_kmers[7])
+            Test.@test length(sparse_multi_k.quality_profiles[7]) == 2
         end
 
         Test.@testset "Dense and sparse file count helpers" begin
@@ -956,6 +966,7 @@ Test.@testset "K-mer Analysis Additional Coverage" begin
         Test.@testset "Count element type and serial fallback branches" begin
             dense_ok_fasta = joinpath(temp_dir, "dense_ok.fasta")
             dense_bad_fasta = joinpath(temp_dir, "dense_bad.fasta")
+            dense_invalid_fasta = joinpath(temp_dir, "dense_invalid.fasta")
             sparse_uint16_fasta = joinpath(temp_dir, "sparse_uint16.fasta")
             sparse_uint32_fasta = joinpath(temp_dir, "sparse_uint32.fasta")
 
@@ -971,6 +982,7 @@ Test.@testset "K-mer Analysis Additional Coverage" begin
                 gzip = false,
                 show_progress = false
             )
+            write(dense_invalid_fasta, "not fasta\nATGC\n")
             Mycelia.write_fasta(
                 outfile = sparse_uint16_fasta,
                 records = [FASTX.FASTA.Record("sparse_uint16", repeat("A", 300))],
@@ -1051,7 +1063,44 @@ Test.@testset "K-mer Analysis Additional Coverage" begin
                 force_progress_bars = false
             )
             Test.@test eltype(sparse_custom_type.counts) == UInt16
-            Test.@test !isfile(sparse_missing_result)
+            Test.@test isfile(sparse_missing_result)
+
+            sparse_missing_rarefaction = Mycelia.fasta_list_to_sparse_kmer_counts(
+                fasta_list = [sparse_uint16_fasta, dense_bad_fasta],
+                k = 1,
+                alphabet = :DNA,
+                out_dir = joinpath(temp_dir, "sparse_missing_rarefaction"),
+                rarefaction_plot_basename = "missing_rarefaction",
+                skip_rarefaction_plot = false,
+                skip_rarefaction_data = true,
+                force_threading = false,
+                force_temp_files = true,
+                force_progress_bars = true
+            )
+            Test.@test eltype(sparse_missing_rarefaction.counts) == UInt16
+            Test.@test size(sparse_missing_rarefaction.counts, 2) == 2
+            Test.@test sum(sparse_missing_rarefaction.counts[:, 1]) == 300
+            Test.@test sum(sparse_missing_rarefaction.counts[:, 2]) == 0
+            Test.@test !isfile(sparse_missing_rarefaction.rarefaction_data_path)
+
+            dense_temp_saved_result = joinpath(temp_dir, "dense_temp_saved_result.jld2")
+            dense_temp_saved = Mycelia.fasta_list_to_dense_kmer_counts(
+                fasta_list = [dense_ok_fasta, dense_invalid_fasta],
+                k = 1,
+                alphabet = :DNA,
+                count_element_type = UInt16,
+                result_file = dense_temp_saved_result,
+                force_threading = false,
+                force_temp_files = true,
+                force_progress_bars = true
+            )
+            Test.@test dense_temp_saved.successful_fasta_list == [dense_ok_fasta]
+            Test.@test length(dense_temp_saved.error_log) == 1
+            Test.@test eltype(dense_temp_saved.counts) == UInt16
+            Test.@test size(dense_temp_saved.counts, 2) == 1
+            Test.@test sum(dense_temp_saved.counts[:, 1]) == 10
+            Test.@test isfile(dense_temp_saved_result)
+            Test.@test JLD2.load_object(dense_temp_saved_result) == dense_temp_saved
 
             dense_missing_result = joinpath(temp_dir, "missing_dense_temp", "dense_result.jld2")
             dense_temp_overflow = Mycelia.fasta_list_to_dense_kmer_counts(
@@ -1069,6 +1118,29 @@ Test.@testset "K-mer Analysis Additional Coverage" begin
             Test.@test size(dense_temp_overflow.counts, 2) == 1
             Test.@test sum(dense_temp_overflow.counts[:, 1]) == 0
             Test.@test !isfile(dense_missing_result)
+
+            dense_uint32 = Mycelia.fasta_list_to_dense_kmer_counts(
+                fasta_list = [sparse_uint32_fasta],
+                k = 1,
+                alphabet = :DNA,
+                force_threading = false,
+                force_temp_files = true,
+                force_progress_bars = false
+            )
+            Test.@test eltype(dense_uint32.counts) == UInt32
+            Test.@test sum(dense_uint32.counts[:, 1]) == 70000
+
+            forced_dense_dna = Mycelia.fasta_list_to_dense_kmer_counts(
+                fasta_list = [sparse_uint16_fasta],
+                k = 12,
+                alphabet = :DNA,
+                force = true,
+                force_threading = false,
+                force_temp_files = true,
+                force_progress_bars = false
+            )
+            Test.@test size(forced_dense_dna.counts, 2) == 1
+            Test.@test sum(forced_dense_dna.counts[:, 1]) == 289
         end
     end
 end

--- a/test/3_feature_extraction_kmer/kmer_analysis_coverage_expansion_test.jl
+++ b/test/3_feature_extraction_kmer/kmer_analysis_coverage_expansion_test.jl
@@ -62,6 +62,21 @@ Test.@testset "K-mer Analysis Coverage Expansion" begin
         Test.@test loaded_invalid_alphabet.metadata["alphabet"] == 17
         Test.@test loaded_invalid_alphabet.metadata["k"] == 3
         Test.@test loaded_invalid_alphabet.metadata["custom_field"] == "kept"
+
+        malformed_alphabet_path = joinpath(temp_dir, "malformed_alphabet.jld2")
+        JLD2.jldopen(malformed_alphabet_path, "w") do file
+            file["kmers"] = kmers
+            file["counts"] = counts
+            file["fasta_list"] = fasta_list
+            file["metadata/k"] = 3
+            file["metadata/alphabet"] = "DNA\0broken"
+        end
+        loaded_malformed_alphabet = Mycelia.load_kmer_results(malformed_alphabet_path)
+        Test.@test loaded_malformed_alphabet !== nothing
+        Test.@test loaded_malformed_alphabet.kmers == kmers
+        Test.@test loaded_malformed_alphabet.counts == counts
+        Test.@test loaded_malformed_alphabet.fasta_list == fasta_list
+        Test.@test loaded_malformed_alphabet.metadata["alphabet"] == "DNA\0broken"
     end
 
     Test.@testset "jellyfish tabular helpers" begin

--- a/test/3_feature_extraction_kmer/kmer_analysis_coverage_expansion_test.jl
+++ b/test/3_feature_extraction_kmer/kmer_analysis_coverage_expansion_test.jl
@@ -1,0 +1,220 @@
+import Test
+import Mycelia
+import BioSequences
+import CodecZlib
+import CSV
+import DataFrames
+import FASTX
+import JLD2
+import Kmers
+import SparseArrays
+
+Test.@testset "K-mer Analysis Coverage Expansion" begin
+    Test.@testset "k-mer results persistence edge cases" begin
+        temp_dir = mktempdir()
+        kmers = Mycelia.generate_all_possible_canonical_kmers(3, Mycelia.DNA_ALPHABET)[1:2]
+        counts = reshape(UInt16[3, 5], 2, 1)
+        fasta_list = ["example.fasta"]
+
+        missing_path = joinpath(temp_dir, "missing.jld2")
+        Test.@test isnothing(Mycelia.load_kmer_results(missing_path))
+
+        no_extension_path = joinpath(temp_dir, "results")
+        Mycelia.save_kmer_results(
+            filename = no_extension_path,
+            kmers = kmers,
+            counts = counts,
+            fasta_list = fasta_list,
+            k = 3,
+            alphabet = :DNA
+        )
+        appended_path = no_extension_path * ".jld2"
+        Test.@test isfile(appended_path)
+
+        loaded_without_extension = Mycelia.load_kmer_results(appended_path)
+        Test.@test loaded_without_extension.kmers == kmers
+        Test.@test loaded_without_extension.counts == counts
+        Test.@test loaded_without_extension.fasta_list == fasta_list
+        Test.@test loaded_without_extension.metadata["alphabet"] == :DNA
+
+        missing_keys_path = joinpath(temp_dir, "missing_keys.jld2")
+        JLD2.jldopen(missing_keys_path, "w") do file
+            file["counts"] = counts
+        end
+        Test.@test isnothing(Mycelia.load_kmer_results(missing_keys_path))
+
+        invalid_alphabet_path = joinpath(temp_dir, "invalid_alphabet.jld2")
+        JLD2.jldopen(invalid_alphabet_path, "w") do file
+            file["kmers"] = kmers
+            file["counts"] = counts
+            file["fasta_list"] = fasta_list
+            file["metadata/k"] = 3
+            file["metadata/alphabet"] = 17
+            file["metadata/custom_field"] = "kept"
+        end
+        loaded_invalid_alphabet = Mycelia.load_kmer_results(invalid_alphabet_path)
+        Test.@test loaded_invalid_alphabet.metadata["alphabet"] == 17
+        Test.@test loaded_invalid_alphabet.metadata["k"] == 3
+        Test.@test loaded_invalid_alphabet.metadata["custom_field"] == "kept"
+    end
+
+    Test.@testset "jellyfish tabular helpers" begin
+        temp_dir = mktempdir()
+        jellyfish_counts_path = joinpath(temp_dir, "counts.jf.tsv.gz")
+
+        open(jellyfish_counts_path, "w") do io
+            gzip_io = CodecZlib.GzipCompressorStream(io)
+            try
+                write(gzip_io, "AAA\t2\nAAC\t3\nAAG\t2\n")
+            finally
+                close(gzip_io)
+            end
+        end
+
+        histogram_path = Mycelia.jellyfish_counts_to_kmer_frequency_histogram(jellyfish_counts_path)
+        Test.@test isfile(histogram_path)
+
+        histogram_table = CSV.read(histogram_path, DataFrames.DataFrame; delim = '\t')
+        histogram_map = Dict(
+            histogram_table[!, "number of observations"] .=> histogram_table[!, "number of kmers"]
+        )
+        Test.@test histogram_map == Dict(2 => 2, 3 => 1)
+
+        Test.@test Mycelia.jellyfish_counts_to_kmer_frequency_histogram(jellyfish_counts_path) ==
+                   histogram_path
+
+        loaded_counts = Mycelia.load_jellyfish_counts(jellyfish_counts_path)
+        Test.@test isa(loaded_counts, DataFrames.DataFrame)
+        Test.@test Kmers.ksize(eltype(loaded_counts[!, "kmer"])) == 3
+        Test.@test loaded_counts[!, "kmer"] == [
+            Kmers.DNAKmer{3}("AAA"),
+            Kmers.DNAKmer{3}("AAC"),
+            Kmers.DNAKmer{3}("AAG")
+        ]
+        Test.@test loaded_counts[!, "count"] == [2, 3, 2]
+
+        Test.@test_throws AssertionError Mycelia.load_jellyfish_counts(
+            joinpath(temp_dir, "counts.tsv")
+        )
+    end
+
+    Test.@testset "reference counting and sequence table helpers" begin
+        temp_dir = mktempdir()
+        fasta_path = joinpath(temp_dir, "reference.fasta")
+        open(fasta_path, "w") do io
+            FASTX.write(io, FASTX.FASTA.Record("ref", "ATGC"))
+        end
+
+        reference_counts = Mycelia.fasta_to_reference_kmer_counts(
+            kmer_type = Kmers.DNAKmer{2},
+            fasta = fasta_path
+        )
+        Test.@test reference_counts[Kmers.DNAKmer{2}("AT")] == 2
+        Test.@test reference_counts[Kmers.DNAKmer{2}("TG")] == 1
+        Test.@test reference_counts[Kmers.DNAKmer{2}("GC")] == 2
+        Test.@test reference_counts[Kmers.DNAKmer{2}("CA")] == 1
+
+        dna_sequences = [
+            BioSequences.LongDNA{4}("ATGC"),
+            BioSequences.LongDNA{4}("ATAT")
+        ]
+        dense_counts = Mycelia.biosequences_to_dense_counts_table(
+            biosequences = dna_sequences,
+            k = 3
+        )
+        Test.@test length(dense_counts.sorted_kmers) ==
+                   Mycelia.determine_max_canonical_kmers(3, Mycelia.DNA_ALPHABET)
+        Test.@test size(dense_counts.kmer_counts_matrix) == (32, 2)
+        Test.@test vec(sum(dense_counts.kmer_counts_matrix; dims = 1)) == [2.0, 2.0]
+
+        sparse_counts = Mycelia.biosequences_to_counts_table(
+            biosequences = dna_sequences,
+            k = 3
+        )
+        Test.@test SparseArrays.issparse(sparse_counts.kmer_counts_matrix)
+        Test.@test size(sparse_counts.kmer_counts_matrix, 2) == 2
+        Test.@test sum(sparse_counts.kmer_counts_matrix) == 4
+
+        Test.@test_throws ErrorException Mycelia.biosequences_to_dense_counts_table(
+            biosequences = dna_sequences,
+            k = 11
+        )
+    end
+
+    Test.@testset "reader overloads and genome estimation variants" begin
+        temp_dir = mktempdir()
+        fastq_path = joinpath(temp_dir, "reads.fastq")
+        Mycelia.write_fastq(
+            records = [
+                FASTX.FASTQ.Record("read1", "ATGC", "IIII"),
+                FASTX.FASTQ.Record("read2", "ATGA", "IIII")
+            ],
+            filename = fastq_path
+        )
+
+        fastq_record = FASTX.FASTQ.Record("record", "AUGC", "IIII")
+        record_counts = Mycelia.count_kmers(Kmers.RNAKmer{2}, fastq_record)
+        Test.@test sum(values(record_counts)) == 3
+
+        reader = Mycelia.open_fastx(fastq_path)
+        reader_counts = Mycelia.count_kmers(Kmers.DNAKmer{2}, reader)
+        Test.@test reader_counts[Kmers.DNAKmer{2}("AT")] == 2
+        Test.@test reader_counts[Kmers.DNAKmer{2}("TG")] == 2
+        close(reader)
+
+        rna_estimate = Mycelia.estimate_genome_size_from_kmers(
+            BioSequences.LongRNA{4}("AUGCAU"),
+            2
+        )
+        Test.@test rna_estimate["unique_kmers"] == 4
+        Test.@test rna_estimate["actual_size"] == 6
+
+        aa_estimate = Mycelia.estimate_genome_size_from_kmers(
+            BioSequences.LongAA("ACDE"),
+            2
+        )
+        Test.@test aa_estimate["total_kmers"] == 3
+        Test.@test aa_estimate["estimated_genome_size"] == 2
+
+        fastq_records = [
+            FASTX.FASTQ.Record("read1", "ATGC", "IIII"),
+            FASTX.FASTQ.Record("read2", "ATGA", "IIII")
+        ]
+        record_estimate = Mycelia.estimate_genome_size_from_kmers(fastq_records, 2)
+        Test.@test record_estimate["num_records"] == 2
+        Test.@test record_estimate["actual_size"] == 8
+    end
+
+    Test.@testset "saturation and adaptive selection helpers" begin
+        temp_dir = mktempdir()
+        fasta_path = joinpath(temp_dir, "reads.fasta")
+        open(fasta_path, "w") do io
+            FASTX.write(io, FASTX.FASTA.Record("seq1", "ATGCATGC"))
+        end
+
+        low_sample = Mycelia.assess_dnamer_saturation(
+            [fasta_path],
+            Kmers.DNAKmer{3};
+            kmers_to_assess = 1,
+            power = 10
+        )
+        Test.@test low_sample.sampling_points == [0, 1]
+        Test.@test low_sample.unique_kmer_counts == [0, 0]
+
+        saturation = Mycelia.assess_dnamer_saturation(
+            [fasta_path],
+            Kmers.DNAKmer{3};
+            kmers_to_assess = 20,
+            power = 2
+        )
+        Test.@test saturation.eof == true
+        Test.@test last(saturation.sampling_points) == 6
+        Test.@test last(saturation.unique_kmer_counts) == 2
+
+        no_match_results = (; coverage_estimates = Dict(3 => 0.5, 5 => 0.7))
+        Test.@test Mycelia.adaptive_kmer_selection(
+            no_match_results;
+            target_coverage = 10.0
+        ) == [5]
+    end
+end

--- a/test/3_feature_extraction_kmer/kmer_analysis_coverage_expansion_test.jl
+++ b/test/3_feature_extraction_kmer/kmer_analysis_coverage_expansion_test.jl
@@ -37,6 +37,12 @@ Test.@testset "K-mer Analysis Coverage Expansion" begin
         Test.@test loaded_without_extension.fasta_list == fasta_list
         Test.@test loaded_without_extension.metadata["alphabet"] == :DNA
 
+        alternate_extension_path = joinpath(temp_dir, "results.txt")
+        cp(appended_path, alternate_extension_path; force = true)
+        loaded_alternate_extension = Mycelia.load_kmer_results(alternate_extension_path)
+        Test.@test loaded_alternate_extension.kmers == kmers
+        Test.@test loaded_alternate_extension.metadata["alphabet"] == :DNA
+
         missing_keys_path = joinpath(temp_dir, "missing_keys.jld2")
         JLD2.jldopen(missing_keys_path, "w") do file
             file["counts"] = counts
@@ -127,6 +133,32 @@ Test.@testset "K-mer Analysis Coverage Expansion" begin
         Test.@test size(dense_counts.kmer_counts_matrix) == (32, 2)
         Test.@test vec(sum(dense_counts.kmer_counts_matrix; dims = 1)) == [2.0, 2.0]
 
+        rna_sequences = [
+            BioSequences.LongRNA{4}("AUGC"),
+            BioSequences.LongRNA{4}("AUGA")
+        ]
+        dense_rna_counts = Mycelia.biosequences_to_dense_counts_table(
+            biosequences = rna_sequences,
+            k = 2
+        )
+        Test.@test length(dense_rna_counts.sorted_kmers) ==
+                   length(Mycelia.generate_all_possible_kmers(2, Mycelia.RNA_ALPHABET))
+        Test.@test size(dense_rna_counts.kmer_counts_matrix) == (16, 2)
+        Test.@test vec(sum(dense_rna_counts.kmer_counts_matrix; dims = 1)) == [3.0, 3.0]
+
+        aa_sequences = [
+            BioSequences.LongAA("ACDE"),
+            BioSequences.LongAA("ACDF")
+        ]
+        dense_aa_counts = Mycelia.biosequences_to_dense_counts_table(
+            biosequences = aa_sequences,
+            k = 2
+        )
+        Test.@test length(dense_aa_counts.sorted_kmers) ==
+                   length(Mycelia.generate_all_possible_kmers(2, Mycelia.AA_ALPHABET))
+        Test.@test size(dense_aa_counts.kmer_counts_matrix, 2) == 2
+        Test.@test vec(sum(dense_aa_counts.kmer_counts_matrix; dims = 1)) == [3.0, 3.0]
+
         sparse_counts = Mycelia.biosequences_to_counts_table(
             biosequences = dna_sequences,
             k = 3
@@ -210,6 +242,20 @@ Test.@testset "K-mer Analysis Coverage Expansion" begin
         Test.@test saturation.eof == true
         Test.@test last(saturation.sampling_points) == 6
         Test.@test last(saturation.unique_kmer_counts) == 2
+
+        complete_path = joinpath(temp_dir, "complete.fasta")
+        open(complete_path, "w") do io
+            FASTX.write(io, FASTX.FASTA.Record("complete", "AC"))
+        end
+
+        complete_saturation = Mycelia.assess_dnamer_saturation(
+            [complete_path],
+            Kmers.DNAKmer{1};
+            power = 2
+        )
+        Test.@test complete_saturation.eof == false
+        Test.@test complete_saturation.sampling_points == [0, 1, 2]
+        Test.@test complete_saturation.unique_kmer_counts == [0, 1, 2]
 
         no_match_results = (; coverage_estimates = Dict(3 => 0.5, 5 => 0.7))
         Test.@test Mycelia.adaptive_kmer_selection(


### PR DESCRIPTION
## Summary
- fix the dense temp-file path so the pass-2 progress lock always exists
- guard empty multi-scale consensus selection to avoid slicing past an empty k-mer list
- add focused coverage tests for sparse result saving, missing rarefaction data, dense temp-file error recovery, UInt32 promotion, and forced dense DNA counting

## Verification
- ran a focused Julia assertion probe covering the malformed dense-input path, sparse result-file save path, and empty-consensus multi-scale case
- reran the same focused probe with `--code-coverage=user`, producing `src/kmer-analysis.jl.66245.cov` with hits on the touched branches

## Review
- manual review lenses: correctness, quality, and security found no additional issues in the final diff
- `coderabbit review --plain --type committed --base master` could not run because the account lacks the required Hoppy CLI addon

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of k-mer analysis result handling and metadata preservation.
  * Fixed edge-case handling in consensus k-mer selection to prevent out-of-bounds errors.

* **Tests**
  * Significantly expanded test coverage for k-mer analysis workflows, including persistence, frequency analysis, and edge cases.
  * Added comprehensive test suite for related utilities and helper functions across multiple alphabet types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->