### PR TITLE
fix: beam-prune the Viterbi read corrector (td-63qy)

### DIFF
--- a/src/iterative-assembly.jl
+++ b/src/iterative-assembly.jl
@@ -1232,10 +1232,16 @@ function try_viterbi_path_improvement(read::FASTX.FASTQ.Record,
         end
 
         quality_scores = collect(FASTX.quality_scores(read))
+        # Bound the exact-Viterbi frontier: without a finite beam the reachable
+        # (vertex, strand) set grows ~unboundedly with read length on real graphs
+        # and the corrector explodes (21B allocations / crash on a 48 kb phage —
+        # td-63qy). 256 keeps enough candidates to preserve correction quality
+        # while making the corrector tractable at read scale; tune via benchmark.
         config = Mycelia.ViterbiCorrectionConfig(
             alphabet = alphabet,
             strand_mode = graph_mode,
-            max_steps = length(observations) - 1
+            max_steps = length(observations) - 1,
+            beam_width = 256
         )
         correction = Mycelia.correct_observations(graph, [observations]; config = config)
         corrected_path = only(correction.corrected_observations)

--- a/src/viterbi-next.jl
+++ b/src/viterbi-next.jl
@@ -76,6 +76,7 @@ struct ViterbiCorrectionConfig{F <: Function}
     target_vertex::Any
     start_strand::Rhizomorph.StrandOrientation
     edge_weight::Function
+    beam_width::Int
 
     function ViterbiCorrectionConfig{F}(;
             error_rate::Float64 = 0.01,
@@ -86,7 +87,8 @@ struct ViterbiCorrectionConfig{F <: Function}
             max_steps::Union{Nothing, Int} = nothing,
             target_vertex = nothing,
             start_strand::Rhizomorph.StrandOrientation = Rhizomorph.Forward,
-            edge_weight::Function = Rhizomorph.edge_data_weight
+            edge_weight::Function = Rhizomorph.edge_data_weight,
+            beam_width::Int = typemax(Int)
     ) where {F <: Function}
         if error_rate <= 0.0 || error_rate >= 0.5
             throw(ArgumentError("error_rate must be in (0, 0.5), got $error_rate"))
@@ -97,6 +99,9 @@ struct ViterbiCorrectionConfig{F <: Function}
         if max_steps !== nothing && max_steps < 0
             throw(ArgumentError("max_steps must be non-negative, got $max_steps"))
         end
+        if beam_width <= 0
+            throw(ArgumentError("beam_width must be positive, got $beam_width"))
+        end
         return new{F}(
             error_rate,
             verbosity,
@@ -106,7 +111,8 @@ struct ViterbiCorrectionConfig{F <: Function}
             max_steps,
             target_vertex,
             start_strand,
-            edge_weight
+            edge_weight,
+            beam_width
         )
     end
 end
@@ -120,7 +126,8 @@ function ViterbiCorrectionConfig(;
         max_steps::Union{Nothing, Int} = nothing,
         target_vertex = nothing,
         start_strand::Rhizomorph.StrandOrientation = Rhizomorph.Forward,
-        edge_weight::Function = Rhizomorph.edge_data_weight
+        edge_weight::Function = Rhizomorph.edge_data_weight,
+        beam_width::Int = typemax(Int)
 )::ViterbiCorrectionConfig{F} where {F <: Function}
     return ViterbiCorrectionConfig{F}(
         error_rate = error_rate,
@@ -131,7 +138,8 @@ function ViterbiCorrectionConfig(;
         max_steps = max_steps,
         target_vertex = target_vertex,
         start_strand = start_strand,
-        edge_weight = edge_weight
+        edge_weight = edge_weight,
+        beam_width = beam_width
     )
 end
 
@@ -846,6 +854,28 @@ function _call_viterbi_emission_logp(
     end
 end
 
+# Keep only the `beam_width` highest-scoring states, pruning the score and
+# predecessor dicts in lockstep so path reconstruction stays consistent. States
+# are ranked by score descending; score ties are broken by `hash(state)` for a
+# deterministic (run-reproducible) beam. Called once per depth by
+# `_viterbi_correct_observation` when the frontier exceeds the beam.
+function _prune_correction_beam(
+        scores::Dict{S, Float64},
+        predecessors::Dict{S, S},
+        beam_width::Int
+)::Tuple{Dict{S, Float64}, Dict{S, S}} where {S}
+    ordered = sort!(collect(scores); by = kv -> (last(kv), hash(first(kv))), rev = true)
+    kept = Dict{S, Float64}()
+    kept_predecessors = Dict{S, S}()
+    for (state, score) in Iterators.take(ordered, beam_width)
+        kept[state] = score
+        if haskey(predecessors, state)
+            kept_predecessors[state] = predecessors[state]
+        end
+    end
+    return kept, kept_predecessors
+end
+
 function _viterbi_correct_observation(
         graph::MetaGraphsNext.MetaGraph,
         observation::AbstractVector,
@@ -998,6 +1028,19 @@ function _viterbi_correct_observation(
 
         if isempty(next_scores)
             break
+        end
+
+        # Beam pruning: cap the frontier to the top `beam_width` states by score
+        # before it becomes the next `active_scores`. Without this, the reachable
+        # (vertex, strand) set grows ~unboundedly with read-length depth on real
+        # branchy graphs (21B allocations / hard crash on a 48 kb phage). Keeping
+        # the top-K by score is the standard beam approximation; with the default
+        # beam_width = typemax(Int) the guard never fires and the decoder stays
+        # exact (B8 correction fixtures are byte-identical).
+        if length(next_scores) > config.beam_width
+            next_scores, next_predecessors = _prune_correction_beam(
+                next_scores, next_predecessors, config.beam_width)
+            diagnostics[:beam_pruned] = get(diagnostics, :beam_pruned, 0) + 1
         end
 
         push!(predecessors_by_depth, next_predecessors)

--- a/test/4_assembly/viterbi_beam_pruning_test.jl
+++ b/test/4_assembly/viterbi_beam_pruning_test.jl
@@ -1,0 +1,97 @@
+# From the Mycelia base directory, run this test with:
+#
+# ```bash
+# julia --project=. -e 'include("test/4_assembly/viterbi_beam_pruning_test.jl")'
+# ```
+#
+# Regression for td-63qy: the exact Viterbi corrector (`_viterbi_correct_observation`)
+# never beam-capped its (vertex, strand) frontier, so the reachable-state set grew
+# ~unboundedly with read-length depth on real branchy graphs — 21 billion
+# allocations and a hard crash on a 48 kb phage. `ViterbiCorrectionConfig` now
+# carries `beam_width` (default `typemax(Int)` = exact/unbounded); a finite value
+# caps the frontier to the top-K states by score each depth.
+
+import BioSequences
+import FASTX
+import Kmers
+import Mycelia
+import Test
+
+function beam_decoded_label_strings(
+    result::Mycelia.ViterbiCorrectionResult
+)::Vector{String}
+    decoded = only(result.corrected_observations)
+    return [string(label) for label in decoded]
+end
+
+Test.@testset "Viterbi corrector beam pruning (td-63qy)" begin
+    # A simple linear graph: the frontier is small, so the exact and bounded
+    # decoders must agree, and pruning must never fire.
+    linear_records = [FASTX.FASTA.Record("dna", BioSequences.dna"ATGCGT")]
+    linear_graph = Mycelia.Rhizomorph.build_kmer_graph(
+        linear_records, 3; dataset_id="beam_linear", mode=:singlestrand
+    )
+    linear_observed = [
+        Kmers.DNAKmer{3}("ATG"),
+        Kmers.DNAKmer{3}("TGA"),
+        Kmers.DNAKmer{3}("GCG"),
+        Kmers.DNAKmer{3}("CGT"),
+    ]
+
+    Test.@testset "default beam_width is unbounded (exact, no regression)" begin
+        result = Mycelia.correct_observations(linear_graph, [linear_observed])
+        # The exact answer from the existing B8 fixture — must be byte-identical.
+        Test.@test beam_decoded_label_strings(result) == ["ATG", "TGC", "GCG", "CGT"]
+        # No pruning on the default (unbounded) path.
+        Test.@test get(only(result.paths).diagnostics, :beam_pruned, 0) == 0
+    end
+
+    Test.@testset "a finite beam still recovers the linear correction" begin
+        config = Mycelia.ViterbiCorrectionConfig(alphabet=:DNA, beam_width=1)
+        result = Mycelia.correct_observations(linear_graph, [linear_observed]; config=config)
+        # Anti-crash guarantee: a bounded corrector completes and returns a
+        # valid, complete correction on a linear graph.
+        Test.@test beam_decoded_label_strings(result) == ["ATG", "TGC", "GCG", "CGT"]
+    end
+
+    # A bubble graph (two paths sharing a start/end k-mer) forces the frontier
+    # above one state at the branch, so a beam_width=1 corrector MUST prune —
+    # and must still complete rather than explode.
+    bubble_records = [
+        FASTX.FASTA.Record("path_a", BioSequences.dna"ATGCGTA"),
+        FASTX.FASTA.Record("path_b", BioSequences.dna"ATGAGTA"),
+    ]
+    bubble_graph = Mycelia.Rhizomorph.build_kmer_graph(
+        bubble_records, 3; dataset_id="beam_bubble", mode=:singlestrand
+    )
+    bubble_observed = [
+        Kmers.DNAKmer{3}("ATG"),
+        Kmers.DNAKmer{3}("TGC"),
+        Kmers.DNAKmer{3}("GCG"),
+        Kmers.DNAKmer{3}("CGT"),
+        Kmers.DNAKmer{3}("GTA"),
+    ]
+
+    Test.@testset "beam pruning activates on a branch and still completes" begin
+        config = Mycelia.ViterbiCorrectionConfig(alphabet=:DNA, beam_width=1)
+        result = Mycelia.correct_observations(bubble_graph, [bubble_observed]; config=config)
+        decoded = only(result.corrected_observations)
+        # Completes with a non-empty correction (did not explode / crash).
+        Test.@test !isempty(decoded)
+        # Pruning fired at least once (the branch pushed the frontier past 1).
+        Test.@test get(only(result.paths).diagnostics, :beam_pruned, 0) >= 1
+    end
+
+    Test.@testset "unbounded decoder on the bubble is at least as good as beamed" begin
+        exact = Mycelia.correct_observations(bubble_graph, [bubble_observed])
+        beamed_config = Mycelia.ViterbiCorrectionConfig(alphabet=:DNA, beam_width=1)
+        beamed = Mycelia.correct_observations(bubble_graph, [bubble_observed]; config=beamed_config)
+        # Beam search is an approximation: the exact score is an upper bound.
+        Test.@test only(exact.paths).score >= only(beamed.paths).score - 1e-9
+    end
+
+    Test.@testset "beam_width must be positive" begin
+        Test.@test_throws ArgumentError Mycelia.ViterbiCorrectionConfig(beam_width=0)
+        Test.@test_throws ArgumentError Mycelia.ViterbiCorrectionConfig(beam_width=-4)
+    end
+end


### PR DESCRIPTION
## Summary
The exact Viterbi corrector (`_viterbi_correct_observation`) never beam-capped its `(vertex, strand)` frontier, so the reachable-state set grew ~unboundedly with read-length depth on real branchy graphs — **21 billion allocations + a hard crash on a 48 kb phage** (WS1 iterative-vs-naive). This blocked the entire foundational iterative-correction assembly method.

- Add `ViterbiCorrectionConfig.beam_width` — default `typemax(Int)` (exact/unbounded), so `correct_observations` and all B8 fixtures stay **byte-identical**.
- A finite width caps the frontier to the top-K states by score each depth (`_prune_correction_beam`, deterministic hash tiebreak, prunes scores + predecessors in lockstep).
- The iterative caller (`try_viterbi_path_improvement`) opts into `beam_width = 256`.

## Test Plan
- [x] B8 correction fixtures **11/11** pass (default unbounded = exact, no regression) — local.
- [x] New beam-pruning regression **8/8**: no-regression, anti-crash on a linear graph, pruning-activates on a bubble graph (`:beam_pruned >= 1`), exact-score ≥ beam-score, `beam_width <= 0` throws — local.
- [ ] End-to-end: WS1 Lambda iterative arm now **completes** (proof run in progress on the combined branch).

Related: td-63qy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable beam pruning for Viterbi correction, letting the decoder limit how many candidate paths it keeps while still producing results.
  * Added a default bounded frontier in iterative assembly to keep correction search constrained.

* **Bug Fixes**
  * Improved path selection behavior in branching cases so decoding remains stable when pruning is enabled.
  * Added validation to reject invalid beam-width values, preventing misconfigured runs.

* **Tests**
  * Added coverage for exact results, pruning behavior, scoring comparisons, and invalid configuration handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->