### PR TITLE
ci: cancel superseded runs + scope doc-build PRs to master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,12 @@ on:
     branches:
       - master
 
+# Cancel superseded runs on a PR branch when a newer commit is pushed; never
+# cancel a master run (post-merge CI must always complete).
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -11,6 +11,12 @@ on:
     - cron: "21 4 * * 1"
   workflow_dispatch:
 
+# Cancel superseded PR-branch scans; never cancel a master run so the security
+# baseline on the default branch always completes.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+
 permissions:
   actions: read
   contents: read

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -5,7 +5,17 @@ on:
     branches:
       - master
     tags: '*'
+  # Only build docs for PRs targeting master (matches ci.yml / codeql.yml);
+  # a full Julia doc build on PRs against other branches has little value.
   pull_request:
+    branches:
+      - master
+
+# Cancel superseded PR-branch doc builds; never cancel a master run so the
+# docs deploy always completes.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 
 jobs:
   build:


### PR DESCRIPTION
## Summary

Reduce redundant GitHub Actions runs without changing what CI/CD validates. (Mycelia is a public repo, so Actions minutes here are free — this improves feedback latency and runner pile-up, not billable quota.)

- Add a `concurrency` group to `ci.yml`, `codeql.yml`, and `documentation.yml`. `cancel-in-progress` is gated on `github.ref != 'refs/heads/master'`, so:
  - **PR branches:** a new push cancels the prior in-flight run (you only care about the latest commit's result).
  - **master:** runs are never cancelled — post-merge CI, the CodeQL security baseline, and the docs *deploy* always complete.
- `documentation.yml` now builds docs only for PRs targeting `master` (matching `ci.yml`/`codeql.yml`). A full Julia doc build for PRs against other branches has little value.

## What does NOT change

- The set of checks that gate a merge is unchanged.
- master always gets full CI + CodeQL + docs deploy.
- The weekly scheduled CodeQL scan and `workflow_dispatch` are untouched.

## Test Plan

- [ ] Open a PR, push two commits quickly → confirm the first run is cancelled, only the latest completes.
- [ ] Confirm CI/CodeQL/Documentation still run and report status on the PR.
- [ ] After merge → confirm master runs all three to completion (no cancellation) and docs deploy.

## Related

GitHub Actions quota investigation. The private-repo quota fixes are in `shoal-trading` PR #142 and `todo` PR #147; this Mycelia change is hygiene-only (public repo, $0 quota impact).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized CI/CD pipeline concurrency controls to cancel redundant pull request runs while preserving production branch builds.
  * Enhanced documentation workflow to focus on master branch updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->