### PR TITLE
refactor: lift durable HPC Julia pattern into sbatch renderer default (td-2rfi)

### DIFF
--- a/src/slurm-templates.jl
+++ b/src/slurm-templates.jl
@@ -562,6 +562,27 @@ function validate(job::JobSpec; check_lawrencium_associations::Bool = true)::Job
         push!(report.errors, "Unsupported container_engine $(normalized_job.container_engine)")
     end
 
+    # td-2rfi: warn if the caller's env shadows a durable-pattern key. For
+    # NERSC/Lawrencium Julia jobs _durable_julia_prelude injects these, and a
+    # caller override (emitted AFTER the durable block, so it wins) silently
+    # reopens the concurrent-depot race or thread oversubscription the pattern
+    # exists to prevent.
+    if normalized_job.site in (:nersc, :lawrencium) &&
+       occursin(r"(?:^|[\s/])julia\b", normalized_job.cmd)
+        for key in (
+            "JULIA_DEPOT_PATH", "JULIA_PKG_OFFLINE", "JULIA_NUM_THREADS",
+            "OPENBLAS_NUM_THREADS", "JULIA_NUM_PRECOMPILE_TASKS"
+        )
+            if haskey(normalized_job.env, key)
+                push!(
+                    report.warnings,
+                    "env['$key'] overrides the td-2rfi durable HPC default; the " *
+                    "concurrent-depot race or thread oversubscription it guards " *
+                    "against may reappear")
+            end
+        end
+    end
+
     return report
 end
 
@@ -1081,7 +1102,9 @@ end
 #   1. concurrent shared-depot writes corrupt the manifest (exit 1) -> per-job
 #      WRITABLE scratch depot layered in FRONT of the shared READ depot;
 #   2. ~50min cold precompile tax + offline safety -> JULIA_PKG_OFFLINE reuses
-#      the cached .ji from the shared layer;
+#      the cached .ji from the shared layer; JULIA_NUM_PRECOMPILE_TASKS caps the
+#      precompile workers (Julia otherwise sizes them to the whole node and
+#      deadlocks thrashing the shared depot);
 #   3. JULIA_NUM_THREADS=auto oversubscribes a shared node and segfaults (exit
 #      139) -> pin threads (and OPENBLAS) to the allocation.
 # Generic on purpose: the shared-depot fallback is the caller's own
@@ -1107,7 +1130,11 @@ function _durable_julia_prelude(job::JobSpec)::Union{Nothing, String}
             "export JULIA_NUM_THREADS=\"$(threads)\"",
             "export OPENBLAS_NUM_THREADS=\"$(threads)\"",
             "export JULIA_DEPOT_PATH=\"$(depot)\"",
-            "export JULIA_PKG_OFFLINE=true"
+            "export JULIA_PKG_OFFLINE=true",
+            "# Cap precompile workers: Julia sizes precompilation to the node's full",
+            "# Sys.CPU_THREADS regardless of our allocation; too many thrash the shared",
+            "# depot and deadlock (no output). Harmless when the allocation is small.",
+            "export JULIA_NUM_PRECOMPILE_TASKS=8"
         ],
         "\n")
 end

--- a/src/slurm-templates.jl
+++ b/src/slurm-templates.jl
@@ -1086,7 +1086,9 @@ end
 #      139) -> pin threads (and OPENBLAS) to the allocation.
 # Generic on purpose: the shared-depot fallback is the caller's own
 # JULIA_DEPOT_PATH (else $HOME/.julia) — no project/user paths baked into the
-# shared package. For live progress, callers should invoke julia with -u.
+# shared package. For live progress, callers should run julia under a pseudo-TTY
+# (e.g. `script -e -q -c "julia ..." /dev/null`) so output line-buffers — Julia
+# has no unbuffered-output flag (`julia -u` errors at startup).
 function _durable_julia_prelude(job::JobSpec)::Union{Nothing, String}
     job.site in (:nersc, :lawrencium) || return nothing
     occursin(r"(?:^|[\s/])julia\b", job.cmd) || return nothing

--- a/src/slurm-templates.jl
+++ b/src/slurm-templates.jl
@@ -557,14 +557,16 @@ function validate(job::JobSpec; check_lawrencium_associations::Bool = true)::Job
         end
     end
 
-    if normalized_job.container_engine !== nothing && !(normalized_job.container_engine in VALID_CONTAINER_ENGINES)
+    if normalized_job.container_engine !== nothing &&
+       !(normalized_job.container_engine in VALID_CONTAINER_ENGINES)
         push!(report.errors, "Unsupported container_engine $(normalized_job.container_engine)")
     end
 
     return report
 end
 
-function _validate_nersc!(report::JobSpecValidation, job::JobSpec, parsed_time::Union{Nothing, Int})
+function _validate_nersc!(report::JobSpecValidation, job::JobSpec, parsed_time::Union{
+        Nothing, Int})
     if job.account === nothing
         push!(report.errors, "NERSC jobs require account (-A)")
     end
@@ -581,7 +583,8 @@ function _validate_nersc!(report::JobSpecValidation, job::JobSpec, parsed_time::
             push!(report.errors, "NERSC debug QoS max walltime is 00:30:00")
         elseif qos == "interactive" && parsed_time > 4 * 60 * 60
             push!(report.errors, "NERSC interactive QoS max walltime is 04:00:00")
-        elseif qos in Set(["regular", "shared", "preempt", "premium", "overrun", "shared_overrun"])
+        elseif qos in Set([
+            "regular", "shared", "preempt", "premium", "overrun", "shared_overrun"])
             if parsed_time > 48 * 60 * 60
                 push!(report.errors, "NERSC $qos QoS max walltime is 48:00:00")
             end
@@ -639,7 +642,8 @@ function _validate_lawrencium!(
         push!(report.errors, "Lawrencium jobs require account")
     end
 
-    if job.partition !== nothing && startswith(lowercase(job.partition), "lr") && job.qos === nothing
+    if job.partition !== nothing && startswith(lowercase(job.partition), "lr") &&
+       job.qos === nothing
         push!(report.warnings,
             "Lawrencium qos not set; defaulting to lr_normal for lr* partitions")
     end
@@ -688,7 +692,8 @@ function _association_permits(job::JobSpec, parsed::Vector{Dict{String, Any}})::
         end
 
         partition = lowercase(something(get(row, "partition", nothing), ""))
-        if !isempty(target_partition) && !isempty(partition) && partition != target_partition
+        if !isempty(target_partition) && !isempty(partition) &&
+           partition != target_partition
             continue
         end
 
@@ -1069,6 +1074,42 @@ function _build_sbatch_directives(job::JobSpec)::String
     return join(lines, "\n")
 end
 
+# Durable HPC Julia pattern (td-2rfi). Emitted only for Julia commands on the
+# HPC sites that have a per-job scratch + shared read depot (NERSC, Lawrencium).
+# Returns `nothing` elsewhere so non-Julia steps and local/scg/cloud jobs render
+# unchanged. The three failure modes this fixes, all root-caused on Perlmutter:
+#   1. concurrent shared-depot writes corrupt the manifest (exit 1) -> per-job
+#      WRITABLE scratch depot layered in FRONT of the shared READ depot;
+#   2. ~50min cold precompile tax + offline safety -> JULIA_PKG_OFFLINE reuses
+#      the cached .ji from the shared layer;
+#   3. JULIA_NUM_THREADS=auto oversubscribes a shared node and segfaults (exit
+#      139) -> pin threads (and OPENBLAS) to the allocation.
+# Generic on purpose: the shared-depot fallback is the caller's own
+# JULIA_DEPOT_PATH (else $HOME/.julia) — no project/user paths baked into the
+# shared package. For live progress, callers should invoke julia with -u.
+function _durable_julia_prelude(job::JobSpec)::Union{Nothing, String}
+    job.site in (:nersc, :lawrencium) || return nothing
+    occursin(r"(?:^|[\s/])julia\b", job.cmd) || return nothing
+    threads = "\${SLURM_CPUS_PER_TASK:-\${SLURM_CPUS_ON_NODE:-8}}"
+    scratch_expr = job.site == :nersc ? "\${SCRATCH:?}" :
+                   "\${SCRATCH:-/global/scratch/users/\$USER}"
+    depot = scratch_expr *
+            "/jldepot_\${SLURM_JOB_ID}:\${JULIA_DEPOT_PATH:-\$HOME/.julia}"
+    return join(
+        [
+            "# --- Durable HPC Julia pattern (td-2rfi) -----------------------------------",
+            "# Per-job WRITABLE scratch depot in front of the shared READ depot, run",
+            "# OFFLINE: avoids the concurrent-depot race (manifest corruption) and the",
+            "# ~50min precompile tax. Threads pinned to the allocation (auto",
+            "# oversubscribes shared nodes -> exit-139 segfault). Inert for non-Julia steps.",
+            "export JULIA_NUM_THREADS=\"$(threads)\"",
+            "export OPENBLAS_NUM_THREADS=\"$(threads)\"",
+            "export JULIA_DEPOT_PATH=\"$(depot)\"",
+            "export JULIA_PKG_OFFLINE=true"
+        ],
+        "\n")
+end
+
 function _build_prelude_block(job::JobSpec)::String
     lines = String[]
 
@@ -1081,6 +1122,11 @@ function _build_prelude_block(job::JobSpec)::String
         for module_name in job.modules
             push!(lines, "module load " * _shell_quote(module_name))
         end
+    end
+
+    durable = _durable_julia_prelude(job)
+    if durable !== nothing
+        push!(lines, durable)
     end
 
     if !isempty(job.env)
@@ -1476,14 +1522,15 @@ function _cloudbuild_content(job::JobSpec)::String
     push!(lines, "steps:")
 
     if has_dockerfile
-        append!(lines, [
-            "- id: build-image",
-            "  name: gcr.io/cloud-builders/docker",
-            "  args: ['build', '-t', '\${_IMAGE_URI}', '.']",
-            "- id: push-image",
-            "  name: gcr.io/cloud-builders/docker",
-            "  args: ['push', '\${_IMAGE_URI}']"
-        ])
+        append!(lines,
+            [
+                "- id: build-image",
+                "  name: gcr.io/cloud-builders/docker",
+                "  args: ['build', '-t', '\${_IMAGE_URI}', '.']",
+                "- id: push-image",
+                "  name: gcr.io/cloud-builders/docker",
+                "  args: ['push', '\${_IMAGE_URI}']"
+            ])
     elseif job.container_image === nothing
         error("cloudbuild backend requires container_image or Dockerfile")
     end
@@ -1675,9 +1722,10 @@ function submit(
                 artifact_path = artifact_path,
                 artifact_text = artifact_text,
                 submit_command = submit_command,
-                warnings = vcat(report.warnings, [
-                    "Cloud Build config written; set execute_cloudbuild=true to run gcloud submit"
-                ]),
+                warnings = vcat(report.warnings,
+                    [
+                        "Cloud Build config written; set execute_cloudbuild=true to run gcloud submit"
+                    ]),
                 errors = report.errors
             )
         end
@@ -1751,9 +1799,10 @@ function submit(
                 backend = :salloc,
                 artifact_text = artifact_text,
                 submit_command = submit_command,
-                warnings = vcat(report.warnings, [
-                    "Interactive command generated; set execute_interactive=true to run it"
-                ]),
+                warnings = vcat(report.warnings,
+                    [
+                        "Interactive command generated; set execute_interactive=true to run it"
+                    ]),
                 errors = report.errors
             )
         end
@@ -1975,11 +2024,12 @@ function parse_lawrencium_associations(raw::AbstractString)::Vector{Dict{String,
             [strip(value) for value in split(qos_raw, ',') if !isempty(strip(value))]
         end
 
-        push!(parsed, Dict(
-            "account" => something(account, ""),
-            "partition" => partition,
-            "qos" => qos_values
-        ))
+        push!(parsed,
+            Dict(
+                "account" => something(account, ""),
+                "partition" => partition,
+                "qos" => qos_values
+            ))
     end
 
     return parsed
@@ -2010,7 +2060,9 @@ function summarize_job(jobid::Union{Int, AbstractString}; io::IO = stdout)
 
     if Sys.which("sacct") !== nothing
         try
-            outputs["sacct"] = read(`sacct -j $jobid_string --format=JobID,JobName,AllocCPUS,Elapsed,State,ExitCode,MaxRSS`, String)
+            outputs["sacct"] = read(
+                `sacct -j $jobid_string --format=JobID,JobName,AllocCPUS,Elapsed,State,ExitCode,MaxRSS`,
+                String)
         catch e
             outputs["sacct"] = "ERROR: $(e)"
         end
@@ -2020,7 +2072,8 @@ function summarize_job(jobid::Union{Int, AbstractString}; io::IO = stdout)
 
     if Sys.which("sstat") !== nothing
         try
-            outputs["sstat"] = read(`sstat -j $(jobid_string).batch --format=JobID,MaxRSS,MaxVMSize,AvgCPU`, String)
+            outputs["sstat"] = read(
+                `sstat -j $(jobid_string).batch --format=JobID,MaxRSS,MaxVMSize,AvgCPU`, String)
         catch e
             outputs["sstat"] = "ERROR: $(e)"
         end

--- a/test/8_tool_integration/slurm_template_system.jl
+++ b/test/8_tool_integration/slurm_template_system.jl
@@ -352,8 +352,17 @@ Test.@testset "Durable HPC Julia prelude (td-2rfi)" begin
     Test.@test occursin(
         "export JULIA_NUM_THREADS=\"\${SLURM_CPUS_PER_TASK:-\${SLURM_CPUS_ON_NODE:-8}}\"",
         rendered)
+    # OpenBLAS pin is part of the exit-139 segfault fix — assert it too.
+    Test.@test occursin(
+        "export OPENBLAS_NUM_THREADS=\"\${SLURM_CPUS_PER_TASK:-\${SLURM_CPUS_ON_NODE:-8}}\"",
+        rendered)
+    # Precompile-worker cap (matches the hand-validated wrappers).
+    Test.@test occursin("export JULIA_NUM_PRECOMPILE_TASKS=8", rendered)
     # Generic shared-depot fallback — no project/user paths baked into the package.
     Test.@test occursin("\${JULIA_DEPOT_PATH:-\$HOME/.julia}", rendered)
+    # NERSC must NOT leak the Lawrencium-specific scratch path (site branches must
+    # not be swapped/collapsed).
+    Test.@test !occursin("/global/scratch/users", rendered)
 
     # A Lawrencium Julia job uses the lrc scratch fallback (NERSC's CFS path
     # does not exist there).
@@ -388,6 +397,47 @@ Test.@testset "Durable HPC Julia prelude (td-2rfi)" begin
         time_limit = "04:00:00"
     )
     Test.@test !occursin("JULIA_PKG_OFFLINE", Mycelia.render_sbatch(nersc_python))
+
+    # The word-boundary guard must reject `julia` as a substring of another token
+    # (e.g. a `myjulia` wrapper) so it can't silently emit a non-durable block.
+    nersc_notjulia = Mycelia.JobSpec(
+        job_name = "durable-nersc-notjulia",
+        cmd = "./myjulia-wrapper run",
+        site = :nersc,
+        account = "m1234",
+        qos = "shared",
+        constraint = "cpu",
+        ntasks = 1,
+        cpus_per_task = 4,
+        mem_gb = 8,
+        time_limit = "04:00:00"
+    )
+    Test.@test !occursin("JULIA_PKG_OFFLINE", Mycelia.render_sbatch(nersc_notjulia))
+
+    # Durable block precedes the user-env block, so a caller's explicit override
+    # wins (emitted after). Lock that ordering, and assert validate() warns that
+    # the override reopens the race the pattern guards against.
+    nersc_julia_env = Mycelia.JobSpec(
+        job_name = "durable-nersc-julia-env",
+        cmd = "julia run.jl",
+        site = :nersc,
+        account = "m1234",
+        qos = "shared",
+        constraint = "cpu",
+        ntasks = 1,
+        cpus_per_task = 16,
+        mem_gb = 64,
+        time_limit = "06:00:00",
+        env = Dict("JULIA_DEPOT_PATH" => "/my/override")
+    )
+    rendered_env = Mycelia.render_sbatch(nersc_julia_env)
+    durable_idx = findfirst("export JULIA_PKG_OFFLINE=true", rendered_env)
+    override_idx = findlast("/my/override", rendered_env)
+    Test.@test durable_idx !== nothing
+    Test.@test override_idx !== nothing
+    Test.@test first(durable_idx) < first(override_idx)
+    warnings = Mycelia.validate(nersc_julia_env; check_lawrencium_associations = false).warnings
+    Test.@test any(w -> occursin("td-2rfi durable", w) && occursin("JULIA_DEPOT_PATH", w), warnings)
 end
 
 Test.@testset "SLURM wrapper entrypoints" begin

--- a/test/8_tool_integration/slurm_template_system.jl
+++ b/test/8_tool_integration/slurm_template_system.jl
@@ -331,6 +331,65 @@ Test.@testset "Template rendering and fixture checks" begin
     Test.@test rendered_cloud == expected_cloud
 end
 
+Test.@testset "Durable HPC Julia prelude (td-2rfi)" begin
+    # A NERSC Julia job inherits the durable pattern: per-job scratch depot
+    # layered over the shared read depot, offline, threads pinned to the alloc.
+    nersc_julia = Mycelia.JobSpec(
+        job_name = "durable-nersc-julia",
+        cmd = "julia --project=. experiments/run.jl",
+        site = :nersc,
+        account = "m1234",
+        qos = "shared",
+        constraint = "cpu",
+        ntasks = 1,
+        cpus_per_task = 16,
+        mem_gb = 64,
+        time_limit = "06:00:00"
+    )
+    rendered = Mycelia.render_sbatch(nersc_julia)
+    Test.@test occursin("export JULIA_PKG_OFFLINE=true", rendered)
+    Test.@test occursin("\${SCRATCH:?}/jldepot_\${SLURM_JOB_ID}", rendered)
+    Test.@test occursin(
+        "export JULIA_NUM_THREADS=\"\${SLURM_CPUS_PER_TASK:-\${SLURM_CPUS_ON_NODE:-8}}\"",
+        rendered)
+    # Generic shared-depot fallback — no project/user paths baked into the package.
+    Test.@test occursin("\${JULIA_DEPOT_PATH:-\$HOME/.julia}", rendered)
+
+    # A Lawrencium Julia job uses the lrc scratch fallback (NERSC's CFS path
+    # does not exist there).
+    lrc_julia = Mycelia.JobSpec(
+        job_name = "durable-lrc-julia",
+        cmd = "julia run.jl",
+        site = :lawrencium,
+        partition = "lr6",
+        qos = "lr_normal",
+        account = "pc_example",
+        ntasks = 1,
+        cpus_per_task = 8,
+        mem_gb = 16,
+        time_limit = "04:00:00"
+    )
+    Test.@test occursin(
+        "\${SCRATCH:-/global/scratch/users/\$USER}/jldepot",
+        Mycelia.render_sbatch(lrc_julia))
+
+    # Guards: a non-Julia NERSC job and an HPC-site mismatch render WITHOUT the
+    # block (this is what keeps the golden fixtures above unchanged).
+    nersc_python = Mycelia.JobSpec(
+        job_name = "durable-nersc-python",
+        cmd = "python train.py",
+        site = :nersc,
+        account = "m1234",
+        qos = "regular",
+        constraint = "cpu",
+        ntasks = 1,
+        cpus_per_task = 4,
+        mem_gb = 8,
+        time_limit = "04:00:00"
+    )
+    Test.@test !occursin("JULIA_PKG_OFFLINE", Mycelia.render_sbatch(nersc_python))
+end
+
 Test.@testset "SLURM wrapper entrypoints" begin
     Test.@testset "lawrencium_sbatch uses env fallbacks with collect executor" begin
         mktempdir() do logdir


### PR DESCRIPTION
## Summary

- Generalizes the durable HPC-job pattern (already applied to the panlingual/rhizomorph wrappers) into the `JobSpec` sbatch renderer so every future NERSC/Lawrencium Julia job inherits it by default.
- `templates/slurm/*.sbatch` are pure token skeletons filled by the renderer, so the lift lands in `_build_prelude_block` (via a new `_durable_julia_prelude` helper), not the template text.
- The injected prelude: per-job WRITABLE scratch depot layered in front of the shared READ depot, `JULIA_PKG_OFFLINE=true`, and thread/OPENBLAS pinned to the allocation — fixing the same three failure modes (concurrent-depot corruption, ~50min precompile tax, `JULIA_NUM_THREADS=auto` segfault).
- Generic by design for a shared package: shared-depot fallback is the caller's own `JULIA_DEPOT_PATH` (else `$HOME/.julia`) — no project/user paths baked in. Scratch expr is site-correct (`${SCRATCH:?}` on NERSC, `${SCRATCH:-/global/scratch/users/$USER}` on Lawrencium).

## Test plan

- [x] Guarded on `site ∈ {nersc, lawrencium}` AND a Julia command, so existing byte-exact golden fixtures (a NERSC python job, a julia-at-SCG job) render unchanged.
- [x] New `Durable HPC Julia prelude (td-2rfi)` testset asserts the block appears for NERSC/Lawrencium Julia jobs and is absent for a NERSC python job.
- [x] Source + test files parse clean.
- [ ] Full `test/8_tool_integration/slurm_template_system.jl` run pending in CI (local full-package load blocked by an unrelated worktree precompile failure; behavior verified via isolated AST evaluation).

## Notes

Comment guidance corrected: callers wanting live progress should use a `script -e` pseudo-TTY wrap, since `julia -u` is not a valid flag.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a durable HPC Julia prelude for supported NERSC/Lawrencium Julia jobs, including thread pinning and a per-job writable scratch-backed package depot with offline/precompile settings.
* **Bug Fixes**
  * Centralized container-engine validation and added warnings when Julia-related environment variables override the durable defaults.
* **Tests**
  * Added integration coverage for NERSC and Lawrencium sbatch rendering, ensuring the prelude appears only for matching Julia jobs and correctly orders user env overrides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->