### PR TITLE
[Draft] Repair Mycelia PR #302 gate blocker

### DIFF
--- a/src/rhizomorph/core/graph-construction.jl
+++ b/src/rhizomorph/core/graph-construction.jl
@@ -479,17 +479,23 @@ function _build_qualmer_graph_core(
         error("Unsupported k-mer type: $KmerType")
     end
 
-    # Get actual kmer type from iterator (includes all type parameters)
-    test_seq = FASTX.sequence(SeqType, records[1])
-
-    # DNA/RNA iterators return (kmer, position), AA iterators return just kmer
+    # Get actual kmer type from the first record that yields a k-mer.
+    # Short/ambiguous inputs can yield no k-mers; fall back to the requested type.
     is_aa = KmerType <: Kmers.AAKmer
-    if is_aa
-        test_kmer = first(KmerIterator(test_seq))
-    else
-        test_kmer, _ = first(KmerIterator(test_seq))
+    actual_kmer_type = nothing
+    for record in records
+        test_seq = FASTX.sequence(SeqType, record)
+        iter = KmerIterator(test_seq)
+        first_item = iterate(iter)
+        if first_item === nothing
+            continue
+        end
+        value = first_item[1]
+        test_kmer = is_aa ? value : value[1]
+        actual_kmer_type = typeof(test_kmer)
+        break
     end
-    ActualKmerType = typeof(test_kmer)
+    ActualKmerType = actual_kmer_type === nothing ? KmerType : actual_kmer_type
 
     # Create empty directed graph with actual kmer type as vertex labels
     # ALWAYS use directed graphs - MetaGraph with DiGraph backend

--- a/test/4_assembly/aa_qualmer_singlestrand_test.jl
+++ b/test/4_assembly/aa_qualmer_singlestrand_test.jl
@@ -103,4 +103,23 @@ Test.@testset "AA Qualmer SingleStrand Graph" begin
     end
 
     Test.@test reconstruction_success
+
+    Test.@testset "first record without k-mers" begin
+        records = FASTX.FASTQ.Record[
+            FASTX.FASTQ.Record("short", "MK", "II"),
+            FASTX.FASTQ.Record("valid", "MKTV", "IIII")
+        ]
+
+        graph_with_short_first = Mycelia.Rhizomorph.build_qualmer_graph(
+            records,
+            3;
+            dataset_id = "test",
+            mode = :singlestrand,
+            type_hint = :AA
+        )
+
+        labels = collect(MetaGraphsNext.labels(graph_with_short_first))
+        Test.@test length(labels) == 2
+        Test.@test all(label -> label isa Kmers.AAKmer, labels)
+    end
 end

--- a/test/4_assembly/end_to_end_assembly_tests.jl
+++ b/test/4_assembly/end_to_end_assembly_tests.jl
@@ -114,7 +114,12 @@ Test.@testset "End-to-End Assembly Tests" begin
                 # Test SingleStrand mode for amino acids
                 kmer_type = Kmers.AAKmer{5}
                 graph = Mycelia.Rhizomorph.build_kmer_graph(
-                    [reference_record], 5; dataset_id = "test", mode = :singlestrand)
+                    [reference_record],
+                    5;
+                    dataset_id = "test",
+                    mode = :singlestrand,
+                    type_hint = :AA
+                )
                 Test.@test graph isa MetaGraphsNext.MetaGraph
                 Test.@test !isempty(MetaGraphsNext.labels(graph))
 
@@ -465,7 +470,12 @@ Test.@testset "End-to-End Assembly Tests" begin
                         # Build k-mer graph in SingleStrand mode
                         kmer_type = Kmers.AAKmer{3}  # Shorter k-mers for AA
                         graph = Mycelia.Rhizomorph.build_kmer_graph(
-                            reads, 3; dataset_id = "test", mode = :singlestrand)
+                            reads,
+                            3;
+                            dataset_id = "test",
+                            mode = :singlestrand,
+                            type_hint = :AA
+                        )
 
                         Test.@test graph isa MetaGraphsNext.MetaGraph
                         Test.@test !isempty(MetaGraphsNext.labels(graph))
@@ -495,7 +505,12 @@ Test.@testset "End-to-End Assembly Tests" begin
                         # Test quality-aware assembly from k-mer graph to FASTQ
                         # Build qualmer graph for quality-aware processing
                         qualmer_graph = Mycelia.Rhizomorph.build_qualmer_graph(
-                            reads, 3; dataset_id = "test", mode = :singlestrand)
+                            reads,
+                            3;
+                            dataset_id = "test",
+                            mode = :singlestrand,
+                            type_hint = :AA
+                        )
                         Test.@test qualmer_graph isa MetaGraphsNext.MetaGraph
 
                         # Convert to quality-aware BioSequence graph


### PR DESCRIPTION
Repair for my-zim / PR #302 gate-bypassed blocker. Keeps review draft while automated gates run.

Fixes the current test(lts) blocker after ae0029dc: amino acid end-to-end tests could infer simulated protein reads as DNA when no type_hint was supplied, producing empty DNA k-mer graphs and a qualmer first() error when no unambiguous DNA k-mers existed.

Local verification:
- julia project include aa_qualmer_singlestrand_test.jl
- julia project include end_to_end_assembly_tests.jl
- git diff --check

@cjprybol @athammack please review after CI and automated gates pass.

<!-- beads:my-zim -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced sequence processing to robustly handle edge cases where early records are shorter than the configured k-mer size, ensuring that valid k-mers from subsequent records are correctly recognized and included.

* **Tests**
  * Added regression test covering sequences with records shorter than the k-mer size.
  * Updated end-to-end assembly tests with explicit type specifications for amino-acid processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->