### PR TITLE
feat: complete rhizomorph efficiency modes — structural RC-dedup + real unitig compaction

### DIFF
--- a/src/rhizomorph/algorithms/contigs.jl
+++ b/src/rhizomorph/algorithms/contigs.jl
@@ -33,6 +33,17 @@ struct ContigPath{T, S}
     end
 end
 
+# Reverse-complement partner of a vertex label, or `nothing` when the label has
+# no defined RC (string / BioSequence / amino-acid graphs). Only nucleotide
+# k-mer labels are RC-dedupable; the typed methods below give a zero-overhead,
+# type-stable dispatch (the generic fallback returns `nothing`). Defined above
+# the docstring so the docstring binds to `find_contigs_next`, not this helper.
+_rc_partner_label(::Any) = nothing
+function _rc_partner_label(
+        label::Kmers.Kmer{A}) where {A <: BioSequences.NucleicAcidAlphabet}
+    return BioSequences.reverse_complement(label)
+end
+
 """
     find_contigs_next(graph::MetaGraphsNext.MetaGraph; min_contig_length::Int=500)
 
@@ -51,16 +62,6 @@ sequence length is at least `min_contig_length`.
 contigs = Mycelia.Rhizomorph.find_contigs_next(graph; min_contig_length=1000)
 ```
 """
-# Reverse-complement partner of a vertex label, or `nothing` when the label has
-# no defined RC (string / BioSequence / amino-acid graphs). Only nucleotide
-# k-mer labels are RC-dedupable; the typed methods below give a zero-overhead,
-# type-stable dispatch (the generic fallback returns `nothing`).
-_rc_partner_label(::Any) = nothing
-function _rc_partner_label(
-        label::Kmers.Kmer{A}) where {A <: BioSequences.NucleicAcidAlphabet}
-    return BioSequences.reverse_complement(label)
-end
-
 function find_contigs_next(graph::MetaGraphsNext.MetaGraph; min_contig_length::Int = 500,
         rc_aware::Bool = false)
     labels = collect(MetaGraphsNext.labels(graph))
@@ -96,8 +97,13 @@ function find_contigs_next(graph::MetaGraphsNext.MetaGraph; min_contig_length::I
                 # contig (the source of QUAST duplication ~2.0). This is a
                 # structural fix: unlike post-hoc whole-contig string dedup, it also
                 # removes RC twins whose fragment breakpoints are OFFSET between the
-                # two strands (which string dedup silently misses). No-op on
-                # single-strand, canonical, string, or BioSequence graphs.
+                # two strands (which string dedup silently misses). Dispatch is
+                # type-based (nucleotide k-mer labels only), so it is inert on
+                # string / BioSequence / amino-acid graphs; on a nucleotide graph it
+                # is a true no-op only when no RC vertex is present. Caveat: like all
+                # RC-collapsing (canonical) de Bruijn assembly, a genuine inverted-
+                # repeat locus shares vertices with another locus's RC and collapses
+                # too — the standard de Bruijn RC ambiguity, not a regression.
                 if rc_aware
                     rc = _rc_partner_label(vertex)
                     if rc !== nothing

--- a/src/rhizomorph/algorithms/contigs.jl
+++ b/src/rhizomorph/algorithms/contigs.jl
@@ -51,7 +51,18 @@ sequence length is at least `min_contig_length`.
 contigs = Mycelia.Rhizomorph.find_contigs_next(graph; min_contig_length=1000)
 ```
 """
-function find_contigs_next(graph::MetaGraphsNext.MetaGraph; min_contig_length::Int = 500)
+# Reverse-complement partner of a vertex label, or `nothing` when the label has
+# no defined RC (string / BioSequence / amino-acid graphs). Only nucleotide
+# k-mer labels are RC-dedupable; the typed methods below give a zero-overhead,
+# type-stable dispatch (the generic fallback returns `nothing`).
+_rc_partner_label(::Any) = nothing
+function _rc_partner_label(
+        label::Kmers.Kmer{A}) where {A <: BioSequences.NucleicAcidAlphabet}
+    return BioSequences.reverse_complement(label)
+end
+
+function find_contigs_next(graph::MetaGraphsNext.MetaGraph; min_contig_length::Int = 500,
+        rc_aware::Bool = false)
     labels = collect(MetaGraphsNext.labels(graph))
     if isempty(labels)
         return ContigPath{Any, Any}[]
@@ -77,6 +88,22 @@ function find_contigs_next(graph::MetaGraphsNext.MetaGraph; min_contig_length::I
 
             for vertex in path
                 push!(visited, vertex)
+                # rc_aware: on a DoubleStrand nucleotide k-mer graph, every vertex
+                # has a distinct reverse-complement vertex representing the SAME
+                # genomic locus read on the opposite strand. Marking that RC partner
+                # visited prevents the traversal from independently walking the
+                # reverse strand and emitting a second, redundant copy of every
+                # contig (the source of QUAST duplication ~2.0). This is a
+                # structural fix: unlike post-hoc whole-contig string dedup, it also
+                # removes RC twins whose fragment breakpoints are OFFSET between the
+                # two strands (which string dedup silently misses). No-op on
+                # single-strand, canonical, string, or BioSequence graphs.
+                if rc_aware
+                    rc = _rc_partner_label(vertex)
+                    if rc !== nothing
+                        push!(visited, rc)
+                    end
+                end
             end
         end
     end

--- a/src/rhizomorph/assembly.jl
+++ b/src/rhizomorph/assembly.jl
@@ -821,30 +821,36 @@ function _assemble_kmer_graph(observations, config)
     contig_names = ["kmer_contig_$i" for i in 1:length(contigs)]
 
     # Mode 3b (opt-in): populate simplified_graph via linear-chain (unitig)
-    # compaction. NOTE the documented caveat: collapse_linear_chains! is a no-op on
-    # fixed-length k-mer graphs — collapsing a linear chain would produce a sequence
-    # longer than k, changing the vertex label type from Kmer to BioSequence and
-    # violating MetaGraphsNext's parametric label_type. Real compaction therefore
-    # requires convert_fixed_to_variable() first (out of scope here). We still run it
-    # on a copy so the field is populated and the contract (contigs unchanged) holds;
-    # for k-mer graphs the simplified graph is structurally identical to `graph`.
+    # compaction. collapse_linear_chains! is a no-op on fixed-length k-mer graphs
+    # (collapsing a linear chain produces a sequence longer than k, which would
+    # change the vertex label type from Kmer to BioSequence and violate
+    # MetaGraphsNext's parametric label_type). The keystone fix is to first run
+    # convert_fixed_to_variable(), which relabels each k-mer vertex as a
+    # variable-length BioSequence vertex (overlap = k-1) while preserving evidence
+    # and edge topology; collapse_linear_chains! can then merge non-branching runs
+    # into single unitig vertices, reducing the vertex count. The k-mer `graph`
+    # returned in the result is unchanged (n_full is measured against it), and the
+    # emitted contigs are untouched (they come from the k-mer traversal above), so
+    # the "contigs unchanged" contract still holds.
     simplified = nothing
     unitig_compaction_effective = false
     if config.compact_unitigs
-        simplified = Rhizomorph.collapse_linear_chains!(deepcopy(graph))
+        variable_graph = Rhizomorph.convert_fixed_to_variable(graph)
+        simplified = Rhizomorph.collapse_linear_chains!(variable_graph)
         n_full = length(MetaGraphsNext.labels(graph))
         n_simpl = length(MetaGraphsNext.labels(simplified))
-        # Record effectiveness, not just intent: for fixed-length k-mer graphs
-        # collapse_linear_chains! cannot reduce the vertex count, so this is false.
+        # Effective when the collapsed variable-length graph has strictly fewer
+        # vertices than the fixed-length k-mer graph (a linear tiling collapses to
+        # a handful of unitigs). Remains false only when the graph is already
+        # maximally branchy (no non-branching runs to merge).
         unitig_compaction_effective = n_simpl < n_full
         _log_info(config,
-            "Unitig compaction: $(n_full) -> $(n_simpl) vertices " *
-            "(no-op for fixed-length k-mer graphs; needs variable-length conversion)")
+            "Unitig compaction: $(n_full) k-mer vertices -> $(n_simpl) unitig " *
+            "vertices (via convert_fixed_to_variable + collapse_linear_chains!)")
         if !unitig_compaction_effective
-            @warn "compact_unitigs requested but had no effect: linear-chain " *
-                  "compaction is a no-op on fixed-length k-mer graphs " *
-                  "(collapsing would change vertex labels from Kmer to " *
-                  "BioSequence). simplified_graph is structurally identical to graph."
+            @warn "compact_unitigs requested but the graph had no non-branching " *
+                  "runs to collapse: simplified_graph has the same vertex count " *
+                  "as the k-mer graph."
         end
     end
 

--- a/src/rhizomorph/assembly.jl
+++ b/src/rhizomorph/assembly.jl
@@ -1052,7 +1052,15 @@ end
 Generate contigs using probabilistic walks when Eulerian paths are not available.
 """
 function _generate_contigs_probabilistic(graph, config)
-    contig_paths = Rhizomorph.find_contigs_next(graph; min_contig_length = 1)
+    # dedup_revcomp: prefer STRUCTURAL reverse-complement dedup during traversal
+    # over the post-hoc whole-contig string dedup applied later. The structural
+    # form marks each walked vertex's RC partner visited, so the reverse strand is
+    # never independently traversed. This removes RC twins with OFFSET fragment
+    # breakpoints that the string-level _dedup_reverse_complements misses (the
+    # empirically-observed case where contig-level dedup halves the count but
+    # leaves QUAST duplication at ~2.0).
+    contig_paths = Rhizomorph.find_contigs_next(
+        graph; min_contig_length = 1, rc_aware = config.dedup_revcomp)
     contigs = String[]
 
     for contig in contig_paths

--- a/test/4_assembly/rhizomorph_efficiency_modes_test.jl
+++ b/test/4_assembly/rhizomorph_efficiency_modes_test.jl
@@ -287,6 +287,39 @@ Test.@testset "Rhizomorph efficiency modes" begin
             graph_mode = Mycelia.Rhizomorph.Canonical)
     end
 
+    Test.@testset "Mode 1b: structural RC-dedup in find_contigs_next" begin
+        # find_contigs_next(; rc_aware=true) marks each walked vertex's
+        # reverse-complement partner visited, so the DoubleStrand graph's reverse
+        # strand is never independently traversed. This is a STRUCTURAL fix for the
+        # QUAST-duplication-~2.0 pathology: unlike post-hoc whole-contig string
+        # dedup, it removes RC twins even when their fragment breakpoints are
+        # OFFSET between strands (the empirically-observed case where contig-level
+        # string dedup halves the count yet leaves duplication at 2.0).
+        reads = eff_tiling_reads(EFF_REF)
+        k = 7
+        g = Mycelia.Rhizomorph.build_kmer_graph(reads, k; mode = :doublestrand)
+
+        c_off = [string(c.sequence)
+                 for c in Mycelia.Rhizomorph.find_contigs_next(g; min_contig_length = 1)]
+        c_on = [string(c.sequence)
+                for c in Mycelia.Rhizomorph.find_contigs_next(
+                    g; min_contig_length = 1, rc_aware = true)]
+
+        # (a) Default (rc_aware=false) is unchanged and still emits RC pairs.
+        Test.@test eff_has_rc_pair(c_off)
+        # (b) rc_aware strictly reduces the contig count (removes the RC strand).
+        Test.@test length(c_on) < length(c_off)
+        # (c) No RC twins remain after structural dedup.
+        Test.@test !eff_has_rc_pair(c_on)
+        # (d) Genome content is PRESERVED: canonical k-mer coverage is unchanged
+        #     (accuracy is not traded for the contig-count reduction).
+        Test.@test eff_canonical_kmers(c_on, k) == eff_canonical_kmers(c_off, k)
+        Test.@test issubset(eff_canonical_kmers([EFF_REF], k), eff_canonical_kmers(c_on, k))
+
+        # (e) The helper is a no-op on labels with no defined reverse complement.
+        Test.@test Mycelia.Rhizomorph._rc_partner_label("ACGT") === nothing
+    end
+
     Test.@testset "FIX 2: efficiency flags on the quality/qualmer path warn" begin
         # The efficiency modes are only honored on the non-quality k-mer path.
         # When use_quality_scores=true (the default, and what FASTQ input auto-sets)

--- a/test/4_assembly/rhizomorph_efficiency_modes_test.jl
+++ b/test/4_assembly/rhizomorph_efficiency_modes_test.jl
@@ -244,32 +244,29 @@ Test.@testset "Rhizomorph efficiency modes" begin
         cfg_compact = Mycelia.Rhizomorph.AssemblyConfig(;
             k = k, graph_mode = Mycelia.Rhizomorph.DoubleStrand, use_quality_scores = false,
             compact_unitigs = true)
-        # FIX 4: compaction on a fixed-length k-mer graph is a no-op and must warn.
-        res_compact = Test.@test_logs (:warn,) match_mode = :any Mycelia.Rhizomorph.assemble_genome(reads, cfg_compact)
+        # Compaction is now effective (convert_fixed_to_variable +
+        # collapse_linear_chains!), so no ineffective-compaction warning is emitted.
+        res_compact = Test.@test_logs min_level = Logging.Warn Mycelia.Rhizomorph.assemble_genome(reads, cfg_compact)
 
-        # Contract: compaction must not change the assembled contig sequences.
+        # Contract: compaction must not change the assembled contig sequences (the
+        # contigs come from the k-mer traversal, not from simplified_graph).
         Test.@test Set(res_compact.contigs) == Set(res_plain.contigs)
 
         # When requested, simplified_graph is populated; default leaves it nothing.
         Test.@test res_compact.simplified_graph !== nothing
         Test.@test res_plain.simplified_graph === nothing
 
-        # Documented caveat: collapse_linear_chains! is a no-op on fixed-length
-        # k-mer graphs (collapsing would change the label type from Kmer to
-        # BioSequence). So the simplified graph currently has the SAME vertex count
-        # as the full graph — no real compaction happens yet.
+        # Keystone: convert_fixed_to_variable() relabels each k-mer vertex as a
+        # variable-length BioSequence vertex, so collapse_linear_chains! can now
+        # merge non-branching runs into unitigs. A linear tiling collapses to
+        # strictly fewer vertices than the full k-mer graph.
         n_full = length(collect(MetaGraphsNext.labels(res_compact.graph)))
         n_simpl = length(collect(MetaGraphsNext.labels(res_compact.simplified_graph)))
-        Test.@test n_simpl == n_full
+        Test.@test n_simpl < n_full
 
-        # FIX 4: the stats disclose that compaction was requested but ineffective.
+        # The stats disclose that compaction was requested AND effective.
         Test.@test res_compact.assembly_stats["unitig_compaction_requested"] == true
-        Test.@test res_compact.assembly_stats["unitig_compaction_effective"] == false
-
-        # The invariant that SHOULD hold once fixed->variable conversion is wired in
-        # (a linear tiling should compact to strictly fewer vertices). Left as
-        # @test_broken to flag the known gap without red-failing the suite.
-        Test.@test_broken n_simpl < n_full
+        Test.@test res_compact.assembly_stats["unitig_compaction_effective"] == true
     end
 
     Test.@testset "Config validation guards" begin


### PR DESCRIPTION
## Summary

Completes the rhizomorph efficiency modes with two tested structural fixes, cherry-picked from a pre-squash-merge branch onto current `master`.

- **Structural reverse-complement dedup (`5c20a03`)** — a *structural* upgrade over the string-level dedup merged in #340. On a DoubleStrand k-mer graph every k-mer's reverse complement is a separate vertex, so `find_contigs_next` walked forward and reverse strands independently and emitted each contig twice (the source of QUAST duplication ~2.0). The post-hoc whole-contig string dedup (`_dedup_reverse_complements`, #340) could not remove RC twins whose fragment breakpoints are *offset* between strands — the benchmark showed it halved the contig count yet left duplication at 2.0. This adds an opt-in `rc_aware` path to `find_contigs_next` that marks each walked vertex's RC partner (`_rc_partner_label`) visited so the reverse strand is never independently traversed, wired to the existing `config.dedup_revcomp` flag. Default behavior is unchanged.

- **Real unitig compaction — keystone (`2b72493`)** — Mode 3b compaction was previously a no-op: `collapse_linear_chains!` cannot reduce a fixed-length k-mer graph (collapsing would change the vertex label type from `Kmer` to `BioSequence`). This wires the *already-existing* `convert_fixed_to_variable(graph)` before `collapse_linear_chains!`, relabeling k-mer vertices as variable-length BioSequence vertices (overlap = k-1, evidence + edge topology preserved) so non-branching runs actually merge into unitigs. The k-mer `graph` returned in the result and the emitted contigs are untouched, so the contigs-unchanged contract holds.

Both changes still need real-genome Lovelace validation (dup 2.0 → ~1.0; vertex reduction with contigs unchanged) before being relied upon.

## Test Plan

- [ ] `LD_LIBRARY_PATH="" julia --project=. test/4_assembly/rhizomorph_efficiency_modes_test.jl` — Mode 3b `n_simpl < n_full` assertion (previously `@test_broken`) now passes; Mode 2 canonical reconstruction remains `@test_broken` (out of scope — needs bidirected traversal).
- [ ] Real-genome Lovelace validation on Lambda: confirm dedup drives QUAST duplication 2.0 → ~1.0 and unitig compaction reduces vertex count while leaving contigs unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional reverse-complement–aware mode for contig extraction, reducing duplicate contigs in nucleotide k-mer graphs.
  * Reworked unitig compaction to actually compact k-mer graphs and to report when compaction is effective.

* **Bug Fixes**
  * Improved reverse-complement deduplication so contig/paths are selected consistently when deduplication is enabled, avoiding redundant “twin” contigs.

* **Tests**
  * Updated assembly efficiency mode expectations and added coverage for reverse-complement–aware contig extraction behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->