### PR TITLE
fix: initialize results in pairwise_minimap_fasta_comparison

### DIFF
--- a/src/sequence-comparison.jl
+++ b/src/sequence-comparison.jl
@@ -972,6 +972,10 @@ function pairwise_minimap_fasta_comparison(; reference_fasta, query_fasta)
         "CS tag"]
 
     Mycelia.add_bioconda_env("minimap2")
+    # Initialize so the trailing `isempty(results)` branch is always well-defined —
+    # when all three asm presets return empty (truly divergent inputs, or a
+    # malformed/empty FASTA) we otherwise hit `UndefVarError: results`.
+    results = UInt8[]
     #     asm5/asm10/asm20: asm-to-ref mapping, for ~0.1/1/5% sequence divergence
     results5 = read(`$(Mycelia.CONDA_RUNNER) run --live-stream -n minimap2 minimap2 -x asm5 --cs -cL $reference_fasta $query_fasta`)
     if !isempty(results5)
@@ -986,6 +990,8 @@ function pairwise_minimap_fasta_comparison(; reference_fasta, query_fasta)
             results20 = read(`$(Mycelia.CONDA_RUNNER) run --live-stream -n minimap2 minimap2 -x asm20 --cs -cL $reference_fasta $query_fasta`)
             if !isempty(results20)
                 results = results20
+            else
+                @warn "no minimap2 hits at asm5, asm10, or asm20 — returning empty result" reference_fasta query_fasta
             end
         end
     end

--- a/test/7_comparative_pangenomics/sequence_comparison.jl
+++ b/test/7_comparative_pangenomics/sequence_comparison.jl
@@ -23,9 +23,66 @@ import Mycelia
 import DataFrames
 import BioSequences
 import FASTX
+import Logging
 import SHA
 import DelimitedFiles
 import StableRNGs
+
+function _write_text_file(path::String, content::AbstractString)
+    mkpath(dirname(path))
+    open(path, "w") do io
+        write(io, content)
+    end
+    return path
+end
+
+function with_fake_conda_env(f::Function, env_name::String)
+    env_dir = joinpath(Mycelia._conda_envs_dir(), env_name)
+    created = false
+    if !isdir(env_dir)
+        mkpath(joinpath(env_dir, "conda-meta"))
+        _write_text_file(joinpath(env_dir, "conda-meta", "history"), "")
+        created = true
+    end
+
+    try
+        return f()
+    finally
+        if created
+            rm(env_dir; recursive = true, force = true)
+        end
+    end
+end
+
+function with_stubbed_conda_runner(f::Function, script_body::AbstractString)
+    runner_path = Mycelia.CONDA_RUNNER
+    isfile(runner_path) || error("Cannot stub missing conda runner: $(runner_path)")
+    backup_path = runner_path * ".mycelia-test-backup"
+    ispath(backup_path) && error("Conda runner backup already exists: $(backup_path)")
+    mv(runner_path, backup_path)
+    _write_text_file(runner_path, "#!/usr/bin/env bash\nset -euo pipefail\n$(script_body)\n")
+    chmod(runner_path, 0o755)
+    try
+        return f()
+    finally
+        rm(runner_path; force = true)
+        mv(backup_path, runner_path)
+    end
+end
+
+function fake_empty_stdout_conda_runner_script()
+    return raw"""
+if [[ "${1:-}" == "run" ]]; then
+    exit 0
+fi
+
+if [[ "${1:-}" == "env" && "${2:-}" == "list" ]]; then
+    exit 0
+fi
+
+exit 0
+"""
+end
 
 Test.@testset "Sequence Comparison Tests" begin
     Test.@testset "Mash Distance Calculation" begin
@@ -159,6 +216,48 @@ Test.@testset "Sequence Comparison Tests" begin
         # Cleanup
         rm(ref_fasta, force = true)
         rm(query_fasta, force = true)
+    end
+
+    Test.@testset "Pairwise Minimap Comparison No-Hit Path" begin
+        temp_dir = mktempdir()
+        try
+            ref_fasta = _write_text_file(
+                joinpath(temp_dir, "reference.fasta"),
+                ">reference\nATCGATCGATCGATCG\n"
+            )
+            query_fasta = _write_text_file(
+                joinpath(temp_dir, "query.fasta"),
+                ">query\nGGGGCCCCAAAATTTT\n"
+            )
+
+            with_fake_conda_env("minimap2") do
+                with_stubbed_conda_runner(fake_empty_stdout_conda_runner_script()) do
+                    result = Test.@test_logs (:warn, r"no hit with asm5, trying asm10") (
+                        :warn, r"no hits with asm5 or asm10, trying asm20") (
+                        :warn, r"no minimap2 hits at asm5, asm10, or asm20") min_level=Logging.Warn match_mode=:all begin
+                        Mycelia.pairwise_minimap_fasta_comparison(
+                            reference_fasta = ref_fasta,
+                            query_fasta = query_fasta
+                        )
+                    end
+
+                    Test.@test result isa DataFrames.DataFrame
+                    Test.@test DataFrames.nrow(result) == 1
+                    Test.@test result[1, :alignment_percent_identity] == ""
+                    Test.@test result[1, :total_equivalent_bases] == ""
+                    Test.@test result[1, :total_alignment_length] == ""
+                    Test.@test result[1, :query_length] == 16
+                    Test.@test result[1, :total_variants] == ""
+                    Test.@test result[1, :total_snps] == ""
+                    Test.@test result[1, :total_indels] == ""
+                    Test.@test result[1, :alignment_coverage_query] == 0
+                    Test.@test result[1, :alignment_coverage_reference] == 0
+                    Test.@test result[1, :size_equivalence_to_reference] == 100.0
+                end
+            end
+        finally
+            rm(temp_dir; recursive = true, force = true)
+        end
     end
 
     Test.@testset "FastANI Mock Tests" begin


### PR DESCRIPTION
## Summary

- Initialize `results = UInt8[]` before the asm5/10/20 fallback chain in `pairwise_minimap_fasta_comparison` so the trailing `if !isempty(results)` branch is always well-defined.
- Without this, minimap2 returning empty at all three asm presets (truly divergent inputs, or a zero-byte FASTA) produced `UndefVarError: results` instead of the empty-match DataFrame the else-branch already knows how to build.
- Adds a `@warn` when all three presets are empty so callers can tell why their result DataFrame reports `alignment_coverage_query = 0`.

## Test plan

- [ ] CI passes on master.
- [ ] Manual smoke test: call `Mycelia.pairwise_minimap_fasta_comparison(reference_fasta=zero_byte.fna, query_fasta=other.fna)` and confirm it returns the zero-match DataFrame (instead of raising `UndefVarError`).

## Context

Reproducer surfaced in the Locus `td-87xwo` patent-phage-vs-parent-ANI notebook when a decompression failure left a parent FASTA at zero bytes. The immediate notebook bug (0-byte stubs from failed `gzip -dc > dst`) was fixed separately; this PR fixes the latent Mycelia bug so genuinely-divergent pairs don't crash the batch.

Closes td-9ko9d.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved initialization handling in sequence comparison operations to ensure consistent and reliable behavior across all code paths.

* **Improvements**
  * Enhanced diagnostic messaging when sequence alignment attempts fail to detect matches, now providing additional file information to assist users in troubleshooting unsuccessful comparisons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->