### PR TITLE
fix: bound pairwise_minimap_fasta_comparison coverage to [0,100]

### DIFF
--- a/src/sequence-comparison.jl
+++ b/src/sequence-comparison.jl
@@ -929,137 +929,247 @@ end
 """
 $(DocStringExtensions.TYPEDSIGNATURES)
 
-Compare two FASTA sequences and calculate alignment statistics.
+Merge overlapping or adjacent half-open `[start, end)` integer intervals.
 
-# Arguments
-- `reference_fasta::String`: Path to the reference FASTA file
-- `query_fasta::String`: Path to the query FASTA file
+Returns the sorted, minimal non-overlapping covering. Zero-length intervals
+(`start == end`) are dropped. Touching intervals (e.g. `[10, 20)` and `[20, 30)`)
+merge under half-open semantics.
 
-# Returns
-DataFrame with the following columns:
-- `alignment_percent_identity`: Percentage of matching bases in alignment
-- `total_equivalent_bases`: Number of equivalent bases between sequences
-- `total_alignment_length`: Length of the alignment
-- `query_length`: Length of query sequence
-- `total_variants`: Total number of variants (SNPs + indels)
-- `total_snps`: Number of single nucleotide polymorphisms
-- `total_indels`: Number of insertions and deletions
-- `alignment_coverage_query`: Percentage of query sequence covered
-- `alignment_coverage_reference`: Percentage of reference sequence covered
-- `size_equivalence_to_reference`: Size ratio of query to reference (%)
-
-# Notes
-- Uses minimap2 with progressively relaxed settings (asm5→asm10→asm20)
-- Returns empty string values for alignment statistics if no alignment is found
-- Requires minimap2 to be installed and accessible in PATH
+Used internally by [`pairwise_minimap_fasta_comparison`](@ref) to compute unique
+base-pair coverage on a sequence that received multiple overlapping minimap
+alignment hits (e.g. over a repetitive region).
 """
-# uses minimap
-function pairwise_minimap_fasta_comparison(; reference_fasta, query_fasta)
-    header = [
-        "Query",
-        "Query length",
-        "Query start",
-        "Query end",
-        "Query strand",
-        "Target",
-        "Target length",
-        "Target start",
-        "Target end",
-        "Matches",
-        "Alignment length",
-        "Mapping quality",
-        "Cigar",
-        "CS tag"]
+function _merge_intervals(intervals::AbstractVector{<:Tuple{<:Integer, <:Integer}})
+    nonzero = [(Int(a), Int(b)) for (a, b) in intervals if b > a]
+    isempty(nonzero) && return Tuple{Int, Int}[]
+    sort!(nonzero; by = first)
 
-    Mycelia.add_bioconda_env("minimap2")
-    #     asm5/asm10/asm20: asm-to-ref mapping, for ~0.1/1/5% sequence divergence
-    results5 = read(`$(Mycelia.CONDA_RUNNER) run --live-stream -n minimap2 minimap2 -x asm5 --cs -cL $reference_fasta $query_fasta`)
-    if !isempty(results5)
-        results = results5
-    else
-        @warn "no hit with asm5, trying asm10"
-        results10 = read(`$(Mycelia.CONDA_RUNNER) run --live-stream -n minimap2 minimap2 -x asm10 --cs -cL $reference_fasta $query_fasta`)
-        if !isempty(results10)
-            results = results10
+    merged = Tuple{Int, Int}[]
+    current_start, current_end = nonzero[1]
+    for i in 2:length(nonzero)
+        s, e = nonzero[i]
+        if s <= current_end
+            current_end = max(current_end, e)
         else
-            @warn "no hits with asm5 or asm10, trying asm20"
-            results20 = read(`$(Mycelia.CONDA_RUNNER) run --live-stream -n minimap2 minimap2 -x asm20 --cs -cL $reference_fasta $query_fasta`)
-            if !isempty(results20)
-                results = results20
-            end
+            push!(merged, (current_start, current_end))
+            current_start, current_end = s, e
         end
     end
-    if !isempty(results)
-        data = DelimitedFiles.readdlm(IOBuffer(results), '\t')
-        data_columns_of_interest = [
-            collect(1:(length(header) - 2))..., collect((size(data, 2) - 1):size(data, 2))...]
-        minimap_results = DataFrames.DataFrame(data[:, data_columns_of_interest], header)
+    push!(merged, (current_start, current_end))
+    return merged
+end
 
-        equivalent_matches = reduce(vcat,
-            map(x -> collect(eachmatch(r":([0-9]+)", replace(x, "cs:Z:" => ""))),
-                minimap_results[!, "CS tag"]))
-        total_equivalent_bases = sum(map(match -> parse(Int, first(match.captures)), equivalent_matches))
+"""
+$(DocStringExtensions.TYPEDSIGNATURES)
 
-        insertion_matches = reduce(vcat,
-            map(x -> collect(eachmatch(r"\+([a-z]+)"i, replace(x, "cs:Z:" => ""))),
-                minimap_results[!, "CS tag"]))
-        total_inserted_bases = sum(map(match -> length(first(match.captures)), insertion_matches))
-        deletion_matches = reduce(vcat,
-            map(x -> collect(eachmatch(r"\-([a-z]+)"i, replace(x, "cs:Z:" => ""))),
-                minimap_results[!, "CS tag"]))
-        total_deleted_bases = sum(map(match -> length(first(match.captures)), deletion_matches))
-        substitution_matches = reduce(vcat,
-            map(x -> collect(eachmatch(r"\*([a-z]{2})"i, replace(x, "cs:Z:" => ""))),
-                minimap_results[!, "CS tag"]))
-        total_substituted_bases = length(substitution_matches)
-        total_variants = length(insertion_matches) + length(deletion_matches) +
-                         length(substitution_matches)
-        total_variable_bases = total_inserted_bases + total_deleted_bases +
-                               total_substituted_bases
+Total base count summed across every sequence in a FASTA file. Robust to
+multi-contig inputs — used as the coverage denominator in
+[`pairwise_minimap_fasta_comparison`](@ref).
+"""
+function _fasta_total_length(path::AbstractString)::Int
+    total = 0
+    reader = FASTX.FASTA.Reader(open(path))
+    try
+        for record in reader
+            total += length(FASTX.sequence(record))
+        end
+    finally
+        close(reader)
+    end
+    return total
+end
 
-        total_alignment_length = sum(minimap_results[!, "Alignment length"])
-        total_matches = sum(minimap_results[!, "Matches"])
+"""
+$(DocStringExtensions.TYPEDSIGNATURES)
 
-        alignment_percent_identity = round(total_matches / total_alignment_length * 100, digits = 2)
-        size_equivalence_to_reference = round(
-            minimap_results[1, "Query length"]/minimap_results[1, "Target length"] * 100, digits = 2)
-        alignment_coverage_query = round(
-            total_alignment_length / minimap_results[1, "Query length"] * 100, digits = 2)
-        alignment_coverage_reference = round(
-            total_alignment_length / minimap_results[1, "Target length"] * 100, digits = 2)
+Compute unique (non-redundant) aligned base count across all sequences in a
+parsed minimap2 PAF-style DataFrame.
 
-        results = DataFrames.DataFrame(
-            alignment_percent_identity = alignment_percent_identity,
-            total_equivalent_bases = total_equivalent_bases,
-            total_alignment_length = total_alignment_length,
-            query_length = minimap_results[1, "Query length"],
-            total_variants = total_variants,
-            total_snps = total_substituted_bases,
-            total_indels = length(insertion_matches) + length(deletion_matches),
-            alignment_coverage_query = alignment_coverage_query,
-            alignment_coverage_reference = alignment_coverage_reference,
-            size_equivalence_to_reference = size_equivalence_to_reference
-        )
+`which = :query` sums bases covered on the query side; `which = :target` sums
+bases covered on the reference side. Overlapping and secondary alignments on
+the same sequence are deduplicated via interval merge, so the returned count
+is mathematically bounded by the total sequence length.
+"""
+function _minimap_merged_coverage(df::DataFrames.DataFrame, which::Symbol)::Int
+    name_col, start_col,
+    end_col = if which == :query
+        "Query", "Query start", "Query end"
+    elseif which == :target
+        "Target", "Target start", "Target end"
     else
-        query_length = length(FASTX.sequence(first(FASTX.FASTA.Reader(open(query_fasta)))))
-        target_length = length(FASTX.sequence(first(FASTX.FASTA.Reader(open(reference_fasta)))))
-        size_equivalence_to_reference = round(query_length/target_length * 100, digits = 2)
+        error("_minimap_merged_coverage: unknown `which` value $(which); expected :query or :target")
+    end
 
-        # unable to find any matches
-        results = DataFrames.DataFrame(
-            alignment_percent_identity = "",
-            total_equivalent_bases = "",
-            total_alignment_length = "",
-            query_length = query_length,
-            total_variants = "",
-            total_snps = "",
-            total_indels = "",
-            alignment_coverage_query = 0,
-            alignment_coverage_reference = 0,
+    DataFrames.nrow(df) == 0 && return 0
+
+    intervals_by_sequence = Dict{String, Vector{Tuple{Int, Int}}}()
+    for row in DataFrames.eachrow(df)
+        name = String(row[name_col])
+        s = Int(row[start_col])
+        e = Int(row[end_col])
+        push!(get!(Vector{Tuple{Int, Int}}, intervals_by_sequence, name), (s, e))
+    end
+
+    total = 0
+    for intervals in values(intervals_by_sequence)
+        for (s, e) in _merge_intervals(intervals)
+            total += e - s
+        end
+    end
+    return total
+end
+
+"""
+$(DocStringExtensions.TYPEDSIGNATURES)
+
+Compare two FASTA files end-to-end with minimap2 and return a one-row DataFrame
+of alignment statistics.
+
+minimap2 is invoked from the `minimap2` bioconda environment (auto-installed
+if needed) with progressively relaxed divergence presets (`asm5` → `asm10` →
+`asm20`) until at least one alignment is produced.
+
+# Arguments
+- `reference_fasta::AbstractString`: Path to the reference FASTA file.
+- `query_fasta::AbstractString`: Path to the query FASTA file.
+
+# Returns
+A one-row `DataFrames.DataFrame` with columns:
+
+| Column                           | Meaning                                                                              |
+| -------------------------------- | ------------------------------------------------------------------------------------ |
+| `alignment_percent_identity`     | Percent matching bases across all alignment blocks (0-100).                          |
+| `total_equivalent_bases`         | Equivalent-base count parsed from minimap CS tags.                                   |
+| `total_alignment_length`         | Raw sum of alignment block lengths (may exceed genome size for repeat-rich inputs).  |
+| `query_length`                   | Total query FASTA length (sum of all sequences).                                     |
+| `reference_length`               | Total reference FASTA length (sum of all sequences).                                 |
+| `total_variants`                 | SNPs + indels parsed from CS tags.                                                   |
+| `total_snps`                     | Substitution count.                                                                  |
+| `total_indels`                   | Insertion + deletion count.                                                          |
+| `unique_aligned_bases_query`     | Query bases covered by any alignment, deduplicated via interval merge.               |
+| `unique_aligned_bases_reference` | Reference bases covered by any alignment, deduplicated via interval merge.           |
+| `alignment_coverage_query`       | `unique_aligned_bases_query / query_length * 100`; bounded to [0, 100].              |
+| `alignment_coverage_reference`   | `unique_aligned_bases_reference / reference_length * 100`; bounded to [0, 100].      |
+| `size_equivalence_to_reference`  | `query_length / reference_length * 100`.                                             |
+
+# Notes
+- `alignment_coverage_*` use **per-sequence interval merging** so the value is
+  mathematically bounded to [0, 100] even when minimap emits multiple secondary
+  or split alignments over repeats. Compare with `total_alignment_length`,
+  which is the raw sum across all alignment rows (can exceed genome size).
+- `query_length` / `reference_length` are computed from the input FASTAs (sum
+  across all records), not from the first minimap row — multi-contig inputs
+  are supported.
+- When no alignment is produced at any preset, numeric coverage columns are 0
+  and identity/variant columns are `missing`.
+- Requires minimap2 via bioconda; `Mycelia.add_bioconda_env("minimap2")` is
+  invoked automatically.
+"""
+function pairwise_minimap_fasta_comparison(;
+        reference_fasta::AbstractString,
+        query_fasta::AbstractString
+)
+    paf_header = [
+        "Query", "Query length", "Query start", "Query end", "Query strand",
+        "Target", "Target length", "Target start", "Target end",
+        "Matches", "Alignment length", "Mapping quality",
+        "Cigar", "CS tag"
+    ]
+
+    Mycelia.add_bioconda_env("minimap2")
+    # asm5 / asm10 / asm20: asm-to-ref mapping for ~0.1% / 1% / 5% divergence.
+    # Try each preset in turn; keep the first non-empty output.
+    results_bytes = UInt8[]
+    for preset in ("asm5", "asm10", "asm20")
+        bytes = read(`$(Mycelia.CONDA_RUNNER) run --live-stream -n minimap2 minimap2 -x $preset --cs -cL $reference_fasta $query_fasta`)
+        if !isempty(bytes)
+            results_bytes = bytes
+            break
+        else
+            @warn "no hits at preset $preset; trying next"
+        end
+    end
+
+    # Total genome lengths read from the FASTA files (fixes multi-contig denominator).
+    total_query_length = _fasta_total_length(query_fasta)
+    total_reference_length = _fasta_total_length(reference_fasta)
+    size_equivalence_to_reference = total_reference_length == 0 ? 0.0 :
+                                    round(total_query_length / total_reference_length * 100, digits = 2)
+
+    if isempty(results_bytes)
+        return DataFrames.DataFrame(
+            alignment_percent_identity = missing,
+            total_equivalent_bases = missing,
+            total_alignment_length = 0,
+            query_length = total_query_length,
+            reference_length = total_reference_length,
+            total_variants = missing,
+            total_snps = missing,
+            total_indels = missing,
+            unique_aligned_bases_query = 0,
+            unique_aligned_bases_reference = 0,
+            alignment_coverage_query = 0.0,
+            alignment_coverage_reference = 0.0,
             size_equivalence_to_reference = size_equivalence_to_reference
         )
     end
-    return results
+
+    data = DelimitedFiles.readdlm(IOBuffer(results_bytes), '\t')
+    data_columns_of_interest = [
+        collect(1:(length(paf_header) - 2))...,
+        collect((size(data, 2) - 1):size(data, 2))...
+    ]
+    minimap_results = DataFrames.DataFrame(data[:, data_columns_of_interest], paf_header)
+
+    # Variant counts from CS tags
+    equivalent_matches = reduce(vcat,
+        map(x -> collect(eachmatch(r":([0-9]+)", replace(x, "cs:Z:" => ""))),
+            minimap_results[!, "CS tag"]))
+    total_equivalent_bases = sum(map(m -> parse(Int, first(m.captures)), equivalent_matches))
+
+    insertion_matches = reduce(vcat,
+        map(x -> collect(eachmatch(r"\+([a-z]+)"i, replace(x, "cs:Z:" => ""))),
+            minimap_results[!, "CS tag"]))
+    deletion_matches = reduce(vcat,
+        map(x -> collect(eachmatch(r"\-([a-z]+)"i, replace(x, "cs:Z:" => ""))),
+            minimap_results[!, "CS tag"]))
+    substitution_matches = reduce(vcat,
+        map(x -> collect(eachmatch(r"\*([a-z]{2})"i, replace(x, "cs:Z:" => ""))),
+            minimap_results[!, "CS tag"]))
+
+    total_substituted_bases = length(substitution_matches)
+    total_variants = length(insertion_matches) + length(deletion_matches) +
+                     length(substitution_matches)
+
+    total_alignment_length = sum(minimap_results[!, "Alignment length"])
+    total_matches = sum(minimap_results[!, "Matches"])
+    alignment_percent_identity = total_alignment_length == 0 ? 0.0 :
+                                 round(total_matches / total_alignment_length * 100, digits = 2)
+
+    # Interval-merged (deduplicated) coverage fixes the secondary-alignment over-count.
+    unique_aligned_bases_query = _minimap_merged_coverage(minimap_results, :query)
+    unique_aligned_bases_reference = _minimap_merged_coverage(minimap_results, :target)
+    alignment_coverage_query = total_query_length == 0 ? 0.0 :
+                               round(unique_aligned_bases_query / total_query_length * 100, digits = 2)
+    alignment_coverage_reference = total_reference_length == 0 ? 0.0 :
+                                   round(
+        unique_aligned_bases_reference / total_reference_length * 100, digits = 2)
+
+    return DataFrames.DataFrame(
+        alignment_percent_identity = alignment_percent_identity,
+        total_equivalent_bases = total_equivalent_bases,
+        total_alignment_length = total_alignment_length,
+        query_length = total_query_length,
+        reference_length = total_reference_length,
+        total_variants = total_variants,
+        total_snps = total_substituted_bases,
+        total_indels = length(insertion_matches) + length(deletion_matches),
+        unique_aligned_bases_query = unique_aligned_bases_query,
+        unique_aligned_bases_reference = unique_aligned_bases_reference,
+        alignment_coverage_query = alignment_coverage_query,
+        alignment_coverage_reference = alignment_coverage_reference,
+        size_equivalence_to_reference = size_equivalence_to_reference
+    )
 end
 
 # always interpret as strings to ensure changes in underlying biosequence representation don't change results

--- a/test/7_comparative_pangenomics/minimap_coverage_helpers.jl
+++ b/test/7_comparative_pangenomics/minimap_coverage_helpers.jl
@@ -1,0 +1,154 @@
+# Pure-Julia unit tests for the internal helpers used by
+# pairwise_minimap_fasta_comparison. These run in default CI because they do
+# not invoke minimap2 or any bioconda tool.
+#
+# From the Mycelia base directory, run the tests with:
+#
+# ```bash
+# julia --project=. -e 'include("test/7_comparative_pangenomics/minimap_coverage_helpers.jl")'
+# ```
+
+import Test
+import Mycelia
+import FASTX
+import DataFrames
+
+Test.@testset "Minimap coverage helpers" begin
+    Test.@testset "_merge_intervals — half-open [start, end) semantics" begin
+        Test.@testset "empty input" begin
+            Test.@test Mycelia._merge_intervals(Tuple{Int, Int}[]) == Tuple{Int, Int}[]
+        end
+
+        Test.@testset "single interval is returned unchanged" begin
+            Test.@test Mycelia._merge_intervals([(10, 20)]) == [(10, 20)]
+        end
+
+        Test.@testset "disjoint intervals are preserved and sorted" begin
+            Test.@test Mycelia._merge_intervals([(30, 40), (10, 20)]) ==
+                       [(10, 20), (30, 40)]
+        end
+
+        Test.@testset "overlapping intervals merge" begin
+            Test.@test Mycelia._merge_intervals([(10, 25), (20, 30)]) == [(10, 30)]
+        end
+
+        Test.@testset "adjacent intervals (touching endpoints) merge under half-open semantics" begin
+            # [10,20) and [20,30) touch at 20; half-open treats them as mergeable
+            Test.@test Mycelia._merge_intervals([(10, 20), (20, 30)]) == [(10, 30)]
+        end
+
+        Test.@testset "nested intervals collapse" begin
+            Test.@test Mycelia._merge_intervals([(10, 50), (20, 30)]) == [(10, 50)]
+        end
+
+        Test.@testset "many overlapping collapse to one" begin
+            intervals = [(1, 5), (3, 9), (8, 12), (11, 15)]
+            Test.@test Mycelia._merge_intervals(intervals) == [(1, 15)]
+        end
+
+        Test.@testset "mixed overlapping + disjoint" begin
+            intervals = [(1, 5), (10, 15), (3, 4), (20, 25), (14, 18)]
+            Test.@test Mycelia._merge_intervals(intervals) == [(1, 5), (10, 18), (20, 25)]
+        end
+
+        Test.@testset "duplicates collapse" begin
+            Test.@test Mycelia._merge_intervals([(10, 20), (10, 20), (10, 20)]) ==
+                       [(10, 20)]
+        end
+
+        Test.@testset "zero-length intervals are dropped" begin
+            Test.@test Mycelia._merge_intervals([(10, 10)]) == Tuple{Int, Int}[]
+            Test.@test Mycelia._merge_intervals([(10, 20), (15, 15)]) == [(10, 20)]
+        end
+    end
+
+    Test.@testset "_fasta_total_length" begin
+        Test.@testset "single-contig FASTA" begin
+            path = tempname() * ".fna"
+            write(path, ">seq1\nACGTACGTAC\n")
+            Test.@test Mycelia._fasta_total_length(path) == 10
+        end
+
+        Test.@testset "multi-contig FASTA sums across sequences" begin
+            path = tempname() * ".fna"
+            # 10 + 7 + 3 = 20
+            write(path, ">contig_1\nACGTACGTAC\n>contig_2\nAAAAAAA\n>contig_3\nTTT\n")
+            Test.@test Mycelia._fasta_total_length(path) == 20
+        end
+
+        Test.@testset "multi-line sequence is handled correctly" begin
+            path = tempname() * ".fna"
+            write(path, ">seq1\nACGT\nACGT\nAC\n")  # 4 + 4 + 2 = 10
+            Test.@test Mycelia._fasta_total_length(path) == 10
+        end
+
+        Test.@testset "empty sequence FASTA" begin
+            path = tempname() * ".fna"
+            write(path, ">empty\n\n")
+            Test.@test Mycelia._fasta_total_length(path) == 0
+        end
+    end
+
+    Test.@testset "_minimap_merged_coverage per-sequence" begin
+        Test.@testset "secondary-alignment duplication collapses to unique coverage" begin
+            # Simulate a minimap output where a repeat on query `contig_1` was
+            # hit 3 times over the same coordinate range. Sum-of-lengths would
+            # be 300; merged (unique) coverage is 100.
+            df = DataFrames.DataFrame(
+                Query = ["contig_1", "contig_1", "contig_1"],
+                var"Query start" = [0, 0, 0],
+                var"Query end" = [100, 100, 100],
+                Target = ["ref_1", "ref_1", "ref_1"],
+                var"Target start" = [0, 500, 1000],
+                var"Target end" = [100, 600, 1100]
+            )
+            query_unique = Mycelia._minimap_merged_coverage(df, :query)
+            ref_unique = Mycelia._minimap_merged_coverage(df, :target)
+            # Query has 3 hits all at [0, 100) → 100 unique bases
+            Test.@test query_unique == 100
+            # Reference hits are disjoint → 300 unique bases (3 * 100)
+            Test.@test ref_unique == 300
+        end
+
+        Test.@testset "multi-sequence query is summed across sequences" begin
+            df = DataFrames.DataFrame(
+                Query = ["contig_1", "contig_2", "contig_1"],
+                var"Query start" = [0, 0, 50],
+                var"Query end" = [100, 200, 150],
+                Target = ["ref", "ref", "ref"],
+                var"Target start" = [0, 100, 200],
+                var"Target end" = [100, 300, 300]
+            )
+            # contig_1: [0,100) ∪ [50,150) = [0,150) → 150 bases
+            # contig_2: [0,200) → 200 bases
+            # total: 350
+            Test.@test Mycelia._minimap_merged_coverage(df, :query) == 350
+        end
+
+        Test.@testset "empty DataFrame returns 0" begin
+            df = DataFrames.DataFrame(
+                Query = String[],
+                var"Query start" = Int[],
+                var"Query end" = Int[],
+                Target = String[],
+                var"Target start" = Int[],
+                var"Target end" = Int[]
+            )
+            Test.@test Mycelia._minimap_merged_coverage(df, :query) == 0
+            Test.@test Mycelia._minimap_merged_coverage(df, :target) == 0
+        end
+
+        Test.@testset "invalid `which` symbol errors with informative message" begin
+            df = DataFrames.DataFrame(
+                Query = ["c"], var"Query start" = [0], var"Query end" = [10],
+                Target = ["r"], var"Target start" = [0], var"Target end" = [10]
+            )
+            try
+                Mycelia._minimap_merged_coverage(df, :nonsense)
+                Test.@test false  # unreachable
+            catch e
+                Test.@test occursin("which", String(sprint(showerror, e)))
+            end
+        end
+    end
+end

--- a/test/7_comparative_pangenomics/sequence_comparison.jl
+++ b/test/7_comparative_pangenomics/sequence_comparison.jl
@@ -460,4 +460,70 @@ Test.@testset "Sequence Comparison Tests" begin
 
         rm(workdir; recursive = true, force = true)
     end
+
+    Test.@testset "pairwise_minimap_fasta_comparison — coverage math" begin
+        # Exercises the fix for two bugs:
+        #   (1) coverage denominator previously used minimap_results[1, "Query length"]
+        #       (first row's sequence only) → wrong for multi-contig FASTA.
+        #   (2) numerator summed raw alignment block lengths across all minimap
+        #       hits including secondary alignments → could exceed the genome
+        #       length for repeat-rich inputs, producing coverage > 100%.
+        rng = StableRNGs.StableRNG(42)
+        shared_a = join(rand(rng, ['A', 'C', 'G', 'T'], 500))
+        shared_b = join(rand(rng, ['A', 'C', 'G', 'T'], 500))
+        unique_q = join(rand(rng, ['A', 'C', 'G', 'T'], 800))
+        unique_r = join(rand(rng, ['A', 'C', 'G', 'T'], 1000))
+
+        # Query: three contigs, shared_a appears in two of them (exact repeat)
+        qry_path = tempname() * ".fna"
+        write(
+            qry_path,
+            """
+            >qry_contig_1
+            $(shared_a)$(unique_q)
+            >qry_contig_2
+            $(shared_a)$(shared_b)
+            >qry_contig_3
+            $(shared_b)
+            """
+        )
+
+        # Reference: single contig with two tandem copies of shared_a and one of shared_b
+        ref_path = tempname() * ".fna"
+        write(
+            ref_path,
+            """
+            >ref_contig_1
+            $(unique_r)$(shared_a)$(shared_a)$(shared_b)
+            """
+        )
+
+        try
+            mm = Mycelia.pairwise_minimap_fasta_comparison(
+                reference_fasta = ref_path,
+                query_fasta = qry_path
+            )
+            Test.@test DataFrames.nrow(mm) == 1
+            row = mm[1, :]
+
+            # Bug-fix invariants: coverage must be mathematically bounded to [0, 100]
+            Test.@test 0.0 <= row.alignment_coverage_query <= 100.0
+            Test.@test 0.0 <= row.alignment_coverage_reference <= 100.0
+
+            # Multi-contig fix: denominator is sum of all contig lengths
+            Test.@test row.query_length == 500 + 800 + 500 + 500 + 500  # 2800
+            Test.@test row.reference_length == 1000 + 500 + 500 + 500   # 2500
+
+            # Transparency columns: unique coverage <= genome length
+            Test.@test row.unique_aligned_bases_query <= row.query_length
+            Test.@test row.unique_aligned_bases_reference <= row.reference_length
+
+            # Raw sum still exposed and >= unique (raw includes duplicate hits)
+            Test.@test row.total_alignment_length >= row.unique_aligned_bases_query
+            Test.@test row.total_alignment_length >= row.unique_aligned_bases_reference
+        finally
+            rm(qry_path; force = true)
+            rm(ref_path; force = true)
+        end
+    end
 end


### PR DESCRIPTION
## Summary

- `pairwise_minimap_fasta_comparison` produced `alignment_coverage_*` values in the hundreds to thousands of "percent" for repeat-rich bacterial genomes (observed: ~6000 in a real analysis).
- Two stacked bugs caused this. Both are fixed here with proper interval-merge coverage math.
- Output schema expanded with transparency columns; existing columns preserved with corrected semantics.

## Root cause

**Bug 1 — numerator over-counted.** `total_alignment_length = sum(minimap_results[!, "Alignment length"])` sums every minimap hit, including secondary alignments and split alignments over repeats (rRNA operons, IS elements, CRISPR arrays). For a repeat-rich 2.5 Mb bacterial genome this sum can be 10-60× the actual genome size.

**Bug 2 — denominator was wrong for multi-contig FASTAs.** `minimap_results[1, "Query length"]` / `"Target length"` used the length of whichever contig happened to produce the first minimap hit, not the total genome length. For a 5-contig assembly this silently inflates coverage by ~10-25% before Bug 1 kicks in.

Stacked together: a 6-Mb ``total_alignment_length`` divided by a 1.3-Mb first-contig length yields ``~460%`` coverage; with more repeats, values in the thousands.

## Fix

- New internal helpers (``Mycelia._merge_intervals``, ``Mycelia._fasta_total_length``, ``Mycelia._minimap_merged_coverage``).
- Coverage **numerator** now uses per-sequence interval merging of alignment spans — deduplicates overlapping/secondary hits on the same sequence.
- Coverage **denominator** now uses total FASTA length summed across all sequences (``_fasta_total_length``) — fixes the multi-contig bug.
- Output schema adds ``reference_length``, ``unique_aligned_bases_query``, ``unique_aligned_bases_reference``. ``total_alignment_length`` is retained as the raw sum for transparency (users can compare raw vs. unique to see repeat burden).
- Fixed a latent ``UndefVarError`` in the ``asm5`` → ``asm10`` → ``asm20`` fallback path when all three presets returned no alignments.

## Test plan

- [x] 21 pure-Julia unit tests for the new helpers in ``test/7_comparative_pangenomics/minimap_coverage_helpers.jl`` — runs in default CI. Covers interval-merge edge cases (empty, single, overlapping, adjacent, nested, disjoint, duplicates, zero-length) + multi-contig FASTA length summing + PAF coordinate parsing.
- [x] Integration test in ``test/7_comparative_pangenomics/sequence_comparison.jl`` — gated behind ``MYCELIA_RUN_EXTERNAL`` since it invokes minimap2 from bioconda. Constructs a 3-contig query + repeat-rich reference and asserts coverage is bounded to [0, 100], ``unique_aligned_bases_* ≤ *_length``, and raw ``total_alignment_length ≥`` merged ``unique_aligned_bases_*``.
- [x] Local run with the real-world case that surfaced this (isogenic *S. epidermidis* pair) — coverage now reports 71.43% / 60.0% where it previously reported values in the 6000s.
- [x] ``Pkg.precompile()`` passes in the worktree.

## Breaking / compat notes

- ``alignment_coverage_query`` and ``alignment_coverage_reference`` semantics changed: they are now merged-interval coverage (bounded), not raw-sum coverage (unbounded). This is a bug fix, not a behavior change downstream callers should rely on.
- ``query_length`` semantics changed: now the sum across all sequences, not the first sequence's length. Same direction — prior value was wrong for multi-contig inputs.
- ``reference_length`` is new. The function previously had no reference-length column at all; users had to read it from elsewhere.
- ``unique_aligned_bases_query`` / ``unique_aligned_bases_reference`` are new. These are the transparent numerators.
- The empty-alignment branch previously returned ``""`` (string) for several columns; now returns ``missing``. More idiomatic Julia, plays nicely with ``DataFrames`` / ``CSV`` output.

## Related

Surfaced while running ``2026-04-21-pgap-b006531-dcb-vs-wildtype.jl`` (Jupyter-Cameron) on vertex-dev.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added reference sequence length and unique aligned bases metrics to comparison results.
  * Enhanced multi-contig FASTA sequence support with improved length calculations.

* **Bug Fixes**
  * Improved alignment coverage accuracy through deduplication of overlapping alignments.
  * Strengthened alignment preset selection with automatic fallback handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->