### PR TITLE
fix: stabilize end-to-end assembly test sweep

### DIFF
--- a/test/4_assembly/end_to_end_assembly_tests.jl
+++ b/test/4_assembly/end_to_end_assembly_tests.jl
@@ -30,8 +30,21 @@ import Kmers
 const TEST_LENGTHS = [10, 50]
 const ERROR_RATES = [0.0, 0.01]  # 0%, 1%
 const COVERAGE_DEPTHS = [5, 20]
+const END_TO_END_ASSEMBLY_TEST_SEED = 0xE2E4A55E
 
-Test.@testset "End-to-End Assembly Tests" begin
+macro with_end_to_end_assembly_test_seed(ex)
+    return quote
+        local saved_rng = copy(Random.default_rng())
+        Random.seed!(END_TO_END_ASSEMBLY_TEST_SEED)
+        try
+            $(esc(ex))
+        finally
+            copy!(Random.default_rng(), saved_rng)
+        end
+    end
+end
+
+@with_end_to_end_assembly_test_seed Test.@testset "End-to-End Assembly Tests" begin
     Test.@testset "Base Case: Reference Sequence Graph Round-trip" begin
         Test.@testset "String Graph Base Case" begin
             # Test with simple strings

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -192,7 +192,7 @@ include_all_tests(joinpath(@__DIR__, "4_assembly"))
 #         "test/4_assembly/dna_qualmer_graph_test.jl",
 #         "test/4_assembly/dna_qualmer_singlestrand_test.jl",
 #         "test/4_assembly/doublestrand_canonicalization_test.jl",
-#         "test/4_assembly/end_to_end_assembly_tests.jl", # broken with infinite loop somewhere?
+#         "test/4_assembly/end_to_end_assembly_tests.jl",
 #         "test/4_assembly/end_to_end_graph_tests.jl",
 #         "test/4_assembly/evidence_functions_test.jl",
 #         "test/4_assembly/evidence_structures_test.jl",


### PR DESCRIPTION
Gas Town recovery submission for bead my-6x0.

Commit: 937efcf30f78b942ce4cf9df8601e43d243d6574

Summary:
- Make end_to_end_assembly_tests.jl deterministic in the stage-4 include sweep.
- Wrap the testset in local RNG seed/restore behavior so default RNG fixture generation does not leak state to later include_all_tests files.
- Remove the stale runtests.jl comment marking the file as broken with an infinite loop.

Verification recorded on bead my-6x0:
- Targeted include of test/4_assembly/end_to_end_assembly_tests.jl passed under timeout with 74,510 pass in 18.6s.
- Stage-4 include-order prefix through end_to_end_assembly_tests.jl passed under timeout, with the target passing in sweep context with 74,510 pass in 3.2s.
- git diff --check clean.

Recovery note:
- gt done was blocked during the Dolt/source-footer failure window; the branch was already pushed. Mayor recovered by verifying the pushed branch and creating this draft PR manually.