### PR TITLE
add: HPC benchmark sbatch wrappers + env preflight

### DIFF
--- a/benchmarking/README.md
+++ b/benchmarking/README.md
@@ -104,6 +104,27 @@ mamba env create -f deps/autocycler/environment.yml
 julia --project=. -e "import Pkg; Pkg.add(\"BenchmarkTools\")"
 ```
 
+### HPC environment preflight
+
+Before submitting a benchmark job on a cluster, run the one-shot preflight on a
+login node. It runs `Pkg.resolve()` → `Pkg.instantiate()` → `Pkg.precompile()`,
+which repairs the common failure where a cluster checkout has a stale, untracked
+`Manifest.toml` missing a dependency (e.g. HDF5 added to `Project.toml` after the
+manifest was last built) — `Pkg.instantiate()` alone refuses to proceed in that
+case. First-time precompilation can take 10-30 min, so do this outside the
+time-limited batch window.
+
+```bash
+# Load the cluster's julia module first, then run the preflight:
+module load julia/1.10.10            # NERSC (Lawrencium: julia/1.10.2-11.4)
+benchmarking/hpc-setup.sh
+```
+
+The SLURM wrappers (`run_talk_subset_benchmark.sbatch` for NERSC,
+`run_talk_subset_benchmark_lrc.sbatch` for Lawrencium) assume this preflight has
+already been run. On a cluster with an unreliable login node, run the preflight
+steps inside the batch job instead (so only `sbatch` needs the connection).
+
 ### Benchmark Configuration
 
 The benchmarking suite supports three scales via environment variables:

--- a/benchmarking/hpc-setup.sh
+++ b/benchmarking/hpc-setup.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+#
+# hpc-setup.sh — one-shot Julia environment preflight for HPC benchmark runs.
+#
+# Resolves, instantiates, and precompiles the Mycelia project so that the first
+# `import Mycelia` inside a batch job does not fail. This guards against the
+# failure mode where a cluster checkout has a stale, untracked Manifest.toml
+# (e.g. missing a dependency such as HDF5 that was added to Project.toml after
+# the manifest was last built) — `Pkg.instantiate()` alone refuses to proceed,
+# so `Pkg.resolve()` must run first to reconcile the manifest with Project.toml.
+#
+# Run this ONCE on a login node before submitting a benchmark sbatch job.
+# Precompilation is CPU-only and allowed on login nodes; it can take 10-30 min
+# the first time, so do NOT bury it inside the (time-limited) batch window.
+#
+# Prerequisite: a `julia` (1.10.x) must already be on PATH — load the cluster's
+# module first, e.g. `module load julia/1.10.10` (NERSC) or
+# `module load julia/1.10.2-11.4` (Lawrencium). On HPC, LD_LIBRARY_PATH is
+# cleared here to avoid system libstdc++ conflicts.
+#
+# Usage:
+#   benchmarking/hpc-setup.sh            # set up the parent Mycelia project
+#   benchmarking/hpc-setup.sh --help
+#
+set -euo pipefail
+
+usage() {
+    grep '^#' "$0" | sed 's/^# \{0,1\}//'
+}
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+    usage
+    exit 0
+fi
+
+# Project root is the parent of this script's benchmarking/ directory.
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+project_dir="$(cd "${script_dir}/.." && pwd)"
+
+if ! command -v julia >/dev/null 2>&1; then
+    echo "ERROR: julia not found on PATH. Load the cluster's julia module first," >&2
+    echo "       e.g. 'module load julia/1.10.10'." >&2
+    exit 1
+fi
+
+echo "=== Mycelia HPC env preflight ==="
+echo "julia:       $(command -v julia) ($(LD_LIBRARY_PATH="" julia --version))"
+echo "project:     ${project_dir}"
+echo "depot:       ${JULIA_DEPOT_PATH:-<julia default>}"
+echo "start:       $(date)"
+
+# resolve (repair stale/missing manifest) -> instantiate -> precompile.
+LD_LIBRARY_PATH="" julia --project="${project_dir}" -e '
+    import Pkg
+    Pkg.resolve()
+    Pkg.instantiate()
+    Pkg.precompile()
+'
+
+echo "--- sanity: import Mycelia ---"
+LD_LIBRARY_PATH="" julia --project="${project_dir}" -e 'import Mycelia; println("MYCELIA_IMPORT_OK")'
+
+echo "=== preflight complete: $(date) ==="

--- a/benchmarking/hpc-setup.sh
+++ b/benchmarking/hpc-setup.sh
@@ -25,7 +25,8 @@
 set -euo pipefail
 
 usage() {
-    grep '^#' "$0" | sed 's/^# \{0,1\}//'
+    # Print the header comment block as help, skipping the shebang line.
+    grep '^#' "$0" | grep -v '^#!' | sed 's/^# \{0,1\}//'
 }
 
 if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then

--- a/benchmarking/run_talk_subset_benchmark.sbatch
+++ b/benchmarking/run_talk_subset_benchmark.sbatch
@@ -1,0 +1,64 @@
+#!/bin/bash
+#SBATCH --job-name=mycelia_talk_bench
+#SBATCH --account=m4269
+#SBATCH --constraint=cpu
+#SBATCH --qos=regular
+#SBATCH --nodes=1
+#SBATCH --cpus-per-task=16
+#SBATCH --time=02:00:00
+#SBATCH --output=talk_bench_%j.out
+#SBATCH --error=talk_bench_%j.err
+
+# Self-contained Julia benchmark subset for the LBNL talk (td-756dg).
+# Pure-Julia steps only (no conda/external-tool deps): k-mer scaling + data processing.
+#
+# NERSC/Perlmutter wrapper. Run from benchmarking/:  sbatch run_talk_subset_benchmark.sbatch
+# Prereq: Mycelia deps instantiated/precompiled once on a login node:
+#   cd ~/workspace/Mycelia && LD_LIBRARY_PATH="" julia --project=. -e 'import Pkg; Pkg.instantiate(); Pkg.precompile()'
+set -uo pipefail
+echo "=== Mycelia talk-subset benchmark ==="
+echo "Job: ${SLURM_JOB_ID}  Node: ${SLURM_NODELIST}  CPUs: ${SLURM_CPUS_PER_TASK}  Start: $(date)"
+
+# Do NOT `module purge` here: it strips the Cray PE defaults, after which NERSC's
+# juliaup modulefile errors ("attempt to index a nil value") and `julia` vanishes
+# from PATH. Restore the PE defaults defensively, then load julia.
+source /opt/cray/pe/cpe/25.09/restore_lmod_system_defaults.sh 2>/dev/null || true
+module load julia/1.10.10
+
+# Resolve the julia binary explicitly so the job fails loudly if the module is broken.
+JULIA="$(command -v julia || true)"
+if [[ -z "${JULIA}" ]]; then
+  JULIA=/global/common/software/nersc9/julia/1.10.10/bin/julia
+fi
+echo "JULIA: ${JULIA}  ($(${JULIA} --version 2>&1 | head -1))"
+
+export JULIA_NUM_THREADS=${SLURM_CPUS_PER_TASK}
+# HPC Julia rule: clear LD_LIBRARY_PATH to avoid system libstdc++ conflicts.
+export LD_LIBRARY_PATH=""
+
+cd "${HOME}/workspace/Mycelia/benchmarking" || exit 1
+
+run_one () {
+  local f="$1"
+  echo ""
+  echo ">>> RUN ${f}  $(date)"
+  if LD_LIBRARY_PATH="" "${JULIA}" --project=.. "${f}"; then
+    echo ">>> OK  ${f}"
+  else
+    echo ">>> FAIL ${f} (continuing)"
+  fi
+}
+
+run_one 02_kmer_analysis_benchmark.jl
+run_one 01_data_processing_benchmark.jl
+
+echo ""
+echo "=== complete: $(date) ==="
+echo "--- result JSONs ---"
+# `|| true`: a non-matching glob makes `ls` exit non-zero, which `pipefail`
+# would otherwise propagate as the job's exit code (false FAILED in sacct).
+ls -t results/*.json 2>/dev/null | head || true
+
+# Per-benchmark status is reported via the >>> OK/FAIL markers above; exit clean
+# so SLURM's job state reflects the wrapper running to completion.
+exit 0

--- a/benchmarking/run_talk_subset_benchmark.sbatch
+++ b/benchmarking/run_talk_subset_benchmark.sbatch
@@ -26,19 +26,31 @@ echo "Job: ${SLURM_JOB_ID}  Node: ${SLURM_NODELIST}  CPUs: ${SLURM_CPUS_PER_TASK
 source /opt/cray/pe/cpe/25.09/restore_lmod_system_defaults.sh 2>/dev/null || true
 module load julia/1.10.10
 
-# Resolve the julia binary explicitly so the job fails loudly if the module is broken.
+# Resolve the julia binary explicitly, with a fallback if the module is broken.
 JULIA="$(command -v julia || true)"
 if [[ -z "${JULIA}" ]]; then
   JULIA=/global/common/software/nersc9/julia/1.10.10/bin/julia
 fi
-echo "JULIA: ${JULIA}  ($(${JULIA} --version 2>&1 | head -1))"
+# Validate it actually runs — a broken `module load` (NERSC's juliaup modulefile
+# can error) or a relocated fallback path must fail the job LOUDLY here, not
+# silently produce a green job with no results downstream.
+if ! "${JULIA}" --version >/dev/null 2>&1; then
+  echo "ERROR: julia not runnable at '${JULIA}' — module load failed or path stale." >&2
+  exit 1
+fi
+echo "JULIA: ${JULIA}  ($("${JULIA}" --version 2>&1 | head -1))"
 
 export JULIA_NUM_THREADS=${SLURM_CPUS_PER_TASK}
+# Pin the depot so the batch job reuses what hpc-setup.sh precompiled on the login
+# node (SLURM does not reliably inherit interactive-shell exports). `:-` keeps any
+# value already exported by the environment/.bashrc.
+export JULIA_DEPOT_PATH="${JULIA_DEPOT_PATH:-${HOME}/.julia}"
 # HPC Julia rule: clear LD_LIBRARY_PATH to avoid system libstdc++ conflicts.
 export LD_LIBRARY_PATH=""
 
 cd "${HOME}/workspace/Mycelia/benchmarking" || exit 1
 
+fail_count=0
 run_one () {
   local f="$1"
   echo ""
@@ -47,6 +59,7 @@ run_one () {
     echo ">>> OK  ${f}"
   else
     echo ">>> FAIL ${f} (continuing)"
+    fail_count=$((fail_count + 1))
   fi
 }
 
@@ -60,6 +73,11 @@ echo "--- result JSONs ---"
 # would otherwise propagate as the job's exit code (false FAILED in sacct).
 ls -t results/*.json 2>/dev/null | head || true
 
-# Per-benchmark status is reported via the >>> OK/FAIL markers above; exit clean
-# so SLURM's job state reflects the wrapper running to completion.
+# Exit non-zero if any benchmark failed so SLURM's job state is truthful — a
+# partial run dropping a result must NOT read as COMPLETED. (The empty-glob above
+# is neutralized separately by `|| true`, so it cannot flip the job red.)
+if [[ "${fail_count}" -gt 0 ]]; then
+  echo "=== ${fail_count} benchmark(s) FAILED ==="
+  exit 1
+fi
 exit 0

--- a/benchmarking/run_talk_subset_benchmark_lrc.sbatch
+++ b/benchmarking/run_talk_subset_benchmark_lrc.sbatch
@@ -22,9 +22,15 @@ echo "Job: ${SLURM_JOB_ID}  Node: ${SLURM_NODELIST}  CPUs: ${SLURM_CPUS_PER_TASK
 
 module load julia/1.10.2-11.4
 
-# Resolve the julia binary explicitly so the job fails loudly if the module is broken.
+# Resolve the julia binary explicitly and fail LOUDLY if the module did not put
+# julia on PATH — otherwise an empty ${JULIA} would run `--project=.. file.jl` as
+# a command, fail both benchmarks, and still exit green with no results.
 JULIA="$(command -v julia || true)"
-echo "JULIA: ${JULIA}"
+if [[ -z "${JULIA}" ]] || ! "${JULIA}" --version >/dev/null 2>&1; then
+  echo "ERROR: julia not runnable after 'module load julia/1.10.2-11.4'." >&2
+  exit 1
+fi
+echo "JULIA: ${JULIA}  ($("${JULIA}" --version 2>&1 | head -1))"
 
 export JULIA_NUM_THREADS=${SLURM_CPUS_PER_TASK}
 # Use the group depot (where hpc-setup.sh precompiled the deps); also set by .bashrc.
@@ -34,6 +40,7 @@ export LD_LIBRARY_PATH=""
 
 cd "${HOME}/workspace/Mycelia/benchmarking" || exit 1
 
+fail_count=0
 run_one () {
   local f="$1"
   echo ""
@@ -42,6 +49,7 @@ run_one () {
     echo ">>> OK  ${f}"
   else
     echo ">>> FAIL ${f} (continuing)"
+    fail_count=$((fail_count + 1))
   fi
 }
 
@@ -55,6 +63,10 @@ echo "--- result JSONs ---"
 # would otherwise propagate as the job's exit code (false FAILED in sacct).
 ls -t results/*.json 2>/dev/null | head || true
 
-# Per-benchmark status is reported via the >>> OK/FAIL markers above; exit clean
-# so SLURM's job state reflects the wrapper running to completion.
+# Exit non-zero if any benchmark failed so SLURM's job state is truthful — a
+# partial run dropping a result must NOT read as COMPLETED.
+if [[ "${fail_count}" -gt 0 ]]; then
+  echo "=== ${fail_count} benchmark(s) FAILED ==="
+  exit 1
+fi
 exit 0

--- a/benchmarking/run_talk_subset_benchmark_lrc.sbatch
+++ b/benchmarking/run_talk_subset_benchmark_lrc.sbatch
@@ -1,39 +1,34 @@
 #!/bin/bash
 #SBATCH --job-name=mycelia_talk_bench
-#SBATCH --account=m4269
-#SBATCH --constraint=cpu
-#SBATCH --qos=regular
+#SBATCH --account=pc_mfnanofabio
+#SBATCH --partition=lr6
+#SBATCH --qos=lr_normal
 #SBATCH --nodes=1
+#SBATCH --ntasks=1
 #SBATCH --cpus-per-task=16
 #SBATCH --time=02:00:00
-#SBATCH --output=talk_bench_%j.out
-#SBATCH --error=talk_bench_%j.err
+#SBATCH --output=talk_bench_lrc_%j.out
+#SBATCH --error=talk_bench_lrc_%j.err
 
-# Self-contained Julia benchmark subset for the LBNL talk (td-756dg).
+# Self-contained Julia benchmark subset for the LBNL talk (td-756dg) — Lawrencium.
 # Pure-Julia steps only (no conda/external-tool deps): k-mer scaling + data processing.
 #
-# NERSC/Perlmutter wrapper. Run from benchmarking/:  sbatch run_talk_subset_benchmark.sbatch
+# Run from benchmarking/:  sbatch run_talk_subset_benchmark_lrc.sbatch
 # Prereq: deps instantiated once on a login node (repairs a stale manifest that
 # is missing HDF5, then precompiles):  benchmarking/hpc-setup.sh
-#   (load the julia module first, e.g. `module load julia/1.10.10`)
 set -uo pipefail
-echo "=== Mycelia talk-subset benchmark ==="
+echo "=== Mycelia talk-subset benchmark (Lawrencium) ==="
 echo "Job: ${SLURM_JOB_ID}  Node: ${SLURM_NODELIST}  CPUs: ${SLURM_CPUS_PER_TASK}  Start: $(date)"
 
-# Do NOT `module purge` here: it strips the Cray PE defaults, after which NERSC's
-# juliaup modulefile errors ("attempt to index a nil value") and `julia` vanishes
-# from PATH. Restore the PE defaults defensively, then load julia.
-source /opt/cray/pe/cpe/25.09/restore_lmod_system_defaults.sh 2>/dev/null || true
-module load julia/1.10.10
+module load julia/1.10.2-11.4
 
 # Resolve the julia binary explicitly so the job fails loudly if the module is broken.
 JULIA="$(command -v julia || true)"
-if [[ -z "${JULIA}" ]]; then
-  JULIA=/global/common/software/nersc9/julia/1.10.10/bin/julia
-fi
-echo "JULIA: ${JULIA}  ($(${JULIA} --version 2>&1 | head -1))"
+echo "JULIA: ${JULIA}"
 
 export JULIA_NUM_THREADS=${SLURM_CPUS_PER_TASK}
+# Use the group depot (where hpc-setup.sh precompiled the deps); also set by .bashrc.
+export JULIA_DEPOT_PATH="${JULIA_DEPOT_PATH:-/global/home/groups-sw/pc_mfnanofabio/cjprybol/.julia_depot}"
 # HPC Julia rule: clear LD_LIBRARY_PATH to avoid system libstdc++ conflicts.
 export LD_LIBRARY_PATH=""
 


### PR DESCRIPTION
## Summary

- Version-controls the talk-subset benchmark SLURM wrappers that previously lived only on the clusters (re-authored every session).
- Adds `benchmarking/hpc-setup.sh`: a one-shot env preflight (`Pkg.resolve()` → `instantiate()` → `precompile()`) that repairs the common cluster failure where a stale, untracked `Manifest.toml` is missing a dependency (HDF5) — `instantiate` alone refuses; `resolve` reconciles it.
- Encodes three HPC fixes found while debugging the blocked benchmark runs:
  - NERSC: don't `module purge` (it breaks NERSC's juliaup modulefile → `julia: command not found`); source the PE-defaults restore script and resolve the binary explicitly.
  - Both wrappers: the final `ls *results*.json | head` tripped `pipefail` on a non-matching glob → false `FAILED` in `sacct`. Fixed with `ls results/*.json || true`.
  - Lawrencium wrapper: the prior cluster-local copy had a no-op `run_one` that never invoked julia.
- Post-review hardening (comprehensive-pr-review, code-reviewer + silent-failure-hunter converged): track `fail_count` and `exit 1` if any benchmark fails (a partial run no longer reads as `COMPLETED`); validate the resolved julia actually runs; guard an empty `JULIA` on lrc.

## Test Plan

- [x] NERSC/perlmutter: verified green — job `54715063` `COMPLETED` (exit `0:0`), both `02_kmer` + `01_data_processing` `>>> OK`, fresh JSONs in `benchmarking/results/`.
- [x] Re-verified after review fixes — job `54750871` (success path unchanged; fixes touch only failure paths).
- [x] `bash -n` clean on all three scripts.
- [ ] Lawrencium: self-contained job submitted (`23322881`); result retrieval deferred (lrc SSH auth is intermittent). The lrc wrapper is a mirror of the verified NERSC one but its own run is unverified pending a stable connection.

## Notes

No Julia source or tests changed — bash/SLURM/docs only. The benchmark code bugs originally attributed to this work were already fixed in master `051e9297`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added HPC cluster environment setup documentation with preflight initialization procedures and recommendations for login node vs. batch job execution scenarios

* **Chores**
  * Added automated Julia environment preflight script for initializing HPC cluster environments
  * Added SLURM batch scripts for submitting and running benchmarking workloads on compute clusters

<!-- end of auto-generated comment: release notes by coderabbit.ai -->