### PR TITLE
feat: additive assembly-efficiency modes for Rhizomorph (dedup, canonical, memory-profile, unitig-compaction)

### DIFF
--- a/benchmarking/mode_comparison.jl
+++ b/benchmarking/mode_comparison.jl
@@ -520,16 +520,27 @@ function print_verdict(results::DataFrames.DataFrame)
         row.mode_label == "baseline" && continue
         notes = String[]
 
-        # Canonical brokenness flag: collapsed GF, no contigs, or failed worker.
-        broken = row.mode_label == "canonical" &&
-                 (!row.worker_ok ||
-                  ismissing(row.genome_fraction_quast) ||
-                  (!ismissing(row.genome_fraction_quast) && !ismissing(b_gf) && row.genome_fraction_quast < 0.5 * b_gf) ||
-                  (!ismissing(row.n_contigs) && row.n_contigs == 0))
+        # Mode-AGNOSTIC brokenness detection, evaluated BEFORE the accuracy
+        # comparison: a crashed worker, zero contigs, or a collapsed genome
+        # fraction is a FAILED/BROKEN result for ANY mode — not merely an
+        # "accuracy CHANGED" result. (Previously this was scoped only to the
+        # canonical mode, so a crashed/degenerate non-canonical worker was
+        # mislabeled as an accuracy change.)
+        gf_collapsed = ismissing(row.genome_fraction_quast) ||
+                       (!ismissing(b_gf) && row.genome_fraction_quast < 0.5 * b_gf)
+        no_contigs = !ismissing(row.n_contigs) && row.n_contigs == 0
+        broken = !row.worker_ok || gf_collapsed || no_contigs
         if broken
             gf_str = ismissing(row.genome_fraction_quast) ? "NA (nothing aligned)" : "$(fmt(row.genome_fraction_quast))%"
-            println("  [$(row.mode_label)] BROKEN — genome fraction $(gf_str) vs baseline $(fmt(b_gf))% " *
-                    "(empirical proof the canonical assembly is incorrect).")
+            reason = !row.worker_ok ? "worker crashed" :
+                     no_contigs ? "no contigs produced" :
+                     "genome fraction collapsed"
+            # The canonical mode is a KNOWN break (undirected reconstruction);
+            # any other mode failing this gate is an unexpected regression.
+            suffix = row.mode_label == "canonical" ?
+                     " (expected: undirected canonical reconstruction is incorrect)." : "."
+            println("  [$(row.mode_label)] FAILED/BROKEN ($(reason)) — genome fraction " *
+                    "$(gf_str) vs baseline $(fmt(b_gf))%$(suffix)")
             continue
         end
 

--- a/benchmarking/mode_comparison.jl
+++ b/benchmarking/mode_comparison.jl
@@ -1,0 +1,583 @@
+# Rhizomorph Assembly-Efficiency Mode-Comparison Benchmark
+#
+# Purpose
+# -------
+# Empirically measures the assembly-efficiency modes introduced in PR #340
+# (cp/rhizomorph-efficiency-modes) so we can build a data-informed
+# accuracy-vs-efficiency recommendation table. For ONE fixed Lambda cell
+# (30x, seed 42) we simulate Illumina reads ONCE, then assemble those SAME
+# reads under each efficiency-mode configuration and score every assembly with
+# QUAST. The only variable across rows is the AssemblyConfig mode; reads,
+# reference, k, and QUAST settings are held constant.
+#
+# Why the NON-quality k-mer path (use_quality_scores = false)
+# -----------------------------------------------------------
+# The three efficiency modes under test — memory_profile, dedup_revcomp,
+# compact_unitigs — are threaded ONLY into `_assemble_kmer_graph`
+# (src/rhizomorph/assembly.jl, the use_quality_scores = false arm). The
+# quality-aware qualmer path (`_assemble_qualmer_graph`, auto-selected for FASTQ
+# input) does NOT honor any of them. To make the modes actually take effect —
+# and to keep "the only variable is the mode" honest — every row here builds an
+# AssemblyConfig with use_quality_scores = false, routing all modes through the
+# same k-mer path. This deliberately differs from track_a_lambda_pilot.jl, which
+# uses the qualmer path; absolute accuracy numbers are therefore not directly
+# comparable to the pilot, but they ARE directly comparable to each other, which
+# is the point of a mode comparison.
+#
+# Memory measurement (chosen approach + caveat)
+# ---------------------------------------------
+# `Sys.maxrss()` is process-cumulative (monotonic peak), so running several
+# assembles sequentially in one process cannot reveal per-mode peak RSS. We
+# therefore run each mode's assemble in a FRESH julia subprocess (the driver
+# re-invokes THIS script in worker mode, once per mode) and report that
+# process's whole-process peak `Sys.maxrss()` as `assemble_peak_rss_kb`. This is
+# the most honest peak-memory figure available.
+#   Caveat: the reported peak includes the CONSTANT cost of loading Julia +
+#   Mycelia + the reads into the worker (hundreds of MB), which is the same for
+#   every mode, so cross-mode DIFFERENCES are meaningful even though the absolute
+#   value is inflated by fixed load. For transparency each row also records:
+#     - baseline_rss_kb        : peak maxrss immediately BEFORE the assemble call
+#     - assemble_rss_delta_kb  : peak_rss - baseline_rss (assembly-attributable
+#                                peak growth)
+#     - gc_live_delta_mb       : Base.gc_live_bytes() delta around the assemble
+#                                (retained live-heap proxy, e.g. the graph)
+#
+# External tools
+# --------------
+# Requires Conda-backed external tools (art_illumina for simulation, QUAST for
+# scoring) — set up on Lovelace, NOT the laptop. This script CANNOT be run
+# locally; it is static-verified (parse + field-name checks) only. QUAST is
+# gated behind MYCELIA_RUN_QUAST (default "true"). LD_LIBRARY_PATH / thread caps
+# / JULIA_DEPOT_PATH are the caller's job (the run command sets them); the driver
+# propagates the current environment to each worker subprocess via `addenv`.
+#
+# Env knobs (all optional):
+#   MYCELIA_RUN_QUAST        default "true"  — run QUAST scoring
+#   MYCELIA_MODE_K           default "31"    — k-mer size for assembly
+#   MYCELIA_QUAST_MIN_CONTIG default "100"   — QUAST --min-contig (fixed across
+#                                              rows so it adds no cross-row noise)
+#   MYCELIA_MODE_COVERAGE    default "30"    — single coverage tier
+#   MYCELIA_MODE_SEED        default "42"    — single ART seed
+#   MYCELIA_MODE_COMPACT     default "true"  — include the optional compact_unitigs
+#                                              no-op-confirmation row
+#
+# Internal env knobs (set by the driver when it re-invokes this script as a
+# worker — do NOT set these by hand):
+#   MYCELIA_MODE_WORKER, MMC_MODE_LABEL, MMC_GRAPH_MODE, MMC_DEDUP,
+#   MMC_MEMPROFILE, MMC_COMPACT, MMC_K, MMC_FWD, MMC_REV, MMC_CONTIGS_OUT,
+#   MMC_METRICS_OUT
+#
+# Usage (on Lovelace — invoke ONCE; the script self-manages a fresh subprocess
+# per mode):
+#   julia --project=. benchmarking/mode_comparison.jl
+
+import Pkg
+if isinteractive()
+    Pkg.activate("..")
+end
+
+import Mycelia
+import FASTX
+import DataFrames
+import CSV
+import Dates
+import BioSequences
+
+# ===========================================================================
+# Shared helpers (used by both driver and worker)
+# ===========================================================================
+
+"""
+    parse_quast_metric(report_tsv, metric) -> Union{Missing, Float64}
+
+Return the numeric value of `metric` from a QUAST `report.tsv`, or `missing` if
+the file/metric is absent or the value is non-numeric (QUAST prints "-" when a
+metric could not be computed, e.g. NGA50 when nothing aligns — the empirical
+signature we expect for the BROKEN canonical mode).
+"""
+function parse_quast_metric(report_tsv::String, metric::String)::Union{Missing, Float64}
+    isfile(report_tsv) || return missing
+    result::Union{Missing, Float64} = missing
+    open(report_tsv, "r") do io
+        for line in eachline(io)
+            fields = split(line, '\t')
+            if length(fields) >= 2 && strip(fields[1]) == metric
+                parsed = tryparse(Float64, strip(fields[2]))
+                result = parsed === nothing ? missing : parsed
+                break
+            end
+        end
+    end
+    return result
+end
+
+"""
+    load_reads_from_paths(fwd, rev) -> Vector{FASTX.FASTQ.Record}
+
+Load forward and (optional) reverse simulated reads into a single flat record
+vector, matching how the k-mer assembler consumes reads (no pairing metadata).
+"""
+function load_reads_from_paths(fwd::String, rev::Union{String, Nothing})::Vector{FASTX.FASTQ.Record}
+    records = FASTX.FASTQ.Record[]
+    read_paths = String[fwd]
+    if rev !== nothing && !isempty(rev)
+        push!(read_paths, rev)
+    end
+    for p in read_paths
+        reader = Mycelia.open_fastx(p)
+        for record in reader
+            push!(records, record)
+        end
+        close(reader)
+    end
+    return records
+end
+
+"""
+    graph_mode_from_string(s) -> Mycelia.Rhizomorph.GraphMode
+
+Map a lowercase mode string to the Rhizomorph GraphMode enum value.
+"""
+function graph_mode_from_string(s::String)::Mycelia.Rhizomorph.GraphMode
+    if s == "doublestrand"
+        return Mycelia.Rhizomorph.DoubleStrand
+    elseif s == "canonical"
+        return Mycelia.Rhizomorph.Canonical
+    elseif s == "singlestrand"
+        return Mycelia.Rhizomorph.SingleStrand
+    else
+        error("Unknown graph_mode string: $(s)")
+    end
+end
+
+# ===========================================================================
+# WORKER MODE — assemble ONE mode in this fresh process and emit metrics
+# ===========================================================================
+
+"""
+    run_worker()
+
+Executed when this script is re-invoked with MYCELIA_MODE_WORKER set. Loads the
+pre-simulated reads, builds the AssemblyConfig for the requested mode, runs the
+assemble in isolation, writes the contigs FASTA, and writes a `key=value`
+metrics file. Because this is a fresh process, `Sys.maxrss()` here is this mode's
+whole-process peak RSS.
+"""
+function run_worker()
+    mode_label = ENV["MMC_MODE_LABEL"]
+    graph_mode = graph_mode_from_string(ENV["MMC_GRAPH_MODE"])
+    dedup = ENV["MMC_DEDUP"] == "true"
+    memprofile = Symbol(ENV["MMC_MEMPROFILE"])
+    compact = ENV["MMC_COMPACT"] == "true"
+    k = parse(Int, ENV["MMC_K"])
+    fwd = ENV["MMC_FWD"]
+    rev = get(ENV, "MMC_REV", "")
+    contigs_out = ENV["MMC_CONTIGS_OUT"]
+    metrics_out = ENV["MMC_METRICS_OUT"]
+
+    println("  [worker:$(mode_label)] loading reads ...")
+    records = load_reads_from_paths(fwd, isempty(rev) ? nothing : rev)
+    if isempty(records)
+        error("[worker:$(mode_label)] no reads loaded from $(fwd)")
+    end
+
+    # Build the exact AssemblyConfig for this mode. use_quality_scores = false
+    # forces the k-mer path where the efficiency modes are wired (see header).
+    seqtype = Mycelia.Rhizomorph._detect_sequence_type(records)
+    config = Mycelia.Rhizomorph.AssemblyConfig(;
+        k = k,
+        sequence_type = seqtype,
+        graph_mode = graph_mode,
+        use_quality_scores = false,
+        verbose = false,
+        dedup_revcomp = dedup,
+        compact_unitigs = compact,
+        memory_profile = memprofile
+    )
+
+    # Establish a clean pre-assemble memory baseline, then measure around the call.
+    GC.gc(true)
+    baseline_rss_kb = Int(Sys.maxrss() ÷ 1024)
+    live_before = Base.gc_live_bytes()
+
+    t0 = time()
+    result = Mycelia.Rhizomorph.assemble_genome(records, config)
+    runtime = time() - t0
+
+    live_after = Base.gc_live_bytes()
+    peak_rss_kb = Int(Sys.maxrss() ÷ 1024)   # whole-process peak for this mode
+
+    n_contigs = length(result.contigs)
+    open(contigs_out, "w") do io
+        for (i, contig) in enumerate(result.contigs)
+            println(io, ">contig_$(i) length=$(length(contig))")
+            println(io, contig)  # contigs are String
+        end
+    end
+
+    gc_live_delta_mb = round((live_after - live_before) / (1024 * 1024); digits = 3)
+    assemble_rss_delta_kb = peak_rss_kb - baseline_rss_kb
+
+    open(metrics_out, "w") do io
+        println(io, "mode_label=$(mode_label)")
+        println(io, "n_contigs=$(n_contigs)")
+        println(io, "assemble_runtime_s=$(round(runtime; digits = 3))")
+        println(io, "assemble_peak_rss_kb=$(peak_rss_kb)")
+        println(io, "baseline_rss_kb=$(baseline_rss_kb)")
+        println(io, "assemble_rss_delta_kb=$(assemble_rss_delta_kb)")
+        println(io, "gc_live_delta_mb=$(gc_live_delta_mb)")
+    end
+    println("  [worker:$(mode_label)] -> $(n_contigs) contigs, " *
+            "$(round(runtime; digits = 2))s, peak_rss=$(peak_rss_kb)kb " *
+            "(delta $(assemble_rss_delta_kb)kb, live +$(gc_live_delta_mb)MB)")
+    return nothing
+end
+
+# ===========================================================================
+# DRIVER MODE — simulate once, spawn a worker per mode, QUAST + aggregate
+# ===========================================================================
+
+"""
+    parse_metrics_file(path) -> Dict{String, String}
+
+Parse a worker `key=value` metrics file into a Dict.
+"""
+function parse_metrics_file(path::String)::Dict{String, String}
+    d = Dict{String, String}()
+    isfile(path) || return d
+    for line in eachline(path)
+        isempty(strip(line)) && continue
+        kv = split(line, '='; limit = 2)
+        length(kv) == 2 && (d[strip(kv[1])] = strip(kv[2]))
+    end
+    return d
+end
+
+function run_driver()
+    organism = "Lambda"
+    accession = "NC_001416"
+    coverage = parse(Int, get(ENV, "MYCELIA_MODE_COVERAGE", "30"))
+    seed = parse(Int, get(ENV, "MYCELIA_MODE_SEED", "42"))
+    k = parse(Int, get(ENV, "MYCELIA_MODE_K", "31"))
+    run_quast = get(ENV, "MYCELIA_RUN_QUAST", "true") in ["1", "true", "yes"]
+    quast_min_contig = parse(Int, get(ENV, "MYCELIA_QUAST_MIN_CONTIG", "100"))
+    include_compact = get(ENV, "MYCELIA_MODE_COMPACT", "true") in ["1", "true", "yes"]
+
+    project_dir = dirname(@__DIR__)   # worktree root (holds Project.toml)
+    script_path = @__FILE__
+
+    println("=== Rhizomorph Mode-Comparison Benchmark ===")
+    println("Start time (UTC): $(Dates.now(Dates.UTC))")
+    println("Fixed cell: $(organism) ($(accession)) illumina, coverage=$(coverage)x seed=$(seed), k=$(k)")
+    println("Assembly path: NON-quality k-mer path (use_quality_scores=false) — required for modes to take effect")
+    println("Memory: fresh subprocess per mode, whole-process peak Sys.maxrss()")
+    println("QUAST scoring: $(run_quast ? "ENABLED (min_contig=$(quast_min_contig))" : "DISABLED")")
+
+    # --- Mode table: only the AssemblyConfig fields vary across rows ---
+    modes = [
+        (label = "baseline", graph_mode = "doublestrand", dedup = false, memprofile = "full", compact = false),
+        (label = "dedup", graph_mode = "doublestrand", dedup = true, memprofile = "full", compact = false),
+        (label = "lightweight", graph_mode = "doublestrand", dedup = false, memprofile = "lightweight", compact = false),
+        (label = "dedup+lightweight", graph_mode = "doublestrand", dedup = true, memprofile = "lightweight", compact = false),
+        (label = "canonical", graph_mode = "canonical", dedup = false, memprofile = "full", compact = false)
+    ]
+    if include_compact
+        push!(modes,
+            (label = "compact_unitigs", graph_mode = "doublestrand", dedup = false, memprofile = "full", compact = true))
+    end
+
+    benchmark_dir = mktempdir(prefix = "mode_comparison_")
+    results_dir = joinpath(@__DIR__, "results")
+    mkpath(results_dir)
+    println("Working directory: $(benchmark_dir)")
+
+    # --- Phase 1: download reference (once) ---
+    println("\n--- Phase 1: download Lambda reference ---")
+    ref_dir = joinpath(benchmark_dir, "reference")
+    mkpath(ref_dir)
+    reference_path = Mycelia.download_genome_by_accession(
+        accession = accession, outdir = ref_dir, compressed = false)
+    if !isfile(reference_path) || filesize(reference_path) == 0
+        error("Failed to download Lambda reference ($(accession)) to $(ref_dir)")
+    end
+    println("Reference: $(reference_path) ($(filesize(reference_path)) bytes)")
+
+    # --- Phase 2: simulate reads ONCE (shared across all modes) ---
+    println("\n--- Phase 2: simulate reads once (coverage=$(coverage)x seed=$(seed)) ---")
+    reads_dir = joinpath(benchmark_dir, "reads")
+    mkpath(reads_dir)
+    outbase = joinpath(reads_dir, "$(organism)_cov$(coverage)x_seed$(seed)")
+    sim = Mycelia.simulate_illumina_reads(
+        fasta = reference_path,
+        coverage = coverage,
+        rndSeed = seed,
+        read_length = 150,
+        paired = true,
+        quiet = true,
+        outbase = outbase)
+    fwd = sim.forward_reads
+    rev = sim.reverse_reads === nothing ? "" : sim.reverse_reads
+    println("Forward reads: $(fwd)")
+    println("Reverse reads: $(isempty(rev) ? "(none)" : rev)")
+
+    # --- Phase 3: per-mode fresh-subprocess assemble + QUAST ---
+    results = DataFrames.DataFrame(
+        organism = String[],
+        mode_label = String[],
+        graph_mode = String[],
+        dedup = Bool[],
+        memory_profile = String[],
+        compact = Bool[],
+        n_contigs = Union{Missing, Int}[],
+        NGA50 = Union{Missing, Float64}[],
+        num_misassemblies = Union{Missing, Float64}[],
+        dup_ratio = Union{Missing, Float64}[],
+        genome_fraction_quast = Union{Missing, Float64}[],
+        assemble_runtime_s = Union{Missing, Float64}[],
+        assemble_peak_rss_kb = Union{Missing, Int}[],
+        baseline_rss_kb = Union{Missing, Int}[],
+        assemble_rss_delta_kb = Union{Missing, Int}[],
+        gc_live_delta_mb = Union{Missing, Float64}[],
+        quast_runtime_s = Union{Missing, Float64}[],
+        worker_ok = Bool[]
+    )
+
+    println("\n--- Phase 3: assemble each mode in a fresh subprocess, then QUAST ---")
+    for m in modes
+        println("\n  mode: $(m.label) (graph_mode=$(m.graph_mode), dedup=$(m.dedup), " *
+                "memory_profile=$(m.memprofile), compact=$(m.compact))")
+        mode_dir = joinpath(benchmark_dir, "mode_$(replace(m.label, r"[^A-Za-z0-9]" => "_"))")
+        mkpath(mode_dir)
+        contigs_out = joinpath(mode_dir, "contigs.fasta")
+        metrics_out = joinpath(mode_dir, "metrics.txt")
+
+        worker_ok = true
+        # Re-invoke THIS script in a fresh worker process. Base.julia_cmd()
+        # preserves the sysimage/flags; --project pins the environment; addenv
+        # augments (never replaces) the inherited env so LD_LIBRARY_PATH,
+        # JULIA_DEPOT_PATH, JULIA_NUM_THREADS set by the run command carry over.
+        worker_cmd = `$(Base.julia_cmd()) --project=$(project_dir) --threads=$(Threads.nthreads()) $(script_path)`
+        worker_cmd = addenv(worker_cmd,
+            "MYCELIA_MODE_WORKER" => "1",
+            "MMC_MODE_LABEL" => m.label,
+            "MMC_GRAPH_MODE" => m.graph_mode,
+            "MMC_DEDUP" => string(m.dedup),
+            "MMC_MEMPROFILE" => m.memprofile,
+            "MMC_COMPACT" => string(m.compact),
+            "MMC_K" => string(k),
+            "MMC_FWD" => fwd,
+            "MMC_REV" => rev,
+            "MMC_CONTIGS_OUT" => contigs_out,
+            "MMC_METRICS_OUT" => metrics_out)
+        try
+            run(worker_cmd)
+        catch e
+            worker_ok = false
+            @warn "Worker process failed for mode=$(m.label) — recording as failure" exception = (e,)
+        end
+
+        metrics = parse_metrics_file(metrics_out)
+        n_contigs = haskey(metrics, "n_contigs") ? tryparse(Int, metrics["n_contigs"]) : missing
+        assemble_runtime_s = haskey(metrics, "assemble_runtime_s") ? tryparse(Float64, metrics["assemble_runtime_s"]) : missing
+        assemble_peak_rss_kb = haskey(metrics, "assemble_peak_rss_kb") ? tryparse(Int, metrics["assemble_peak_rss_kb"]) : missing
+        baseline_rss_kb = haskey(metrics, "baseline_rss_kb") ? tryparse(Int, metrics["baseline_rss_kb"]) : missing
+        assemble_rss_delta_kb = haskey(metrics, "assemble_rss_delta_kb") ? tryparse(Int, metrics["assemble_rss_delta_kb"]) : missing
+        gc_live_delta_mb = haskey(metrics, "gc_live_delta_mb") ? tryparse(Float64, metrics["gc_live_delta_mb"]) : missing
+
+        # -- QUAST aligned-truth scoring on the produced contigs --
+        nga50 = missing
+        num_misassemblies = missing
+        dup_ratio = missing
+        genome_fraction = missing
+        quast_runtime_s = missing
+        have_contigs = (n_contigs !== missing && n_contigs !== nothing && n_contigs > 0 &&
+                        isfile(contigs_out) && filesize(contigs_out) > 0)
+        if run_quast && have_contigs
+            quast_dir = joinpath(mode_dir, "quast")
+            tq = time()
+            try
+                Mycelia.run_quast(
+                    contigs_out;
+                    outdir = quast_dir,
+                    reference = reference_path,
+                    min_contig = quast_min_contig)
+                quast_runtime_s = round(time() - tq; digits = 3)
+                report_tsv = joinpath(quast_dir, "report.tsv")
+                nga50 = parse_quast_metric(report_tsv, "NGA50")
+                num_misassemblies = parse_quast_metric(report_tsv, "# misassemblies")
+                dup_ratio = parse_quast_metric(report_tsv, "Duplication ratio")
+                genome_fraction = parse_quast_metric(report_tsv, "Genome fraction (%)")
+            catch e
+                @warn "QUAST failed for mode=$(m.label) — leaving accuracy metrics missing" exception = (e,)
+            end
+        elseif run_quast && !have_contigs
+            println("    (no contigs to score — mode likely BROKEN; leaving QUAST metrics missing)")
+        end
+
+        push!(results,
+            (
+                organism = organism,
+                mode_label = m.label,
+                graph_mode = m.graph_mode,
+                dedup = m.dedup,
+                memory_profile = m.memprofile,
+                compact = m.compact,
+                n_contigs = (n_contigs === nothing ? missing : n_contigs),
+                NGA50 = nga50,
+                num_misassemblies = num_misassemblies,
+                dup_ratio = dup_ratio,
+                genome_fraction_quast = genome_fraction,
+                assemble_runtime_s = (assemble_runtime_s === nothing ? missing : assemble_runtime_s),
+                assemble_peak_rss_kb = (assemble_peak_rss_kb === nothing ? missing : assemble_peak_rss_kb),
+                baseline_rss_kb = (baseline_rss_kb === nothing ? missing : baseline_rss_kb),
+                assemble_rss_delta_kb = (assemble_rss_delta_kb === nothing ? missing : assemble_rss_delta_kb),
+                gc_live_delta_mb = (gc_live_delta_mb === nothing ? missing : gc_live_delta_mb),
+                quast_runtime_s = quast_runtime_s,
+                worker_ok = worker_ok
+            ))
+    end
+
+    # --- Phase 4: write CSV ---
+    # UTC timestamp, yyyymmdd_HHMMSS (no 'Z' directive — 'Z' is a TimeZones token
+    # that errors on a plain Dates.DateTime).
+    timestamp = Dates.format(Dates.now(Dates.UTC), "yyyymmdd_HHMMSS")
+    csv_path = joinpath(results_dir, "mode_comparison_$(timestamp).csv")
+    CSV.write(csv_path, results)
+    println("\nResults written to: $(csv_path)")
+
+    # --- Phase 5: comparison table + verdict ---
+    print_comparison_table(results)
+    print_verdict(results)
+
+    println("\n=== Mode-Comparison complete (UTC): $(Dates.now(Dates.UTC)) ===")
+    return nothing
+end
+
+"""
+    fmt(x) -> String
+
+Compact fixed-width-friendly formatter for possibly-missing metric values.
+"""
+function fmt(x)::String
+    ismissing(x) && return "NA"
+    x isa AbstractFloat && return string(round(x; digits = 3))
+    return string(x)
+end
+
+"""
+    print_comparison_table(results)
+
+Print a mode x {dup, GF, NGA50, misasm, runtime, memory} comparison table.
+"""
+function print_comparison_table(results::DataFrames.DataFrame)
+    println("\n--- Comparison table (mode x accuracy/efficiency) ---")
+    header = rpad("mode", 18) * rpad("contigs", 9) * rpad("dup", 8) *
+             rpad("GF%", 9) * rpad("NGA50", 10) * rpad("misasm", 8) *
+             rpad("run_s", 9) * rpad("peak_rss_kb", 13) * rpad("rss_delta_kb", 14) *
+             rpad("live_MB", 9)
+    println(header)
+    println(repeat("-", length(header)))
+    for row in eachrow(results)
+        line = rpad(row.mode_label, 18) *
+               rpad(fmt(row.n_contigs), 9) *
+               rpad(fmt(row.dup_ratio), 8) *
+               rpad(fmt(row.genome_fraction_quast), 9) *
+               rpad(fmt(row.NGA50), 10) *
+               rpad(fmt(row.num_misassemblies), 8) *
+               rpad(fmt(row.assemble_runtime_s), 9) *
+               rpad(fmt(row.assemble_peak_rss_kb), 13) *
+               rpad(fmt(row.assemble_rss_delta_kb), 14) *
+               rpad(fmt(row.gc_live_delta_mb), 9)
+        println(line)
+    end
+end
+
+"""
+    print_verdict(results)
+
+Compare every mode against the `baseline` row and print a short verdict block:
+which modes preserve accuracy (GF / misasm / NGA50 unchanged), which reduce the
+duplication ratio, which reduce memory, and flag `canonical` as BROKEN if its
+genome fraction collapsed (or its worker/QUAST produced no aligned metrics).
+"""
+function print_verdict(results::DataFrames.DataFrame)
+    println("\n--- Verdict ---")
+    base_rows = results[results.mode_label .== "baseline", :]
+    if DataFrames.nrow(base_rows) == 0
+        println("No baseline row present — cannot compute relative verdict.")
+        return nothing
+    end
+    base = base_rows[1, :]
+    b_gf = base.genome_fraction_quast
+    b_misasm = base.num_misassemblies
+    b_nga50 = base.NGA50
+    b_dup = base.dup_ratio
+    b_mem = base.assemble_rss_delta_kb   # assembly-attributable peak growth
+
+    approx(a, b; rtol = 0.02) = (!ismissing(a) && !ismissing(b) && b != 0) ? (abs(a - b) / abs(b) <= rtol) : (a === b)
+
+    for row in eachrow(results)
+        row.mode_label == "baseline" && continue
+        notes = String[]
+
+        # Canonical brokenness flag: collapsed GF, no contigs, or failed worker.
+        broken = row.mode_label == "canonical" &&
+                 (!row.worker_ok ||
+                  ismissing(row.genome_fraction_quast) ||
+                  (!ismissing(row.genome_fraction_quast) && !ismissing(b_gf) && row.genome_fraction_quast < 0.5 * b_gf) ||
+                  (!ismissing(row.n_contigs) && row.n_contigs == 0))
+        if broken
+            gf_str = ismissing(row.genome_fraction_quast) ? "NA (nothing aligned)" : "$(fmt(row.genome_fraction_quast))%"
+            println("  [$(row.mode_label)] BROKEN — genome fraction $(gf_str) vs baseline $(fmt(b_gf))% " *
+                    "(empirical proof the canonical assembly is incorrect).")
+            continue
+        end
+
+        # Accuracy preservation.
+        acc_preserved = approx(row.genome_fraction_quast, b_gf) &&
+                        approx(row.NGA50, b_nga50) &&
+                        (ismissing(row.num_misassemblies) == ismissing(b_misasm)) &&
+                        (ismissing(row.num_misassemblies) || row.num_misassemblies == b_misasm)
+        push!(notes, acc_preserved ? "accuracy PRESERVED (GF/NGA50/misasm ~ baseline)" :
+              "accuracy CHANGED (GF=$(fmt(row.genome_fraction_quast)) vs $(fmt(b_gf)), " *
+              "NGA50=$(fmt(row.NGA50)) vs $(fmt(b_nga50)), misasm=$(fmt(row.num_misassemblies)) vs $(fmt(b_misasm)))")
+
+        # Duplication reduction.
+        if !ismissing(row.dup_ratio) && !ismissing(b_dup)
+            if row.dup_ratio < b_dup - 1.0e-6
+                push!(notes, "dup REDUCED $(fmt(b_dup)) -> $(fmt(row.dup_ratio))")
+            elseif approx(row.dup_ratio, b_dup; rtol = 0.001)
+                push!(notes, "dup unchanged ($(fmt(row.dup_ratio)))")
+            else
+                push!(notes, "dup INCREASED $(fmt(b_dup)) -> $(fmt(row.dup_ratio))")
+            end
+        end
+
+        # Memory reduction (assembly-attributable peak growth).
+        if !ismissing(row.assemble_rss_delta_kb) && !ismissing(b_mem)
+            if row.assemble_rss_delta_kb < b_mem
+                push!(notes, "memory REDUCED $(b_mem) -> $(row.assemble_rss_delta_kb) kb (assemble delta)")
+            elseif row.assemble_rss_delta_kb == b_mem
+                push!(notes, "memory unchanged")
+            else
+                push!(notes, "memory HIGHER $(b_mem) -> $(row.assemble_rss_delta_kb) kb")
+            end
+        end
+
+        println("  [$(row.mode_label)] " * join(notes, "; "))
+    end
+
+    println("\nNote: accuracy comparisons use QUAST aligned-truth metrics; memory uses the")
+    println("fresh-subprocess assemble-attributable peak-RSS delta (baseline-subtracted).")
+    return nothing
+end
+
+# ===========================================================================
+# Entry point: worker vs driver
+# ===========================================================================
+
+if get(ENV, "MYCELIA_MODE_WORKER", "") == "1"
+    run_worker()
+else
+    run_driver()
+end

--- a/src/rhizomorph/assembly.jl
+++ b/src/rhizomorph/assembly.jl
@@ -134,6 +134,8 @@ struct AssemblyConfig
 
     # Additive efficiency modes (all default to today's behavior, so existing
     # assemblies are byte-for-byte unchanged unless a caller opts in).
+    # NOTE: with dedup_revcomp on, a reported contig may be the reverse-complement
+    # (canonical) orientation of the sequence that was actually assembled.
     dedup_revcomp::Bool                     # Collapse RC-pair contigs to one canonical rep (post-assembly)
     compact_unitigs::Bool                   # Populate simplified_graph via linear-chain compaction
     memory_profile::Symbol                  # build_kmer_graph evidence footprint (:full|:lightweight|:ultralight|...)
@@ -191,6 +193,21 @@ struct AssemblyConfig
         end
         if min_coverage < 1
             error("min_coverage must be positive, got min_coverage=$(min_coverage)")
+        end
+
+        # The additive efficiency modes (dedup_revcomp / compact_unitigs /
+        # memory_profile) are only implemented on the non-quality k-mer path
+        # (_assemble_kmer_graph). FASTQ input auto-sets use_quality_scores=true,
+        # which dispatches to the qualmer arm and silently ignores these flags.
+        # Warn unconditionally so a caller opting in on quality data is not left
+        # believing the flag took effect. (Default config sets no flags, so this
+        # never fires for existing assemblies.)
+        if use_quality_scores &&
+           (dedup_revcomp || compact_unitigs || memory_profile != :full)
+            @warn "Efficiency modes (dedup_revcomp / compact_unitigs / " *
+                  "memory_profile) are only implemented on the non-quality " *
+                  "k-mer path and are ignored on the quality/qualmer path. " *
+                  "Set use_quality_scores=false to use them."
         end
 
         new(
@@ -735,6 +752,21 @@ K-mer graph assembly implementation (fixed-length k-mer foundation).
 function _assemble_kmer_graph(observations, config)
     _log_info(config, "Using k-mer graph assembly strategy (fixed-length k-mer foundation)")
     mode = _graph_mode_symbol(config.graph_mode)
+    # Canonical graph_mode does not yet support correct contig reconstruction:
+    # undirected canonical traversal is not orientation-aware, so adjacent
+    # canonical labels do not carry which strand their (k-1)-overlap is on and
+    # the reconstructed contigs are INVALID (see the Canonical @test_broken in
+    # test/4_assembly/rhizomorph_efficiency_modes_test.jl). Warn UNCONDITIONALLY
+    # (matching the codebase's warn-on-incomplete-path convention) and flag the
+    # result; do NOT hard-error, so the mode stays runnable for the benchmark and
+    # to track the keystone fix.
+    reconstruction_valid = config.graph_mode != Canonical
+    if config.graph_mode == Canonical
+        @warn "Canonical graph_mode does not yet support correct contig " *
+              "reconstruction (undirected canonical traversal is not " *
+              "orientation-aware); emitted contigs are INVALID. Use " *
+              "graph_mode=DoubleStrand for correct assembly."
+    end
     # Mode 3a (opt-in): memory_profile selects the k-mer graph's evidence footprint
     # (:full default, or :lightweight / :ultralight / *_quality). This is an internal
     # representation change; the assembled contigs are expected to be identical.
@@ -797,13 +829,23 @@ function _assemble_kmer_graph(observations, config)
     # on a copy so the field is populated and the contract (contigs unchanged) holds;
     # for k-mer graphs the simplified graph is structurally identical to `graph`.
     simplified = nothing
+    unitig_compaction_effective = false
     if config.compact_unitigs
         simplified = Rhizomorph.collapse_linear_chains!(deepcopy(graph))
         n_full = length(MetaGraphsNext.labels(graph))
         n_simpl = length(MetaGraphsNext.labels(simplified))
+        # Record effectiveness, not just intent: for fixed-length k-mer graphs
+        # collapse_linear_chains! cannot reduce the vertex count, so this is false.
+        unitig_compaction_effective = n_simpl < n_full
         _log_info(config,
             "Unitig compaction: $(n_full) -> $(n_simpl) vertices " *
             "(no-op for fixed-length k-mer graphs; needs variable-length conversion)")
+        if !unitig_compaction_effective
+            @warn "compact_unitigs requested but had no effect: linear-chain " *
+                  "compaction is a no-op on fixed-length k-mer graphs " *
+                  "(collapsing would change vertex labels from Kmer to " *
+                  "BioSequence). simplified_graph is structurally identical to graph."
+        end
     end
 
     # Assembly statistics
@@ -824,6 +866,10 @@ function _assemble_kmer_graph(observations, config)
         "repeat_resolution_requested" => config.repeat_resolution,
         "graph_cleaning_applied" => false,
         "unitig_compaction_requested" => config.compact_unitigs,
+        "unitig_compaction_effective" => unitig_compaction_effective,
+        # false for Canonical graph_mode: undirected canonical traversal is not
+        # orientation-aware, so the emitted contigs are not a valid reconstruction.
+        "reconstruction_valid" => reconstruction_valid,
         "assembly_date" => string(Mycelia.Dates.now())
     )
 
@@ -842,6 +888,16 @@ function _assemble_qualmer_graph(observations, config)
 
     # Build qualmer graph using Phase 2 quality-aware algorithms
     mode = _graph_mode_symbol(config.graph_mode)
+    # See _assemble_kmer_graph: Canonical graph_mode does not yet support correct
+    # contig reconstruction (undirected canonical traversal is not orientation-
+    # aware). Warn UNCONDITIONALLY and flag the result; do NOT hard-error.
+    reconstruction_valid = config.graph_mode != Canonical
+    if config.graph_mode == Canonical
+        @warn "Canonical graph_mode does not yet support correct contig " *
+              "reconstruction (undirected canonical traversal is not " *
+              "orientation-aware); emitted contigs are INVALID. Use " *
+              "graph_mode=DoubleStrand for correct assembly."
+    end
     graph = Rhizomorph.build_qualmer_graph(fastq_records, config.k; mode = mode)
 
     # Apply Phase 2 graph algorithms if enabled
@@ -898,6 +954,8 @@ function _assemble_qualmer_graph(observations, config)
         "graph_mode" => string(config.graph_mode),
         "num_vertices" => length(MetaGraphsNext.labels(graph)),
         "quality_preserved" => true,  # Mark that quality information is preserved
+        # false for Canonical graph_mode (undirected traversal is not orientation-aware).
+        "reconstruction_valid" => reconstruction_valid,
         "num_fastq_contigs" => length(contig_records),
         "num_edges" => length(MetaGraphsNext.edge_labels(graph)),
         "num_input_sequences" => length(observations),
@@ -978,7 +1036,13 @@ function _canonical_string(seq::AbstractString)::String
     fwd = String(seq)
     rc = try
         String(BioSequences.reverse_complement(BioSequences.LongDNA{4}(fwd)))
-    catch
+    catch e
+        # Only a genuine invalid-DNA conversion failure means "not DNA — pass the
+        # sequence through unchanged". BioSequences.LongDNA{4} throws an
+        # ErrorException on unencodable characters (verified). Let anything else
+        # (InterruptException, OutOfMemoryError, MethodError, ...) propagate rather
+        # than silently masking a real fault.
+        e isa ErrorException || rethrow()
         return fwd
     end
     return min(fwd, rc)

--- a/src/rhizomorph/assembly.jl
+++ b/src/rhizomorph/assembly.jl
@@ -788,6 +788,24 @@ function _assemble_kmer_graph(observations, config)
 
     contig_names = ["kmer_contig_$i" for i in 1:length(contigs)]
 
+    # Mode 3b (opt-in): populate simplified_graph via linear-chain (unitig)
+    # compaction. NOTE the documented caveat: collapse_linear_chains! is a no-op on
+    # fixed-length k-mer graphs — collapsing a linear chain would produce a sequence
+    # longer than k, changing the vertex label type from Kmer to BioSequence and
+    # violating MetaGraphsNext's parametric label_type. Real compaction therefore
+    # requires convert_fixed_to_variable() first (out of scope here). We still run it
+    # on a copy so the field is populated and the contract (contigs unchanged) holds;
+    # for k-mer graphs the simplified graph is structurally identical to `graph`.
+    simplified = nothing
+    if config.compact_unitigs
+        simplified = Rhizomorph.collapse_linear_chains!(deepcopy(graph))
+        n_full = length(MetaGraphsNext.labels(graph))
+        n_simpl = length(MetaGraphsNext.labels(simplified))
+        _log_info(config,
+            "Unitig compaction: $(n_full) -> $(n_simpl) vertices " *
+            "(no-op for fixed-length k-mer graphs; needs variable-length conversion)")
+    end
+
     # Assembly statistics
     stats = Dict{String, Any}(
         "method" => "KmerGraph",
@@ -805,10 +823,12 @@ function _assemble_kmer_graph(observations, config)
         "bubble_resolution_requested" => config.bubble_resolution,
         "repeat_resolution_requested" => config.repeat_resolution,
         "graph_cleaning_applied" => false,
+        "unitig_compaction_requested" => config.compact_unitigs,
         "assembly_date" => string(Mycelia.Dates.now())
     )
 
-    return AssemblyResult(contigs, contig_names; graph = graph, assembly_stats = stats)
+    return AssemblyResult(contigs, contig_names;
+        graph = graph, simplified_graph = simplified, assembly_stats = stats)
 end
 
 """

--- a/src/rhizomorph/assembly.jl
+++ b/src/rhizomorph/assembly.jl
@@ -735,7 +735,11 @@ K-mer graph assembly implementation (fixed-length k-mer foundation).
 function _assemble_kmer_graph(observations, config)
     _log_info(config, "Using k-mer graph assembly strategy (fixed-length k-mer foundation)")
     mode = _graph_mode_symbol(config.graph_mode)
-    graph = Rhizomorph.build_kmer_graph(observations, config.k; mode = mode)
+    # Mode 3a (opt-in): memory_profile selects the k-mer graph's evidence footprint
+    # (:full default, or :lightweight / :ultralight / *_quality). This is an internal
+    # representation change; the assembled contigs are expected to be identical.
+    graph = Rhizomorph.build_kmer_graph(
+        observations, config.k; mode = mode, memory_profile = config.memory_profile)
 
     # NOTE: detect_bubbles_next / resolve_repeats_next are intentionally NOT run
     # here. They return analysis structures that this function only logged and

--- a/src/rhizomorph/assembly.jl
+++ b/src/rhizomorph/assembly.jl
@@ -773,6 +773,15 @@ function _assemble_kmer_graph(observations, config)
         contigs = _generate_contigs_probabilistic(graph, config)
     end
 
+    # Mode 1 (opt-in): collapse contigs that are reverse complements of each other
+    # to a single canonical representative. Default (dedup_revcomp=false) leaves the
+    # RC pairs a DoubleStrand assembly naturally emits, preserving today's behavior.
+    if config.dedup_revcomp
+        n_before = length(contigs)
+        contigs = _dedup_reverse_complements(contigs)
+        _log_info(config, "Reverse-complement dedup: $(n_before) -> $(length(contigs)) contigs")
+    end
+
     contig_names = ["kmer_contig_$i" for i in 1:length(contigs)]
 
     # Assembly statistics
@@ -905,6 +914,50 @@ function _assemble_multi_k(observations, config)
     # Future implementation would use multiple k-mer sizes and merge results
     @warn "Multi-k assembly not fully implemented, using single-k assembly"
     return _assemble_kmer_graph(observations, config)
+end
+
+"""
+    _dedup_reverse_complements(contigs::Vector{String}) -> Vector{String}
+
+Collapse contigs that are reverse complements of one another onto a single
+canonical representative (the lexicographically-smaller of a sequence and its
+reverse complement), preserving first-seen order.
+
+A DoubleStrand assembly emits both orientations of each traversal, so the
+contig set contains RC pairs. This is a lossless deduplication for downstream
+consumers that treat a sequence and its reverse complement as equivalent: the
+genome content is fully retained (every input contig maps to a canonical rep
+that is either itself or its RC), while the redundant second orientation is
+removed. Sequences that cannot be reverse-complemented as DNA (e.g. amino-acid
+or general-string contigs) are passed through unchanged.
+"""
+function _dedup_reverse_complements(contigs::Vector{String})::Vector{String}
+    canonical_reps = String[]
+    seen = Set{String}()
+    for contig in contigs
+        canonical = _canonical_string(contig)
+        if !(canonical in seen)
+            push!(seen, canonical)
+            push!(canonical_reps, canonical)
+        end
+    end
+    return canonical_reps
+end
+
+"""
+    _canonical_string(seq::AbstractString) -> String
+
+Return `min(seq, reverse_complement(seq))` as an uppercase DNA string. If `seq`
+is not valid DNA it is returned unchanged (no reverse complement is defined).
+"""
+function _canonical_string(seq::AbstractString)::String
+    fwd = String(seq)
+    rc = try
+        String(BioSequences.reverse_complement(BioSequences.LongDNA{4}(fwd)))
+    catch
+        return fwd
+    end
+    return min(fwd, rc)
 end
 
 """

--- a/src/rhizomorph/assembly.jl
+++ b/src/rhizomorph/assembly.jl
@@ -26,6 +26,8 @@ function _graph_mode_symbol(graph_mode::GraphMode)
         return :singlestrand
     elseif graph_mode == DoubleStrand
         return :doublestrand
+    elseif graph_mode == Canonical
+        return :canonical
     end
     return :singlestrand
 end
@@ -130,6 +132,12 @@ struct AssemblyConfig
     verbose::Bool                           # Whether to emit info logs during assembly
     tda::Union{Nothing, Mycelia.TDAConfig}  # Optional TDA configuration for topology-aware metrics/cleaning
 
+    # Additive efficiency modes (all default to today's behavior, so existing
+    # assemblies are byte-for-byte unchanged unless a caller opts in).
+    dedup_revcomp::Bool                     # Collapse RC-pair contigs to one canonical rep (post-assembly)
+    compact_unitigs::Bool                   # Populate simplified_graph via linear-chain compaction
+    memory_profile::Symbol                  # build_kmer_graph evidence footprint (:full|:lightweight|:ultralight|...)
+
     # Constructor with validation
     function AssemblyConfig(;
             k::Union{Int, Nothing} = nothing,
@@ -143,7 +151,10 @@ struct AssemblyConfig
             bubble_resolution::Bool = true,
             repeat_resolution::Bool = true,
             verbose::Bool = false,
-            tda::Union{Nothing, Mycelia.TDAConfig} = nothing
+            tda::Union{Nothing, Mycelia.TDAConfig} = nothing,
+            dedup_revcomp::Bool = false,
+            compact_unitigs::Bool = false,
+            memory_profile::Symbol = :full
     )
         # Validation: Must specify exactly one of k or min_overlap
         if k === nothing && min_overlap === nothing
@@ -152,12 +163,20 @@ struct AssemblyConfig
             error("Cannot specify both k ($(k)) and min_overlap ($(min_overlap)). Choose one approach.")
         end
 
-        # Validation: Check strand compatibility with sequence types
-        if sequence_type <: BioSequences.LongAA && graph_mode == DoubleStrand
+        # Validation: Check strand compatibility with sequence types.
+        # DoubleStrand and Canonical both require a defined reverse complement,
+        # so both are rejected for amino acids and general strings.
+        if sequence_type <: BioSequences.LongAA && (graph_mode == DoubleStrand || graph_mode == Canonical)
             error("Amino acid sequences can only use SingleStrand mode (reverse complement undefined for proteins)")
         end
-        if sequence_type == String && graph_mode == DoubleStrand
+        if sequence_type == String && (graph_mode == DoubleStrand || graph_mode == Canonical)
             error("String sequences can only use SingleStrand mode (reverse complement undefined for general strings)")
+        end
+
+        # Validation: memory_profile must be one recognized by build_kmer_graph
+        _valid_memory_profiles = (:full, :lightweight, :ultralight, :lightweight_quality, :ultralight_quality)
+        if !(memory_profile in _valid_memory_profiles)
+            error("memory_profile must be one of $(_valid_memory_profiles), got :$(memory_profile)")
         end
 
         # Validation: Parameter ranges
@@ -186,7 +205,10 @@ struct AssemblyConfig
             bubble_resolution,
             repeat_resolution,
             verbose,
-            tda
+            tda,
+            dedup_revcomp,
+            compact_unitigs,
+            memory_profile
         )
     end
 end

--- a/src/rhizomorph/core/enums.jl
+++ b/src/rhizomorph/core/enums.jl
@@ -29,6 +29,7 @@ Graph mode for handling strand representation.
 # Values
 - `SingleStrand`: Graph contains one strand orientation
 - `DoubleStrand`: Graph contains both forward and reverse-complement strands
+- `Canonical`: RC pairs merged onto a single canonical vertex (undirected)
 
 # Details
 This enum defines the structural representation of the graph:
@@ -48,5 +49,10 @@ This enum defines the structural representation of the graph:
 This is **orthogonal** to strand specificity (whether evidence is merged across RC pairs).
 Strand representation (SingleStrand/DoubleStrand) is about graph structure.
 Strand specificity is about evidence tracking methodology.
+
+**Canonical**: Each k-mer and its reverse complement are merged onto one
+canonical vertex (lexicographically-minimal orientation). Produces the most
+compact (≈1x) representation but yields an **undirected** graph — additive,
+non-default; the default remains `DoubleStrand`.
 """
-@enum GraphMode SingleStrand DoubleStrand
+@enum GraphMode SingleStrand DoubleStrand Canonical

--- a/test/4_assembly/rhizomorph_efficiency_modes_test.jl
+++ b/test/4_assembly/rhizomorph_efficiency_modes_test.jl
@@ -147,6 +147,33 @@ Test.@testset "Rhizomorph efficiency modes" begin
         Test.@test_broken canon_frac == ds_frac
     end
 
+    Test.@testset "Mode 3a: memory_profile threading" begin
+        reads = eff_tiling_reads(EFF_REF)
+        k = 7
+
+        cfg_full = R.AssemblyConfig(;
+            k = k, graph_mode = R.DoubleStrand, use_quality_scores = false,
+            memory_profile = :full)
+        res_full = R.assemble_genome(reads, cfg_full)
+
+        cfg_light = R.AssemblyConfig(;
+            k = k, graph_mode = R.DoubleStrand, use_quality_scores = false,
+            memory_profile = :lightweight)
+        res_light = R.assemble_genome(reads, cfg_light)
+
+        # memory_profile is an internal footprint change, not an output change:
+        # the assembled contigs must be identical (order-independent).
+        Test.@test Set(res_light.contigs) == Set(res_full.contigs)
+        Test.@test length(res_light.contigs) == length(res_full.contigs)
+
+        # Same expectation for the most compact profile.
+        cfg_ultra = R.AssemblyConfig(;
+            k = k, graph_mode = R.DoubleStrand, use_quality_scores = false,
+            memory_profile = :ultralight)
+        res_ultra = R.assemble_genome(reads, cfg_ultra)
+        Test.@test Set(res_ultra.contigs) == Set(res_full.contigs)
+    end
+
 end
 
 println("✓ Rhizomorph efficiency mode tests completed")

--- a/test/4_assembly/rhizomorph_efficiency_modes_test.jl
+++ b/test/4_assembly/rhizomorph_efficiency_modes_test.jl
@@ -19,8 +19,7 @@ import FASTX
 import BioSequences
 import MetaGraphsNext
 import Graphs
-
-const R = Mycelia.Rhizomorph
+import Logging
 
 # ---------------------------------------------------------------------------
 # Shared fixtures / helpers
@@ -34,6 +33,17 @@ function eff_tiling_reads(ref::AbstractString; read_len::Int = 15)
     reads = FASTX.FASTA.Record[]
     for i in 1:(length(ref) - read_len + 1)
         push!(reads, FASTX.FASTA.Record("r$(i)", ref[i:(i + read_len - 1)]))
+    end
+    return reads
+end
+
+"Tile the reference into overlapping FASTQ reads (quality => qualmer graph arm)."
+function eff_tiling_fastq_reads(ref::AbstractString; read_len::Int = 15)
+    reads = FASTX.FASTQ.Record[]
+    for i in 1:(length(ref) - read_len + 1)
+        sub = ref[i:(i + read_len - 1)]
+        qual = repeat("I", length(sub))  # Phred+33 'I' == Q40
+        push!(reads, FASTX.FASTQ.Record("r$(i)", sub, qual))
     end
     return reads
 end
@@ -74,17 +84,17 @@ Test.@testset "Rhizomorph efficiency modes" begin
         k = 7
 
         # (a) Default (dedup off) still emits RC pairs from the DoubleStrand arm.
-        cfg_default = R.AssemblyConfig(;
-            k = k, graph_mode = R.DoubleStrand, use_quality_scores = false)
-        res_default = R.assemble_genome(reads, cfg_default)
+        cfg_default = Mycelia.Rhizomorph.AssemblyConfig(;
+            k = k, graph_mode = Mycelia.Rhizomorph.DoubleStrand, use_quality_scores = false)
+        res_default = Mycelia.Rhizomorph.assemble_genome(reads, cfg_default)
         Test.@test !isempty(res_default.contigs)
         Test.@test eff_has_rc_pair(res_default.contigs)
 
         # (b) With dedup on, contig count drops and no two remaining contigs are RCs.
-        cfg_dedup = R.AssemblyConfig(;
-            k = k, graph_mode = R.DoubleStrand, use_quality_scores = false,
+        cfg_dedup = Mycelia.Rhizomorph.AssemblyConfig(;
+            k = k, graph_mode = Mycelia.Rhizomorph.DoubleStrand, use_quality_scores = false,
             dedup_revcomp = true)
-        res_dedup = R.assemble_genome(reads, cfg_dedup)
+        res_dedup = Mycelia.Rhizomorph.assemble_genome(reads, cfg_dedup)
         Test.@test !isempty(res_dedup.contigs)
         Test.@test length(res_dedup.contigs) < length(res_default.contigs)
         Test.@test !eff_has_rc_pair(res_dedup.contigs)
@@ -108,22 +118,30 @@ Test.@testset "Rhizomorph efficiency modes" begin
         ref_kmers = eff_canonical_kmers([EFF_REF], k)
 
         # DoubleStrand baseline: correct reconstruction (full canonical coverage).
-        cfg_ds = R.AssemblyConfig(;
-            k = k, graph_mode = R.DoubleStrand, use_quality_scores = false)
-        res_ds = R.assemble_genome(reads, cfg_ds)
+        cfg_ds = Mycelia.Rhizomorph.AssemblyConfig(;
+            k = k, graph_mode = Mycelia.Rhizomorph.DoubleStrand, use_quality_scores = false)
+        res_ds = Mycelia.Rhizomorph.assemble_genome(reads, cfg_ds)
         ds_frac = length(intersect(ref_kmers, eff_canonical_kmers(res_ds.contigs, k))) /
                   length(ref_kmers)
         Test.@test ds_frac == 1.0
 
-        cfg_canon = R.AssemblyConfig(;
-            k = k, graph_mode = R.Canonical, use_quality_scores = false)
-        res_canon = R.assemble_genome(reads, cfg_canon)
+        # DoubleStrand reconstruction is flagged valid.
+        Test.@test res_ds.assembly_stats["reconstruction_valid"] == true
+
+        cfg_canon = Mycelia.Rhizomorph.AssemblyConfig(;
+            k = k, graph_mode = Mycelia.Rhizomorph.Canonical, use_quality_scores = false)
+        # FIX 1: Canonical assembly must warn UNCONDITIONALLY (not verbose-gated)
+        # that contig reconstruction is not yet correct.
+        res_canon = Test.@test_logs (:warn,) match_mode = :any Mycelia.Rhizomorph.assemble_genome(reads, cfg_canon)
+
+        # FIX 1: and it must flag the result as an invalid reconstruction.
+        Test.@test res_canon.assembly_stats["reconstruction_valid"] == false
 
         # WHAT WORKS: the canonical graph is the compact (~1x) representation the
         # mode is meant to produce — undirected, with roughly half the vertices of
         # the DoubleStrand graph (RC pairs merged onto one canonical vertex).
-        canon_graph = R.build_kmer_graph(reads, k; mode = :canonical)
-        ds_graph = R.build_kmer_graph(reads, k; mode = :doublestrand)
+        canon_graph = Mycelia.Rhizomorph.build_kmer_graph(reads, k; mode = :canonical)
+        ds_graph = Mycelia.Rhizomorph.build_kmer_graph(reads, k; mode = :doublestrand)
         Test.@test !Graphs.is_directed(canon_graph)
         Test.@test length(collect(MetaGraphsNext.labels(canon_graph))) <=
                    0.6 * length(collect(MetaGraphsNext.labels(ds_graph)))
@@ -151,15 +169,15 @@ Test.@testset "Rhizomorph efficiency modes" begin
         reads = eff_tiling_reads(EFF_REF)
         k = 7
 
-        cfg_full = R.AssemblyConfig(;
-            k = k, graph_mode = R.DoubleStrand, use_quality_scores = false,
+        cfg_full = Mycelia.Rhizomorph.AssemblyConfig(;
+            k = k, graph_mode = Mycelia.Rhizomorph.DoubleStrand, use_quality_scores = false,
             memory_profile = :full)
-        res_full = R.assemble_genome(reads, cfg_full)
+        res_full = Mycelia.Rhizomorph.assemble_genome(reads, cfg_full)
 
-        cfg_light = R.AssemblyConfig(;
-            k = k, graph_mode = R.DoubleStrand, use_quality_scores = false,
+        cfg_light = Mycelia.Rhizomorph.AssemblyConfig(;
+            k = k, graph_mode = Mycelia.Rhizomorph.DoubleStrand, use_quality_scores = false,
             memory_profile = :lightweight)
-        res_light = R.assemble_genome(reads, cfg_light)
+        res_light = Mycelia.Rhizomorph.assemble_genome(reads, cfg_light)
 
         # memory_profile is an internal footprint change, not an output change:
         # the assembled contigs must be identical (order-independent).
@@ -167,10 +185,10 @@ Test.@testset "Rhizomorph efficiency modes" begin
         Test.@test length(res_light.contigs) == length(res_full.contigs)
 
         # Same expectation for the most compact profile.
-        cfg_ultra = R.AssemblyConfig(;
-            k = k, graph_mode = R.DoubleStrand, use_quality_scores = false,
+        cfg_ultra = Mycelia.Rhizomorph.AssemblyConfig(;
+            k = k, graph_mode = Mycelia.Rhizomorph.DoubleStrand, use_quality_scores = false,
             memory_profile = :ultralight)
-        res_ultra = R.assemble_genome(reads, cfg_ultra)
+        res_ultra = Mycelia.Rhizomorph.assemble_genome(reads, cfg_ultra)
         Test.@test Set(res_ultra.contigs) == Set(res_full.contigs)
     end
 
@@ -178,14 +196,15 @@ Test.@testset "Rhizomorph efficiency modes" begin
         reads = eff_tiling_reads(EFF_REF)
         k = 7
 
-        cfg_plain = R.AssemblyConfig(;
-            k = k, graph_mode = R.DoubleStrand, use_quality_scores = false)
-        res_plain = R.assemble_genome(reads, cfg_plain)
+        cfg_plain = Mycelia.Rhizomorph.AssemblyConfig(;
+            k = k, graph_mode = Mycelia.Rhizomorph.DoubleStrand, use_quality_scores = false)
+        res_plain = Mycelia.Rhizomorph.assemble_genome(reads, cfg_plain)
 
-        cfg_compact = R.AssemblyConfig(;
-            k = k, graph_mode = R.DoubleStrand, use_quality_scores = false,
+        cfg_compact = Mycelia.Rhizomorph.AssemblyConfig(;
+            k = k, graph_mode = Mycelia.Rhizomorph.DoubleStrand, use_quality_scores = false,
             compact_unitigs = true)
-        res_compact = R.assemble_genome(reads, cfg_compact)
+        # FIX 4: compaction on a fixed-length k-mer graph is a no-op and must warn.
+        res_compact = Test.@test_logs (:warn,) match_mode = :any Mycelia.Rhizomorph.assemble_genome(reads, cfg_compact)
 
         # Contract: compaction must not change the assembled contig sequences.
         Test.@test Set(res_compact.contigs) == Set(res_plain.contigs)
@@ -202,10 +221,47 @@ Test.@testset "Rhizomorph efficiency modes" begin
         n_simpl = length(collect(MetaGraphsNext.labels(res_compact.simplified_graph)))
         Test.@test n_simpl == n_full
 
+        # FIX 4: the stats disclose that compaction was requested but ineffective.
+        Test.@test res_compact.assembly_stats["unitig_compaction_requested"] == true
+        Test.@test res_compact.assembly_stats["unitig_compaction_effective"] == false
+
         # The invariant that SHOULD hold once fixed->variable conversion is wired in
         # (a linear tiling should compact to strictly fewer vertices). Left as
         # @test_broken to flag the known gap without red-failing the suite.
         Test.@test_broken n_simpl < n_full
+    end
+
+    Test.@testset "Config validation guards" begin
+        # (a) An unrecognized memory_profile is rejected at construction.
+        Test.@test_throws ErrorException Mycelia.Rhizomorph.AssemblyConfig(;
+            k = 7, use_quality_scores = false, memory_profile = :bogus)
+
+        # (b) Canonical (like DoubleStrand) requires a defined reverse complement,
+        # so it is rejected for amino-acid and general-string sequence types.
+        Test.@test_throws ErrorException Mycelia.Rhizomorph.AssemblyConfig(;
+            k = 7, sequence_type = BioSequences.LongAA,
+            graph_mode = Mycelia.Rhizomorph.Canonical)
+        Test.@test_throws ErrorException Mycelia.Rhizomorph.AssemblyConfig(;
+            k = 7, sequence_type = String,
+            graph_mode = Mycelia.Rhizomorph.Canonical)
+    end
+
+    Test.@testset "FIX 2: efficiency flags on the quality/qualmer path warn" begin
+        # The efficiency modes are only honored on the non-quality k-mer path.
+        # When use_quality_scores=true (the default, and what FASTQ input auto-sets)
+        # AND an efficiency flag is requested, construction must warn UNCONDITIONALLY
+        # that the flag is a no-op on the quality path.
+        Test.@test_logs (:warn,) match_mode = :any Mycelia.Rhizomorph.AssemblyConfig(;
+            k = 7, use_quality_scores = true, dedup_revcomp = true)
+        Test.@test_logs (:warn,) match_mode = :any Mycelia.Rhizomorph.AssemblyConfig(;
+            k = 7, use_quality_scores = true, compact_unitigs = true)
+        Test.@test_logs (:warn,) match_mode = :any Mycelia.Rhizomorph.AssemblyConfig(;
+            k = 7, use_quality_scores = true, memory_profile = :lightweight)
+
+        # And it must NOT warn for the default (no efficiency flag) quality config —
+        # existing quality assemblies stay byte-for-byte unchanged with no noise.
+        Test.@test_logs min_level = Logging.Warn Mycelia.Rhizomorph.AssemblyConfig(;
+            k = 7, use_quality_scores = true)
     end
 
 end

--- a/test/4_assembly/rhizomorph_efficiency_modes_test.jl
+++ b/test/4_assembly/rhizomorph_efficiency_modes_test.jl
@@ -18,6 +18,7 @@ import Mycelia
 import FASTX
 import BioSequences
 import MetaGraphsNext
+import Graphs
 
 const R = Mycelia.Rhizomorph
 
@@ -99,6 +100,51 @@ Test.@testset "Rhizomorph efficiency modes" begin
         # And dedup preserves canonical coverage relative to the full set (no loss).
         default_kmers = eff_canonical_kmers(res_default.contigs, k)
         Test.@test contig_kmers == default_kmers
+    end
+
+    Test.@testset "Mode 2: canonical graph (BLOCKED — undirected path reconstruction)" begin
+        reads = eff_tiling_reads(EFF_REF)
+        k = 7
+        ref_kmers = eff_canonical_kmers([EFF_REF], k)
+
+        # DoubleStrand baseline: correct reconstruction (full canonical coverage).
+        cfg_ds = R.AssemblyConfig(;
+            k = k, graph_mode = R.DoubleStrand, use_quality_scores = false)
+        res_ds = R.assemble_genome(reads, cfg_ds)
+        ds_frac = length(intersect(ref_kmers, eff_canonical_kmers(res_ds.contigs, k))) /
+                  length(ref_kmers)
+        Test.@test ds_frac == 1.0
+
+        cfg_canon = R.AssemblyConfig(;
+            k = k, graph_mode = R.Canonical, use_quality_scores = false)
+        res_canon = R.assemble_genome(reads, cfg_canon)
+
+        # WHAT WORKS: the canonical graph is the compact (~1x) representation the
+        # mode is meant to produce — undirected, with roughly half the vertices of
+        # the DoubleStrand graph (RC pairs merged onto one canonical vertex).
+        canon_graph = R.build_kmer_graph(reads, k; mode = :canonical)
+        ds_graph = R.build_kmer_graph(reads, k; mode = :doublestrand)
+        Test.@test !Graphs.is_directed(canon_graph)
+        Test.@test length(collect(MetaGraphsNext.labels(canon_graph))) <=
+                   0.6 * length(collect(MetaGraphsNext.labels(ds_graph)))
+
+        # WHAT IS BROKEN: path reconstruction over the UNDIRECTED canonical graph is
+        # incorrect. find_eulerian_paths_next + path_to_sequence assume a single
+        # fixed forward orientation and concatenate the trailing base of each
+        # successive canonical k-mer. On an undirected/canonical graph, adjacent
+        # canonical labels do not carry which strand their (k-1)-overlap is on, so
+        # the reconstructed sequence corresponds to no real read path. Empirically
+        # the emitted contig is genome-length but shares almost none of the
+        # reference's canonical k-mers (~1/32 on this fixture).
+        canon_frac = length(intersect(ref_kmers, eff_canonical_kmers(res_canon.contigs, k))) /
+                     length(ref_kmers)
+        # Documents the break: canonical coverage is far below the correct 1.0.
+        Test.@test canon_frac < 0.5
+
+        # The invariant that SHOULD hold once orientation-aware traversal exists for
+        # the canonical graph. Left as @test_broken so a future fix flips it to a
+        # visible pass (and any accidental "fix" that regresses is surfaced).
+        Test.@test_broken canon_frac == ds_frac
     end
 
 end

--- a/test/4_assembly/rhizomorph_efficiency_modes_test.jl
+++ b/test/4_assembly/rhizomorph_efficiency_modes_test.jl
@@ -174,6 +174,40 @@ Test.@testset "Rhizomorph efficiency modes" begin
         Test.@test Set(res_ultra.contigs) == Set(res_full.contigs)
     end
 
+    Test.@testset "Mode 3b: unitig compaction (partial — k-mer graph caveat)" begin
+        reads = eff_tiling_reads(EFF_REF)
+        k = 7
+
+        cfg_plain = R.AssemblyConfig(;
+            k = k, graph_mode = R.DoubleStrand, use_quality_scores = false)
+        res_plain = R.assemble_genome(reads, cfg_plain)
+
+        cfg_compact = R.AssemblyConfig(;
+            k = k, graph_mode = R.DoubleStrand, use_quality_scores = false,
+            compact_unitigs = true)
+        res_compact = R.assemble_genome(reads, cfg_compact)
+
+        # Contract: compaction must not change the assembled contig sequences.
+        Test.@test Set(res_compact.contigs) == Set(res_plain.contigs)
+
+        # When requested, simplified_graph is populated; default leaves it nothing.
+        Test.@test res_compact.simplified_graph !== nothing
+        Test.@test res_plain.simplified_graph === nothing
+
+        # Documented caveat: collapse_linear_chains! is a no-op on fixed-length
+        # k-mer graphs (collapsing would change the label type from Kmer to
+        # BioSequence). So the simplified graph currently has the SAME vertex count
+        # as the full graph — no real compaction happens yet.
+        n_full = length(collect(MetaGraphsNext.labels(res_compact.graph)))
+        n_simpl = length(collect(MetaGraphsNext.labels(res_compact.simplified_graph)))
+        Test.@test n_simpl == n_full
+
+        # The invariant that SHOULD hold once fixed->variable conversion is wired in
+        # (a linear tiling should compact to strictly fewer vertices). Left as
+        # @test_broken to flag the known gap without red-failing the suite.
+        Test.@test_broken n_simpl < n_full
+    end
+
 end
 
 println("✓ Rhizomorph efficiency mode tests completed")

--- a/test/4_assembly/rhizomorph_efficiency_modes_test.jl
+++ b/test/4_assembly/rhizomorph_efficiency_modes_test.jl
@@ -1,0 +1,106 @@
+# From the Mycelia base directory, run the tests with:
+#
+# ```bash
+# julia --project=. -e 'include("test/4_assembly/rhizomorph_efficiency_modes_test.jl")'
+# ```
+#
+# Tests for the three additive assembly-efficiency modes:
+#   Mode 1: reverse-complement contig dedup   (config.dedup_revcomp)
+#   Mode 2: canonical graph mode              (graph_mode = Canonical)
+#   Mode 3a: memory_profile threading         (config.memory_profile)
+#   Mode 3b: unitig compaction                (config.compact_unitigs)
+#
+# Every mode is opt-in; the default AssemblyConfig must reproduce today's
+# DoubleStrand / :full / no-dedup / no-compaction behavior exactly.
+
+import Test
+import Mycelia
+import FASTX
+import BioSequences
+import MetaGraphsNext
+
+const R = Mycelia.Rhizomorph
+
+# ---------------------------------------------------------------------------
+# Shared fixtures / helpers
+# ---------------------------------------------------------------------------
+
+"A small reference with no exact repeats at k=7, so assembly is well-defined."
+const EFF_REF = "ATCGGCTAATGCCGATTGCACGTACGTTAGCTAGGCATG"
+
+"Tile the reference into overlapping FASTA reads (no quality => k-mer graph arm)."
+function eff_tiling_reads(ref::AbstractString; read_len::Int = 15)
+    reads = FASTX.FASTA.Record[]
+    for i in 1:(length(ref) - read_len + 1)
+        push!(reads, FASTX.FASTA.Record("r$(i)", ref[i:(i + read_len - 1)]))
+    end
+    return reads
+end
+
+function eff_rc(seq::AbstractString)::String
+    return String(BioSequences.reverse_complement(BioSequences.LongDNA{4}(String(seq))))
+end
+
+"Canonical set of k-mers (as strings) for a collection of sequences."
+function eff_canonical_kmers(seqs, k::Int)
+    kmers = Set{String}()
+    for s in seqs
+        str = String(s)
+        for i in 1:(length(str) - k + 1)
+            sub = str[i:(i + k - 1)]
+            push!(kmers, min(sub, eff_rc(sub)))
+        end
+    end
+    return kmers
+end
+
+"True if any two distinct contigs in the set are reverse complements of each other."
+function eff_has_rc_pair(contigs)
+    s = Set(String.(contigs))
+    for c in contigs
+        rc = eff_rc(c)
+        if rc != c && rc in s
+            return true
+        end
+    end
+    return false
+end
+
+Test.@testset "Rhizomorph efficiency modes" begin
+
+    Test.@testset "Mode 1: reverse-complement dedup" begin
+        reads = eff_tiling_reads(EFF_REF)
+        k = 7
+
+        # (a) Default (dedup off) still emits RC pairs from the DoubleStrand arm.
+        cfg_default = R.AssemblyConfig(;
+            k = k, graph_mode = R.DoubleStrand, use_quality_scores = false)
+        res_default = R.assemble_genome(reads, cfg_default)
+        Test.@test !isempty(res_default.contigs)
+        Test.@test eff_has_rc_pair(res_default.contigs)
+
+        # (b) With dedup on, contig count drops and no two remaining contigs are RCs.
+        cfg_dedup = R.AssemblyConfig(;
+            k = k, graph_mode = R.DoubleStrand, use_quality_scores = false,
+            dedup_revcomp = true)
+        res_dedup = R.assemble_genome(reads, cfg_dedup)
+        Test.@test !isempty(res_dedup.contigs)
+        Test.@test length(res_dedup.contigs) < length(res_default.contigs)
+        Test.@test !eff_has_rc_pair(res_dedup.contigs)
+        # No exact duplicates remain either.
+        Test.@test length(unique(res_dedup.contigs)) == length(res_dedup.contigs)
+
+        # (c) The deduped set still covers the reference genome content: every
+        # canonical reference k-mer is present among the deduped contigs.
+        ref_kmers = eff_canonical_kmers([EFF_REF], k)
+        contig_kmers = eff_canonical_kmers(res_dedup.contigs, k)
+        Test.@test issubset(ref_kmers, contig_kmers)
+
+        # And dedup preserves canonical coverage relative to the full set (no loss).
+        default_kmers = eff_canonical_kmers(res_default.contigs, k)
+        Test.@test contig_kmers == default_kmers
+    end
+
+end
+
+println("✓ Rhizomorph efficiency mode tests completed")


### PR DESCRIPTION
## Summary

Adds four opt-in efficiency modes to the Rhizomorph k-mer assembler, all wired through `AssemblyConfig` and sharing one branch (they share the struct). **Every new flag defaults to today's exact behavior**, so all existing assemblies are byte-for-byte unchanged (default `DoubleStrand`, `:full` profile, no dedup, no compaction). Full regression suite is green.

- **Step 0 — config scaffold:** `AssemblyConfig` gains `dedup_revcomp::Bool=false`, `compact_unitigs::Bool=false`, `memory_profile::Symbol=:full`; `GraphMode` gains a `Canonical` value; `_graph_mode_symbol` maps it to `:canonical`. `Canonical`/`DoubleStrand` both require a defined reverse complement, so both are rejected for AA/String inputs. `memory_profile` is validated against the profiles `build_kmer_graph` accepts.
- **Mode 1 — reverse-complement dedup (`dedup_revcomp`):** new `_dedup_reverse_complements` collapses RC-pair contigs onto their lexicographically-minimal canonical rep after assembly. **Verified working.**
- **Mode 2 — canonical graph (`graph_mode=Canonical`):** flows through to `build_kmer_graph(mode=:canonical)`. Graph compaction works (undirected, ~1x vertices) but **contig reconstruction is BROKEN** on the undirected graph — see below. **Documented blocker, not shipped as working.**
- **Mode 3a — `memory_profile` threading:** passes the profile into `build_kmer_graph`. **Verified working** (lightweight/ultralight produce identical contigs to full).
- **Mode 3b — unitig compaction (`compact_unitigs`):** runs `collapse_linear_chains!` on a graph copy and populates `AssemblyResult.simplified_graph`. **Partial** — no-op on fixed-length k-mer graphs per the documented label-type caveat.

## Per-mode status

| Mode | Flag | Status |
| --- | --- | --- |
| 1 dedup | `dedup_revcomp` | **WORKING** — count drops, no RC pair remains, canonical k-mer coverage preserved |
| 2 canonical | `graph_mode=Canonical` | **BLOCKED** — compact graph built, but reconstruction incorrect (undirected traversal) |
| 3a memory_profile | `memory_profile` | **WORKING** — `:lightweight`/`:ultralight` == `:full` contigs |
| 3b compaction | `compact_unitigs` | **PARTIAL** — `simplified_graph` populated; no-op on k-mer graphs (needs fixed→variable conversion) |

### Mode 2 blocker detail (the key question)

`graph_mode=Canonical` produces a compact **undirected** graph (~half the vertices of DoubleStrand — the memory goal), but `find_eulerian_paths_next` + `path_to_sequence` assume a single fixed forward orientation and concatenate the trailing base of each successive canonical k-mer. An undirected/canonical graph does not record which strand each adjacency's (k-1)-overlap is on, so the walk reconstructs a sequence matching no real read path. Empirically the emitted contig is genome-length but shares ~1/32 of the reference's canonical k-mers (coverage fraction 0.03 vs the correct 1.0 for DoubleStrand). Orientation-aware canonical traversal is required and is out of scope for this additive-config change; the correctness invariant is left as `@test_broken`.

### Mode 3b caveat detail

`collapse_linear_chains!` is a no-op on fixed-length k-mer graphs: collapsing a linear chain yields a sequence longer than k, which would change the vertex label type from `Kmer` to `BioSequence` and violate MetaGraphsNext's parametric `label_type`. Genuine compaction needs `convert_fixed_to_variable()` first. The hook is in place and the contigs-unchanged contract holds; `n_simpl < n_full` is left as `@test_broken`.

## Config field names (for the benchmark harness)

- `dedup_revcomp::Bool` (default `false`)
- `compact_unitigs::Bool` (default `false`)
- `memory_profile::Symbol` (default `:full`; also `:lightweight`, `:ultralight`, `:lightweight_quality`, `:ultralight_quality`)
- `graph_mode = Mycelia.Rhizomorph.Canonical` (new enum value alongside `SingleStrand`/`DoubleStrand`)

## Test Plan

New: `test/4_assembly/rhizomorph_efficiency_modes_test.jl` — 19 pass, 2 `@test_broken` (Mode 2 correctness, Mode 3b true-compaction).

- [x] `rhizomorph_efficiency_modes_test.jl` — 19 pass / 2 broken
- [x] Regression (no changes to existing behavior):
  - `rhizomorph_doublestrand_traversal_test.jl` (5), `rhizomorph_kmer_mode_support_test.jl` (14)
  - `dna_kmer_doublestrand_test.jl` (10), `dna_kmer_singlestrand_test.jl` (20)
  - `assembly_core_coverage_test.jl` (69), `assembly_core_helper_branches_test.jl` (119)
  - `assembly_result_test.jl` (22), `graph_conversion_test.jl` (10)
  - `comprehensive_correctness_tests.jl` (141), `end_to_end_assembly_tests.jl` (74166)
  - All pass, zero failures.

Run: `LD_LIBRARY_PATH="" julia --project=. -e 'include("test/4_assembly/rhizomorph_efficiency_modes_test.jl")'`

Epic td-zv5c (Mode 1 td-eo3n, Mode 2 td-1wvp, Mode 3 td-sfz6). Do not merge — for review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional canonical graph mode for more compact k-mer handling.
  * Added new assembly options for reverse-complement deduplication, unitig compaction, and selectable memory profiles.
  * Assembly results can now include a simplified graph when compaction is enabled.

* **Bug Fixes**
  * Tightened input validation for sequence types and graph modes.
  * Improved assembly statistics and output consistency across the new modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->