### PR TITLE
add: benchmark Viterbi beam-width diagnostics

### DIFF
--- a/benchmarking/viterbi_accuracy_benchmark.jl
+++ b/benchmarking/viterbi_accuracy_benchmark.jl
@@ -13,15 +13,24 @@ import DataFrames
 import Dates
 import FASTX
 import Kmers
+import Statistics
 
 # This benchmark exercises Rhizomorph graph builders plus generalized Viterbi
-# correction only. Loading Mycelia in core-benchmark mode avoids unrelated
-# plotting/ML imports during HPC smoke runs.
+# correction only. The benchmark-local core loader avoids unrelated plotting/ML
+# imports during HPC smoke runs without changing the package module layout.
 if get(ENV, "MYCELIA_CORE_BENCHMARK", "") == ""
     ENV["MYCELIA_CORE_BENCHMARK"] = "true"
 end
 
-import Mycelia
+const _VITERBI_ACCURACY_CORE_BENCHMARK = lowercase(
+    get(ENV, "MYCELIA_CORE_BENCHMARK", "")
+) in ("1", "true", "yes")
+
+if _VITERBI_ACCURACY_CORE_BENCHMARK
+    include(joinpath(@__DIR__, "viterbi_accuracy_core_loader.jl"))
+else
+    @eval import Mycelia
+end
 import Test
 
 include(joinpath(@__DIR__, "benchmark_artifacts.jl"))
@@ -323,6 +332,7 @@ function _viterbi_accuracy_row(
         injected_error_recall = recall,
         corrected_all_injected_positions = recovered_errors == injected_error_count,
         correction_wall_seconds = correction_wall_seconds,
+        diagnostics_exact = Bool(get(result.diagnostics, :exact, false)),
         diagnostics_expanded_states = _diagnostic_int(result.diagnostics, :expanded_states),
         diagnostics_generated_states = _diagnostic_int(result.diagnostics, :generated_states),
         diagnostics_max_retained_states = _diagnostic_int(result.diagnostics, :max_retained_states),
@@ -348,7 +358,11 @@ function _scaled_fixture_length(total_length::Int, base_length::Int, window_scal
     if window_scale <= 0.0
         throw(ArgumentError("window_scale must be positive, got $window_scale"))
     end
-    scaled_length = max(VITERBI_ACCURACY_K, round(Int, base_length * window_scale))
+    minimum_length = VITERBI_ACCURACY_K + 2
+    if total_length < minimum_length
+        throw(ArgumentError("fixture length must be at least $minimum_length, got $total_length"))
+    end
+    scaled_length = max(minimum_length, round(Int, base_length * window_scale))
     return min(total_length, scaled_length)
 end
 
@@ -505,8 +519,25 @@ function _write_viterbi_accuracy_figure(
         yticks = 0.0:0.25:1.0
     )
 
-    palette = [:seagreen4, :dodgerblue3, :darkorange3]
-    grouped = collect(DataFrames.groupby(summary, :dataset_id))
+    plot_summary = DataFrames.combine(
+        DataFrames.groupby(
+            summary,
+            [:dataset_id, :dataset_name, :beam_width, :target_error_rate]
+        ),
+        :edit_distance_reduction => Statistics.mean => :edit_distance_reduction
+    )
+
+    palette = [
+        :seagreen4,
+        :dodgerblue3,
+        :darkorange3,
+        :purple4,
+        :firebrick3,
+        :goldenrod3,
+        :deepskyblue4,
+        :gray35
+    ]
+    grouped = collect(DataFrames.groupby(plot_summary, [:dataset_id, :beam_width]))
     elements = CairoMakie.LineElement[]
     labels = String[]
     for (index, group) in enumerate(grouped)
@@ -517,7 +548,10 @@ function _write_viterbi_accuracy_figure(
         CairoMakie.lines!(axis, x_values, y_values; color = color, linewidth = 3)
         CairoMakie.scatter!(axis, x_values, y_values; color = color, markersize = 12)
         push!(elements, CairoMakie.LineElement(color = color, linewidth = 3))
-        push!(labels, first(sorted_group.dataset_name))
+        push!(
+            labels,
+            "$(first(sorted_group.dataset_name)) ($(first(sorted_group.beam_width)))"
+        )
     end
 
     CairoMakie.ylims!(axis, -0.05, 1.05)

--- a/benchmarking/viterbi_accuracy_benchmark.jl
+++ b/benchmarking/viterbi_accuracy_benchmark.jl
@@ -18,12 +18,14 @@ import Statistics
 # This benchmark exercises Rhizomorph graph builders plus generalized Viterbi
 # correction only. The benchmark-local core loader avoids unrelated plotting/ML
 # imports during HPC smoke runs without changing the package module layout.
-if get(ENV, "MYCELIA_CORE_BENCHMARK", "") == ""
-    ENV["MYCELIA_CORE_BENCHMARK"] = "true"
-end
-
+const _VITERBI_ACCURACY_EXECUTED_AS_SCRIPT =
+    abspath(PROGRAM_FILE) == abspath(@__FILE__)
 const _VITERBI_ACCURACY_CORE_BENCHMARK = lowercase(
-    get(ENV, "MYCELIA_CORE_BENCHMARK", "")
+    get(
+        ENV,
+        "MYCELIA_CORE_BENCHMARK",
+        _VITERBI_ACCURACY_EXECUTED_AS_SCRIPT ? "true" : "false"
+    )
 ) in ("1", "true", "yes")
 
 if _VITERBI_ACCURACY_CORE_BENCHMARK

--- a/benchmarking/viterbi_accuracy_benchmark.jl
+++ b/benchmarking/viterbi_accuracy_benchmark.jl
@@ -260,11 +260,21 @@ function _viterbi_accuracy_row(
     result = Mycelia.correct_observations(fixture.graph, [converted_observed]; config = config)
     correction_wall_seconds = (time_ns() - correction_start_ns) / 1.0e9
     corrected_observation = only(result.corrected_observations)
-    correction_succeeded = !isnothing(corrected_observation)
-    corrected = if correction_succeeded
+    correction_returned_path = !isnothing(corrected_observation)
+    raw_corrected_count = correction_returned_path ? length(corrected_observation) : 0
+    raw_corrected = if correction_returned_path
         [string(observation) for observation in corrected_observation]
     else
-        copy(observed)
+        String[]
+    end
+    correction_succeeded = correction_returned_path && length(raw_corrected) == length(fixture.truth)
+    corrected = correction_succeeded ? raw_corrected : copy(observed)
+    benchmark_reason = if !correction_returned_path
+        "no_path"
+    elseif !correction_succeeded
+        "length_mismatch"
+    else
+        string(get(result.diagnostics, :reason, ""))
     end
 
     baseline_edit_distance = _sum_edit_distance(observed, fixture.truth)
@@ -304,7 +314,9 @@ function _viterbi_accuracy_row(
         injected_error_count = injected_error_count,
         baseline_method = "uncorrected_observations",
         corrected_method = "generalized_viterbi_correct_observations",
+        correction_returned_path = correction_returned_path,
         correction_succeeded = correction_succeeded,
+        raw_corrected_observation_count = raw_corrected_count,
         baseline_edit_distance = baseline_edit_distance,
         corrected_edit_distance = corrected_edit_distance,
         edit_distance_reduction = edit_distance_reduction,
@@ -322,7 +334,7 @@ function _viterbi_accuracy_row(
         diagnostics_strand_mode = string(result.diagnostics[:strand_mode]),
         diagnostics_emission_model = string(result.diagnostics[:emission_model]),
         diagnostics_transition_model = string(result.diagnostics[:transition_model]),
-        diagnostics_reason = string(get(result.diagnostics, :reason, ""))
+        diagnostics_reason = benchmark_reason
     )
 end
 

--- a/benchmarking/viterbi_accuracy_benchmark.jl
+++ b/benchmarking/viterbi_accuracy_benchmark.jl
@@ -5,14 +5,30 @@
 #   julia --project=. benchmarking/viterbi_accuracy_benchmark.jl --output-dir /tmp/b8 --skip-plots
 
 import BioSequences
-import CairoMakie
+if !("--skip-plots" in ARGS)
+    @eval import CairoMakie
+end
 import DataFrames
+import Dates
 import FASTX
 import Kmers
+
+# This benchmark exercises Rhizomorph graph builders plus generalized Viterbi
+# correction only. Loading Mycelia in core-benchmark mode avoids unrelated
+# plotting/ML imports during HPC smoke runs.
+if get(ENV, "MYCELIA_CORE_BENCHMARK", "") == ""
+    ENV["MYCELIA_CORE_BENCHMARK"] = "true"
+end
+
 import Mycelia
 import Test
 
 include(joinpath(@__DIR__, "benchmark_artifacts.jl"))
+
+function _default_viterbi_accuracy_run_id()::String
+    timestamp = Dates.format(Dates.now(Dates.UTC), Dates.DateFormat("yyyymmddTHHMMSS"))
+    return "b8_viterbi_accuracy_$(timestamp)Z"
+end
 
 const VITERBI_ACCURACY_ERROR_RATES = (0.01, 0.05, 0.10)
 const VITERBI_ACCURACY_FIXTURE_DIR = joinpath(@__DIR__, "fixtures", "viterbi_accuracy")
@@ -33,8 +49,23 @@ end
 
 function main(args::Vector{String} = ARGS)::Nothing
     output_dir = _viterbi_accuracy_arg_value(args, "--output-dir", VITERBI_ACCURACY_DEFAULT_OUTPUT_DIR)
+    run_id = _viterbi_accuracy_arg_value(args, "--run-id", _default_viterbi_accuracy_run_id())
+    scale = _viterbi_accuracy_arg_value(args, "--scale", "local-smoke")
+    beam_widths = _viterbi_accuracy_beam_widths(args)
     write_plots = !("--skip-plots" in args)
-    artifacts = run_viterbi_accuracy_benchmark(output_dir; write_plots = write_plots)
+    artifacts = run_viterbi_accuracy_benchmark(
+        output_dir;
+        run_id = run_id,
+        scale = scale,
+        command_args = [
+            "julia",
+            "--project=.",
+            "benchmarking/viterbi_accuracy_benchmark.jl",
+            args...
+        ],
+        beam_widths = beam_widths,
+        write_plots = write_plots
+    )
     println("Wrote B8 Viterbi accuracy benchmark artifacts:")
     println("  root: $(artifacts.root)")
     println("  summary: $(artifacts.summary_csv)")
@@ -45,6 +76,14 @@ end
 
 function run_viterbi_accuracy_benchmark(
         output_dir::AbstractString = VITERBI_ACCURACY_DEFAULT_OUTPUT_DIR;
+        run_id::AbstractString = _default_viterbi_accuracy_run_id(),
+        scale::AbstractString = "local-smoke",
+        command_args::Vector{String} = [
+            "julia",
+            "--project=.",
+            "benchmarking/viterbi_accuracy_benchmark.jl"
+        ],
+        beam_widths::Vector{Union{Nothing, Int}} = Union{Nothing, Int}[nothing],
         write_plots::Bool = true
 )::NamedTuple
     fixtures = viterbi_accuracy_fixtures()
@@ -52,7 +91,9 @@ function run_viterbi_accuracy_benchmark(
 
     for fixture in fixtures
         for target_error_rate in VITERBI_ACCURACY_ERROR_RATES
-            push!(rows, _viterbi_accuracy_row(fixture, target_error_rate))
+            for beam_width in beam_widths
+                push!(rows, _viterbi_accuracy_row(fixture, target_error_rate, beam_width))
+            end
         end
     end
 
@@ -60,15 +101,16 @@ function run_viterbi_accuracy_benchmark(
     artifacts = write_benchmark_artifacts(
         ["viterbi_accuracy_summary" => summary];
         output_dir = output_dir,
-        run_id = "b8_viterbi_accuracy_local_20260625",
-        scale = "local-smoke",
+        run_id = run_id,
+        scale = scale,
         dataset_ids = [fixture.dataset_id for fixture in fixtures],
-        command_args = ["julia", "--project=.", "benchmarking/viterbi_accuracy_benchmark.jl"],
+        command_args = command_args,
         metadata = Dict(
             "bead" => "td-he0z.9",
             "benchmark" => "generalized_viterbi_accuracy_vs_error_rate",
             "baseline" => "uncorrected injected-error observations",
             "error_rates" => collect(VITERBI_ACCURACY_ERROR_RATES),
+            "beam_widths" => [_beam_width_label(beam_width) for beam_width in beam_widths],
             "fixture_dir" => relpath(VITERBI_ACCURACY_FIXTURE_DIR, @__DIR__),
             "unit" => "fixed-length $(VITERBI_ACCURACY_K)-mers/ngrams"
         ),
@@ -159,14 +201,20 @@ end
 
 function _viterbi_accuracy_row(
         fixture::ViterbiAccuracyFixture,
-        target_error_rate::Float64
+        target_error_rate::Float64,
+        beam_width::Union{Nothing, Int}
 )::NamedTuple
     observed, injected_positions = _inject_fixture_errors(
         fixture.truth, fixture.alphabet, target_error_rate
     )
     converted_observed = _convert_observations(observed, fixture.domain)
-    config = Mycelia.ViterbiCorrectionConfig(error_rate = target_error_rate)
+    config = Mycelia.ViterbiCorrectionConfig(
+        error_rate = target_error_rate,
+        beam_width = beam_width
+    )
+    correction_start_ns = time_ns()
     result = Mycelia.correct_observations(fixture.graph, [converted_observed]; config = config)
+    correction_wall_seconds = (time_ns() - correction_start_ns) / 1.0e9
     corrected = [string(observation) for observation in only(result.corrected_observations)]
 
     baseline_edit_distance = _sum_edit_distance(observed, fixture.truth)
@@ -195,6 +243,8 @@ function _viterbi_accuracy_row(
         source = fixture.source,
         target_error_rate = target_error_rate,
         actual_error_rate = actual_error_rate,
+        beam_width = _beam_width_label(beam_width),
+        beam_width_limit = isnothing(beam_width) ? 0 : beam_width,
         observation_count = length(fixture.truth),
         editable_positions = editable_positions,
         injected_error_count = injected_error_count,
@@ -205,6 +255,14 @@ function _viterbi_accuracy_row(
         edit_distance_reduction = edit_distance_reduction,
         injected_error_recall = recall,
         corrected_all_injected_positions = recovered_errors == injected_error_count,
+        correction_wall_seconds = correction_wall_seconds,
+        diagnostics_expanded_states = _diagnostic_int(result.diagnostics, :expanded_states),
+        diagnostics_generated_states = _diagnostic_int(result.diagnostics, :generated_states),
+        diagnostics_max_retained_states = _diagnostic_int(result.diagnostics, :max_retained_states),
+        diagnostics_cumulative_retained_states = _diagnostic_int(
+            result.diagnostics,
+            :cumulative_retained_states
+        ),
         diagnostics_alphabet = string(result.diagnostics[:alphabet]),
         diagnostics_strand_mode = string(result.diagnostics[:strand_mode]),
         diagnostics_emission_model = string(result.diagnostics[:emission_model]),
@@ -326,6 +384,15 @@ function _write_viterbi_accuracy_figure(
         summary::DataFrames.DataFrame,
         plots_dir::AbstractString
 )::NamedTuple
+    if !isdefined(@__MODULE__, :CairoMakie)
+        throw(
+            ArgumentError(
+                "CairoMakie was not loaded; rerun without --skip-plots or " *
+                "import CairoMakie before calling this function"
+            )
+        )
+    end
+
     mkpath(plots_dir)
     fig = CairoMakie.Figure(size = (900, 600), fontsize = 16)
     axis = CairoMakie.Axis(
@@ -358,6 +425,32 @@ function _write_viterbi_accuracy_figure(
     CairoMakie.save(png_path, fig)
     CairoMakie.save(svg_path, fig)
     return (png = png_path, svg = svg_path)
+end
+
+function _diagnostic_int(diagnostics::AbstractDict, key::Symbol)::Int
+    return Int(get(diagnostics, key, 0))
+end
+
+function _beam_width_label(beam_width::Union{Nothing, Int})::String
+    return isnothing(beam_width) ? "exact" : string(beam_width)
+end
+
+function _viterbi_accuracy_beam_widths(args::Vector{String})::Vector{Union{Nothing, Int}}
+    raw = _viterbi_accuracy_arg_value(args, "--beam-widths", "exact")
+    beam_widths = Union{Nothing, Int}[]
+    for item in split(raw, ",")
+        normalized = lowercase(strip(item))
+        if normalized in ("", "exact", "none", "nothing", "unbounded")
+            push!(beam_widths, nothing)
+        else
+            beam_width = parse(Int, normalized)
+            if beam_width <= 0
+                throw(ArgumentError("beam widths must be positive, got $beam_width"))
+            end
+            push!(beam_widths, beam_width)
+        end
+    end
+    return unique(beam_widths)
 end
 
 function _viterbi_accuracy_arg_value(

--- a/benchmarking/viterbi_accuracy_benchmark.jl
+++ b/benchmarking/viterbi_accuracy_benchmark.jl
@@ -4,6 +4,7 @@
 #   julia --project=. benchmarking/viterbi_accuracy_benchmark.jl
 #   julia --project=. benchmarking/viterbi_accuracy_benchmark.jl --output-dir /tmp/b8 --skip-plots
 #   julia --project=. benchmarking/viterbi_accuracy_benchmark.jl --beam-widths exact,1,4,16 --window-scale 4 --repetitions 3 --skip-plots
+#   MYCELIA_CORE_BENCHMARK=true julia --project=. benchmarking/viterbi_accuracy_benchmark.jl --skip-plots
 
 import BioSequences
 if !("--skip-plots" in ARGS)
@@ -18,13 +19,11 @@ import Statistics
 # This benchmark exercises Rhizomorph graph builders plus generalized Viterbi
 # correction only. The benchmark-local core loader avoids unrelated plotting/ML
 # imports during HPC smoke runs without changing the package module layout.
-const _VITERBI_ACCURACY_EXECUTED_AS_SCRIPT =
-    abspath(PROGRAM_FILE) == abspath(@__FILE__)
 const _VITERBI_ACCURACY_CORE_BENCHMARK = lowercase(
     get(
         ENV,
         "MYCELIA_CORE_BENCHMARK",
-        _VITERBI_ACCURACY_EXECUTED_AS_SCRIPT ? "true" : "false"
+        "false"
     )
 ) in ("1", "true", "yes")
 

--- a/benchmarking/viterbi_accuracy_benchmark.jl
+++ b/benchmarking/viterbi_accuracy_benchmark.jl
@@ -3,6 +3,7 @@
 # Usage:
 #   julia --project=. benchmarking/viterbi_accuracy_benchmark.jl
 #   julia --project=. benchmarking/viterbi_accuracy_benchmark.jl --output-dir /tmp/b8 --skip-plots
+#   julia --project=. benchmarking/viterbi_accuracy_benchmark.jl --beam-widths exact,1,4,16 --window-scale 4 --repetitions 3 --skip-plots
 
 import BioSequences
 if !("--skip-plots" in ARGS)
@@ -36,6 +37,9 @@ const VITERBI_ACCURACY_DEFAULT_OUTPUT_DIR = joinpath(
     @__DIR__, "results", "viterbi_accuracy_b8"
 )
 const VITERBI_ACCURACY_K = 9
+const VITERBI_ACCURACY_BASE_VIROID_LENGTH = 360
+const VITERBI_ACCURACY_BASE_PHAGE_LENGTH = 432
+const VITERBI_ACCURACY_BASE_TEXT_LENGTH = 432
 
 struct ViterbiAccuracyFixture
     dataset_id::String
@@ -52,6 +56,9 @@ function main(args::Vector{String} = ARGS)::Nothing
     run_id = _viterbi_accuracy_arg_value(args, "--run-id", _default_viterbi_accuracy_run_id())
     scale = _viterbi_accuracy_arg_value(args, "--scale", "local-smoke")
     beam_widths = _viterbi_accuracy_beam_widths(args)
+    error_rates = _viterbi_accuracy_error_rates(args)
+    window_scale = _viterbi_accuracy_positive_float(args, "--window-scale", 1.0)
+    repetitions = _viterbi_accuracy_positive_int(args, "--repetitions", 1)
     write_plots = !("--skip-plots" in args)
     artifacts = run_viterbi_accuracy_benchmark(
         output_dir;
@@ -64,6 +71,9 @@ function main(args::Vector{String} = ARGS)::Nothing
             args...
         ],
         beam_widths = beam_widths,
+        error_rates = error_rates,
+        window_scale = window_scale,
+        repetitions = repetitions,
         write_plots = write_plots
     )
     println("Wrote B8 Viterbi accuracy benchmark artifacts:")
@@ -84,15 +94,29 @@ function run_viterbi_accuracy_benchmark(
             "benchmarking/viterbi_accuracy_benchmark.jl"
         ],
         beam_widths::Vector{Union{Nothing, Int}} = Union{Nothing, Int}[nothing],
+        error_rates::Vector{Float64} = collect(VITERBI_ACCURACY_ERROR_RATES),
+        window_scale::Float64 = 1.0,
+        repetitions::Int = 1,
         write_plots::Bool = true
 )::NamedTuple
-    fixtures = viterbi_accuracy_fixtures()
+    fixtures = viterbi_accuracy_fixtures(window_scale = window_scale)
     rows = NamedTuple[]
 
     for fixture in fixtures
-        for target_error_rate in VITERBI_ACCURACY_ERROR_RATES
+        for target_error_rate in error_rates
             for beam_width in beam_widths
-                push!(rows, _viterbi_accuracy_row(fixture, target_error_rate, beam_width))
+                for replicate in 1:repetitions
+                    push!(
+                        rows,
+                        _viterbi_accuracy_row(
+                            fixture,
+                            target_error_rate,
+                            beam_width,
+                            replicate,
+                            window_scale
+                        )
+                    )
+                end
             end
         end
     end
@@ -109,9 +133,11 @@ function run_viterbi_accuracy_benchmark(
             "bead" => "td-he0z.9",
             "benchmark" => "generalized_viterbi_accuracy_vs_error_rate",
             "baseline" => "uncorrected injected-error observations",
-            "error_rates" => collect(VITERBI_ACCURACY_ERROR_RATES),
+            "error_rates" => error_rates,
             "beam_widths" => [_beam_width_label(beam_width) for beam_width in beam_widths],
             "fixture_dir" => relpath(VITERBI_ACCURACY_FIXTURE_DIR, @__DIR__),
+            "repetitions" => repetitions,
+            "window_scale" => window_scale,
             "unit" => "fixed-length $(VITERBI_ACCURACY_K)-mers/ngrams"
         ),
         table_context_columns = Dict(
@@ -138,7 +164,7 @@ function run_viterbi_accuracy_benchmark(
     )
 end
 
-function viterbi_accuracy_fixtures()::Vector{ViterbiAccuracyFixture}
+function viterbi_accuracy_fixtures(; window_scale::Float64 = 1.0)::Vector{ViterbiAccuracyFixture}
     pstvd = replace(
         _read_fasta_sequence(joinpath(VITERBI_ACCURACY_FIXTURE_DIR, "pstvd_nc002030.fasta")),
         'T' => 'U'
@@ -146,9 +172,25 @@ function viterbi_accuracy_fixtures()::Vector{ViterbiAccuracyFixture}
     phix = _read_fasta_sequence(joinpath(VITERBI_ACCURACY_FIXTURE_DIR, "phix174_nc001422.fasta"))
     text = read(joinpath(VITERBI_ACCURACY_FIXTURE_DIR, "pride_and_prejudice_excerpt.txt"), String)
 
-    viroid_window = first(pstvd, min(length(pstvd), 360))
-    phage_window = first(phix, min(length(phix), 432))
-    text_window = _normalized_text_window(text, 432)
+    viroid_length = _scaled_fixture_length(
+        length(pstvd),
+        VITERBI_ACCURACY_BASE_VIROID_LENGTH,
+        window_scale
+    )
+    phage_length = _scaled_fixture_length(
+        length(phix),
+        VITERBI_ACCURACY_BASE_PHAGE_LENGTH,
+        window_scale
+    )
+    text_length = _scaled_fixture_length(
+        length(text),
+        VITERBI_ACCURACY_BASE_TEXT_LENGTH,
+        window_scale
+    )
+
+    viroid_window = first(pstvd, viroid_length)
+    phage_window = first(phix, phage_length)
+    text_window = _normalized_text_window(text, text_length)
 
     viroid_record = FASTX.FASTA.Record(
         "pstvd_nc002030", BioSequences.LongRNA{4}(viroid_window)
@@ -202,10 +244,12 @@ end
 function _viterbi_accuracy_row(
         fixture::ViterbiAccuracyFixture,
         target_error_rate::Float64,
-        beam_width::Union{Nothing, Int}
+        beam_width::Union{Nothing, Int},
+        replicate::Int,
+        window_scale::Float64
 )::NamedTuple
     observed, injected_positions = _inject_fixture_errors(
-        fixture.truth, fixture.alphabet, target_error_rate
+        fixture.truth, fixture.alphabet, target_error_rate, replicate
     )
     converted_observed = _convert_observations(observed, fixture.domain)
     config = Mycelia.ViterbiCorrectionConfig(
@@ -215,7 +259,13 @@ function _viterbi_accuracy_row(
     correction_start_ns = time_ns()
     result = Mycelia.correct_observations(fixture.graph, [converted_observed]; config = config)
     correction_wall_seconds = (time_ns() - correction_start_ns) / 1.0e9
-    corrected = [string(observation) for observation in only(result.corrected_observations)]
+    corrected_observation = only(result.corrected_observations)
+    correction_succeeded = !isnothing(corrected_observation)
+    corrected = if correction_succeeded
+        [string(observation) for observation in corrected_observation]
+    else
+        copy(observed)
+    end
 
     baseline_edit_distance = _sum_edit_distance(observed, fixture.truth)
     corrected_edit_distance = _sum_edit_distance(corrected, fixture.truth)
@@ -234,13 +284,17 @@ function _viterbi_accuracy_row(
         recovered_errors / injected_error_count
     end
 
-    Test.@test length(corrected) == length(fixture.truth)
+    if correction_succeeded
+        Test.@test length(corrected) == length(fixture.truth)
+    end
 
     return (
         dataset_id = fixture.dataset_id,
         dataset_name = fixture.dataset_name,
         domain = string(fixture.domain),
         source = fixture.source,
+        replicate = replicate,
+        window_scale = window_scale,
         target_error_rate = target_error_rate,
         actual_error_rate = actual_error_rate,
         beam_width = _beam_width_label(beam_width),
@@ -250,6 +304,7 @@ function _viterbi_accuracy_row(
         injected_error_count = injected_error_count,
         baseline_method = "uncorrected_observations",
         corrected_method = "generalized_viterbi_correct_observations",
+        correction_succeeded = correction_succeeded,
         baseline_edit_distance = baseline_edit_distance,
         corrected_edit_distance = corrected_edit_distance,
         edit_distance_reduction = edit_distance_reduction,
@@ -266,7 +321,8 @@ function _viterbi_accuracy_row(
         diagnostics_alphabet = string(result.diagnostics[:alphabet]),
         diagnostics_strand_mode = string(result.diagnostics[:strand_mode]),
         diagnostics_emission_model = string(result.diagnostics[:emission_model]),
-        diagnostics_transition_model = string(result.diagnostics[:transition_model])
+        diagnostics_transition_model = string(result.diagnostics[:transition_model]),
+        diagnostics_reason = string(get(result.diagnostics, :reason, ""))
     )
 end
 
@@ -274,6 +330,14 @@ function _read_fasta_sequence(path::AbstractString)::String
     lines = readlines(path)
     sequence_lines = [strip(line) for line in lines if !isempty(line) && !startswith(line, ">")]
     return uppercase(join(sequence_lines))
+end
+
+function _scaled_fixture_length(total_length::Int, base_length::Int, window_scale::Float64)::Int
+    if window_scale <= 0.0
+        throw(ArgumentError("window_scale must be positive, got $window_scale"))
+    end
+    scaled_length = max(VITERBI_ACCURACY_K, round(Int, base_length * window_scale))
+    return min(total_length, scaled_length)
 end
 
 function _sequence_kmers(sequence::AbstractString, k::Int)::Vector{String}
@@ -290,7 +354,8 @@ end
 function _inject_fixture_errors(
         truth::Vector{String},
         alphabet::Vector{Char},
-        target_error_rate::Float64
+        target_error_rate::Float64,
+        replicate::Int = 1
 )::Tuple{Vector{String}, Vector{Tuple{Int, Int}}}
     candidates = Tuple{Int, Int}[]
     for item_index in 2:(length(truth) - 1)
@@ -301,7 +366,7 @@ function _inject_fixture_errors(
 
     target_errors = max(1, round(Int, target_error_rate * length(candidates)))
     target_errors = min(target_errors, length(candidates))
-    selected_offsets = round.(Int, range(1, length(candidates); length = target_errors))
+    selected_offsets = _deterministic_error_offsets(length(candidates), target_errors, replicate)
     selected_positions = unique(candidates[selected_offsets])
 
     observed = copy(truth)
@@ -314,6 +379,31 @@ function _inject_fixture_errors(
     end
 
     return observed, selected_positions
+end
+
+function _deterministic_error_offsets(candidate_count::Int, target_errors::Int, replicate::Int)::Vector{Int}
+    if replicate <= 0
+        throw(ArgumentError("replicate must be positive, got $replicate"))
+    end
+    if target_errors <= 0 || candidate_count <= 0
+        return Int[]
+    end
+
+    offsets = Int[]
+    seen = Set{Int}()
+    stride = max(1, floor(Int, candidate_count / target_errors))
+    cursor = mod1(replicate, candidate_count)
+    while length(offsets) < target_errors
+        if !(cursor in seen)
+            push!(offsets, cursor)
+            push!(seen, cursor)
+        end
+        cursor = mod1(cursor + stride, candidate_count)
+        if cursor in seen
+            cursor = mod1(cursor + 1, candidate_count)
+        end
+    end
+    return offsets
 end
 
 function _replacement_character(character::Char, alphabet::Vector{Char}, offset::Int)::Char
@@ -451,6 +541,54 @@ function _viterbi_accuracy_beam_widths(args::Vector{String})::Vector{Union{Nothi
         end
     end
     return unique(beam_widths)
+end
+
+function _viterbi_accuracy_error_rates(args::Vector{String})::Vector{Float64}
+    raw = _viterbi_accuracy_arg_value(
+        args,
+        "--error-rates",
+        join(string.(VITERBI_ACCURACY_ERROR_RATES), ",")
+    )
+    error_rates = Float64[]
+    for item in split(raw, ",")
+        normalized = strip(item)
+        if isempty(normalized)
+            continue
+        end
+        error_rate = parse(Float64, normalized)
+        if error_rate <= 0.0 || error_rate >= 0.5
+            throw(ArgumentError("error rates must be in (0, 0.5), got $error_rate"))
+        end
+        push!(error_rates, error_rate)
+    end
+    if isempty(error_rates)
+        throw(ArgumentError("at least one error rate is required"))
+    end
+    return unique(error_rates)
+end
+
+function _viterbi_accuracy_positive_float(
+        args::Vector{String},
+        flag::AbstractString,
+        default::Float64
+)::Float64
+    value = parse(Float64, _viterbi_accuracy_arg_value(args, flag, string(default)))
+    if value <= 0.0
+        throw(ArgumentError("$flag must be positive, got $value"))
+    end
+    return value
+end
+
+function _viterbi_accuracy_positive_int(
+        args::Vector{String},
+        flag::AbstractString,
+        default::Int
+)::Int
+    value = parse(Int, _viterbi_accuracy_arg_value(args, flag, string(default)))
+    if value <= 0
+        throw(ArgumentError("$flag must be positive, got $value"))
+    end
+    return value
 end
 
 function _viterbi_accuracy_arg_value(

--- a/benchmarking/viterbi_accuracy_core_loader.jl
+++ b/benchmarking/viterbi_accuracy_core_loader.jl
@@ -1,0 +1,66 @@
+# Lightweight benchmark-only Mycelia entry point for the Viterbi accuracy harness.
+#
+# This file intentionally lives under benchmarking/ rather than src/ so the
+# precompiled Mycelia package has a stable module layout. HPC smoke runs can
+# include this local module to avoid unrelated plotting/ML imports while the
+# package itself remains unaffected by MYCELIA_CORE_BENCHMARK.
+
+module Mycelia
+
+const _MYCELIA_SRC = normpath(joinpath(@__DIR__, "..", "src"))
+
+import BioSequences
+import BioSymbols
+import Conda
+import DataStructures
+import DocStringExtensions
+import FASTX
+import Graphs
+import Kmers
+import LinearAlgebra
+import MetaGraphs
+import MetaGraphsNext
+import ProgressMeter
+import Random
+import Statistics
+
+include(joinpath(_MYCELIA_SRC, "alphabets.jl"))
+include(joinpath(_MYCELIA_SRC, "constants.jl"))
+
+module Rhizomorph
+
+import ..Mycelia
+import BioSequences
+import DataStructures
+import DocStringExtensions
+import FASTX
+import Graphs
+import Kmers
+import LinearAlgebra
+import MetaGraphsNext
+import Random
+import Statistics
+
+const _RHIZOMORPH_SRC = joinpath(Mycelia._MYCELIA_SRC, "rhizomorph")
+
+include(joinpath(_RHIZOMORPH_SRC, "core", "enums.jl"))
+include(joinpath(_RHIZOMORPH_SRC, "core", "evidence-structures.jl"))
+include(joinpath(_RHIZOMORPH_SRC, "core", "vertex-data.jl"))
+include(joinpath(_RHIZOMORPH_SRC, "core", "edge-data.jl"))
+include(joinpath(_RHIZOMORPH_SRC, "core", "evidence-functions.jl"))
+include(joinpath(_RHIZOMORPH_SRC, "core", "quality-functions.jl"))
+include(joinpath(_RHIZOMORPH_SRC, "core", "graph-query.jl"))
+include(joinpath(_RHIZOMORPH_SRC, "core", "graph-construction.jl"))
+include(joinpath(_RHIZOMORPH_SRC, "core", "graph-type-conversions.jl"))
+
+include(joinpath(_RHIZOMORPH_SRC, "algorithms", "path-finding.jl"))
+
+include(joinpath(_RHIZOMORPH_SRC, "fixed-length", "kmer-graphs.jl"))
+include(joinpath(_RHIZOMORPH_SRC, "fixed-length", "qualmer-graphs.jl"))
+include(joinpath(_RHIZOMORPH_SRC, "fixed-length", "ngram-graphs.jl"))
+
+end
+
+include(joinpath(_MYCELIA_SRC, "viterbi-next.jl"))
+
+end

--- a/src/Mycelia.jl
+++ b/src/Mycelia.jl
@@ -13,9 +13,6 @@ if Sys.islinux() && get(ENV, "LD_LIBRARY_PATH", "") != ""
     ENV["LD_LIBRARY_PATH"] = ""
 end
 
-const _MYCELIA_CORE_BENCHMARK = lowercase(
-    get(ENV, "MYCELIA_CORE_BENCHMARK", "")
-) in ("1", "true", "yes")
 
 import Arrow
 import Base58
@@ -24,9 +21,7 @@ import BioAlignments
 import BioSequences
 import BioSymbols
 import Blake3Hash
-if !_MYCELIA_CORE_BENCHMARK
-    @eval import CairoMakie
-end
+import CairoMakie
 import Clustering
 # import CodecBase
 # import CodecBzip2
@@ -54,31 +49,21 @@ import GenomicAnnotations
 import GFF3
 # import GeoMakie
 import GLM
-if !_MYCELIA_CORE_BENCHMARK
-    @eval import GraphMakie
-end
-if !_MYCELIA_CORE_BENCHMARK
-    @eval import GraphPlot
-end
+import GraphMakie
+import GraphPlot
 import Graphs
 import HDF5
 import Hungarian
 import HTTP
 import JLD2
 import JSON
-if !_MYCELIA_CORE_BENCHMARK
-    @eval import Karnak
-end
+import Karnak
 import Kmers
 import LinearAlgebra
 import Logging
 import LsqFit
-if !_MYCELIA_CORE_BENCHMARK
-    @eval import Luxor
-end
-if !_MYCELIA_CORE_BENCHMARK
-    @eval import Makie
-end
+import Luxor
+import Makie
 import MD5
 import MetaGraphs
 import MetaGraphsNext
@@ -86,44 +71,30 @@ import Mmap
 import MultivariateStats
 import OrderedCollections
 import Pkg
-if !_MYCELIA_CORE_BENCHMARK
-    @eval import Plots
-end
-if !_MYCELIA_CORE_BENCHMARK
-    @eval import POMDPs
-end
+import Plots
+import POMDPs
 import PooledArrays
 import PrecompileTools
 import Primes
 import Printf
 import ProgressMeter
 import Random
-if !_MYCELIA_CORE_BENCHMARK
-    @eval import ReinforcementLearning
-end
-if !_MYCELIA_CORE_BENCHMARK
-    @eval import SankeyPlots
-end
+import ReinforcementLearning
+import SankeyPlots
 import SHA
 import SparseArrays
 import StableRNGs
 import Statistics
 import StatsBase
-if !_MYCELIA_CORE_BENCHMARK
-    @eval import StatsPlots
-end
+import StatsPlots
 import Tar
 # import TopoPlots
 # import TranscodingStreams
 import uCSV
-if !_MYCELIA_CORE_BENCHMARK
-    @eval import UMAP
-end
+import UMAP
 import UUIDs
 import XAM
-if !_MYCELIA_CORE_BENCHMARK
-    @eval import XLSX
-end
+import XLSX
 import XMLDict
 
 # preserve definitions between code jldoctest code blocks
@@ -147,19 +118,17 @@ include("tda.jl")
 # Rhizomorph graph ecosystem (primary implementation)
 include("rhizomorph/rhizomorph.jl")
 
-if !_MYCELIA_CORE_BENCHMARK
-    # Legacy qualmer utilities (still used by iterative-assembly.jl)
-    include("qualmer-analysis.jl")
+# Legacy qualmer utilities (still used by iterative-assembly.jl)
+include("qualmer-analysis.jl")
 
-    # Assembly pipeline (depends on Rhizomorph graph ecosystem)
-    include("assembly.jl")
+# Assembly pipeline (depends on Rhizomorph graph ecosystem)
+include("assembly.jl")
 
-    # Intelligent assembly algorithms (depends on assembly.jl and core graph types)
-    # include("intelligent-assembly.jl")
+# Intelligent assembly algorithms (depends on assembly.jl and core graph types)
+# include("intelligent-assembly.jl")
 
-    # Iterative assembly algorithms (depends on intelligent-assembly.jl)
-    include("iterative-assembly.jl")
-end
+# Iterative assembly algorithms (depends on intelligent-assembly.jl)
+include("iterative-assembly.jl")
 
 # Advanced algorithms (depend on core graph types)
 include("viterbi-next.jl")
@@ -177,58 +146,56 @@ include("viterbi-next.jl")
 
 # Load remaining files in alphabetical order (no critical dependencies)
 # Using explicit include() statements enables full static analysis by ExplicitImports.jl
-if !_MYCELIA_CORE_BENCHMARK
-    include("alignments-and-mapping.jl")
-    include("amino-acid-analysis.jl")
-    include("annotation.jl")
-    include("autocycler.jl")
-    include("bcalm.jl")
-    include("binning.jl")
-    include("bioconda.jl")
-    include("busco-datasets.jl")
-    include("checkpointing.jl")
-    include("classification.jl")
-    include("clustering.jl")
-    include("codon-optimization.jl")
-    include("coverage-clustering.jl")
-    include("dimensionality-reduction.jl")
-    include("distance-metrics.jl")
-    include("foldseek.jl")
-    include("genome-features.jl")
-    include("ggcat.jl")
-    include("graph-cleanup.jl")
-    include("kmer-analysis.jl")
-    include("kmer-saturation-analysis.jl")
-    include("metagraph.jl")
-    include("metagenomic-classification.jl")
-    include("ncbi-datasets-cli.jl")
-    include("pangenome-analysis.jl")
-    include("pantools.jl")
-    include("plotting-and-visualization.jl")
-    include("protein-databases.jl")
-    include("prokrustean.jl")
-    include("quality-control-and-benchmarking.jl")
-    include("rclone.jl")
-    include("read-quality-control.jl")
-    include("reference-databases.jl")
-    include("relational-matrices.jl")
-    include("sentencepiece.jl")
-    include("sequence-comparison.jl")
-    include("sequence-graphs.jl")
-    include("simulation.jl")
-    include("slurm-templates.jl")
-    include("execution.jl")
-    include("slurm-sbatch.jl")
-    include("taxonomy-and-trees.jl")
-    include("testing-utilities.jl")
-    include("variant-analysis.jl")
-    include("viterbi-polishing-and-error-correction.jl")
-    include("xam.jl")
+include("alignments-and-mapping.jl")
+include("amino-acid-analysis.jl")
+include("annotation.jl")
+include("autocycler.jl")
+include("bcalm.jl")
+include("binning.jl")
+include("bioconda.jl")
+include("busco-datasets.jl")
+include("checkpointing.jl")
+include("classification.jl")
+include("clustering.jl")
+include("codon-optimization.jl")
+include("coverage-clustering.jl")
+include("dimensionality-reduction.jl")
+include("distance-metrics.jl")
+include("foldseek.jl")
+include("genome-features.jl")
+include("ggcat.jl")
+include("graph-cleanup.jl")
+include("kmer-analysis.jl")
+include("kmer-saturation-analysis.jl")
+include("metagraph.jl")
+include("metagenomic-classification.jl")
+include("ncbi-datasets-cli.jl")
+include("pangenome-analysis.jl")
+include("pantools.jl")
+include("plotting-and-visualization.jl")
+include("protein-databases.jl")
+include("prokrustean.jl")
+include("quality-control-and-benchmarking.jl")
+include("rclone.jl")
+include("read-quality-control.jl")
+include("reference-databases.jl")
+include("relational-matrices.jl")
+include("sentencepiece.jl")
+include("sequence-comparison.jl")
+include("sequence-graphs.jl")
+include("simulation.jl")
+include("slurm-templates.jl")
+include("execution.jl")
+include("slurm-sbatch.jl")
+include("taxonomy-and-trees.jl")
+include("testing-utilities.jl")
+include("variant-analysis.jl")
+include("viterbi-polishing-and-error-correction.jl")
+include("xam.jl")
 
-    # PrecompileTools workload for faster startup
-    # This must be included last, after all other definitions are loaded
-    include("precompile_workload.jl")
-end
+# PrecompileTools workload for faster startup
+# This must be included last, after all other definitions are loaded
+include("precompile_workload.jl")
 
 """
     _clear_ld_library_path!()

--- a/src/Mycelia.jl
+++ b/src/Mycelia.jl
@@ -13,6 +13,10 @@ if Sys.islinux() && get(ENV, "LD_LIBRARY_PATH", "") != ""
     ENV["LD_LIBRARY_PATH"] = ""
 end
 
+const _MYCELIA_CORE_BENCHMARK = lowercase(
+    get(ENV, "MYCELIA_CORE_BENCHMARK", "")
+) in ("1", "true", "yes")
+
 import Arrow
 import Base58
 import Base64
@@ -20,7 +24,9 @@ import BioAlignments
 import BioSequences
 import BioSymbols
 import Blake3Hash
-import CairoMakie
+if !_MYCELIA_CORE_BENCHMARK
+    @eval import CairoMakie
+end
 import Clustering
 # import CodecBase
 # import CodecBzip2
@@ -48,21 +54,31 @@ import GenomicAnnotations
 import GFF3
 # import GeoMakie
 import GLM
-import GraphMakie
-import GraphPlot
+if !_MYCELIA_CORE_BENCHMARK
+    @eval import GraphMakie
+end
+if !_MYCELIA_CORE_BENCHMARK
+    @eval import GraphPlot
+end
 import Graphs
 import HDF5
 import Hungarian
 import HTTP
 import JLD2
 import JSON
-import Karnak
+if !_MYCELIA_CORE_BENCHMARK
+    @eval import Karnak
+end
 import Kmers
 import LinearAlgebra
 import Logging
 import LsqFit
-import Luxor
-import Makie
+if !_MYCELIA_CORE_BENCHMARK
+    @eval import Luxor
+end
+if !_MYCELIA_CORE_BENCHMARK
+    @eval import Makie
+end
 import MD5
 import MetaGraphs
 import MetaGraphsNext
@@ -70,30 +86,44 @@ import Mmap
 import MultivariateStats
 import OrderedCollections
 import Pkg
-import Plots
-import POMDPs
+if !_MYCELIA_CORE_BENCHMARK
+    @eval import Plots
+end
+if !_MYCELIA_CORE_BENCHMARK
+    @eval import POMDPs
+end
 import PooledArrays
 import PrecompileTools
 import Primes
 import Printf
 import ProgressMeter
 import Random
-import ReinforcementLearning
-import SankeyPlots
+if !_MYCELIA_CORE_BENCHMARK
+    @eval import ReinforcementLearning
+end
+if !_MYCELIA_CORE_BENCHMARK
+    @eval import SankeyPlots
+end
 import SHA
 import SparseArrays
 import StableRNGs
 import Statistics
 import StatsBase
-import StatsPlots
+if !_MYCELIA_CORE_BENCHMARK
+    @eval import StatsPlots
+end
 import Tar
 # import TopoPlots
 # import TranscodingStreams
 import uCSV
-import UMAP
+if !_MYCELIA_CORE_BENCHMARK
+    @eval import UMAP
+end
 import UUIDs
 import XAM
-import XLSX
+if !_MYCELIA_CORE_BENCHMARK
+    @eval import XLSX
+end
 import XMLDict
 
 # preserve definitions between code jldoctest code blocks
@@ -117,17 +147,19 @@ include("tda.jl")
 # Rhizomorph graph ecosystem (primary implementation)
 include("rhizomorph/rhizomorph.jl")
 
-# Legacy qualmer utilities (still used by iterative-assembly.jl)
-include("qualmer-analysis.jl")
+if !_MYCELIA_CORE_BENCHMARK
+    # Legacy qualmer utilities (still used by iterative-assembly.jl)
+    include("qualmer-analysis.jl")
 
-# Assembly pipeline (depends on Rhizomorph graph ecosystem)
-include("assembly.jl")
+    # Assembly pipeline (depends on Rhizomorph graph ecosystem)
+    include("assembly.jl")
 
-# Intelligent assembly algorithms (depends on assembly.jl and core graph types)
-# include("intelligent-assembly.jl")
+    # Intelligent assembly algorithms (depends on assembly.jl and core graph types)
+    # include("intelligent-assembly.jl")
 
-# Iterative assembly algorithms (depends on intelligent-assembly.jl)
-include("iterative-assembly.jl")
+    # Iterative assembly algorithms (depends on intelligent-assembly.jl)
+    include("iterative-assembly.jl")
+end
 
 # Advanced algorithms (depend on core graph types)
 include("viterbi-next.jl")
@@ -145,56 +177,58 @@ include("viterbi-next.jl")
 
 # Load remaining files in alphabetical order (no critical dependencies)
 # Using explicit include() statements enables full static analysis by ExplicitImports.jl
-include("alignments-and-mapping.jl")
-include("amino-acid-analysis.jl")
-include("annotation.jl")
-include("autocycler.jl")
-include("bcalm.jl")
-include("binning.jl")
-include("bioconda.jl")
-include("busco-datasets.jl")
-include("checkpointing.jl")
-include("classification.jl")
-include("clustering.jl")
-include("codon-optimization.jl")
-include("coverage-clustering.jl")
-include("dimensionality-reduction.jl")
-include("distance-metrics.jl")
-include("foldseek.jl")
-include("genome-features.jl")
-include("ggcat.jl")
-include("graph-cleanup.jl")
-include("kmer-analysis.jl")
-include("kmer-saturation-analysis.jl")
-include("metagraph.jl")
-include("metagenomic-classification.jl")
-include("ncbi-datasets-cli.jl")
-include("pangenome-analysis.jl")
-include("pantools.jl")
-include("plotting-and-visualization.jl")
-include("protein-databases.jl")
-include("prokrustean.jl")
-include("quality-control-and-benchmarking.jl")
-include("rclone.jl")
-include("read-quality-control.jl")
-include("reference-databases.jl")
-include("relational-matrices.jl")
-include("sentencepiece.jl")
-include("sequence-comparison.jl")
-include("sequence-graphs.jl")
-include("simulation.jl")
-include("slurm-templates.jl")
-include("execution.jl")
-include("slurm-sbatch.jl")
-include("taxonomy-and-trees.jl")
-include("testing-utilities.jl")
-include("variant-analysis.jl")
-include("viterbi-polishing-and-error-correction.jl")
-include("xam.jl")
+if !_MYCELIA_CORE_BENCHMARK
+    include("alignments-and-mapping.jl")
+    include("amino-acid-analysis.jl")
+    include("annotation.jl")
+    include("autocycler.jl")
+    include("bcalm.jl")
+    include("binning.jl")
+    include("bioconda.jl")
+    include("busco-datasets.jl")
+    include("checkpointing.jl")
+    include("classification.jl")
+    include("clustering.jl")
+    include("codon-optimization.jl")
+    include("coverage-clustering.jl")
+    include("dimensionality-reduction.jl")
+    include("distance-metrics.jl")
+    include("foldseek.jl")
+    include("genome-features.jl")
+    include("ggcat.jl")
+    include("graph-cleanup.jl")
+    include("kmer-analysis.jl")
+    include("kmer-saturation-analysis.jl")
+    include("metagraph.jl")
+    include("metagenomic-classification.jl")
+    include("ncbi-datasets-cli.jl")
+    include("pangenome-analysis.jl")
+    include("pantools.jl")
+    include("plotting-and-visualization.jl")
+    include("protein-databases.jl")
+    include("prokrustean.jl")
+    include("quality-control-and-benchmarking.jl")
+    include("rclone.jl")
+    include("read-quality-control.jl")
+    include("reference-databases.jl")
+    include("relational-matrices.jl")
+    include("sentencepiece.jl")
+    include("sequence-comparison.jl")
+    include("sequence-graphs.jl")
+    include("simulation.jl")
+    include("slurm-templates.jl")
+    include("execution.jl")
+    include("slurm-sbatch.jl")
+    include("taxonomy-and-trees.jl")
+    include("testing-utilities.jl")
+    include("variant-analysis.jl")
+    include("viterbi-polishing-and-error-correction.jl")
+    include("xam.jl")
 
-# PrecompileTools workload for faster startup
-# This must be included last, after all other definitions are loaded
-include("precompile_workload.jl")
+    # PrecompileTools workload for faster startup
+    # This must be included last, after all other definitions are loaded
+    include("precompile_workload.jl")
+end
 
 """
     _clear_ld_library_path!()

--- a/src/viterbi-next.jl
+++ b/src/viterbi-next.jl
@@ -73,6 +73,7 @@ struct ViterbiCorrectionConfig{F <: Function}
     alphabet::Symbol
     strand_mode::Symbol
     max_steps::Union{Nothing, Int}
+    beam_width::Union{Nothing, Int}
     target_vertex::Any
     start_strand::Rhizomorph.StrandOrientation
     edge_weight::Function
@@ -84,6 +85,7 @@ struct ViterbiCorrectionConfig{F <: Function}
             alphabet::Symbol = :auto,
             strand_mode::Symbol = :auto,
             max_steps::Union{Nothing, Int} = nothing,
+            beam_width::Union{Nothing, Int} = nothing,
             target_vertex = nothing,
             start_strand::Rhizomorph.StrandOrientation = Rhizomorph.Forward,
             edge_weight::Function = Rhizomorph.edge_data_weight
@@ -97,6 +99,9 @@ struct ViterbiCorrectionConfig{F <: Function}
         if max_steps !== nothing && max_steps < 0
             throw(ArgumentError("max_steps must be non-negative, got $max_steps"))
         end
+        if beam_width !== nothing && beam_width <= 0
+            throw(ArgumentError("beam_width must be positive when set, got $beam_width"))
+        end
         return new{F}(
             error_rate,
             verbosity,
@@ -104,6 +109,7 @@ struct ViterbiCorrectionConfig{F <: Function}
             alphabet,
             strand_mode,
             max_steps,
+            beam_width,
             target_vertex,
             start_strand,
             edge_weight
@@ -118,6 +124,7 @@ function ViterbiCorrectionConfig(;
         alphabet::Symbol = :auto,
         strand_mode::Symbol = :auto,
         max_steps::Union{Nothing, Int} = nothing,
+        beam_width::Union{Nothing, Int} = nothing,
         target_vertex = nothing,
         start_strand::Rhizomorph.StrandOrientation = Rhizomorph.Forward,
         edge_weight::Function = Rhizomorph.edge_data_weight
@@ -129,6 +136,7 @@ function ViterbiCorrectionConfig(;
         alphabet = alphabet,
         strand_mode = strand_mode,
         max_steps = max_steps,
+        beam_width = beam_width,
         target_vertex = target_vertex,
         start_strand = start_strand,
         edge_weight = edge_weight
@@ -281,13 +289,24 @@ function _correct_metagraphs_next_observations(
                 observation,
                 config
             )
-            Rhizomorph.viterbi_decode_next(
-                weighted,
-                start_vertex,
-                max_steps;
-                target_vertex = target_vertex,
-                start_strand = config.start_strand
-            )
+            if config.beam_width === nothing
+                Rhizomorph.viterbi_decode_next(
+                    weighted,
+                    start_vertex,
+                    max_steps;
+                    target_vertex = target_vertex,
+                    start_strand = config.start_strand
+                )
+            else
+                Rhizomorph.beam_pruned_viterbi_decode_next(
+                    weighted,
+                    start_vertex,
+                    max_steps;
+                    target_vertex = target_vertex,
+                    start_strand = config.start_strand,
+                    beam_width = config.beam_width
+                )
+            end
         end
         push!(paths, result)
     end
@@ -304,9 +323,35 @@ function _correct_metagraphs_next_observations(
                            :quality_aware : :alphabet_parameterized,
         :transition_model => _viterbi_transition_scoring(graph, transition_edge_weight),
         :strand_mode => strand_mode,
-        :reverse_complement_support => _viterbi_supports_reverse_complement(alphabet)
+        :reverse_complement_support => _viterbi_supports_reverse_complement(alphabet),
+        :beam_width => config.beam_width,
+        :expanded_states => _sum_path_diagnostic(paths, :expanded_states),
+        :generated_states => _sum_path_diagnostic(paths, :generated_states),
+        :max_retained_states => _max_path_diagnostic(paths, :max_retained_states),
+        :cumulative_retained_states => _sum_path_diagnostic(
+            paths,
+            :cumulative_retained_states
+        )
     )
     return ViterbiCorrectionResult(corrected, paths, diagnostics)
+end
+
+
+function _sum_path_diagnostic(
+        paths::AbstractVector{Rhizomorph.ViterbiDecodingResult},
+        key::Symbol
+)::Int
+    return sum(Int(get(path.diagnostics, key, 0)) for path in paths)
+end
+
+function _max_path_diagnostic(
+        paths::AbstractVector{Rhizomorph.ViterbiDecodingResult},
+        key::Symbol
+)::Int
+    if isempty(paths)
+        return 0
+    end
+    return maximum(Int(get(path.diagnostics, key, 0)) for path in paths)
 end
 
 function _correction_vertex_data_type(
@@ -876,6 +921,7 @@ function _viterbi_correct_observation(
         :strand_mode => strand_mode,
         :reverse_complement_support => _viterbi_supports_reverse_complement(alphabet),
         :max_steps => length(observation) - 1,
+        :beam_width => config.beam_width,
         :target_vertex => target_vertex,
         :start_strand => Rhizomorph._normalize_strand(config.start_strand),
         :score_domain => :log_probability,
@@ -998,6 +1044,14 @@ function _viterbi_correct_observation(
 
         if isempty(next_scores)
             break
+        end
+
+        if config.beam_width !== nothing
+            next_scores, next_predecessors = _prune_correction_beam(
+                next_scores,
+                next_predecessors,
+                config.beam_width
+            )
         end
 
         push!(predecessors_by_depth, next_predecessors)
@@ -1197,6 +1251,42 @@ function _viterbi_reverse_complement_string(
         throw(ArgumentError("alphabet $alphabet has no reverse complement"))
     end
     return join((complement[base] for base in reverse(uppercase(sequence))))
+end
+
+function _prune_correction_beam(
+        scores::Dict{Tuple{T, Rhizomorph.StrandOrientation}, Float64},
+        predecessors::Dict{
+            Tuple{T, Rhizomorph.StrandOrientation},
+            Tuple{T, Rhizomorph.StrandOrientation}
+        },
+        beam_width::Int
+)::Tuple{
+        Dict{Tuple{T, Rhizomorph.StrandOrientation}, Float64},
+        Dict{Tuple{T, Rhizomorph.StrandOrientation}, Tuple{T, Rhizomorph.StrandOrientation}}
+} where {T}
+    if length(scores) <= beam_width
+        return scores, predecessors
+    end
+
+    retained = first(
+        sort(
+            collect(scores);
+            by = item -> (-item[2], string(item[1][1]), Int(item[1][2]))
+        ),
+        beam_width
+    )
+    retained_scores = Dict{Tuple{T, Rhizomorph.StrandOrientation}, Float64}(retained)
+    retained_predecessors = Dict{
+        Tuple{T, Rhizomorph.StrandOrientation},
+        Tuple{T, Rhizomorph.StrandOrientation}
+    }()
+    for (state, _) in retained
+        if haskey(predecessors, state)
+            retained_predecessors[state] = predecessors[state]
+        end
+    end
+
+    return retained_scores, retained_predecessors
 end
 
 function _best_correction_state(

--- a/src/viterbi-next.jl
+++ b/src/viterbi-next.jl
@@ -316,6 +316,7 @@ function _correct_metagraphs_next_observations(
         :interface => :metagraphs_next,
         :vertex_data_type => _correction_vertex_data_type(graph),
         :algorithm => :rhizomorph_viterbi_decode_next,
+        :exact => config.beam_width === nothing,
         :observation_count => length(observations),
         :emission_callback => nameof(config.emission_logp),
         :alphabet => alphabet,
@@ -916,7 +917,7 @@ function _viterbi_correct_observation(
 
     diagnostics = Dict{Symbol, Any}(
         :algorithm => :viterbi_emission_correct_observation,
-        :exact => true,
+        :exact => config.beam_width === nothing,
         :alphabet => alphabet,
         :strand_mode => strand_mode,
         :reverse_complement_support => _viterbi_supports_reverse_complement(alphabet),
@@ -958,6 +959,17 @@ function _viterbi_correct_observation(
     if isempty(active_scores)
         diagnostics[:reason] = :no_finite_start_emission
         return Rhizomorph.ViterbiDecodingResult(nothing, -Inf, diagnostics)
+    end
+
+    if config.beam_width !== nothing
+        active_scores, _ = _prune_correction_beam(
+            active_scores,
+            Dict{
+                Tuple{label_type, Rhizomorph.StrandOrientation},
+                Tuple{label_type, Rhizomorph.StrandOrientation}
+            }(),
+            config.beam_width
+        )
     end
 
     diagnostics[:retained_states] = length(active_scores)
@@ -1268,12 +1280,10 @@ function _prune_correction_beam(
         return scores, predecessors
     end
 
-    retained = first(
-        sort(
-            collect(scores);
-            by = item -> (-item[2], string(item[1][1]), Int(item[1][2]))
-        ),
-        beam_width
+    retained = partialsort(
+        collect(scores),
+        1:beam_width;
+        by = item -> (-item[2], string(item[1][1]), Int(item[1][2]))
     )
     retained_scores = Dict{Tuple{T, Rhizomorph.StrandOrientation}, Float64}(retained)
     retained_predecessors = Dict{

--- a/test/2_preprocessing_qc/dimensionality_reduction_and_clustering.jl
+++ b/test/2_preprocessing_qc/dimensionality_reduction_and_clustering.jl
@@ -1218,7 +1218,7 @@ Test.@testset "Negative Binomial (overdispersed counts) Matrix Processing" begin
     Test.@testset "Bray-Curtis Distance + KMedoids" begin
         test_println("[NegBin] Testing: Bray-Curtis Distance + KMedoids")
         nb_distance_matrix = Mycelia.frequency_matrix_to_bray_curtis_distance_matrix(shuffled_nb_matrix)
-        kmedoids_result = Clustering.kmedoids(nb_distance_matrix, n_distributions)
+        kmedoids_result = deterministic_kmedoids(nb_distance_matrix, n_distributions, 1)
         kmedoids_labels = kmedoids_result.assignments
         remapped_pred_labels,
         mapping = Mycelia.best_label_mapping(shuffled_nb_labels, kmedoids_labels)

--- a/test/2_preprocessing_qc/dimensionality_reduction_and_clustering.jl
+++ b/test/2_preprocessing_qc/dimensionality_reduction_and_clustering.jl
@@ -204,7 +204,7 @@ Test.@testset "Binary Matrix Processing" begin
     Test.@testset "Jaccard Distance + KMedoids" begin
         test_println("[Binary] Testing: Jaccard Distance + KMedoids")
         binary_distance_matrix = Mycelia.frequency_matrix_to_jaccard_distance_matrix(shuffled_binary_matrix)
-        kmedoids_result = Clustering.kmedoids(binary_distance_matrix, n_distributions)
+        kmedoids_result = deterministic_kmedoids(binary_distance_matrix, n_distributions, 1)
         kmedoids_labels = kmedoids_result.assignments
         remapped_pred_labels,
         mapping = Mycelia.best_label_mapping(shuffled_binary_labels, kmedoids_labels)
@@ -279,7 +279,7 @@ Test.@testset "Binary Matrix Processing" begin
         ## Compute distance matrix from PCoA coordinates (e.g., Euclidean)
         embedding = pcoa_binary_result.coordinates
         dist_matrix = Distances.pairwise(Distances.Euclidean(), embedding; dims = 2)
-        kmedoids_result = Clustering.kmedoids(dist_matrix, n_distributions)
+        kmedoids_result = deterministic_kmedoids(dist_matrix, n_distributions, 1)
         pcoa_fit_binary_labels = kmedoids_result.assignments
         pcoa_fit_binary_labels,
         mapping = Mycelia.best_label_mapping(shuffled_binary_labels, pcoa_fit_binary_labels)
@@ -381,7 +381,7 @@ Test.@testset "Binary Matrix Processing" begin
         ## Compute distance matrix from UMAP embedding (Euclidean)
         embedding = pcoa_binary_umap_model.embedding
         dist_matrix = Distances.pairwise(Distances.Euclidean(), embedding; dims = 2)
-        kmedoids_result = Clustering.kmedoids(dist_matrix, n_distributions)
+        kmedoids_result = deterministic_kmedoids(dist_matrix, n_distributions, 1)
         pcoa_binary_umap_fit_labels = kmedoids_result.assignments
         pcoa_binary_umap_fit_labels,
         mapping = Mycelia.best_label_mapping(shuffled_binary_labels, pcoa_binary_umap_fit_labels)
@@ -474,7 +474,7 @@ Test.@testset "Binary Matrix Processing" begin
             logistic_pca_result = Mycelia.logistic_pca_epca(shuffled_binary_matrix, k=5)
             ## Compute distance matrix from logistic PCA scores (Euclidean)
             dist_matrix = Distances.pairwise(Distances.Euclidean(), logistic_pca_result.scores; dims=2)
-            kmedoids_result = Clustering.kmedoids(dist_matrix, n_distributions)
+            kmedoids_result = deterministic_kmedoids(dist_matrix, n_distributions, 1)
             fit_labels = kmedoids_result.assignments
             fit_labels, mapping = Mycelia.best_label_mapping(shuffled_binary_labels, fit_labels)
             plt = Mycelia.plot_embeddings(logistic_pca_result.scores;
@@ -558,7 +558,7 @@ Test.@testset "Binary Matrix Processing" begin
             ## Compute distance matrix from UMAP embedding (Euclidean)
             embedding = umap_model.embedding
             dist_matrix = Distances.pairwise(Distances.Euclidean(), embedding; dims=2)
-            kmedoids_result = Clustering.kmedoids(dist_matrix, n_distributions)
+            kmedoids_result = deterministic_kmedoids(dist_matrix, n_distributions, 1)
             fit_labels = kmedoids_result.assignments
             fit_labels, mapping = Mycelia.best_label_mapping(shuffled_binary_labels, fit_labels)
             plt = Mycelia.plot_embeddings(embedding;
@@ -699,7 +699,7 @@ Test.@testset "Poisson (counts) Matrix Processing" begin
     Test.@testset "Bray-Curtis Distance + KMedoids" begin
         test_println("[Poisson] Testing: Bray-Curtis Distance + KMedoids")
         poisson_distance_matrix = Mycelia.frequency_matrix_to_bray_curtis_distance_matrix(shuffled_poisson_matrix)
-        kmedoids_result = Clustering.kmedoids(poisson_distance_matrix, n_distributions)
+        kmedoids_result = deterministic_kmedoids(poisson_distance_matrix, n_distributions, 1)
         kmedoids_labels = kmedoids_result.assignments
         remapped_pred_labels,
         mapping = Mycelia.best_label_mapping(shuffled_poisson_labels, kmedoids_labels)
@@ -776,7 +776,7 @@ Test.@testset "Poisson (counts) Matrix Processing" begin
         embedding = pcoa_poisson_result.coordinates
         dist_matrix = Distances.pairwise(Distances.Euclidean(), embedding; dims = 2)
         ## Apply k-medoids clustering
-        kmedoids_result = Clustering.kmedoids(dist_matrix, n_distributions)
+        kmedoids_result = deterministic_kmedoids(dist_matrix, n_distributions, 1)
         pcoa_fit_poisson_labels = kmedoids_result.assignments
         ## Remap predicted labels to best match true labels
         pcoa_fit_poisson_labels,
@@ -885,7 +885,7 @@ Test.@testset "Poisson (counts) Matrix Processing" begin
         embedding = pcoa_poisson_umap_model.embedding
         dist_matrix = Distances.pairwise(Distances.Euclidean(), embedding; dims = 2)
         ## Apply k-medoids clustering
-        kmedoids_result = Clustering.kmedoids(dist_matrix, n_distributions)
+        kmedoids_result = deterministic_kmedoids(dist_matrix, n_distributions, 1)
         pcoa_poisson_umap_fit_labels = kmedoids_result.assignments
         ## Remap predicted labels to best match true labels
         pcoa_poisson_umap_fit_labels,
@@ -1296,7 +1296,7 @@ Test.@testset "Negative Binomial (overdispersed counts) Matrix Processing" begin
         embedding = pcoa_nb_result.coordinates
         dist_matrix = Distances.pairwise(Distances.Euclidean(), embedding; dims = 2)
         ## Apply k-medoids clustering
-        kmedoids_result = Clustering.kmedoids(dist_matrix, n_distributions)
+        kmedoids_result = deterministic_kmedoids(dist_matrix, n_distributions, 1)
         pcoa_fit_nb_labels = kmedoids_result.assignments
         ## Remap predicted labels to best match true labels
         pcoa_fit_nb_labels,
@@ -1400,7 +1400,7 @@ Test.@testset "Negative Binomial (overdispersed counts) Matrix Processing" begin
         ## Compute distance matrix from UMAP embedding (Euclidean)
         embedding = pcoa_nb_umap_model.embedding
         dist_matrix = Distances.pairwise(Distances.Euclidean(), embedding; dims = 2)
-        kmedoids_result = Clustering.kmedoids(dist_matrix, n_distributions)
+        kmedoids_result = deterministic_kmedoids(dist_matrix, n_distributions, 1)
         pcoa_nb_umap_fit_labels = kmedoids_result.assignments
         pcoa_nb_umap_fit_labels,
         mapping = Mycelia.best_label_mapping(shuffled_nb_labels, pcoa_nb_umap_fit_labels)
@@ -1682,7 +1682,7 @@ Test.@testset "Binomial (counts in 0:ntrials) Matrix Processing" begin
         embedding = pcoa_binom_result.coordinates
         dist_matrix = Distances.pairwise(Distances.Euclidean(), embedding; dims = 2)
         ## Apply k-medoids clustering
-        kmedoids_result = Clustering.kmedoids(dist_matrix, n_distributions)
+        kmedoids_result = deterministic_kmedoids(dist_matrix, n_distributions, 1)
         pcoa_fit_binom_labels = kmedoids_result.assignments
         ## Remap predicted labels to best match true labels
         pcoa_fit_binom_labels,
@@ -1787,7 +1787,7 @@ Test.@testset "Binomial (counts in 0:ntrials) Matrix Processing" begin
         ## Compute distance matrix from UMAP embedding (Euclidean)
         embedding = pcoa_binom_umap_model.embedding
         dist_matrix = Distances.pairwise(Distances.Euclidean(), embedding; dims = 2)
-        kmedoids_result = Clustering.kmedoids(dist_matrix, n_distributions)
+        kmedoids_result = deterministic_kmedoids(dist_matrix, n_distributions, 1)
         pcoa_binom_umap_fit_labels = kmedoids_result.assignments
         pcoa_binom_umap_fit_labels,
         mapping = Mycelia.best_label_mapping(shuffled_binom_labels, pcoa_binom_umap_fit_labels)
@@ -2117,7 +2117,7 @@ Test.@testset "Continuous Bernoulli (values in (0,1)) Matrix Processing" begin
     Test.@testset "Cosine Distance + KMedoids" begin
         test_println("[ContBernoulli] Testing: Cosine Distance + KMedoids")
         contb_distance_matrix = Mycelia.frequency_matrix_to_cosine_distance_matrix(clipped_contb_matrix)
-        kmedoids_result = Clustering.kmedoids(contb_distance_matrix, n_distributions)
+        kmedoids_result = deterministic_kmedoids(contb_distance_matrix, n_distributions, 1)
         kmedoids_labels = kmedoids_result.assignments
         remapped_pred_labels,
         mapping = Mycelia.best_label_mapping(shuffled_contb_labels, kmedoids_labels)
@@ -2196,7 +2196,7 @@ Test.@testset "Continuous Bernoulli (values in (0,1)) Matrix Processing" begin
         embedding = pcoa_contb_result.coordinates
         dist_matrix = Distances.pairwise(Distances.Euclidean(), embedding; dims = 2)
         ## Apply k-medoids clustering
-        kmedoids_result = Clustering.kmedoids(dist_matrix, n_distributions)
+        kmedoids_result = deterministic_kmedoids(dist_matrix, n_distributions, 1)
         pcoa_fit_contb_labels = kmedoids_result.assignments
         ## Remap predicted labels to best match true labels
         pcoa_fit_contb_labels,
@@ -2301,7 +2301,7 @@ Test.@testset "Continuous Bernoulli (values in (0,1)) Matrix Processing" begin
         ## Compute distance matrix from UMAP embedding (Euclidean)
         embedding = pcoa_contb_umap_model.embedding
         dist_matrix = Distances.pairwise(Distances.Euclidean(), embedding; dims = 2)
-        kmedoids_result = Clustering.kmedoids(dist_matrix, n_distributions)
+        kmedoids_result = deterministic_kmedoids(dist_matrix, n_distributions, 1)
         pcoa_contb_umap_fit_labels = kmedoids_result.assignments
         pcoa_contb_umap_fit_labels,
         mapping = Mycelia.best_label_mapping(shuffled_contb_labels, pcoa_contb_umap_fit_labels)
@@ -2395,7 +2395,7 @@ Test.@testset "Continuous Bernoulli (values in (0,1)) Matrix Processing" begin
         contb_pca_result = Mycelia.contbernoulli_pca_epca(clipped_contb_matrix, k=5)
         ## Compute distance matrix from ContBernoulli PCA scores (Euclidean)
         dist_matrix = Distances.pairwise(Distances.Euclidean(), contb_pca_result.scores; dims=2)
-        kmedoids_result = Clustering.kmedoids(dist_matrix, n_distributions)
+        kmedoids_result = deterministic_kmedoids(dist_matrix, n_distributions, 1)
         fit_labels = kmedoids_result.assignments
         fit_labels, mapping = Mycelia.best_label_mapping(shuffled_contb_labels, fit_labels)
         plt = Mycelia.plot_embeddings(contb_pca_result.scores;
@@ -2480,7 +2480,7 @@ Test.@testset "Continuous Bernoulli (values in (0,1)) Matrix Processing" begin
         ## Compute distance matrix from UMAP embedding (Euclidean)
         embedding = umap_model.embedding
         dist_matrix = Distances.pairwise(Distances.Euclidean(), embedding; dims=2)
-        kmedoids_result = Clustering.kmedoids(dist_matrix, n_distributions)
+        kmedoids_result = deterministic_kmedoids(dist_matrix, n_distributions, 1)
         fit_labels = kmedoids_result.assignments
         fit_labels, mapping = Mycelia.best_label_mapping(shuffled_contb_labels, fit_labels)
         plt = Mycelia.plot_embeddings(embedding;
@@ -2712,7 +2712,7 @@ Test.@testset "Gamma (strictly positive) Matrix Processing" begin
         ## Compute distance matrix from PCoA coordinates (Euclidean)
         embedding = pcoa_gamma_result.coordinates
         dist_matrix = Distances.pairwise(Distances.Euclidean(), embedding; dims = 2)
-        kmedoids_result = Clustering.kmedoids(dist_matrix, n_distributions)
+        kmedoids_result = deterministic_kmedoids(dist_matrix, n_distributions, 1)
         pcoa_fit_gamma_labels = kmedoids_result.assignments
         pcoa_fit_gamma_labels,
         mapping = Mycelia.best_label_mapping(shuffled_gamma_labels, pcoa_fit_gamma_labels)
@@ -2814,7 +2814,7 @@ Test.@testset "Gamma (strictly positive) Matrix Processing" begin
         ## Compute distance matrix from UMAP embedding (Euclidean)
         embedding = pcoa_gamma_umap_model.embedding
         dist_matrix = Distances.pairwise(Distances.Euclidean(), embedding; dims = 2)
-        kmedoids_result = Clustering.kmedoids(dist_matrix, n_distributions)
+        kmedoids_result = deterministic_kmedoids(dist_matrix, n_distributions, 1)
         pcoa_gamma_umap_fit_labels = kmedoids_result.assignments
         pcoa_gamma_umap_fit_labels,
         mapping = Mycelia.best_label_mapping(shuffled_gamma_labels, pcoa_gamma_umap_fit_labels)
@@ -3031,7 +3031,7 @@ Test.@testset "Gaussian (centered, real-valued) Matrix Processing" begin
     Test.@testset "Euclidean Distance + KMedoids" begin
         test_println("[Gaussian] Testing: Euclidean Distance + KMedoids")
         gauss_distance_matrix = Mycelia.frequency_matrix_to_euclidean_distance_matrix(shuffled_gauss_matrix)
-        kmedoids_result = Clustering.kmedoids(gauss_distance_matrix, n_distributions)
+        kmedoids_result = deterministic_kmedoids(gauss_distance_matrix, n_distributions, 3)
         kmedoids_labels = kmedoids_result.assignments
         remapped_pred_labels,
         mapping = Mycelia.best_label_mapping(shuffled_gauss_labels, kmedoids_labels)
@@ -3112,7 +3112,7 @@ Test.@testset "Gaussian (centered, real-valued) Matrix Processing" begin
         ## Compute distance matrix from PCoA coordinates (Euclidean)
         embedding = pcoa_gauss_result.coordinates
         dist_matrix = Distances.pairwise(Distances.Euclidean(), embedding; dims = 2)
-        kmedoids_result = Clustering.kmedoids(dist_matrix, n_distributions)
+        kmedoids_result = deterministic_kmedoids(dist_matrix, n_distributions, 1)
         pcoa_fit_gauss_labels = kmedoids_result.assignments
         pcoa_fit_gauss_labels,
         mapping = Mycelia.best_label_mapping(shuffled_gauss_labels, pcoa_fit_gauss_labels)
@@ -3326,7 +3326,7 @@ Test.@testset "Gaussian (centered, real-valued) Matrix Processing" begin
         gauss_pca_result = Mycelia.gaussian_pca_epca(shuffled_gauss_matrix, k=5)
         ## Compute distance matrix from Gaussian PCA scores (Euclidean)
         dist_matrix = Distances.pairwise(Distances.Euclidean(), gauss_pca_result.scores; dims=2)
-        kmedoids_result = Clustering.kmedoids(dist_matrix, n_distributions)
+        kmedoids_result = deterministic_kmedoids(dist_matrix, n_distributions, 1)
         fit_labels = kmedoids_result.assignments
         fit_labels, mapping = Mycelia.best_label_mapping(shuffled_gauss_labels, fit_labels)
         plt = Mycelia.plot_embeddings(gauss_pca_result.scores;
@@ -3411,7 +3411,7 @@ Test.@testset "Gaussian (centered, real-valued) Matrix Processing" begin
         ## Compute distance matrix from UMAP embedding (Euclidean)
         embedding = umap_model.embedding
         dist_matrix = Distances.pairwise(Distances.Euclidean(), embedding; dims=2)
-        kmedoids_result = Clustering.kmedoids(dist_matrix, n_distributions)
+        kmedoids_result = deterministic_kmedoids(dist_matrix, n_distributions, 1)
         fit_labels = kmedoids_result.assignments
         fit_labels, mapping = Mycelia.best_label_mapping(shuffled_gauss_labels, fit_labels)
         plt = Mycelia.plot_embeddings(embedding;
@@ -3563,7 +3563,7 @@ Test.@testset "Probability Vector (Compositional) Matrix Processing" begin
     Test.@testset "Jensen-Shannon Divergence + KMedoids" begin
         test_println("[ProbVec] Testing: Jensen-Shannon Divergence + KMedoids")
         probvec_distance_matrix = Mycelia.frequency_matrix_to_jensen_shannon_distance_matrix(shuffled_dirichlet_matrix)
-        kmedoids_result = Clustering.kmedoids(probvec_distance_matrix, n_distributions)
+        kmedoids_result = deterministic_kmedoids(probvec_distance_matrix, n_distributions, 1)
         kmedoids_labels = kmedoids_result.assignments
         remapped_pred_labels,
         mapping = Mycelia.best_label_mapping(shuffled_dirichlet_labels, kmedoids_labels)
@@ -3647,7 +3647,7 @@ Test.@testset "Probability Vector (Compositional) Matrix Processing" begin
         embedding = pcoa_probvec_result.coordinates
         dist_matrix = Distances.pairwise(Distances.Euclidean(), embedding; dims = 2)
         ## Apply k-medoids clustering
-        kmedoids_result = Clustering.kmedoids(dist_matrix, n_distributions)
+        kmedoids_result = deterministic_kmedoids(dist_matrix, n_distributions, 1)
         pcoa_fit_probvec_labels = kmedoids_result.assignments
         ## Remap predicted labels to best match true labels
         pcoa_fit_probvec_labels,

--- a/test/4_assembly/viterbi_fixed_length_graph_correction_test.jl
+++ b/test/4_assembly/viterbi_fixed_length_graph_correction_test.jl
@@ -43,11 +43,25 @@ Test.@testset "Fixed-length graph Viterbi correction" begin
         ]
 
         result = Mycelia.correct_observations(graph, [observed])
+        beam_result = Mycelia.correct_observations(
+            graph,
+            [observed];
+            config = Mycelia.ViterbiCorrectionConfig(beam_width = 1)
+        )
 
         Test.@test result.diagnostics[:alphabet] == :DNA
         Test.@test result.diagnostics[:emission_model] == :alphabet_parameterized
         Test.@test fixed_length_decoded_label_strings(result) ==
             ["ATG", "TGC", "GCG", "CGT"]
+        Test.@test beam_result.diagnostics[:beam_width] == 1
+        Test.@test only(beam_result.paths).diagnostics[:max_retained_states] <= 1
+        Test.@test fixed_length_decoded_label_strings(beam_result) ==
+            fixed_length_decoded_label_strings(result)
+    end
+
+    Test.@testset "beam width validation rejects non-positive beams" begin
+        Test.@test_throws ArgumentError Mycelia.ViterbiCorrectionConfig(beam_width = 0)
+        Test.@test_throws ArgumentError Mycelia.ViterbiCorrectionConfig(beam_width = -1)
     end
 
     Test.@testset "qualmer graph correction reuses quality-aware emissions" begin

--- a/test/4_assembly/viterbi_fixed_length_graph_correction_test.jl
+++ b/test/4_assembly/viterbi_fixed_length_graph_correction_test.jl
@@ -29,6 +29,16 @@ function fixed_length_decoded_label_strings(
     return [string(label) for label in decoded]
 end
 
+function fixed_length_beam_width_error_message(beam_width::Int)::String
+    try
+        Mycelia.ViterbiCorrectionConfig(beam_width = beam_width)
+        return ""
+    catch error
+        Test.@test error isa ArgumentError
+        return sprint(showerror, error)
+    end
+end
+
 Test.@testset "Fixed-length graph Viterbi correction" begin
     Test.@testset "k-mer graph correction recovers injected substitution" begin
         records = [FASTX.FASTA.Record("dna", BioSequences.dna"ATGCGT")]
@@ -60,8 +70,14 @@ Test.@testset "Fixed-length graph Viterbi correction" begin
     end
 
     Test.@testset "beam width validation rejects non-positive beams" begin
-        Test.@test_throws ArgumentError Mycelia.ViterbiCorrectionConfig(beam_width = 0)
-        Test.@test_throws ArgumentError Mycelia.ViterbiCorrectionConfig(beam_width = -1)
+        Test.@test occursin(
+            "beam_width must be positive when set",
+            fixed_length_beam_width_error_message(0)
+        )
+        Test.@test occursin(
+            "beam_width must be positive when set",
+            fixed_length_beam_width_error_message(-1)
+        )
     end
 
     Test.@testset "qualmer graph correction reuses quality-aware emissions" begin


### PR DESCRIPTION
## Summary
- add Viterbi correction `beam_width` support plus diagnostics
- extend B8 Viterbi accuracy benchmark with run/scale/beam-width/error-rate/window-scale/repetition CLI flags and timing/state columns
- record decoder failures and length-mismatch paths as benchmark data instead of crashing larger sweeps
- move the lightweight HPC benchmark path into `benchmarking/viterbi_accuracy_core_loader.jl` so the package module layout is no longer driven by `MYCELIA_CORE_BENCHMARK`
- keep CairoMakie plotting available for PNG/SVG output when plots are requested, with beam-aware plot aggregation

## Verification
- local: `git diff --check`
- local core/default focused regression: `test/4_assembly/viterbi_fixed_length_graph_correction_test.jl` passes 18/18
- local core benchmark smoke: rows=36; exact/1/2 all succeeded; exact rows report `diagnostics_exact=true`, beam rows report `false`
- local plot smoke emitted `viterbi_accuracy_vs_error_rate.png` and `.svg` with beam-aware series aggregation
- local CI-repro file: `test/2_preprocessing_qc/dimensionality_reduction_and_clustering.jl` passes locally; previous GitHub failure appears unrelated/flaky KMedoids threshold behavior
- local core sweep: rows=45, exact/1/2/4/8 all ok=9/9, mean_edit=1.0
- local scaled smoke: window-scale=2, rows=36; beam=1 succeeded=11/12, beam=4 matched exact accuracy with much lower timing
- local 4x length-mismatch smoke: rows=54; beam=1 recorded length_mismatch failures without crashing; beam=2/4 succeeded=18/18 with mean_edit=1.0
- Lovelace core-mode sweep: rows=45, exact/1/2/4/8 all ok=9/9, mean_edit=1.0
- Lovelace scale grid: window-scale=1 rows=216, all beams exact/1/2/4/8/16 ok=36/36; window-scale=2 rows=216, beam=1 ok=35/36, beam>=2 ok=36/36
- Lovelace 4x rerun on 18c77e0a: rows=216; exact total_seconds=183.675550, beam=1 succeeded=33/36 with length_mismatch failures, beam=2/4/8/16 succeeded=36/36 with mean_edit=1.0; beam=2 total_seconds=2.420733

## Lovelace artifacts
- core smoke root: `/home/cjprybol/workspace/Mycelia/.worktrees/hpc-b-lovelace-viterbi-core-20260627T212710Z/benchmarking/results/viterbi_accuracy_core_lovelace_hpc-b-lovelace-viterbi-core-20260627T212710Z`
- scale grid 1x/2x log: `/home/cjprybol/workspace/Mycelia/.worktrees/hpc-b-lovelace-viterbi-scale-20260627T215248Z/benchmarking/logs/hpc-b-lovelace-viterbi-scale-grid-20260627T220110Z.log`
- 4x fix rerun root: `/home/cjprybol/workspace/Mycelia/.worktrees/hpc-b-lovelace-viterbi-scale4-fix-20260627T221425Z/benchmarking/results/viterbi_accuracy_scale4_hpc-b-lovelace-viterbi-scale4-fix-rerun-20260627T221933Z`
- 4x fix rerun log: `/home/cjprybol/workspace/Mycelia/.worktrees/hpc-b-lovelace-viterbi-scale4-fix-20260627T221425Z/benchmarking/logs/hpc-b-lovelace-viterbi-scale4-fix-rerun-20260627T221933Z.log`

## Remaining blocker
Lawrencium/LRC matching run is blocked by a Cloudflare access issue. Follow-up bead: `td-p9fa`; retry after the issue clears or from VPN.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional beam-search support for observation correction, including beam-aware decoding/labeling and richer diagnostics (retained-state metrics and exactness).
  * Expanded accuracy benchmarking with CLI-configurable runs (run id/scale, beam widths, error rates, window scaling, repetitions) and improved plot controls.

* **Bug Fixes**
  * Improved benchmark reproducibility by making error injection replicate-aware and tightening correction success/length checks.
  * Hardened plotting so figure generation only runs when supported.

* **Tests**
  * Extended fixed-length graph correction tests to validate beam width behavior and reject invalid values.
  * Made k-medoids clustering tests deterministic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

