### PR TITLE
add: dispatch quality gates and test isolation guardrails

### DIFF
--- a/.codex/skills/test-isolation/SKILL.md
+++ b/.codex/skills/test-isolation/SKILL.md
@@ -56,6 +56,8 @@ of 34 PRs during a comprehensive audit (2026-04-04), causing:
 
 ### Checklist for PR Authors
 
+- These checks are surfaced automatically by the CI lint job and the repo
+  pre-commit hook, so violations should be visible before merge.
 - [ ] No `@eval Mycelia` in files without `zz_` prefix
 - [ ] If `@eval` is used, a save/restore pattern is in place
 - [ ] Prefer fake CONDA_RUNNER scripts over method replacement

--- a/.codex/skills/test-isolation/SKILL.md
+++ b/.codex/skills/test-isolation/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: test-isolation
+description:
+  Rules for test isolation — preventing global state leakage from @eval
+  monkeypatching
+---
+
+# Test Isolation Rules
+
+Mycelia's test suite runs all files in a single Julia process via
+`include_all_tests`. Global state mutations persist across files.
+
+## @eval Monkeypatching Convention
+
+**NEVER** use `@eval Mycelia` to redefine module functions in test files unless
+**both** of the following are true:
+
+1. The file uses a `zz_` prefix (e.g., `zz_simulation_wrappers.jl`) so it runs
+   last in alphabetical include order
+2. The redefined functions are not exercised by any subsequent test file
+
+### Preferred Alternatives (in order)
+
+1. **Fake CONDA_RUNNER scripts** — write a shell stub to a temp dir, override
+   `Mycelia.CONDA_RUNNER` path (see `with_fake_conda_runner` pattern)
+2. **Dependency injection** — accept a callable parameter that defaults to the
+   real implementation
+3. **Environment variable gating** — skip the code path when
+   `MYCELIA_RUN_EXTERNAL=false`
+4. **Save/restore pattern** — if `@eval` is unavoidable:
+
+```julia
+Test.@testset "Guarded monkeypatch" begin
+    original = Mycelia.some_function
+    try
+        @eval Mycelia function some_function(args...)
+            # stub
+        end
+        # ... test code ...
+    finally
+        @eval Mycelia some_function = $original
+    end
+end
+```
+
+### Why This Matters
+
+`@eval Mycelia` permanently replaces methods in the module's method table for
+the entire process lifetime. Files sorted alphabetically after the patching file
+will silently get the stub instead of the real function. This was found in ~12
+of 34 PRs during a comprehensive audit (2026-04-04), causing:
+
+- Tests passing with stubs instead of real implementations (false coverage)
+- Integration tests silently disabled when `MYCELIA_RUN_EXTERNAL=true`
+- Non-deterministic failures depending on file include order
+
+### Checklist for PR Authors
+
+- [ ] No `@eval Mycelia` in files without `zz_` prefix
+- [ ] If `@eval` is used, a save/restore pattern is in place
+- [ ] Prefer fake CONDA_RUNNER scripts over method replacement
+- [ ] Test file does not redefine core APIs (`simulate_*`, `add_bioconda_env`,
+      `concatenate_fastq_files`)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,10 +19,12 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Check @eval monkeypatching in non-zz test files
         run: |
-          violations=$(grep -rl '@eval\s*Mycelia' test/ --include='*.jl' | grep -v '/zz_' || true)
+          violations=$(grep -rlE '@eval[[:space:]]*Mycelia' test/ --include='*.jl' | grep -v '/zz_' || true)
           if [[ -n "${violations}" ]]; then
             echo "::warning::@eval Mycelia found in test files without zz_ prefix:"
             echo "${violations}"
@@ -30,8 +32,12 @@ jobs:
           fi
 
       - name: Check for committed benchmark artifacts
+        env:
+          BASE_REF: ${{ github.base_ref }}
         run: |
-          artifacts=$(git diff --name-only origin/master...HEAD -- 'results/*.json' 'results/*.csv' 2>/dev/null || true)
+          base_ref="${BASE_REF:-master}"
+          git fetch --no-tags --depth=1 origin "${base_ref}" || true
+          artifacts=$(git diff --name-only "origin/${base_ref}"...HEAD -- results 2>/dev/null | grep -E '^results/.*\.(json|csv)$' || true)
           if [[ -n "${artifacts}" ]]; then
             echo "::error::Benchmark artifacts committed in results/:"
             echo "${artifacts}"
@@ -39,13 +45,12 @@ jobs:
             exit 1
           fi
 
-      - name: Check for StatsPlots/Plots.jl usage in source
+      - name: Check for new StatsPlots usage in source
         run: |
-          violations=$(grep -rl 'import StatsPlots\|import Plots$' src/ --include='*.jl' || true)
+          violations=$(grep -rl 'import StatsPlots' src/ --include='*.jl' || true)
           if [[ -n "${violations}" ]]; then
-            echo "::error::StatsPlots or Plots.jl used in source files (use CairoMakie):"
+            echo "::warning::StatsPlots found in source files (prefer CairoMakie for new code):"
             echo "${violations}"
-            exit 1
           fi
 
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,43 @@ permissions:
   contents: read
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Check @eval monkeypatching in non-zz test files
+        run: |
+          violations=$(grep -rl '@eval\s*Mycelia' test/ --include='*.jl' | grep -v '/zz_' || true)
+          if [[ -n "${violations}" ]]; then
+            echo "::warning::@eval Mycelia found in test files without zz_ prefix:"
+            echo "${violations}"
+            echo "See .codex/skills/test-isolation/SKILL.md for alternatives."
+          fi
+
+      - name: Check for committed benchmark artifacts
+        run: |
+          artifacts=$(git diff --name-only origin/master...HEAD -- 'results/*.json' 'results/*.csv' 2>/dev/null || true)
+          if [[ -n "${artifacts}" ]]; then
+            echo "::error::Benchmark artifacts committed in results/:"
+            echo "${artifacts}"
+            echo "Remove generated outputs from the PR."
+            exit 1
+          fi
+
+      - name: Check for StatsPlots/Plots.jl usage in source
+        run: |
+          violations=$(grep -rl 'import StatsPlots\|import Plots$' src/ --include='*.jl' || true)
+          if [[ -n "${violations}" ]]; then
+            echo "::error::StatsPlots or Plots.jl used in source files (use CairoMakie):"
+            echo "${violations}"
+            exit 1
+          fi
+
   test:
+    needs: lint
     runs-on: ubuntu-latest
     timeout-minutes: 360
     strategy:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,8 +90,9 @@ closure.**
 
 ### Code Quality
 
-- **CairoMakie only** — never use `StatsPlots` or `Plots.jl`. See global
-  CLAUDE.md plotting preference.
+- **CairoMakie for new code** — do not add new `StatsPlots` or `Plots.jl`
+  usage. Existing `Plots.jl` usage in `plotting-and-visualization.jl` is being
+  migrated to CairoMakie. See global CLAUDE.md plotting preference.
 - **No committed artifacts** — `results/*.json`, `results/*.csv`, benchmark
   outputs, and generated data must not be committed. Add to `.gitignore`.
 - **No undefined variables** — all references must be defined. Run

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,6 +61,55 @@ already delegates to this repo hook automatically.
 
 ---
 
+## Dispatch Quality Gates
+
+Rules for automated agents (Gas Town polecats, Codex, etc.) generating PRs.
+Derived from a 34-PR audit (2026-04-04). **Violations will result in PR
+closure.**
+
+### Test Isolation
+
+- **No `@eval Mycelia` without `zz_` prefix** — monkeypatching leaks across test
+  files in the same process. See `.codex/skills/test-isolation/SKILL.md`.
+- **Prefer fake CONDA_RUNNER scripts** over method replacement for stubbing
+  external tools.
+- **No destructive test fixtures** — never `mv` real conda environments, never
+  redefine `Base.sleep` or core APIs (`simulate_*`, `add_bioconda_env`).
+- **Save/restore if `@eval` is unavoidable** — store the original method and
+  restore in a `finally` block.
+
+### Test Coverage
+
+- **Tests must run in default CI** — do not place pure-Julia tests behind
+  `MYCELIA_RUN_EXTERNAL`. Only tests requiring real conda tools, network access,
+  or HPC belong there.
+- **All `@test_throws` must validate message content** — use try/catch with
+  `occursin` on the error message, not bare `@test_throws ErrorException`.
+- **No hardcoded developer paths** — use `mktempdir()`, `@__DIR__`, or
+  `Mycelia.DEFAULT_*` constants instead of `/Users/cameronprybol/...`.
+
+### Code Quality
+
+- **CairoMakie only** — never use `StatsPlots` or `Plots.jl`. See global
+  CLAUDE.md plotting preference.
+- **No committed artifacts** — `results/*.json`, `results/*.csv`, benchmark
+  outputs, and generated data must not be committed. Add to `.gitignore`.
+- **No undefined variables** — all references must be defined. Run
+  `julia --project=. -e "import Pkg; Pkg.precompile()"` to verify.
+- **Correct constructor calls** — verify struct constructors match field
+  definitions (positional vs keyword).
+
+### PR Hygiene
+
+- **CI must pass before requesting review** — do not submit PRs with failing CI.
+- **Commit type must match content** — `fix:` for bug fixes, `add:` for new
+  features, `docs:` for documentation-only changes, `test:` for test-only
+  changes.
+- **No duplicate PRs** — check for existing PRs touching the same files before
+  creating a new one.
+
+---
+
 ## Codebase Map
 
 ### Source Files (`src/`) - 53 modules

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -50,3 +50,33 @@ if [[ ${errors} -gt 0 ]]; then
     echo "=== COMMIT BLOCKED: ${errors} file(s) with import-in-function ==="
     exit 1
 fi
+
+# Check for @eval monkeypatching in test files without zz_ prefix.
+# See .codex/skills/test-isolation/SKILL.md for the full convention.
+eval_warnings=0
+staged_test_jl=$(printf '%s\n' "${staged_jl}" | grep '^test/' || true)
+
+for file in ${staged_test_jl}; do
+    basename_file=$(basename "${file}")
+    if [[ "${basename_file}" == zz_* ]]; then
+        continue
+    fi
+    content=$(git show ":${file}" 2>/dev/null) || continue
+    eval_matches=$(printf '%s\n' "${content}" | grep -nE '@eval\s+Mycelia' 2>/dev/null || true)
+    if [[ -n "${eval_matches}" ]]; then
+        echo "WARNING: @eval Mycelia in ${file} (no zz_ prefix):"
+        printf '%s\n' "${eval_matches}" | while IFS= read -r line; do
+            echo "  ${line}"
+        done
+        echo "  See .codex/skills/test-isolation/SKILL.md for alternatives."
+        echo ""
+        eval_warnings=$((eval_warnings + 1))
+    fi
+done
+
+if [[ ${eval_warnings} -gt 0 ]]; then
+    echo "=== WARNING: ${eval_warnings} test file(s) use @eval Mycelia without zz_ prefix ==="
+    echo "  This can leak global state into subsequent test files."
+    echo "  Consider: zz_ prefix, save/restore pattern, or fake CONDA_RUNNER approach."
+    echo ""
+fi

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -62,7 +62,7 @@ for file in ${staged_test_jl}; do
         continue
     fi
     content=$(git show ":${file}" 2>/dev/null) || continue
-    eval_matches=$(printf '%s\n' "${content}" | grep -nE '@eval\s+Mycelia' 2>/dev/null || true)
+    eval_matches=$(printf '%s\n' "${content}" | grep -nE '@eval[[:space:]]*Mycelia' 2>/dev/null || true)
     if [[ -n "${eval_matches}" ]]; then
         echo "WARNING: @eval Mycelia in ${file} (no zz_ prefix):"
         printf '%s\n' "${eval_matches}" | while IFS= read -r line; do

--- a/src/variant-analysis.jl
+++ b/src/variant-analysis.jl
@@ -71,16 +71,28 @@ function update_fasta_with_vcf(;
     add_bioconda_env("htslib")
     add_bioconda_env("tabix")
     add_bioconda_env("bcftools")
-    isfile("$(vcf_file).gz") && rm("$(vcf_file).gz")
-    isfile("$(vcf_file).gz.tbi") && rm("$(vcf_file).gz.tbi")
+    # Work on a copy to preserve the original VCF
+    work_vcf = vcf_file * ".work.vcf"
     normalized_vcf_file = replace(vcf_file, ".vcf" => ".normalized.vcf")
-    run(`$(Mycelia.CONDA_RUNNER) run --live-stream -n htslib bgzip $(vcf_file)`)
-    run(`$(Mycelia.CONDA_RUNNER) run --live-stream -n tabix tabix -f -p vcf $(vcf_file).gz`)
-    run(pipeline(
-        `$(Mycelia.CONDA_RUNNER) run --live-stream -n bcftools bcftools norm -cs --fasta-ref $(in_fasta) $(vcf_file).gz`,
-        normalized_vcf_file))
-    rm("$(vcf_file).gz")
-    rm("$(vcf_file).gz.tbi")
+    normalization_complete = false
+    try
+        cp(vcf_file, work_vcf; force = true)
+        isfile("$(work_vcf).gz") && rm("$(work_vcf).gz")
+        isfile("$(work_vcf).gz.tbi") && rm("$(work_vcf).gz.tbi")
+        run(`$(Mycelia.CONDA_RUNNER) run --live-stream -n htslib bgzip $(work_vcf)`)
+        run(`$(Mycelia.CONDA_RUNNER) run --live-stream -n tabix tabix -f -p vcf $(work_vcf).gz`)
+        run(pipeline(
+            `$(Mycelia.CONDA_RUNNER) run --live-stream -n bcftools bcftools norm -cs --fasta-ref $(in_fasta) $(work_vcf).gz`,
+            normalized_vcf_file))
+        normalization_complete = true
+    finally
+        isfile(work_vcf) && rm(work_vcf)
+        isfile("$(work_vcf).gz") && rm("$(work_vcf).gz")
+        isfile("$(work_vcf).gz.tbi") && rm("$(work_vcf).gz.tbi")
+        if !normalization_complete
+            isfile(normalized_vcf_file) && rm(normalized_vcf_file)
+        end
+    end
     isfile("$(normalized_vcf_file).gz") && rm("$(normalized_vcf_file).gz")
     isfile("$(normalized_vcf_file).gz.tbi") && rm("$(normalized_vcf_file).gz.tbi")
     isfile("$(normalized_vcf_file).fna") && rm("$(normalized_vcf_file).fna")


### PR DESCRIPTION
## Summary

Adds guardrails for Gas Town polecat-generated PRs based on a comprehensive
audit of 34 open PRs (2026-04-04) that found systemic quality issues.

- **AGENTS.md**: New "Dispatch Quality Gates" section with explicit rules for
  test isolation, test coverage, code quality, and PR hygiene
- **CI lint job**: Lightweight pre-test checks for @eval monkeypatching,
  committed artifacts, and StatsPlots usage
- **Test isolation skill**: `.codex/skills/test-isolation/SKILL.md` documents
  the zz_ prefix convention and preferred alternatives to @eval
- **Pre-commit hook**: Warns on @eval Mycelia in test files without zz_ prefix
- **Non-destructive VCF**: `update_fasta_with_vcf` now preserves the original
  input file by working on a copy

## Test plan

- [ ] CI lint job passes on this PR
- [ ] Pre-commit hook detects @eval in non-zz_ test files
- [ ] Polecats pick up new AGENTS.md rules on next dispatch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added detailed test-isolation and PR-generator quality gates documenting safe test patterns, required checks, and PR checklist items.

* **Tests**
  * Added a commit-time warning that flags unsafe test monkeypatching patterns to improve test hygiene.

* **Chores**
  * Introduced CI linting that runs before tests to enforce policy checks and block runs on detected violations.

* **Bug Fixes**
  * Variant processing no longer overwrites original VCF artifacts; intermediate files are used and reliably cleaned up.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->