### PR TITLE
fix(review): broaden julia-cmd regex + document salloc asymmetry (td-b05w)

### DIFF
--- a/src/slurm-templates.jl
+++ b/src/slurm-templates.jl
@@ -568,7 +568,7 @@ function validate(job::JobSpec; check_lawrencium_associations::Bool = true)::Job
     # reopens the concurrent-depot race or thread oversubscription the pattern
     # exists to prevent.
     if normalized_job.site in (:nersc, :lawrencium) &&
-       occursin(r"(?:^|[\s/])julia\b", normalized_job.cmd)
+       occursin(_JULIA_CMD_RE, normalized_job.cmd)
         for key in (
             "JULIA_DEPOT_PATH", "JULIA_PKG_OFFLINE", "JULIA_NUM_THREADS",
             "OPENBLAS_NUM_THREADS", "JULIA_NUM_PRECOMPILE_TASKS"
@@ -1095,6 +1095,12 @@ function _build_sbatch_directives(job::JobSpec)::String
     return join(lines, "\n")
 end
 
+# Matches a command that invokes the `julia` binary. The leading char class
+# accepts start-of-string, whitespace, a path separator, OR a quote/paren prefix
+# (`'julia ...'`, `(julia ...)`) so a quoted/subshelled invocation is not silently
+# treated as non-Julia; `\b` still rejects `myjulia` / `julia_helper`. (td-b05w)
+const _JULIA_CMD_RE = r"(?:^|[\s/'\"(])julia\b"
+
 # Durable HPC Julia pattern (td-2rfi). Emitted only for Julia commands on the
 # HPC sites that have a per-job scratch + shared read depot (NERSC, Lawrencium).
 # Returns `nothing` elsewhere so non-Julia steps and local/scg/cloud jobs render
@@ -1114,7 +1120,7 @@ end
 # has no unbuffered-output flag (`julia -u` errors at startup).
 function _durable_julia_prelude(job::JobSpec)::Union{Nothing, String}
     job.site in (:nersc, :lawrencium) || return nothing
-    occursin(r"(?:^|[\s/])julia\b", job.cmd) || return nothing
+    occursin(_JULIA_CMD_RE, job.cmd) || return nothing
     threads = "\${SLURM_CPUS_PER_TASK:-\${SLURM_CPUS_ON_NODE:-8}}"
     scratch_expr = job.site == :nersc ? "\${SCRATCH:?}" :
                    "\${SCRATCH:-/global/scratch/users/\$USER}"
@@ -1363,6 +1369,14 @@ $(DocStringExtensions.TYPEDSIGNATURES)
 
 Render an interactive allocation command (`salloc ... srun --pty`) where supported.
 """
+# Note (td-b05w): render_salloc emits an interactive-shell launcher
+# (`salloc ... srun --pty bash -l`), NOT a batch script with a prelude, so the
+# td-2rfi durable Julia pattern (_durable_julia_prelude / _build_prelude_block)
+# is intentionally NOT injected here — it applies to render_sbatch only. The
+# durable depot pattern guards against concurrent BATCH jobs racing on the shared
+# depot; an interactive session is a single shell where the user sets their own
+# env. A user wanting the durable depot interactively should export it by hand
+# (or `source` a snippet) inside the allocated shell.
 function render_salloc(job::JobSpec)::String
     normalized_job = normalize_job_spec(job)
     report = validate(normalized_job)

--- a/test/8_tool_integration/slurm_template_system.jl
+++ b/test/8_tool_integration/slurm_template_system.jl
@@ -414,6 +414,22 @@ Test.@testset "Durable HPC Julia prelude (td-2rfi)" begin
     )
     Test.@test !occursin("JULIA_PKG_OFFLINE", Mycelia.render_sbatch(nersc_notjulia))
 
+    # ...but a quote-/paren-prefixed real julia invocation MUST still get the
+    # block (td-b05w broadened the cmd regex to accept those prefixes).
+    nersc_quoted_julia = Mycelia.JobSpec(
+        job_name = "durable-nersc-quoted-julia",
+        cmd = "bash -c '(julia run.jl)'",
+        site = :nersc,
+        account = "m1234",
+        qos = "shared",
+        constraint = "cpu",
+        ntasks = 1,
+        cpus_per_task = 4,
+        mem_gb = 8,
+        time_limit = "04:00:00"
+    )
+    Test.@test occursin("JULIA_PKG_OFFLINE", Mycelia.render_sbatch(nersc_quoted_julia))
+
     # Durable block precedes the user-env block, so a caller's explicit override
     # wins (emitted after). Lock that ordering, and assert validate() warns that
     # the override reopens the race the pattern guards against.


### PR DESCRIPTION
## Summary

Two deferred Minors from the td-2rfi durable-pattern review:

- **Regex false-negative**: the julia-cmd guard `r"(?:^|[\s/])julia\b"` missed quote-/paren-prefixed invocations (`'julia' run.jl`, `(julia ...)`), which would silently render a NERSC/Lawrencium Julia job WITHOUT the durable depot block (reopening the depot race with no signal). Factored the regex into a single const `_JULIA_CMD_RE` (was duplicated in `_durable_julia_prelude` and `validate()`) and broadened the leading char class to accept quote/paren prefixes; `\b` still rejects `myjulia` / `julia_helper`.
- **render_salloc parity**: documented that the durable pattern is intentionally `render_sbatch`-only — `render_salloc` emits an interactive-shell launcher (`salloc ... srun --pty bash -l`), not a batch script with a prelude, and the depot pattern guards concurrent *batch* jobs.

## Test plan

- [x] Added a positive test for a quoted/paren-prefixed `julia` invocation (gets the block) alongside the existing `myjulia` negative.
- [x] Isolated AST evaluation: plain / quoted / single-quoted `julia` → block; `myjulia` / `python` / `scg-julia` → no block; existing golden fixtures unchanged.
- [x] src + test parse clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of Julia commands in job submissions, including quoted or wrapped command forms.
  * Updated when the durable Julia environment settings are added, making batch jobs more reliable.
  * Clarified that interactive sessions do not receive the durable Julia setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->