### PR TITLE
[B] Rhizomorph benchmark harness and dataset manifest

### DIFF
--- a/benchmarking/README.md
+++ b/benchmarking/README.md
@@ -79,6 +79,12 @@ This directory contains a comprehensive performance benchmarking infrastructure 
 - Fork accuracy, unresolved rate, and misassembly counts across `MomentumForkResolver` weighting modes
 - CSV outputs for per-scenario and per-threshold summaries plus JSON benchmark metadata
 
+### Rhizomorph Public-Record Harness (`rhizomorph_benchmark_harness.jl`)
+- Dataset manifest for toy controls, public isolate references, and heterogeneous-sample candidates
+- H1-H7 dry-run benchmark slices with expected inputs, outputs, and follow-on runner entry points
+- CI/full/candidate scale filtering so benchmark plans can be inspected without downloading data
+- Manifest validation for dataset identifiers, provenance, expected outputs, and slice references
+
 ## Usage
 
 ### Prerequisites
@@ -134,6 +140,12 @@ julia --project=. benchmarking/04_annotation_benchmark.jl
 
 # Run synthetic repeat benchmarks for MomentumForkResolver
 julia --project=. benchmarking/08_momentum_fork_resolution_benchmark.jl
+
+# Inspect Rhizomorph public-record datasets and H1-H7 dry-run plans
+julia --project=. benchmarking/rhizomorph_benchmark_harness.jl --list-datasets
+julia --project=. benchmarking/rhizomorph_benchmark_harness.jl --list-slices
+julia --project=. benchmarking/rhizomorph_benchmark_harness.jl --plan --scale ci
+julia --project=. benchmarking/rhizomorph_benchmark_harness.jl --slice H2 --slice H7 --scale full
 ```
 
 ### Running Complete Benchmark Suite

--- a/benchmarking/rhizomorph_benchmark_harness.jl
+++ b/benchmarking/rhizomorph_benchmark_harness.jl
@@ -1,0 +1,321 @@
+#!/usr/bin/env julia
+
+import DataFrames
+import TOML
+
+const RHIZOMORPH_BENCHMARK_MANIFEST =
+    joinpath(@__DIR__, "rhizomorph_benchmark_manifest.toml")
+
+const RHIZOMORPH_BENCHMARK_SCALE_RANK = Dict(
+    "ci" => 1,
+    "full" => 2,
+    "candidate" => 3
+)
+
+"""
+    load_rhizomorph_benchmark_manifest(manifest_path=RHIZOMORPH_BENCHMARK_MANIFEST; validate=true)
+
+Load the Rhizomorph benchmark dataset and H1-H7 slice manifest.
+"""
+function load_rhizomorph_benchmark_manifest(
+        manifest_path::AbstractString = RHIZOMORPH_BENCHMARK_MANIFEST;
+        validate::Bool = true)
+    manifest = TOML.parsefile(manifest_path)
+    if validate
+        validate_rhizomorph_benchmark_manifest(manifest)
+    end
+    return manifest
+end
+
+"""
+    validate_rhizomorph_benchmark_manifest(manifest)
+
+Validate required fields, unique identifiers, scale labels, and slice dataset references.
+"""
+function validate_rhizomorph_benchmark_manifest(manifest::AbstractDict)
+    _require_keys(manifest, ["schema_version", "schema", "datasets", "hypothesis_slices"], "manifest")
+    schema = manifest["schema"]
+    _require_keys(schema, ["dataset_required_fields", "hypothesis_required_fields"], "schema")
+
+    dataset_required_fields = schema["dataset_required_fields"]
+    hypothesis_required_fields = schema["hypothesis_required_fields"]
+    allowed_suitability = Set(get(schema, "ci_suitability_values", collect(keys(RHIZOMORPH_BENCHMARK_SCALE_RANK))))
+
+    dataset_ids = Set{String}()
+    for dataset in manifest["datasets"]
+        _require_keys(dataset, dataset_required_fields, "dataset")
+        dataset_id = string(dataset["id"])
+        if dataset_id in dataset_ids
+            error("Duplicate Rhizomorph benchmark dataset id: $(dataset_id)")
+        end
+        push!(dataset_ids, dataset_id)
+
+        suitability = string(dataset["ci_suitability"])
+        if !(suitability in allowed_suitability)
+            error("Dataset $(dataset_id) has invalid ci_suitability=$(suitability)")
+        end
+        _require_keys(dataset["provenance"], ["kind", "source", "accessions"], "dataset $(dataset_id) provenance")
+    end
+
+    slice_ids = Set{String}()
+    for slice in manifest["hypothesis_slices"]
+        _require_keys(slice, hypothesis_required_fields, "hypothesis slice")
+        slice_id = string(slice["id"])
+        if slice_id in slice_ids
+            error("Duplicate Rhizomorph benchmark hypothesis id: $(slice_id)")
+        end
+        push!(slice_ids, slice_id)
+
+        for dataset_id in slice["dataset_ids"]
+            if !(string(dataset_id) in dataset_ids)
+                error("Hypothesis slice $(slice_id) references unknown dataset: $(dataset_id)")
+            end
+        end
+    end
+
+    return true
+end
+
+"""
+    list_rhizomorph_benchmark_datasets(; manifest_path=RHIZOMORPH_BENCHMARK_MANIFEST)
+
+Return a table of benchmark datasets, provenance, expected outputs, and CI/full suitability.
+"""
+function list_rhizomorph_benchmark_datasets(;
+        manifest_path::AbstractString = RHIZOMORPH_BENCHMARK_MANIFEST)
+    manifest = load_rhizomorph_benchmark_manifest(manifest_path)
+    rows = NamedTuple[]
+
+    for dataset in manifest["datasets"]
+        provenance = dataset["provenance"]
+        push!(rows, (
+            id = string(dataset["id"]),
+            name = string(dataset["name"]),
+            category = string(dataset["category"]),
+            ci_suitability = string(dataset["ci_suitability"]),
+            materialization = string(dataset["materialization"]),
+            provenance_kind = string(provenance["kind"]),
+            provenance_source = string(provenance["source"]),
+            accessions = join(string.(provenance["accessions"]), ","),
+            expected_outputs = join(string.(dataset["expected_outputs"]), "; ")
+        ))
+    end
+
+    return DataFrames.DataFrame(rows)
+end
+
+"""
+    list_rhizomorph_benchmark_slices(; manifest_path=RHIZOMORPH_BENCHMARK_MANIFEST)
+
+Return a table describing the H1-H7 benchmark slices and their harness entry points.
+"""
+function list_rhizomorph_benchmark_slices(;
+        manifest_path::AbstractString = RHIZOMORPH_BENCHMARK_MANIFEST)
+    manifest = load_rhizomorph_benchmark_manifest(manifest_path)
+    rows = NamedTuple[]
+
+    for slice in manifest["hypothesis_slices"]
+        push!(rows, (
+            id = string(slice["id"]),
+            title = string(slice["title"]),
+            status = string(get(slice, "status", "stub")),
+            dataset_ids = join(string.(slice["dataset_ids"]), ","),
+            entrypoint = string(slice["entrypoint"]),
+            expected_outputs = join(string.(slice["expected_outputs"]), "; ")
+        ))
+    end
+
+    return DataFrames.DataFrame(rows)
+end
+
+"""
+    build_rhizomorph_benchmark_plan(; scale="ci", hypothesis_ids=nothing, dataset_ids=nothing, manifest_path=...)
+
+Build a dry-run plan that maps H1-H7 benchmark slices to datasets and expected outputs.
+
+`scale="ci"` includes only CI-suitable datasets, `scale="full"` includes CI and
+full public-reference datasets, and `scale="candidate"` also includes planned
+heterogeneous candidates.
+"""
+function build_rhizomorph_benchmark_plan(;
+        scale::AbstractString = "ci",
+        hypothesis_ids = nothing,
+        dataset_ids = nothing,
+        manifest_path::AbstractString = RHIZOMORPH_BENCHMARK_MANIFEST)
+    _validate_scale(scale)
+    manifest = load_rhizomorph_benchmark_manifest(manifest_path)
+    dataset_by_id = Dict(string(dataset["id"]) => dataset for dataset in manifest["datasets"])
+    selected_hypothesis_ids = _selected_id_set(hypothesis_ids)
+    selected_dataset_ids = _selected_id_set(dataset_ids)
+    rows = NamedTuple[]
+
+    for slice in manifest["hypothesis_slices"]
+        slice_id = string(slice["id"])
+        if selected_hypothesis_ids !== nothing && !(slice_id in selected_hypothesis_ids)
+            continue
+        end
+
+        for dataset_id_value in slice["dataset_ids"]
+            dataset_id = string(dataset_id_value)
+            dataset = dataset_by_id[dataset_id]
+            if !_dataset_allowed_for_scale(dataset, scale)
+                continue
+            end
+            if selected_dataset_ids !== nothing && !(dataset_id in selected_dataset_ids)
+                continue
+            end
+
+            push!(rows, (
+                scale = string(scale),
+                hypothesis_id = slice_id,
+                hypothesis_title = string(slice["title"]),
+                dataset_id = dataset_id,
+                dataset_category = string(dataset["category"]),
+                ci_suitability = string(dataset["ci_suitability"]),
+                materialization = string(dataset["materialization"]),
+                entrypoint = string(slice["entrypoint"]),
+                expected_inputs = join(string.(slice["expected_inputs"]), "; "),
+                expected_outputs = join(string.(slice["expected_outputs"]), "; "),
+                implemented = string(get(slice, "status", "stub")) != "stub"
+            ))
+        end
+    end
+
+    _validate_requested_ids("hypothesis", selected_hypothesis_ids, string.(getindex.(manifest["hypothesis_slices"], "id")))
+    _validate_requested_ids("dataset", selected_dataset_ids, collect(keys(dataset_by_id)))
+    return DataFrames.DataFrame(rows)
+end
+
+"""
+    run_rhizomorph_benchmark_harness(; dry_run=true, kwargs...)
+
+Return the dry-run benchmark plan. Executing benchmark slices is intentionally a
+stub until follow-on issues implement each H1-H7 runner.
+"""
+function run_rhizomorph_benchmark_harness(; dry_run::Bool = true, kwargs...)
+    plan = build_rhizomorph_benchmark_plan(; kwargs...)
+    if dry_run
+        return plan
+    end
+    error("Rhizomorph benchmark slice execution is not implemented yet; use dry_run=true to inspect the plan.")
+end
+
+function _require_keys(table::AbstractDict, keys, context::AbstractString)
+    missing_keys = String[]
+    for key in keys
+        if !haskey(table, key)
+            push!(missing_keys, string(key))
+        end
+    end
+    if !isempty(missing_keys)
+        error("Missing required $(context) key(s): $(join(missing_keys, ", "))")
+    end
+    return nothing
+end
+
+function _validate_scale(scale::AbstractString)
+    if !haskey(RHIZOMORPH_BENCHMARK_SCALE_RANK, string(scale))
+        error("Unknown Rhizomorph benchmark scale: $(scale). Use ci, full, or candidate.")
+    end
+    return nothing
+end
+
+function _selected_id_set(ids)
+    if ids === nothing
+        return nothing
+    end
+    return Set(string.(ids))
+end
+
+function _dataset_allowed_for_scale(dataset::AbstractDict, scale::AbstractString)
+    dataset_scale = string(dataset["ci_suitability"])
+    return RHIZOMORPH_BENCHMARK_SCALE_RANK[dataset_scale] <=
+           RHIZOMORPH_BENCHMARK_SCALE_RANK[string(scale)]
+end
+
+function _validate_requested_ids(kind::AbstractString, requested_ids, known_ids)
+    if requested_ids === nothing
+        return nothing
+    end
+
+    known_id_set = Set(string.(known_ids))
+    unknown_ids = sort(collect(setdiff(requested_ids, known_id_set)))
+    if !isempty(unknown_ids)
+        error("Unknown Rhizomorph benchmark $(kind) id(s): $(join(unknown_ids, ", "))")
+    end
+    return nothing
+end
+
+function _flag_values(args, flag::AbstractString)
+    values = String[]
+    index = 1
+    while index <= length(args)
+        if args[index] == flag
+            if index == length(args)
+                error("Missing value after $(flag)")
+            end
+            push!(values, args[index + 1])
+            index += 2
+        else
+            index += 1
+        end
+    end
+    return values
+end
+
+function _flag_value(args, flag::AbstractString, default::AbstractString)
+    values = _flag_values(args, flag)
+    return isempty(values) ? default : values[end]
+end
+
+function print_rhizomorph_benchmark_usage()
+    println("Rhizomorph benchmark harness")
+    println()
+    println("Usage:")
+    println("  julia --project=. benchmarking/rhizomorph_benchmark_harness.jl --list-datasets")
+    println("  julia --project=. benchmarking/rhizomorph_benchmark_harness.jl --list-slices")
+    println("  julia --project=. benchmarking/rhizomorph_benchmark_harness.jl --plan --scale ci")
+    println("  julia --project=. benchmarking/rhizomorph_benchmark_harness.jl --slice H1 --slice H7 --scale full")
+    println()
+    println("Scales: ci, full, candidate")
+    println("Execution is currently stubbed; the script emits dry-run plans for follow-on runners.")
+    return nothing
+end
+
+function main(args = ARGS)
+    if "--help" in args || "-h" in args
+        print_rhizomorph_benchmark_usage()
+        return nothing
+    end
+
+    manifest_path = _flag_value(args, "--manifest", RHIZOMORPH_BENCHMARK_MANIFEST)
+    if "--list-datasets" in args
+        show(list_rhizomorph_benchmark_datasets(manifest_path = manifest_path); allrows = true, allcols = true)
+        println()
+        return nothing
+    end
+    if "--list-slices" in args
+        show(list_rhizomorph_benchmark_slices(manifest_path = manifest_path); allrows = true, allcols = true)
+        println()
+        return nothing
+    end
+
+    scale = _flag_value(args, "--scale", "ci")
+    hypothesis_ids = _flag_values(args, "--slice")
+    dataset_ids = _flag_values(args, "--dataset")
+    dry_run = !("--execute" in args)
+    plan = run_rhizomorph_benchmark_harness(
+        dry_run = dry_run,
+        scale = scale,
+        hypothesis_ids = isempty(hypothesis_ids) ? nothing : hypothesis_ids,
+        dataset_ids = isempty(dataset_ids) ? nothing : dataset_ids,
+        manifest_path = manifest_path
+    )
+    show(plan; allrows = true, allcols = true)
+    println()
+    return nothing
+end
+
+if abspath(PROGRAM_FILE) == @__FILE__
+    main()
+end

--- a/benchmarking/rhizomorph_benchmark_manifest.toml
+++ b/benchmarking/rhizomorph_benchmark_manifest.toml
@@ -1,0 +1,341 @@
+schema_version = 1
+title = "Rhizomorph H1-H7 benchmark manifest"
+description = "Dataset and hypothesis-slice manifest for reproducible Rhizomorph public-record benchmarks."
+
+[schema]
+dataset_required_fields = [
+    "id",
+    "name",
+    "category",
+    "ci_suitability",
+    "materialization",
+    "provenance",
+    "expected_inputs",
+    "expected_outputs"
+]
+hypothesis_required_fields = [
+    "id",
+    "title",
+    "dataset_ids",
+    "entrypoint",
+    "expected_inputs",
+    "expected_outputs"
+]
+ci_suitability_values = ["ci", "full", "candidate"]
+
+[[datasets]]
+id = "synthetic_isolate_5386"
+name = "Synthetic 5.4 kb isolate fixture"
+category = "toy_control"
+ci_suitability = "ci"
+materialization = "implemented"
+fixture_entrypoint = "benchmarking/standard_assembler_fixtures.jl:materialize_standard_assembler_fixture"
+description = "Single deterministic short-read isolate fixture matching PhiX174 scale."
+expected_inputs = ["reference_fasta", "paired_fastq", "truth_table"]
+expected_outputs = ["contigs_fasta", "assembly_metrics_csv", "graph_summary_json"]
+notes = "Already covered by test/4_assembly/standard_assembler_fixture_catalog_test.jl."
+[datasets.provenance]
+kind = "generated"
+source = "BioSequences.randdnaseq with StableRNGs seed 17401"
+accessions = []
+
+[[datasets]]
+id = "synthetic_metagenome_pair"
+name = "Synthetic two-genome low-complexity metagenome"
+category = "toy_control"
+ci_suitability = "ci"
+materialization = "implemented"
+fixture_entrypoint = "benchmarking/standard_assembler_fixtures.jl:materialize_standard_assembler_fixture"
+description = "Deterministic two-genome community with uneven coverage."
+expected_inputs = ["reference_fasta", "paired_fastq", "truth_table"]
+expected_outputs = ["bin_membership_table", "contigs_fasta", "assembly_metrics_csv", "community_recovery_csv"]
+notes = "Small enough for CI dry-runs and targeted correctness checks."
+[datasets.provenance]
+kind = "generated"
+source = "BioSequences.randdnaseq with StableRNGs seeds 17402 and 17403"
+accessions = []
+
+[[datasets]]
+id = "synthetic_repeat_fork_panel"
+name = "Synthetic repeat-fork calibration panel"
+category = "toy_control"
+ci_suitability = "ci"
+materialization = "implemented"
+fixture_entrypoint = "benchmarking/08_momentum_fork_resolution_benchmark.jl:benchmark_config"
+description = "Controlled repeat length, divergence, coverage, and threshold sweeps for fork resolution."
+expected_inputs = ["repeat_length_grid", "divergence_grid", "coverage_grid", "threshold_grid"]
+expected_outputs = ["scenario_csv", "threshold_csv", "benchmark_summary_json"]
+notes = "Existing benchmark writes scenario and threshold CSV files."
+[datasets.provenance]
+kind = "generated"
+source = "StableRNGs repeat-window simulator"
+accessions = []
+
+[[datasets]]
+id = "rhizomorph_graph_unit_fixtures"
+name = "Rhizomorph graph unit fixture suite"
+category = "toy_control"
+ci_suitability = "ci"
+materialization = "implemented"
+fixture_entrypoint = "test/4_assembly/rhizomorph_*_test.jl"
+description = "Small graph fixtures covering k-mer, qualmer, FASTA, FASTQ, string, strand-mode, GFA, and path-finding behavior."
+expected_inputs = ["in-memory_sequences", "temporary_fasta", "temporary_fastq", "graph_literals"]
+expected_outputs = ["graph_metrics", "path_sequences", "gfa_files", "evidence_tables"]
+notes = "Inventory target for converting unit fixtures into reusable benchmark microcases."
+[datasets.provenance]
+kind = "repo_fixture"
+source = "test/4_assembly Rhizomorph fixtures"
+accessions = []
+
+[[datasets]]
+id = "pstv_viroid"
+name = "Potato spindle tuber viroid reference"
+category = "public_isolate"
+ci_suitability = "full"
+materialization = "download"
+fixture_entrypoint = "benchmarking/real_genome_benchmark.jl"
+description = "Tiny RNA reference used in existing Rhizomorph real-genome k sweeps."
+expected_inputs = ["reference_fasta"]
+expected_outputs = ["k_sweep_metrics_csv", "contigs_fasta", "quast_metrics"]
+notes = "Use for full benchmark runs because it requires public reference retrieval."
+[datasets.provenance]
+kind = "ncbi_refseq"
+source = "NCBI RefSeq"
+accessions = ["NC_002030"]
+
+[[datasets]]
+id = "cccv_viroid"
+name = "Coconut cadang-cadang viroid reference"
+category = "public_isolate"
+ci_suitability = "full"
+materialization = "download"
+fixture_entrypoint = "benchmarking/real_genome_benchmark.jl"
+description = "Tiny RNA reference used in existing Rhizomorph real-genome k sweeps."
+expected_inputs = ["reference_fasta"]
+expected_outputs = ["k_sweep_metrics_csv", "contigs_fasta", "quast_metrics"]
+notes = "The existing benchmark now measures actual downloaded sequence length."
+[datasets.provenance]
+kind = "ncbi_refseq"
+source = "NCBI RefSeq"
+accessions = ["NC_003540"]
+
+[[datasets]]
+id = "hsvd_viroid"
+name = "Hop stunt viroid reference"
+category = "public_isolate"
+ci_suitability = "full"
+materialization = "download"
+fixture_entrypoint = "benchmarking/real_genome_benchmark.jl"
+description = "Tiny RNA reference used in existing Rhizomorph real-genome k sweeps."
+expected_inputs = ["reference_fasta"]
+expected_outputs = ["k_sweep_metrics_csv", "contigs_fasta", "quast_metrics"]
+notes = "Suitable for full lightweight public-reference runs."
+[datasets.provenance]
+kind = "ncbi_refseq"
+source = "NCBI RefSeq"
+accessions = ["NC_001351"]
+
+[[datasets]]
+id = "phix174"
+name = "Enterobacteria phage PhiX174 reference"
+category = "public_isolate"
+ci_suitability = "full"
+materialization = "download"
+fixture_entrypoint = "benchmarking/real_genome_benchmark.jl"
+description = "5.4 kb circular ssDNA phage reference for isolate-scale k sweeps and assembler comparisons."
+expected_inputs = ["reference_fasta", "optional_simulated_reads"]
+expected_outputs = ["k_sweep_metrics_csv", "contigs_fasta", "assembly_metrics_csv"]
+notes = "Public counterpart to synthetic_isolate_5386."
+[datasets.provenance]
+kind = "ncbi_refseq"
+source = "NCBI RefSeq"
+accessions = ["NC_001422"]
+
+[[datasets]]
+id = "lambda_phage"
+name = "Enterobacteria phage lambda reference"
+category = "public_isolate"
+ci_suitability = "full"
+materialization = "download"
+fixture_entrypoint = "benchmarking/real_genome_benchmark.jl"
+description = "48.5 kb dsDNA phage reference for medium isolate sweeps."
+expected_inputs = ["reference_fasta", "optional_simulated_reads"]
+expected_outputs = ["k_sweep_metrics_csv", "contigs_fasta", "assembly_metrics_csv"]
+notes = "Existing benchmark shows full-length assembly at k >= 21."
+[datasets.provenance]
+kind = "ncbi_refseq"
+source = "NCBI RefSeq"
+accessions = ["NC_001416"]
+
+[[datasets]]
+id = "t4_phage"
+name = "Enterobacteria phage T4 reference"
+category = "public_isolate"
+ci_suitability = "full"
+materialization = "download"
+fixture_entrypoint = "benchmarking/real_genome_benchmark.jl"
+description = "168.9 kb repetitive dsDNA phage reference for repeat-heavy isolate sweeps."
+expected_inputs = ["reference_fasta", "optional_simulated_reads"]
+expected_outputs = ["k_sweep_metrics_csv", "contigs_fasta", "repeat_resolution_metrics_csv"]
+notes = "Full benchmark only; current results remain fragmented at all tested k values."
+[datasets.provenance]
+kind = "ncbi_refseq"
+source = "NCBI RefSeq"
+accessions = ["NC_000866"]
+
+[[datasets]]
+id = "cami_toy_low_complexity"
+name = "CAMI toy low-complexity metagenome"
+category = "heterogeneous_candidate"
+ci_suitability = "candidate"
+materialization = "planned_download"
+fixture_entrypoint = "follow-on: CAMI manifest materializer"
+description = "Candidate public heterogeneous sample for low-complexity community assembly validation."
+expected_inputs = ["paired_fastq", "reference_genomes", "taxonomic_truth"]
+expected_outputs = ["contigs_fasta", "bin_membership_table", "community_recovery_csv", "taxonomic_profile_csv"]
+notes = "Do not run in CI until a small pinned artifact strategy exists."
+[datasets.provenance]
+kind = "public_challenge"
+source = "CAMI Challenge toy datasets"
+accessions = []
+
+[[datasets]]
+id = "zymo_d6300"
+name = "ZymoBIOMICS Microbial Community Standard D6300"
+category = "heterogeneous_candidate"
+ci_suitability = "candidate"
+materialization = "planned_external_input"
+fixture_entrypoint = "follow-on: physical mock-community manifest materializer"
+description = "Low-complexity bacterial and yeast mock community candidate."
+expected_inputs = ["paired_fastq_or_long_reads", "strain_truth", "reference_genomes"]
+expected_outputs = ["contigs_fasta", "bin_membership_table", "strain_recovery_csv", "abundance_error_csv"]
+notes = "Candidate full benchmark dataset; no reads are committed."
+[datasets.provenance]
+kind = "physical_mock"
+source = "Zymo Research D6300"
+accessions = []
+
+[[datasets]]
+id = "zymo_d6331"
+name = "ZymoBIOMICS Gut Microbiome Standard D6331"
+category = "heterogeneous_candidate"
+ci_suitability = "candidate"
+materialization = "planned_external_input"
+fixture_entrypoint = "follow-on: physical mock-community manifest materializer"
+description = "Medium-complexity gut mock-community candidate."
+expected_inputs = ["paired_fastq_or_long_reads", "strain_truth", "reference_genomes"]
+expected_outputs = ["contigs_fasta", "bin_membership_table", "strain_recovery_csv", "abundance_error_csv"]
+notes = "Candidate full benchmark dataset; no reads are committed."
+[datasets.provenance]
+kind = "physical_mock"
+source = "Zymo Research D6331"
+accessions = []
+
+[[datasets]]
+id = "atcc_msa_1002"
+name = "ATCC MSA-1002 even mock community"
+category = "heterogeneous_candidate"
+ci_suitability = "candidate"
+materialization = "planned_external_input"
+fixture_entrypoint = "follow-on: physical mock-community manifest materializer"
+description = "20-strain even-mix candidate for abundance and strain recovery checks."
+expected_inputs = ["paired_fastq_or_long_reads", "strain_truth", "reference_genomes"]
+expected_outputs = ["contigs_fasta", "bin_membership_table", "strain_recovery_csv", "abundance_error_csv"]
+notes = "Candidate full benchmark dataset; no reads are committed."
+[datasets.provenance]
+kind = "physical_mock"
+source = "ATCC MSA-1002"
+accessions = []
+
+[[datasets]]
+id = "atcc_msa_1003"
+name = "ATCC MSA-1003 staggered mock community"
+category = "heterogeneous_candidate"
+ci_suitability = "candidate"
+materialization = "planned_external_input"
+fixture_entrypoint = "follow-on: physical mock-community manifest materializer"
+description = "20-strain staggered-mix candidate for abundance-range stress testing."
+expected_inputs = ["paired_fastq_or_long_reads", "strain_truth", "reference_genomes"]
+expected_outputs = ["contigs_fasta", "bin_membership_table", "strain_recovery_csv", "abundance_error_csv"]
+notes = "Candidate full benchmark dataset; no reads are committed."
+[datasets.provenance]
+kind = "physical_mock"
+source = "ATCC MSA-1003"
+accessions = []
+
+[[hypothesis_slices]]
+id = "H1"
+title = "Graph construction scaling"
+summary = "Measure fixed-length and variable-length Rhizomorph graph construction time, memory, and graph-size growth."
+dataset_ids = ["synthetic_isolate_5386", "synthetic_metagenome_pair", "rhizomorph_graph_unit_fixtures", "phix174", "lambda_phage", "t4_phage"]
+entrypoint = "benchmarking/rhizomorph_benchmark_harness.jl --slice H1"
+status = "stub"
+expected_inputs = ["sequence_records", "k_values", "strand_modes", "graph_type"]
+expected_outputs = ["graph_construction_metrics_csv", "memory_profile_json", "graph_summary_json"]
+follow_on_work = "Implement construction runners for k-mer, qualmer, FASTA, FASTQ, and string graph builders."
+
+[[hypothesis_slices]]
+id = "H2"
+title = "Assembly contiguity across k and strand modes"
+summary = "Compare Rhizomorph contig recovery as k and strand mode change across toy and public isolate inputs."
+dataset_ids = ["synthetic_isolate_5386", "pstv_viroid", "cccv_viroid", "hsvd_viroid", "phix174", "lambda_phage", "t4_phage"]
+entrypoint = "benchmarking/rhizomorph_benchmark_harness.jl --slice H2"
+status = "stub"
+expected_inputs = ["reference_fasta", "optional_reads", "k_values", "strand_modes"]
+expected_outputs = ["contigs_fasta", "assembly_metrics_csv", "k_sweep_summary_csv"]
+follow_on_work = "Normalize existing real_genome_benchmark outputs into the harness result schema."
+
+[[hypothesis_slices]]
+id = "H3"
+title = "Repeat and fork resolution"
+summary = "Stress repeat-aware branch selection, unresolved rate, and misassembly behavior."
+dataset_ids = ["synthetic_repeat_fork_panel", "t4_phage", "cami_toy_low_complexity"]
+entrypoint = "benchmarking/rhizomorph_benchmark_harness.jl --slice H3"
+status = "stub"
+expected_inputs = ["repeat_scenarios", "threshold_grid", "coverage_grid", "reference_fasta"]
+expected_outputs = ["scenario_csv", "threshold_csv", "misassembly_summary_csv", "repeat_resolution_metrics_csv"]
+follow_on_work = "Promote 08_momentum_fork_resolution_benchmark.jl into a slice runner."
+
+[[hypothesis_slices]]
+id = "H4"
+title = "Quality-weighted graph robustness"
+summary = "Measure qualmer and FASTQ graph robustness under quality decay, error injection, and coverage changes."
+dataset_ids = ["synthetic_isolate_5386", "synthetic_metagenome_pair", "rhizomorph_graph_unit_fixtures"]
+entrypoint = "benchmarking/rhizomorph_benchmark_harness.jl --slice H4"
+status = "stub"
+expected_inputs = ["paired_fastq", "quality_profiles", "error_rates", "coverage_grid"]
+expected_outputs = ["error_correction_metrics_csv", "qualmer_graph_summary_json", "contig_quality_csv"]
+follow_on_work = "Add deterministic quality-profile generators and qualmer graph comparison metrics."
+
+[[hypothesis_slices]]
+id = "H5"
+title = "Heterogeneous community recovery"
+summary = "Evaluate low- and medium-complexity mixed-sample assembly, bin recovery, and abundance distortion."
+dataset_ids = ["synthetic_metagenome_pair", "cami_toy_low_complexity", "zymo_d6300", "zymo_d6331", "atcc_msa_1002", "atcc_msa_1003"]
+entrypoint = "benchmarking/rhizomorph_benchmark_harness.jl --slice H5"
+status = "stub"
+expected_inputs = ["paired_fastq_or_long_reads", "reference_genomes", "community_truth"]
+expected_outputs = ["contigs_fasta", "bin_membership_table", "community_recovery_csv", "abundance_error_csv"]
+follow_on_work = "Define truth-table schema for synthetic and physical mock communities."
+
+[[hypothesis_slices]]
+id = "H6"
+title = "Generative sequence fidelity"
+summary = "Evaluate graph-walk sequence generation against source distributions and graph topology constraints."
+dataset_ids = ["rhizomorph_graph_unit_fixtures", "synthetic_isolate_5386", "synthetic_metagenome_pair"]
+entrypoint = "benchmarking/rhizomorph_benchmark_harness.jl --slice H6"
+status = "stub"
+expected_inputs = ["weighted_graph", "walk_length", "sample_count", "seed"]
+expected_outputs = ["generated_sequences_fasta", "generation_quality_csv", "transition_entropy_json"]
+follow_on_work = "Route Mycelia.Rhizomorph.generate_sequences and evaluate_generation_quality through benchmark outputs."
+
+[[hypothesis_slices]]
+id = "H7"
+title = "External assembler comparison"
+summary = "Compare Rhizomorph outputs against accepted assemblers on the same fixture materializations."
+dataset_ids = ["synthetic_isolate_5386", "synthetic_metagenome_pair", "phix174", "lambda_phage", "cami_toy_low_complexity"]
+entrypoint = "benchmarking/rhizomorph_benchmark_harness.jl --slice H7"
+status = "stub"
+expected_inputs = ["paired_fastq", "reference_fasta", "assembler_list"]
+expected_outputs = ["benchmark_plan_csv", "assembler_comparison_csv", "contigs_fasta", "tool_versions_json"]
+follow_on_work = "Wrap assembler_comparison_standard_fixtures.jl and external-tool checks in a scale-aware runner."

--- a/docs/src/benchmarks.md
+++ b/docs/src/benchmarks.md
@@ -45,6 +45,39 @@ This benchmark compares `Mycelia.Rhizomorph.assemble_genome`, `run_megahit`, and
 `run_metaspades` on the same generated FASTQ inputs and writes the run plan plus
 results as CSV files.
 
+## Rhizomorph H1-H7 Benchmark Harness
+
+The Rhizomorph public-record benchmark surface is defined by
+`benchmarking/rhizomorph_benchmark_manifest.toml` and inspected through
+`benchmarking/rhizomorph_benchmark_harness.jl`. The manifest inventories the
+current reusable benchmark assets:
+
+- deterministic toy controls from `benchmarking/standard_assembler_fixtures.jl`
+- repeat-fork calibration from `benchmarking/08_momentum_fork_resolution_benchmark.jl`
+- small Rhizomorph graph fixtures in `test/4_assembly/rhizomorph_*_test.jl`
+- public isolate references already used by `benchmarking/real_genome_benchmark.jl`
+- heterogeneous community candidates such as CAMI, Zymo, and ATCC mock communities
+
+Each manifest dataset records provenance, expected inputs, expected outputs, and
+whether it is suitable for CI dry-runs, full public-reference benchmark runs, or
+candidate follow-on work. H1-H7 slices route graph construction, k/strand sweeps,
+repeat resolution, qualmer robustness, heterogeneous community recovery,
+generative sequence fidelity, and external assembler comparisons to their
+expected datasets and output tables.
+
+Inspect the harness without running heavy work:
+
+```bash
+julia --project=. benchmarking/rhizomorph_benchmark_harness.jl --list-datasets
+julia --project=. benchmarking/rhizomorph_benchmark_harness.jl --list-slices
+julia --project=. benchmarking/rhizomorph_benchmark_harness.jl --plan --scale ci
+julia --project=. benchmarking/rhizomorph_benchmark_harness.jl --slice H2 --slice H7 --scale full
+```
+
+The harness is intentionally a dry-run contract today; follow-on implementation
+issues should promote each H1-H7 slice from `status = "stub"` to a concrete
+runner while preserving the manifest output schema.
+
 ## Standardized Test Datasets
 
 To ensure rigorous validation across platforms, Mycelia uses the following

--- a/test/4_assembly/rhizomorph_benchmark_manifest_test.jl
+++ b/test/4_assembly/rhizomorph_benchmark_manifest_test.jl
@@ -1,0 +1,53 @@
+import DataFrames
+import Test
+
+include(joinpath(@__DIR__, "..", "..", "benchmarking", "rhizomorph_benchmark_harness.jl"))
+
+Test.@testset "Rhizomorph benchmark manifest" begin
+    manifest = load_rhizomorph_benchmark_manifest()
+    Test.@test manifest["schema_version"] == 1
+    Test.@test validate_rhizomorph_benchmark_manifest(manifest)
+
+    datasets = list_rhizomorph_benchmark_datasets()
+    Test.@test DataFrames.nrow(datasets) >= 10
+    Test.@test issubset(
+        Set(["toy_control", "public_isolate", "heterogeneous_candidate"]),
+        Set(datasets.category)
+    )
+    Test.@test "synthetic_isolate_5386" in datasets.id
+    Test.@test "phix174" in datasets.id
+    Test.@test "zymo_d6300" in datasets.id
+
+    slices = list_rhizomorph_benchmark_slices()
+    Test.@test DataFrames.nrow(slices) == 7
+    Test.@test Set(slices.id) == Set(["H1", "H2", "H3", "H4", "H5", "H6", "H7"])
+    Test.@test all(occursin("benchmarking/rhizomorph_benchmark_harness.jl", entrypoint)
+        for entrypoint in slices.entrypoint)
+end
+
+Test.@testset "Rhizomorph benchmark dry-run plans" begin
+    ci_plan = build_rhizomorph_benchmark_plan(scale = "ci")
+    Test.@test !isempty(ci_plan)
+    Test.@test all(ci_plan.ci_suitability .== "ci")
+    Test.@test "synthetic_isolate_5386" in ci_plan.dataset_id
+    Test.@test !("phix174" in ci_plan.dataset_id)
+    Test.@test all(.!ci_plan.implemented)
+
+    full_plan = build_rhizomorph_benchmark_plan(scale = "full", hypothesis_ids = ["H2", "H7"])
+    Test.@test Set(full_plan.hypothesis_id) == Set(["H2", "H7"])
+    Test.@test "phix174" in full_plan.dataset_id
+    Test.@test !("zymo_d6300" in full_plan.dataset_id)
+
+    candidate_plan = build_rhizomorph_benchmark_plan(
+        scale = "candidate",
+        hypothesis_ids = ["H5"],
+        dataset_ids = ["zymo_d6300", "atcc_msa_1003"]
+    )
+    Test.@test Set(candidate_plan.dataset_id) == Set(["zymo_d6300", "atcc_msa_1003"])
+    Test.@test all(candidate_plan.hypothesis_id .== "H5")
+
+    Test.@test_throws ErrorException build_rhizomorph_benchmark_plan(scale = "tiny")
+    Test.@test_throws ErrorException build_rhizomorph_benchmark_plan(hypothesis_ids = ["H9"])
+    Test.@test_throws ErrorException build_rhizomorph_benchmark_plan(dataset_ids = ["unknown_dataset"])
+    Test.@test_throws ErrorException run_rhizomorph_benchmark_harness(dry_run = false)
+end


### PR DESCRIPTION
Closes #304

## Summary
- Add a Rhizomorph benchmark dataset manifest covering CI and full-run candidate inputs.
- Add a dry-run H1-H7 benchmark harness and documentation for follow-on implementation work.
- Add manifest/harness verification coverage.

## Verification
- julia --project=. test/4_assembly/rhizomorph_benchmark_manifest_test.jl
- julia --project=. benchmarking/rhizomorph_benchmark_harness.jl --plan --scale ci
- julia --project=. benchmarking/rhizomorph_benchmark_harness.jl --slice H2 --slice H7 --scale full
- git diff --check origin/master...HEAD