### PR TITLE
fix: O(out-degree) graph-walk + multibyte k-mer extraction (Rhizomorph)

### DIFF
--- a/src/rhizomorph/algorithms/path-finding.jl
+++ b/src/rhizomorph/algorithms/path-finding.jl
@@ -513,26 +513,36 @@ end
 function _get_valid_transitions(graph, vertex_label, strand)
     transitions = []
 
-    for edge_labels in MetaGraphsNext.edge_labels(graph)
-        if length(edge_labels) == 2 && edge_labels[1] == vertex_label
-            target_vertex = edge_labels[2]
-            edge_data = graph[edge_labels...]
+    # Enumerate only this vertex's out-edges via the underlying graph adjacency
+    # (O(out-degree)) instead of scanning every edge label in the graph (O(E)).
+    # The previous full-scan made each call O(E); since this is invoked once per
+    # vertex during start-vertex selection and once per step during every walk,
+    # the old behavior was O(V*E) for selection and O(steps*E) for generation —
+    # the dominant cost in large-graph generative modeling (notebook 15). The
+    # returned set of transitions and their probabilities are identical; only the
+    # within-vertex iteration order may differ (distribution-preserving under a
+    # fixed seed).
+    haskey(graph, vertex_label) || return transitions
 
-            edge_src_strand = _normalize_strand(edge_data.src_strand)
-            if edge_src_strand == strand
-                probability = _edge_transition_weight(edge_data)
-                if probability <= 0.0
-                    continue
-                end
+    src_code = MetaGraphsNext.code_for(graph, vertex_label)
+    for dst_code in Graphs.outneighbors(graph.graph, src_code)
+        target_vertex = MetaGraphsNext.label_for(graph, dst_code)
+        edge_data = graph[vertex_label, target_vertex]
 
-                push!(transitions,
-                    Dict(
-                        :target_vertex => target_vertex,
-                        :target_strand => _normalize_strand(edge_data.dst_strand),
-                        :probability => probability,
-                        :edge_data => edge_data
-                    ))
+        edge_src_strand = _normalize_strand(edge_data.src_strand)
+        if edge_src_strand == strand
+            probability = _edge_transition_weight(edge_data)
+            if probability <= 0.0
+                continue
             end
+
+            push!(transitions,
+                Dict(
+                    :target_vertex => target_vertex,
+                    :target_strand => _normalize_strand(edge_data.dst_strand),
+                    :probability => probability,
+                    :edge_data => edge_data
+                ))
         end
     end
 

--- a/src/rhizomorph/algorithms/path-finding.jl
+++ b/src/rhizomorph/algorithms/path-finding.jl
@@ -510,39 +510,57 @@ function _normalize_strand(strand)
     return Forward
 end
 
+# Apply the strand filter + positive-weight filter to one candidate out-edge and,
+# if it passes, append the transition Dict. Shared by both enumeration paths below.
+function _maybe_push_transition!(transitions, graph, vertex_label, target_vertex, strand)
+    edge_data = graph[vertex_label, target_vertex]
+    if _normalize_strand(edge_data.src_strand) == strand
+        probability = _edge_transition_weight(edge_data)
+        probability <= 0.0 && return
+        push!(transitions,
+            Dict(
+                :target_vertex => target_vertex,
+                :target_strand => _normalize_strand(edge_data.dst_strand),
+                :probability => probability,
+                :edge_data => edge_data
+            ))
+    end
+    return
+end
+
 function _get_valid_transitions(graph, vertex_label, strand)
     transitions = []
-
-    # Enumerate only this vertex's out-edges via the underlying graph adjacency
-    # (O(out-degree)) instead of scanning every edge label in the graph (O(E)).
-    # The previous full-scan made each call O(E); since this is invoked once per
-    # vertex during start-vertex selection and once per step during every walk,
-    # the old behavior was O(V*E) for selection and O(steps*E) for generation —
-    # the dominant cost in large-graph generative modeling (notebook 15). The
-    # returned set of transitions and their probabilities are identical; only the
-    # within-vertex iteration order may differ (distribution-preserving under a
-    # fixed seed).
     haskey(graph, vertex_label) || return transitions
 
-    src_code = MetaGraphsNext.code_for(graph, vertex_label)
-    for dst_code in Graphs.outneighbors(graph.graph, src_code)
-        target_vertex = MetaGraphsNext.label_for(graph, dst_code)
-        edge_data = graph[vertex_label, target_vertex]
-
-        edge_src_strand = _normalize_strand(edge_data.src_strand)
-        if edge_src_strand == strand
-            probability = _edge_transition_weight(edge_data)
-            if probability <= 0.0
-                continue
+    if Graphs.is_directed(graph.graph)
+        # Directed graphs (the production walk path: every walk caller routes
+        # through weighted_graph_from_rhizomorph, which builds a DiGraph) — read
+        # out-edges from the adjacency in O(out-degree) instead of scanning every
+        # edge label in the graph (O(E)). The previous full-scan made each call
+        # O(E); since this runs once per vertex during start-vertex selection and
+        # once per step during every walk, the old cost was O(V*E)/O(steps*E) and
+        # dominated large-graph generative modeling (notebook 15). For a DiGraph,
+        # outneighbors enumerates exactly the edges whose stored source is
+        # vertex_label, so the returned transition set and probabilities are
+        # identical; only within-vertex order may differ (distribution-preserving
+        # under a fixed seed).
+        src_code = MetaGraphsNext.code_for(graph, vertex_label)
+        for dst_code in Graphs.outneighbors(graph.graph, src_code)
+            target_vertex = MetaGraphsNext.label_for(graph, dst_code)
+            _maybe_push_transition!(transitions, graph, vertex_label, target_vertex, strand)
+        end
+    else
+        # Undirected graphs store each edge once with a fixed src/dst orientation,
+        # but their adjacency is symmetric — outneighbors would return both
+        # endpoints (a superset) with strand fields oriented backwards for the
+        # reverse-stored direction. Preserve the exact original semantics by
+        # scanning edge labels and keeping only edges whose stored source is
+        # vertex_label.
+        for edge_labels in MetaGraphsNext.edge_labels(graph)
+            if length(edge_labels) == 2 && edge_labels[1] == vertex_label
+                _maybe_push_transition!(
+                    transitions, graph, vertex_label, edge_labels[2], strand)
             end
-
-            push!(transitions,
-                Dict(
-                    :target_vertex => target_vertex,
-                    :target_strand => _normalize_strand(edge_data.dst_strand),
-                    :probability => probability,
-                    :edge_data => edge_data
-                ))
         end
     end
 

--- a/src/rhizomorph/analysis/sequence-quality.jl
+++ b/src/rhizomorph/analysis/sequence-quality.jl
@@ -143,18 +143,30 @@ function evaluate_generation_quality(
             end
         end
 
-        # Build training profile from graph vertices
+        # Build training profile from graph vertices. Vertices whose payload has
+        # no evidence count (e.g. reduced types) legitimately fall back to 1, but
+        # only swallow the expected lookup/dispatch errors — rethrow anything else
+        # so a systematic failure can't silently collapse the training profile to
+        # a uniform distribution and produce a meaningless divergence.
         train_counts = Dict{String, Int}()
         train_total = 0
+        n_fallback = 0
         for label in labels
             key = string(label)
             count = try
                 count_evidence(training_graph[label])
-            catch
+            catch err
+                (err isa MethodError || err isa KeyError) || rethrow()
+                n_fallback += 1
                 1
             end
             train_counts[key] = count
             train_total += count
+        end
+        if n_fallback > 0 && n_fallback == length(labels)
+            @warn "evaluate_generation_quality: count_evidence fell back to 1 for ALL " *
+                  "$(length(labels)) vertices — training k-mer profile is uniform and the " *
+                  "resulting divergence is not meaningful."
         end
         train_profile = Dict{String, Float64}()
         if train_total > 0

--- a/src/rhizomorph/analysis/sequence-quality.jl
+++ b/src/rhizomorph/analysis/sequence-quality.jl
@@ -126,9 +126,12 @@ function evaluate_generation_quality(
         gen_counts = Dict{String, Int}()
         gen_total = 0
         for seq in generated
-            s = string(seq)
-            for i in 1:(length(s) - k + 1)
-                kmer = s[i:(i + k - 1)]
+            # Slice over a Char vector, not the raw String: byte-indexing
+            # (s[i:i+k-1]) on a multibyte sequence (e.g. SentencePiece tokens
+            # containing the U+2581 word-boundary marker) throws StringIndexError.
+            chars = collect(string(seq))
+            for i in 1:(length(chars) - k + 1)
+                kmer = String(chars[i:(i + k - 1)])
                 gen_counts[kmer] = get(gen_counts, kmer, 0) + 1
                 gen_total += 1
             end
@@ -179,9 +182,10 @@ function evaluate_generation_quality(
         # Unique k-mers in generated sequences vs training graph vertices
         gen_kmers = Set{String}()
         for seq in generated
-            s = string(seq)
-            for i in 1:(length(s) - k + 1)
-                push!(gen_kmers, s[i:(i + k - 1)])
+            # Char-vector slicing (multibyte-safe); see kmer_divergence above.
+            chars = collect(string(seq))
+            for i in 1:(length(chars) - k + 1)
+                push!(gen_kmers, String(chars[i:(i + k - 1)]))
             end
         end
         n_training = length(labels)

--- a/test/4_assembly/generation_test.jl
+++ b/test/4_assembly/generation_test.jl
@@ -138,6 +138,20 @@ Test.@testset "Generation - _get_valid_transitions adjacency == full-scan" begin
     end
 end
 
+Test.@testset "Generation - evaluate_generation_quality multibyte-safe" begin
+    graph = _build_test_ngram_graph()
+    # SentencePiece-style sequences contain the U+2581 word-boundary marker (a
+    # 3-byte UTF-8 char). K-mer extraction must slice by character, not byte, or
+    # it throws StringIndexError mid-codepoint.
+    multibyte = ["▁ABC▁DEF", "AB▁CDE▁F"]
+    result = Mycelia.Rhizomorph.evaluate_generation_quality(
+        multibyte, graph; metrics = [:kmer_divergence, :diversity])
+    Test.@test haskey(result, :kmer_divergence)
+    Test.@test haskey(result, :diversity)
+    Test.@test isfinite(result[:kmer_divergence])
+    Test.@test isfinite(result[:diversity])
+end
+
 Test.@testset "Generation - compute_sequence_likelihood" begin
     graph = _build_test_ngram_graph()
     weighted = Mycelia.Rhizomorph.weighted_graph_from_rhizomorph(graph)

--- a/test/4_assembly/generation_test.jl
+++ b/test/4_assembly/generation_test.jl
@@ -100,6 +100,44 @@ Test.@testset "Generation - select_start_vertices" begin
         weighted, 1; strategy = :unknown)
 end
 
+Test.@testset "Generation - _get_valid_transitions adjacency == full-scan" begin
+    # Branching graph: "ABC" fans out to both "BCD" and "BCX".
+    # "ABCDEF" → ABC,BCD,CDE,DEF ; "ABCXYZ" → ABC,BCX,CXY,XYZ
+    graph = Mycelia.Rhizomorph.build_ngram_graph(
+        ["ABCDEF", "ABCXYZ"], 3; dataset_id = "branch_test")
+    weighted = Mycelia.Rhizomorph.weighted_graph_from_rhizomorph(graph)
+
+    # Reference: the old O(E) full edge-label scan, recomputed inline.
+    function _reference_transitions(g, vertex_label, strand)
+        out = Set{Tuple{String, Float64}}()
+        for edge_labels in MetaGraphsNext.edge_labels(g)
+            if length(edge_labels) == 2 && edge_labels[1] == vertex_label
+                edge_data = g[edge_labels...]
+                if Mycelia.Rhizomorph._normalize_strand(edge_data.src_strand) == strand
+                    prob = Mycelia.Rhizomorph._edge_transition_weight(edge_data)
+                    prob <= 0.0 && continue
+                    push!(out, (string(edge_labels[2]), prob))
+                end
+            end
+        end
+        return out
+    end
+
+    # The fan-out vertex must report >1 transition (guards against a trivial pass).
+    fanout = Mycelia.Rhizomorph._get_valid_transitions(
+        weighted, "ABC", Mycelia.Rhizomorph.Forward)
+    Test.@test length(fanout) >= 2
+
+    for vertex_label in MetaGraphsNext.labels(weighted)
+        new_set = Set(
+            (string(t[:target_vertex]), t[:probability])
+        for t in Mycelia.Rhizomorph._get_valid_transitions(
+            weighted, vertex_label, Mycelia.Rhizomorph.Forward))
+        ref_set = _reference_transitions(weighted, vertex_label, Mycelia.Rhizomorph.Forward)
+        Test.@test new_set == ref_set
+    end
+end
+
 Test.@testset "Generation - compute_sequence_likelihood" begin
     graph = _build_test_ngram_graph()
     weighted = Mycelia.Rhizomorph.weighted_graph_from_rhizomorph(graph)

--- a/test/4_assembly/generation_test.jl
+++ b/test/4_assembly/generation_test.jl
@@ -138,6 +138,53 @@ Test.@testset "Generation - _get_valid_transitions adjacency == full-scan" begin
     end
 end
 
+Test.@testset "Generation - _get_valid_transitions undirected stored-source semantics" begin
+    # On an undirected graph, adjacency is symmetric, but _get_valid_transitions
+    # must keep the original edge-label-scan semantics (only edges whose STORED
+    # source is the query vertex), NOT the symmetric-adjacency superset that
+    # outneighbors would return. Build an undirected weighted graph and assert the
+    # result matches a full edge-label scan for every vertex.
+    g = MetaGraphsNext.MetaGraph(
+        Mycelia.Graphs.Graph(),
+        label_type = String,
+        vertex_data_type = Any,
+        edge_data_type = Mycelia.Rhizomorph.StrandWeightedEdgeData,
+        weight_function = Mycelia.Rhizomorph.edge_data_weight,
+        default_weight = 0.0)
+    g["A"] = nothing
+    g["B"] = nothing
+    g["C"] = nothing
+    g["A", "B"] = Mycelia.Rhizomorph.StrandWeightedEdgeData(
+        2.0, Mycelia.Rhizomorph.Forward, Mycelia.Rhizomorph.Forward)
+    g["B", "C"] = Mycelia.Rhizomorph.StrandWeightedEdgeData(
+        3.0, Mycelia.Rhizomorph.Forward, Mycelia.Rhizomorph.Forward)
+
+    function _ref_undirected(vertex_label)
+        out = Set{Tuple{String, Float64}}()
+        for el in MetaGraphsNext.edge_labels(g)
+            if length(el) == 2 && el[1] == vertex_label
+                ed = g[el...]
+                Mycelia.Rhizomorph._normalize_strand(ed.src_strand) ==
+                Mycelia.Rhizomorph.Forward || continue
+                p = Mycelia.Rhizomorph._edge_transition_weight(ed)
+                p <= 0.0 && continue
+                push!(out, (string(el[2]), p))
+            end
+        end
+        return out
+    end
+
+    for v in MetaGraphsNext.labels(g)
+        got = Set((string(t[:target_vertex]), t[:probability])
+        for t in Mycelia.Rhizomorph._get_valid_transitions(
+            g, v, Mycelia.Rhizomorph.Forward))
+        Test.@test got == _ref_undirected(v)
+    end
+    # The undirected branch executed and found the stored-source edge from "A".
+    Test.@test !isempty(Mycelia.Rhizomorph._get_valid_transitions(
+        g, "A", Mycelia.Rhizomorph.Forward))
+end
+
 Test.@testset "Generation - evaluate_generation_quality multibyte-safe" begin
     graph = _build_test_ngram_graph()
     # SentencePiece-style sequences contain the U+2581 word-boundary marker (a


### PR DESCRIPTION
## Summary
- `_get_valid_transitions` rewritten from an O(E) full edge-label scan to an O(out-degree) adjacency lookup for **directed** graphs (the production walk path), collapsing start-vertex selection from O(V·E) to O(E) and per-step walk cost from O(E) to O(degree). Undirected graphs retain the exact edge-label scan (symmetric adjacency would otherwise return a superset with reversed strand fields).
- `evaluate_generation_quality` k-mer extraction made multibyte-safe (Char-vector slicing) — SentencePiece sequences containing the U+2581 word-boundary marker no longer throw `StringIndexError`.
- `count_evidence` fallback narrowed to expected `MethodError`/`KeyError` (rethrows otherwise) + warns if all vertices hit the fallback.

## Test Plan
- `test/4_assembly/generation_test.jl`: directed adjacency==full-scan equivalence (with fan-out guard), undirected stored-source semantics, multibyte-safe evaluation. Full suite passes on NERSC (gentest exit 0).

## Related
- Unblocks panlingual-metagraphs notebook 15 generative modeling: prior 6h timeout was this O(V·E) primitive; now generates on a 3.1M-vertex / 34M-edge graph in seconds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transition selection so only valid outgoing paths are considered, with better handling for directed and undirected graphs.
  * Made generation quality checks safe for multibyte text, avoiding incorrect sequence slicing.
  * Tightened fallback handling in quality scoring and added a warning when fallback values could make results unreliable.

* **Tests**
  * Added coverage for transition filtering, graph direction behavior, and multibyte sequence evaluation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->