### PR TITLE
fix: merge :global into parse_dnadiff_report summary (expose TotalBases)

### DIFF
--- a/src/alignments-and-mapping.jl
+++ b/src/alignments-and-mapping.jl
@@ -690,7 +690,16 @@ function parse_dnadiff_report(report_file::String)
     if !isempty(sections)
         primary_section = haskey(sections, Symbol("1_to_1")) ? Symbol("1_to_1") :
                           first(keys(sections))
-        summary = get(sections, primary_section, Dict{Symbol, Any}())
+        # Merge the :global section (which holds TotalBases/AlignedBases/
+        # UnalignedBases — top-level [Bases] fields that live outside the
+        # 1-to-1/M-to-M alignment sections) into the primary section's dict
+        # so callers can find both the per-alignment AvgIdentity and the
+        # base-count totals in one summary NamedTuple. 1_to_1 keys win on
+        # overlap, preserving prior behavior.
+        summary = merge(
+            get(sections, Symbol("global"), Dict{Symbol, Any}()),
+            get(sections, primary_section, Dict{Symbol, Any}())
+        )
     end
 
     avg_identity = get(summary, :avg_identity, missing)

--- a/test/8_tool_integration/alignments_parsing_test.jl
+++ b/test/8_tool_integration/alignments_parsing_test.jl
@@ -22,6 +22,29 @@ Test.@testset "Alignment Parsing Helpers" begin
             Test.@test parsed.distance ≈ 0.015
             Test.@test parsed.distance_aligned ≈ 0.01
         end
+
+        mktempdir() do dir
+            report_path = joinpath(dir, "global-section.report")
+            open(report_path, "w") do io
+                println(io, "TotalBases 1000 900")
+                println(io, "AlignedBases 800 700 80.0 77.8")
+                println(io, "UnalignedBases 200 200 20.0 22.2")
+                println(io, "1-to-1")
+                println(io, "AvgIdentity 98.5")
+                println(io, "AvgIdentity(Aligned) 99.0")
+                println(io, "SNPs 5")
+                println(io, "Indels 2 3")
+            end
+
+            parsed = Mycelia.parse_dnadiff_report(report_path)
+            Test.@test parsed.summary.total_bases_ref == 1000
+            Test.@test parsed.summary.total_bases_query == 900
+            Test.@test parsed.summary.aligned_pct_ref ≈ 80.0
+            Test.@test parsed.summary.aligned_pct_query ≈ 77.8
+            Test.@test parsed.summary.avg_identity == 98.5
+            Test.@test !haskey(parsed.raw_sections[Symbol("1_to_1")], :total_bases_ref)
+            Test.@test parsed.raw_sections[Symbol("global")][:total_bases_ref] == 1000
+        end
     end
 
     Test.@testset "MUMmer coords parsing and summary" begin


### PR DESCRIPTION
## Summary

- \`parse_dnadiff_report\` returned a summary that was only the \`:1_to_1\` section, so top-level \`[Bases]\` stats (\`TotalBases\`, \`AlignedBases\`, \`UnalignedBases\`) parked under \`:global\` were invisible to downstream callers.
- \`summarize_mummer_coords\` (via \`calculate_mummer_genome_distance\`) relies on \`summary[:total_bases_ref]\` / \`[:total_bases_query]\` to compute \`aligned_pct_ref\` / \`aligned_pct_query\`. With those always missing, MUMmer coverage columns came back blank for every call.
- Fix: merge \`:global\` into the primary section dict before returning. The \`1_to_1\` keys still win on overlap, so \`AvgIdentity\` (which exists in both) stays at the 1-to-1 alignment value, same as before.

## Test plan

- [ ] CI passes on master.
- [ ] Manual smoke test: \`Mycelia.calculate_mummer_genome_distance\` on two similar phage genomes now returns \`coords_summary.aligned_pct_ref\` and \`.aligned_pct_query\` as real Float64 values instead of \`missing\`.

## Context

Fourth patch in the \`td-87xwo\` patent-phage work-session:

1. #288 — results initializer so empty minimap output doesn't \`UndefVarError\`
2. #289 — \`PYTHONNOUSERSITE=1\` in \`run_pyorthoani\` so \`.local/\` doesn't shadow the conda env
3. #290 — typed \`missing\` in the zero-hits fallback DataFrame so batch append doesn't type-conflict
4. (this) — expose dnadiff \`[Bases]\` fields so MUMmer coverage stats get populated

With all four landed, the patent-phage ensemble now fills out minimap, MUMmer (identity + coverage), and skani columns for every attempted pair.

Closes td-w0i51.