### PR TITLE
feat: wire Stage 0 classifier into corrector to skip all-solid reads (td-1do7)

### DIFF
--- a/benchmarking/stage0_completion_benchmark.jl
+++ b/benchmarking/stage0_completion_benchmark.jl
@@ -1,0 +1,65 @@
+# Stage 0 completion benchmark (td-1do7): does the iterative corrector COMPLETE
+# once all-solid reads are skipped, and what skip fraction does it report?
+#
+# The iterative pipeline never completed at real scale because it decoded EVERY
+# read (td-ve02). Stage 0 skips reads with no weak k-mer; this benchmark measures
+# whether that lets the pipeline finish, and the skip fraction (the work saved).
+#
+# Toy-scale defaults so it completes locally; env vars scale it up:
+#   MYCELIA_S0C_REFLEN / COVERAGE / READLEN / ERR / MAXK / SEED
+#   MYCELIA_S0C_SKIP (true|false) — toggle the skip to compare
+
+import Mycelia
+import Random
+
+getenv(k, d) = haskey(ENV, k) ? parse(typeof(d), ENV[k]) : d
+const REFLEN   = getenv("MYCELIA_S0C_REFLEN", 3000)
+const COVERAGE = getenv("MYCELIA_S0C_COVERAGE", 20)
+const READLEN  = getenv("MYCELIA_S0C_READLEN", 100)
+const ERR      = getenv("MYCELIA_S0C_ERR", 0.01)
+const MAXK     = getenv("MYCELIA_S0C_MAXK", 19)
+const SEED     = getenv("MYCELIA_S0C_SEED", 42)
+const SKIP     = get(ENV, "MYCELIA_S0C_SKIP", "true") == "true"
+const BASES = ['A', 'C', 'G', 'T']
+
+function simulate_fastq(path)
+    rng = Random.MersenneTwister(SEED)
+    ref = join(rand(rng, BASES, REFLEN))
+    n_reads = max(1, round(Int, COVERAGE * REFLEN / READLEN))
+    open(path, "w") do io
+        for i in 1:n_reads
+            s = rand(rng, 1:(REFLEN - READLEN + 1))
+            seq = collect(ref[s:(s + READLEN - 1)])
+            quals = fill('I', READLEN)
+            for j in 1:READLEN
+                if rand(rng) < ERR
+                    seq[j] = rand(rng, filter(!=(seq[j]), BASES))
+                    quals[j] = Char(clamp(round(Int, 22 + 8 * randn(rng)), 2, 40) + 33)
+                end
+            end
+            println(io, "@r$i"); println(io, join(seq)); println(io, "+"); println(io, join(quals))
+        end
+    end
+    return n_reads
+end
+
+function main()
+    outdir = mktempdir()
+    fastq = joinpath(outdir, "reads.fastq")
+    n_reads = simulate_fastq(fastq)
+    println("=== Stage 0 completion benchmark ===")
+    println("reflen=$REFLEN cov=$COVERAGE readlen=$READLEN err=$ERR max_k=$MAXK seed=$SEED skip_solid=$SKIP reads=$n_reads")
+    t0 = time()
+    Mycelia.mycelia_iterative_assemble(fastq;
+        max_k = MAXK,
+        skip_solid = SKIP,
+        verbose = true,
+        enable_parallel = true,
+        enable_checkpointing = false,
+        output_dir = joinpath(outdir, "asm"))
+    elapsed = time() - t0
+    println("=== COMPLETED in $(round(elapsed; digits = 1))s (skip_solid=$SKIP) ===")
+    println("(skip fraction is reported per iteration in the verbose output above)")
+end
+
+main()

--- a/src/iterative-assembly.jl
+++ b/src/iterative-assembly.jl
@@ -437,6 +437,56 @@ end
 # Read Likelihood Improvement Functions
 # =============================================================================
 
+# ------------------------------------------------------------------------------
+# Stage 0 skip support (td-1do7): classify k-mers once per graph so that reads
+# with no weak k-mers can skip the expensive per-read Viterbi decode. This is the
+# volume reduction that motivated the staged-correction architecture — the
+# corrector should only decode reads that actually need correction.
+# ------------------------------------------------------------------------------
+
+"""
+    _solid_kmer_set(graph; classifier) -> Set
+
+Classify every k-mer once and return the set of SOLID (real-genomic) canonical
+k-mer labels. Defaults to the auto-threshold `MixtureModelClassifier` (a top
+default in the Stage 0 comparison matrix, coverage-based so it needs no per-arm
+tuning). Returns all labels (i.e. skip nothing) when the graph has no dataset
+evidence, so the skip can never drop a real k-mer by mistake.
+"""
+function _solid_kmer_set(graph;
+        classifier = Mycelia.Rhizomorph.MixtureModelClassifier())
+    labels = collect(MetaGraphsNext.labels(graph))
+    isempty(labels) && return Set{eltype(labels)}()
+    dataset_id = _rhizomorph_first_dataset_id(graph[first(labels)])
+    dataset_id === nothing && return Set{eltype(labels)}(labels)
+    classification = Mycelia.Rhizomorph.classify_kmers(classifier, graph;
+        dataset_id = dataset_id)
+    solid = Set{eltype(labels)}()
+    for (label, is_solid) in classification.verdicts
+        is_solid && push!(solid, label)
+    end
+    return solid
+end
+
+"""
+    _read_is_all_solid(read, k, solid_kmers) -> Bool
+
+True iff every canonical k-mer of `read` is in `solid_kmers` (⇒ no weak region ⇒
+the read needs no correction and can skip the decode). A read with no k-mers
+(shorter than k, or fully ambiguous) returns `false` so it is never skipped on the
+basis of absent evidence.
+"""
+function _read_is_all_solid(read::FASTX.FASTQ.Record, k::Int, solid_kmers::AbstractSet)
+    isempty(solid_kmers) && return false
+    sequence = FASTX.sequence(BioSequences.LongDNA{4}, read)
+    saw_kmer = false
+    for (kmer, _) in Kmers.UnambiguousDNAMers{k}(sequence)
+        saw_kmer = true
+        (BioSequences.canonical(kmer) in solid_kmers) || return false
+    end
+    return saw_kmer
+end
+
 """
 Improve likelihood of entire read set using current graph and k-mer size.
 Returns updated reads and count of improvements made.
@@ -446,10 +496,18 @@ function improve_read_set_likelihood(reads::Vector{<:FASTX.FASTQ.Record}, graph,
         verbose::Bool = false,
         batch_size::Int = 10000,
         enable_parallel::Bool = false,
-        graph_mode::Symbol = :canonical)::Tuple{Vector{FASTX.FASTQ.Record}, Int}
+        graph_mode::Symbol = :canonical,
+        skip_solid::Bool = false)::Tuple{Vector{FASTX.FASTQ.Record}, Int}
     total_reads = length(reads)
     updated_reads = Vector{FASTX.FASTQ.Record}(undef, total_reads)
     improvements_made = 0
+
+    # Stage 0 skip (td-1do7): classify k-mers once; a read whose every k-mer is
+    # solid has no weak region to correct and skips the per-read decode. Opt-in
+    # (default off) so existing callers are unchanged. `solid_kmers === nothing`
+    # ⇒ correct every read as before.
+    solid_kmers = skip_solid ? _solid_kmer_set(graph) : nothing
+    skipped_solid = 0
 
     if verbose
         println("  Processing $total_reads reads in batches of $batch_size")
@@ -466,11 +524,19 @@ function improve_read_set_likelihood(reads::Vector{<:FASTX.FASTQ.Record}, graph,
             # Parallel processing for large batches
             batch_results = Vector{Tuple{FASTX.FASTQ.Record, Bool}}(undef, length(batch_reads))
 
+            skip_flags = falses(length(batch_reads))
             Threads.@threads for i in eachindex(batch_reads)
-                improved_read,
-                was_improved = improve_read_likelihood(batch_reads[i], graph, k; graph_mode = graph_mode)
-                batch_results[i] = (improved_read, was_improved)
+                read = batch_reads[i]
+                if solid_kmers !== nothing && _read_is_all_solid(read, k, solid_kmers)
+                    batch_results[i] = (read, false)   # all-solid ⇒ skip the decode
+                    skip_flags[i] = true
+                else
+                    improved_read,
+                    was_improved = improve_read_likelihood(read, graph, k; graph_mode = graph_mode)
+                    batch_results[i] = (improved_read, was_improved)
+                end
             end
+            skipped_solid += count(skip_flags)
 
             # Collect results
             for (i, (improved_read, was_improved)) in enumerate(batch_results)
@@ -482,6 +548,11 @@ function improve_read_set_likelihood(reads::Vector{<:FASTX.FASTQ.Record}, graph,
         else
             # Sequential processing
             for (i, read) in enumerate(batch_reads)
+                if solid_kmers !== nothing && _read_is_all_solid(read, k, solid_kmers)
+                    updated_reads[batch_start + i - 1] = read   # all-solid ⇒ skip
+                    skipped_solid += 1
+                    continue
+                end
                 improved_read,
                 was_improved = improve_read_likelihood(read, graph, k; graph_mode = graph_mode)
                 updated_reads[batch_start + i - 1] = improved_read
@@ -511,6 +582,10 @@ function improve_read_set_likelihood(reads::Vector{<:FASTX.FASTQ.Record}, graph,
     if verbose
         total_improvement_rate = improvements_made / total_reads * 100
         println("  Total improvements: $improvements_made/$total_reads ($(round(total_improvement_rate, digits=1))%)")
+        if skip_solid
+            skip_rate = total_reads > 0 ? skipped_solid / total_reads * 100 : 0.0
+            println("  Stage 0 skipped (all-solid, no decode): $skipped_solid/$total_reads ($(round(skip_rate, digits=1))%)")
+        end
     end
 
     return updated_reads, improvements_made

--- a/src/iterative-assembly.jl
+++ b/src/iterative-assembly.jl
@@ -161,7 +161,8 @@ function mycelia_iterative_assemble(input_fastq::String;
         enable_parallel::Bool = false,
         batch_size::Int = 10000,
         enable_checkpointing::Bool = true,
-        checkpoint_interval::Int = 5)
+        checkpoint_interval::Int = 5,
+        skip_solid::Bool = false)
     start_time = time()
 
     if verbose
@@ -302,7 +303,8 @@ function mycelia_iterative_assemble(input_fastq::String;
                 verbose = verbose,
                 batch_size = batch_size,
                 enable_parallel = enable_parallel,
-                graph_mode = graph_mode
+                graph_mode = graph_mode,
+                skip_solid = skip_solid
             )
 
             # Calculate iteration metrics

--- a/src/iterative-assembly.jl
+++ b/src/iterative-assembly.jl
@@ -258,6 +258,11 @@ function mycelia_iterative_assemble(input_fastq::String;
 
         iteration = 1
         improvements_this_k = 0
+        # Declared in the outer-k scope so it is visible after the while loop
+        # (it is assigned inside the loop; Julia loop scope would otherwise leave
+        # it undefined at the post-loop "Final improvement rate" line — a latent
+        # crash that prevented the pipeline from completing past the first k).
+        current_reads = FASTX.FASTQ.Record[]
 
         # Iterative improvement loop for current k
         while iteration <= max_iterations_per_k
@@ -452,15 +457,22 @@ end
 Classify every k-mer once and return the set of SOLID (real-genomic) canonical
 k-mer labels. Defaults to the auto-threshold `MixtureModelClassifier` (a top
 default in the Stage 0 comparison matrix, coverage-based so it needs no per-arm
-tuning). Returns all labels (i.e. skip nothing) when the graph has no dataset
-evidence, so the skip can never drop a real k-mer by mistake.
+tuning). Returns the EMPTY set (⇒ `_read_is_all_solid` skips nothing ⇒ correct
+every read) when classification cannot run — no labels or no dataset evidence —
+so the skip is never applied on evidence it could not compute (review C1). The
+conservative default is "decode everything", NOT "skip everything": returning all
+labels would mark error k-mers (graph vertices at coverage 1) as solid and
+silently skip reads that needed correction.
 """
 function _solid_kmer_set(graph;
         classifier = Mycelia.Rhizomorph.MixtureModelClassifier())
     labels = collect(MetaGraphsNext.labels(graph))
     isempty(labels) && return Set{eltype(labels)}()
     dataset_id = _rhizomorph_first_dataset_id(graph[first(labels)])
-    dataset_id === nothing && return Set{eltype(labels)}(labels)
+    if dataset_id === nothing
+        @warn "skip_solid: graph has no dataset evidence; classification skipped, correcting all reads (no skip)."
+        return Set{eltype(labels)}()   # empty ⇒ skip nothing ⇒ correct everything
+    end
     classification = Mycelia.Rhizomorph.classify_kmers(classifier, graph;
         dataset_id = dataset_id)
     solid = Set{eltype(labels)}()
@@ -508,7 +520,13 @@ function improve_read_set_likelihood(reads::Vector{<:FASTX.FASTQ.Record}, graph,
     # solid has no weak region to correct and skips the per-read decode. Opt-in
     # (default off) so existing callers are unchanged. `solid_kmers === nothing`
     # ⇒ correct every read as before.
-    solid_kmers = skip_solid ? _solid_kmer_set(graph) : nothing
+    # The skip helpers canonicalize read k-mers, so they are only valid on a
+    # :canonical graph; on any other mode disable the skip (correct all) rather
+    # than mis-match strands and wrongly skip (review I1/I2 graph_mode).
+    if skip_solid && graph_mode != :canonical
+        @warn "skip_solid is only supported for graph_mode=:canonical; disabling skip (correcting all reads)." graph_mode
+    end
+    solid_kmers = (skip_solid && graph_mode == :canonical) ? _solid_kmer_set(graph) : nothing
     skipped_solid = 0
 
     if verbose
@@ -526,7 +544,10 @@ function improve_read_set_likelihood(reads::Vector{<:FASTX.FASTQ.Record}, graph,
             # Parallel processing for large batches
             batch_results = Vector{Tuple{FASTX.FASTQ.Record, Bool}}(undef, length(batch_reads))
 
-            skip_flags = falses(length(batch_reads))
+            # Vector{Bool} (one byte/elem), NOT falses()/BitVector (64 bits share a
+            # word) — the @threads writes below would otherwise race on the shared
+            # word and undercount the skip fraction (review I2).
+            skip_flags = fill(false, length(batch_reads))
             Threads.@threads for i in eachindex(batch_reads)
                 read = batch_reads[i]
                 if solid_kmers !== nothing && _read_is_all_solid(read, k, solid_kmers)

--- a/test/2_preprocessing_qc/dimensionality_reduction_and_clustering.jl
+++ b/test/2_preprocessing_qc/dimensionality_reduction_and_clustering.jl
@@ -184,7 +184,7 @@ Test.@testset "Binary Matrix Processing" begin
         binary_distance_matrix = Mycelia.frequency_matrix_to_jaccard_distance_matrix(shuffled_binary_matrix)
         ## Classical MDS/PCoA to get coordinates from distance matrix
         pcoa_result = Mycelia.pcoa_from_dist(binary_distance_matrix)
-        kmeans_labels = Clustering.kmeans(pcoa_result.coordinates, n_distributions).assignments
+        kmeans_labels = Clustering.kmeans(pcoa_result.coordinates, n_distributions; rng = StableRNGs.StableRNG(42)).assignments
         remapped_pred_labels,
         mapping = Mycelia.best_label_mapping(shuffled_binary_labels, kmeans_labels)
         evaluation_result = Mycelia.evaluate_classification(
@@ -249,7 +249,7 @@ Test.@testset "Binary Matrix Processing" begin
     Test.@testset "Jaccard Distance + PCoA + KMeans" begin
         test_println("[Binary] Testing: Jaccard Distance + PCoA + KMeans")
         pcoa_binary_result = Mycelia.pcoa_from_dist(Mycelia.frequency_matrix_to_jaccard_distance_matrix(shuffled_binary_matrix))
-        pcoa_fit_binary_labels = Clustering.kmeans(pcoa_binary_result.coordinates, n_distributions).assignments
+        pcoa_fit_binary_labels = Clustering.kmeans(pcoa_binary_result.coordinates, n_distributions; rng = StableRNGs.StableRNG(42)).assignments
         pcoa_fit_binary_labels,
         mapping = Mycelia.best_label_mapping(shuffled_binary_labels, pcoa_fit_binary_labels)
         plt = Mycelia.plot_embeddings(pcoa_binary_result.coordinates;
@@ -351,7 +351,7 @@ Test.@testset "Binary Matrix Processing" begin
         pcoa_binary_umap_model = Mycelia.umap_embed(pcoa_binary_result.coordinates)
         Test.@test size(pcoa_binary_umap_model.embedding) ==
                    (2, n_samples * n_distributions)
-        pcoa_binary_umap_fit_labels = Clustering.kmeans(pcoa_binary_umap_model.embedding, n_distributions).assignments
+        pcoa_binary_umap_fit_labels = Clustering.kmeans(pcoa_binary_umap_model.embedding, n_distributions; rng = StableRNGs.StableRNG(42)).assignments
         pcoa_binary_umap_fit_labels,
         mapping = Mycelia.best_label_mapping(shuffled_binary_labels, pcoa_binary_umap_fit_labels)
         plt = Mycelia.plot_embeddings(pcoa_binary_umap_model.embedding;
@@ -456,7 +456,7 @@ Test.@testset "Binary Matrix Processing" begin
         Test.@testset "logisticPCA-EPCA + KMeans" begin
             test_println("[Binary] Testing: logisticPCA-EPCA + KMeans")
             logistic_pca_result = Mycelia.logistic_pca_epca(shuffled_binary_matrix, k=5)
-            fit_labels = Clustering.kmeans(logistic_pca_result.scores, n_distributions).assignments
+            fit_labels = Clustering.kmeans(logistic_pca_result.scores, n_distributions; rng = StableRNGs.StableRNG(42)).assignments
             fit_labels, mapping = Mycelia.best_label_mapping(shuffled_binary_labels, fit_labels)
             plt = Mycelia.plot_embeddings(logistic_pca_result.scores;
                            title="logisticPCA-EPCA + KMeans",
@@ -538,7 +538,7 @@ Test.@testset "Binary Matrix Processing" begin
             test_println("[Binary] Testing: logisticPCA-EPCA + UMAP + KMeans")
             logistic_pca_result = Mycelia.logistic_pca_epca(shuffled_binary_matrix, k=5)
             umap_model = Mycelia.umap_embed(logistic_pca_result.scores)
-            fit_labels = Clustering.kmeans(umap_model.embedding, n_distributions).assignments
+            fit_labels = Clustering.kmeans(umap_model.embedding, n_distributions; rng = StableRNGs.StableRNG(42)).assignments
             fit_labels, mapping = Mycelia.best_label_mapping(shuffled_binary_labels, fit_labels)
             plt = Mycelia.plot_embeddings(umap_model.embedding;
                            title="logisticPCA-EPCA + UMAP + KMeans",
@@ -688,7 +688,7 @@ Test.@testset "Poisson (counts) Matrix Processing" begin
         poisson_distance_matrix = Mycelia.frequency_matrix_to_bray_curtis_distance_matrix(shuffled_poisson_matrix)
         ## Classical MDS/PCoA to get coordinates from distance matrix
         pcoa_result = Mycelia.pcoa_from_dist(poisson_distance_matrix)
-        kmeans_labels = Clustering.kmeans(pcoa_result.coordinates, n_distributions).assignments
+        kmeans_labels = Clustering.kmeans(pcoa_result.coordinates, n_distributions; rng = StableRNGs.StableRNG(42)).assignments
         remapped_pred_labels,
         mapping = Mycelia.best_label_mapping(shuffled_poisson_labels, kmeans_labels)
         evaluation_result = Mycelia.evaluate_classification(
@@ -753,7 +753,7 @@ Test.@testset "Poisson (counts) Matrix Processing" begin
     Test.@testset "Bray-Curtis Distance + PCoA + KMeans" begin
         test_println("[Poisson] Testing: Bray-Curtis Distance + PCoA + KMeans")
         pcoa_poisson_result = Mycelia.pcoa_from_dist(Mycelia.frequency_matrix_to_bray_curtis_distance_matrix(shuffled_poisson_matrix))
-        pcoa_fit_poisson_labels = Clustering.kmeans(pcoa_poisson_result.coordinates, n_distributions).assignments
+        pcoa_fit_poisson_labels = Clustering.kmeans(pcoa_poisson_result.coordinates, n_distributions; rng = StableRNGs.StableRNG(42)).assignments
         pcoa_fit_poisson_labels,
         mapping = Mycelia.best_label_mapping(shuffled_poisson_labels, pcoa_fit_poisson_labels)
         plt = Mycelia.plot_embeddings(pcoa_poisson_result.coordinates;
@@ -860,7 +860,7 @@ Test.@testset "Poisson (counts) Matrix Processing" begin
         pcoa_poisson_umap_model = Mycelia.umap_embed(pcoa_poisson_result.coordinates)
         Test.@test size(pcoa_poisson_umap_model.embedding) ==
                    (2, n_samples * n_distributions)
-        pcoa_poisson_umap_fit_labels = Clustering.kmeans(pcoa_poisson_umap_model.embedding, n_distributions).assignments
+        pcoa_poisson_umap_fit_labels = Clustering.kmeans(pcoa_poisson_umap_model.embedding, n_distributions; rng = StableRNGs.StableRNG(42)).assignments
         pcoa_poisson_umap_fit_labels,
         mapping = Mycelia.best_label_mapping(shuffled_poisson_labels, pcoa_poisson_umap_fit_labels)
         plt = Mycelia.plot_embeddings(pcoa_poisson_umap_model.embedding;
@@ -977,7 +977,7 @@ Test.@testset "Poisson (counts) Matrix Processing" begin
     # Test.@testset "PoissonPCA-EPCA + KMeans" begin
     #     test_println("[Poisson] Testing: PoissonPCA-EPCA + KMeans")
     #     poisson_pca_result = Mycelia.poisson_pca_epca(shuffled_poisson_matrix, k=5)
-    #     fit_labels = Clustering.kmeans(poisson_pca_result.scores, n_distributions).assignments
+    #     fit_labels = Clustering.kmeans(poisson_pca_result.scores, n_distributions; rng = StableRNGs.StableRNG(42)).assignments
     #     fit_labels, mapping = Mycelia.best_label_mapping(shuffled_poisson_labels, fit_labels)
     #     plt = Mycelia.plot_embeddings(poisson_pca_result.scores;
     #                    title="PoissonPCA-EPCA + KMeans",
@@ -1060,7 +1060,7 @@ Test.@testset "Poisson (counts) Matrix Processing" begin
     #     test_println("[Poisson] Testing: PoissonPCA-EPCA + UMAP + KMeans")
     #     poisson_pca_result = Mycelia.poisson_pca_epca(shuffled_poisson_matrix, k=5)
     #     umap_model = Mycelia.umap_embed(poisson_pca_result.scores)
-    #     fit_labels = Clustering.kmeans(umap_model.embedding, n_distributions).assignments
+    #     fit_labels = Clustering.kmeans(umap_model.embedding, n_distributions; rng = StableRNGs.StableRNG(42)).assignments
     #     fit_labels, mapping = Mycelia.best_label_mapping(shuffled_poisson_labels, fit_labels)
     #     plt = Mycelia.plot_embeddings(umap_model.embedding;
     #                    title="PoissonPCA-EPCA + UMAP + KMeans",
@@ -1216,7 +1216,7 @@ Test.@testset "Negative Binomial (overdispersed counts) Matrix Processing" begin
         nb_distance_matrix = Mycelia.frequency_matrix_to_bray_curtis_distance_matrix(shuffled_nb_matrix)
         ## Classical MDS/PCoA to get coordinates from distance matrix
         pcoa_result = Mycelia.pcoa_from_dist(nb_distance_matrix)
-        kmeans_labels = Clustering.kmeans(pcoa_result.coordinates, n_distributions).assignments
+        kmeans_labels = Clustering.kmeans(pcoa_result.coordinates, n_distributions; rng = StableRNGs.StableRNG(42)).assignments
         remapped_pred_labels,
         mapping = Mycelia.best_label_mapping(shuffled_nb_labels, kmeans_labels)
         evaluation_result = Mycelia.evaluate_classification(
@@ -1281,7 +1281,7 @@ Test.@testset "Negative Binomial (overdispersed counts) Matrix Processing" begin
     Test.@testset "Bray-Curtis Distance + PCoA + KMeans" begin
         test_println("[NegBin] Testing: Bray-Curtis Distance + PCoA + KMeans")
         pcoa_nb_result = Mycelia.pcoa_from_dist(Mycelia.frequency_matrix_to_bray_curtis_distance_matrix(shuffled_nb_matrix))
-        pcoa_fit_nb_labels = Clustering.kmeans(pcoa_nb_result.coordinates, n_distributions).assignments
+        pcoa_fit_nb_labels = Clustering.kmeans(pcoa_nb_result.coordinates, n_distributions; rng = StableRNGs.StableRNG(42)).assignments
         pcoa_fit_nb_labels,
         mapping = Mycelia.best_label_mapping(shuffled_nb_labels, pcoa_fit_nb_labels)
         plt = Mycelia.plot_embeddings(pcoa_nb_result.coordinates;
@@ -1388,7 +1388,7 @@ Test.@testset "Negative Binomial (overdispersed counts) Matrix Processing" begin
         Random.seed!(42)
         pcoa_nb_umap_model = Mycelia.umap_embed(pcoa_nb_result.coordinates)
         Test.@test size(pcoa_nb_umap_model.embedding) == (2, n_samples * n_distributions)
-        pcoa_nb_umap_fit_labels = Clustering.kmeans(pcoa_nb_umap_model.embedding, n_distributions).assignments
+        pcoa_nb_umap_fit_labels = Clustering.kmeans(pcoa_nb_umap_model.embedding, n_distributions; rng = StableRNGs.StableRNG(42)).assignments
         pcoa_nb_umap_fit_labels,
         mapping = Mycelia.best_label_mapping(shuffled_nb_labels, pcoa_nb_umap_fit_labels)
         plt = Mycelia.plot_embeddings(pcoa_nb_umap_model.embedding;
@@ -1491,7 +1491,7 @@ Test.@testset "Negative Binomial (overdispersed counts) Matrix Processing" begin
     ## # NegBinPCA-EPCA + KMeans
     ## Test.@testset "NegBinPCA-EPCA + KMeans" begin
     ##     negbin_pca_result = Mycelia.negbin_pca_epca(shuffled_nb_matrix, k=5)
-    ##     fit_labels = Clustering.kmeans(negbin_pca_result.scores, n_distributions).assignments
+    ##     fit_labels = Clustering.kmeans(negbin_pca_result.scores, n_distributions; rng = StableRNGs.StableRNG(42)).assignments
     ##     fit_labels, mapping = Mycelia.best_label_mapping(shuffled_nb_labels, fit_labels)
     ##     plt = Mycelia.plot_embeddings(negbin_pca_result.scores;
     ##                    title="Negative Binomial PCA-EPCA - Negative Binomial Matrix",
@@ -1515,7 +1515,7 @@ Test.@testset "Negative Binomial (overdispersed counts) Matrix Processing" begin
     ## Test.@testset "NegBinPCA-EPCA + UMAP + KMeans" begin
     ##     negbin_pca_result = Mycelia.negbin_pca_epca(shuffled_nb_matrix, k=5)
     ##     umap_model = Mycelia.umap_embed(negbin_pca_result.scores)
-    ##     fit_labels = Clustering.kmeans(umap_model.embedding, n_distributions).assignments
+    ##     fit_labels = Clustering.kmeans(umap_model.embedding, n_distributions; rng = StableRNGs.StableRNG(42)).assignments
     ##     fit_labels, mapping = Mycelia.best_label_mapping(shuffled_nb_labels, fit_labels)
     ##     plt = Mycelia.plot_embeddings(umap_model.embedding;
     ##                    title="UMAP - Negative Binomial PCA-EPCA - Negative Binomial Matrix",
@@ -1611,7 +1611,7 @@ Test.@testset "Binomial (counts in 0:ntrials) Matrix Processing" begin
         binom_distance_matrix = Mycelia.frequency_matrix_to_bray_curtis_distance_matrix(shuffled_binom_matrix)
         ## Classical MDS/PCoA to get coordinates from distance matrix
         pcoa_result = Mycelia.pcoa_from_dist(binom_distance_matrix)
-        kmeans_labels = Clustering.kmeans(pcoa_result.coordinates, n_distributions).assignments
+        kmeans_labels = Clustering.kmeans(pcoa_result.coordinates, n_distributions; rng = StableRNGs.StableRNG(42)).assignments
         remapped_pred_labels,
         mapping = Mycelia.best_label_mapping(shuffled_binom_labels, kmeans_labels)
         evaluation_result = Mycelia.evaluate_classification(
@@ -1676,7 +1676,7 @@ Test.@testset "Binomial (counts in 0:ntrials) Matrix Processing" begin
     Test.@testset "Bray-Curtis Distance + PCoA + KMeans" begin
         test_println("[Binom] Testing: Bray-Curtis Distance + PCoA + KMeans")
         pcoa_binom_result = Mycelia.pcoa_from_dist(Mycelia.frequency_matrix_to_bray_curtis_distance_matrix(shuffled_binom_matrix))
-        pcoa_fit_binom_labels = Clustering.kmeans(pcoa_binom_result.coordinates, n_distributions).assignments
+        pcoa_fit_binom_labels = Clustering.kmeans(pcoa_binom_result.coordinates, n_distributions; rng = StableRNGs.StableRNG(42)).assignments
         pcoa_fit_binom_labels,
         mapping = Mycelia.best_label_mapping(shuffled_binom_labels, pcoa_fit_binom_labels)
         plt = Mycelia.plot_embeddings(pcoa_binom_result.coordinates;
@@ -1784,7 +1784,7 @@ Test.@testset "Binomial (counts in 0:ntrials) Matrix Processing" begin
         Random.seed!(42)
         pcoa_binom_umap_model = Mycelia.umap_embed(pcoa_binom_result.coordinates)
         Test.@test size(pcoa_binom_umap_model.embedding) == (2, n_samples * n_distributions)
-        pcoa_binom_umap_fit_labels = Clustering.kmeans(pcoa_binom_umap_model.embedding, n_distributions).assignments
+        pcoa_binom_umap_fit_labels = Clustering.kmeans(pcoa_binom_umap_model.embedding, n_distributions; rng = StableRNGs.StableRNG(42)).assignments
         pcoa_binom_umap_fit_labels,
         mapping = Mycelia.best_label_mapping(shuffled_binom_labels, pcoa_binom_umap_fit_labels)
         plt = Mycelia.plot_embeddings(pcoa_binom_umap_model.embedding;
@@ -1888,7 +1888,7 @@ Test.@testset "Binomial (counts in 0:ntrials) Matrix Processing" begin
     # Test.@testset "PoissonPCA-EPCA + KMeans" begin
     #     test_println("[Binom] Testing: PoissonPCA-EPCA + KMeans")
     #     poisson_pca_result = Mycelia.poisson_pca_epca(shuffled_binom_matrix, k=5)
-    #     fit_labels = Clustering.kmeans(poisson_pca_result.scores, n_distributions).assignments
+    #     fit_labels = Clustering.kmeans(poisson_pca_result.scores, n_distributions; rng = StableRNGs.StableRNG(42)).assignments
     #     fit_labels, mapping = Mycelia.best_label_mapping(shuffled_binom_labels, fit_labels)
     #     plt = Mycelia.plot_embeddings(poisson_pca_result.scores;
     #                    title="PoissonPCA-EPCA + KMeans",
@@ -1971,7 +1971,7 @@ Test.@testset "Binomial (counts in 0:ntrials) Matrix Processing" begin
     #     test_println("[Binom] Testing: PoissonPCA-EPCA + UMAP + KMeans")
     #     poisson_pca_result = Mycelia.poisson_pca_epca(shuffled_binom_matrix, k=5)
     #     umap_model = Mycelia.umap_embed(poisson_pca_result.scores)
-    #     fit_labels = Clustering.kmeans(umap_model.embedding, n_distributions).assignments
+    #     fit_labels = Clustering.kmeans(umap_model.embedding, n_distributions; rng = StableRNGs.StableRNG(42)).assignments
     #     fit_labels, mapping = Mycelia.best_label_mapping(shuffled_binom_labels, fit_labels)
     #     plt = Mycelia.plot_embeddings(umap_model.embedding;
     #                    title="PoissonPCA-EPCA + UMAP + KMeans",
@@ -2132,7 +2132,7 @@ Test.@testset "Continuous Bernoulli (values in (0,1)) Matrix Processing" begin
         contb_distance_matrix = Mycelia.frequency_matrix_to_cosine_distance_matrix(clipped_contb_matrix)
         ## Classical MDS/PCoA to get coordinates from distance matrix
         pcoa_result = Mycelia.pcoa_from_dist(contb_distance_matrix)
-        kmeans_labels = Clustering.kmeans(pcoa_result.coordinates, n_distributions).assignments
+        kmeans_labels = Clustering.kmeans(pcoa_result.coordinates, n_distributions; rng = StableRNGs.StableRNG(42)).assignments
         remapped_pred_labels,
         mapping = Mycelia.best_label_mapping(shuffled_contb_labels, kmeans_labels)
         evaluation_result = Mycelia.evaluate_classification(
@@ -2199,7 +2199,7 @@ Test.@testset "Continuous Bernoulli (values in (0,1)) Matrix Processing" begin
     Test.@testset "Cosine Distance + PCoA + KMeans" begin
         test_println("[ContBernoulli] Testing: Cosine Distance + PCoA + KMeans")
         pcoa_contb_result = Mycelia.pcoa_from_dist(Mycelia.frequency_matrix_to_cosine_distance_matrix(clipped_contb_matrix))
-        pcoa_fit_contb_labels = Clustering.kmeans(pcoa_contb_result.coordinates, n_distributions).assignments
+        pcoa_fit_contb_labels = Clustering.kmeans(pcoa_contb_result.coordinates, n_distributions; rng = StableRNGs.StableRNG(42)).assignments
         pcoa_fit_contb_labels,
         mapping = Mycelia.best_label_mapping(shuffled_contb_labels, pcoa_fit_contb_labels)
         plt = Mycelia.plot_embeddings(pcoa_contb_result.coordinates;
@@ -2307,7 +2307,7 @@ Test.@testset "Continuous Bernoulli (values in (0,1)) Matrix Processing" begin
         Random.seed!(42)
         pcoa_contb_umap_model = Mycelia.umap_embed(pcoa_contb_result.coordinates)
         Test.@test size(pcoa_contb_umap_model.embedding) == (2, n_samples * n_distributions)
-        pcoa_contb_umap_fit_labels = Clustering.kmeans(pcoa_contb_umap_model.embedding, n_distributions).assignments
+        pcoa_contb_umap_fit_labels = Clustering.kmeans(pcoa_contb_umap_model.embedding, n_distributions; rng = StableRNGs.StableRNG(42)).assignments
         pcoa_contb_umap_fit_labels,
         mapping = Mycelia.best_label_mapping(shuffled_contb_labels, pcoa_contb_umap_fit_labels)
         plt = Mycelia.plot_embeddings(pcoa_contb_umap_model.embedding;
@@ -2413,7 +2413,7 @@ Test.@testset "Continuous Bernoulli (values in (0,1)) Matrix Processing" begin
     Test.@testset "ContBernoulliPCA-EPCA + KMeans" begin
         test_println("[ContBernoulli] Testing: ContBernoulliPCA-EPCA + KMeans")
         contb_pca_result = Mycelia.contbernoulli_pca_epca(clipped_contb_matrix, k=5)
-        fit_labels = Clustering.kmeans(contb_pca_result.scores, n_distributions).assignments
+        fit_labels = Clustering.kmeans(contb_pca_result.scores, n_distributions; rng = StableRNGs.StableRNG(42)).assignments
         fit_labels, mapping = Mycelia.best_label_mapping(shuffled_contb_labels, fit_labels)
         plt = Mycelia.plot_embeddings(contb_pca_result.scores;
                        title="ContBernoulliPCA-EPCA + KMeans",
@@ -2496,7 +2496,7 @@ Test.@testset "Continuous Bernoulli (values in (0,1)) Matrix Processing" begin
         test_println("[ContBernoulli] Testing: ContBernoulliPCA-EPCA + UMAP + KMeans")
         contb_pca_result = Mycelia.contbernoulli_pca_epca(clipped_contb_matrix, k=5)
         umap_model = Mycelia.umap_embed(contb_pca_result.scores)
-        fit_labels = Clustering.kmeans(umap_model.embedding, n_distributions).assignments
+        fit_labels = Clustering.kmeans(umap_model.embedding, n_distributions; rng = StableRNGs.StableRNG(42)).assignments
         fit_labels, mapping = Mycelia.best_label_mapping(shuffled_contb_labels, fit_labels)
         plt = Mycelia.plot_embeddings(umap_model.embedding;
                        title="ContBernoulliPCA-EPCA + UMAP + KMeans",
@@ -2659,7 +2659,7 @@ Test.@testset "Gamma (strictly positive) Matrix Processing" begin
         gamma_distance_matrix = Mycelia.frequency_matrix_to_cosine_distance_matrix(clipped_gamma_matrix)
         ## Classical MDS/PCoA to get coordinates from distance matrix
         pcoa_result = Mycelia.pcoa_from_dist(gamma_distance_matrix)
-        kmeans_labels = Clustering.kmeans(pcoa_result.coordinates, n_distributions).assignments
+        kmeans_labels = Clustering.kmeans(pcoa_result.coordinates, n_distributions; rng = StableRNGs.StableRNG(42)).assignments
         remapped_pred_labels,
         mapping = Mycelia.best_label_mapping(shuffled_gamma_labels, kmeans_labels)
         evaluation_result = Mycelia.evaluate_classification(
@@ -2726,7 +2726,7 @@ Test.@testset "Gamma (strictly positive) Matrix Processing" begin
     Test.@testset "Cosine Distance + PCoA + KMeans" begin
         test_println("[Gamma] Testing: Cosine Distance + PCoA + KMeans")
         pcoa_gamma_result = Mycelia.pcoa_from_dist(Mycelia.frequency_matrix_to_cosine_distance_matrix(clipped_gamma_matrix))
-        pcoa_fit_gamma_labels = Clustering.kmeans(pcoa_gamma_result.coordinates, n_distributions).assignments
+        pcoa_fit_gamma_labels = Clustering.kmeans(pcoa_gamma_result.coordinates, n_distributions; rng = StableRNGs.StableRNG(42)).assignments
         pcoa_fit_gamma_labels,
         mapping = Mycelia.best_label_mapping(shuffled_gamma_labels, pcoa_fit_gamma_labels)
         plt = Mycelia.plot_embeddings(pcoa_gamma_result.coordinates;
@@ -2829,7 +2829,7 @@ Test.@testset "Gamma (strictly positive) Matrix Processing" begin
         Random.seed!(42)
         pcoa_gamma_umap_model = Mycelia.umap_embed(pcoa_gamma_result.coordinates)
         Test.@test size(pcoa_gamma_umap_model.embedding) == (2, n_samples * n_distributions)
-        pcoa_gamma_umap_fit_labels = Clustering.kmeans(pcoa_gamma_umap_model.embedding, n_distributions).assignments
+        pcoa_gamma_umap_fit_labels = Clustering.kmeans(pcoa_gamma_umap_model.embedding, n_distributions; rng = StableRNGs.StableRNG(42)).assignments
         pcoa_gamma_umap_fit_labels,
         mapping = Mycelia.best_label_mapping(shuffled_gamma_labels, pcoa_gamma_umap_fit_labels)
         plt = Mycelia.plot_embeddings(pcoa_gamma_umap_model.embedding;
@@ -2938,7 +2938,7 @@ Test.@testset "Gamma (strictly positive) Matrix Processing" begin
     ## Test.@testset "GammaPCA-EPCA + KMeans" begin
     ##     test_println("[Gamma] Testing: GammaPCA-EPCA + KMeans")
     ##     gamma_pca_result = Mycelia.gamma_pca_epca(clipped_gamma_matrix, k=5)
-    ##     fit_labels = Clustering.kmeans(gamma_pca_result.scores, n_distributions).assignments
+    ##     fit_labels = Clustering.kmeans(gamma_pca_result.scores, n_distributions; rng = StableRNGs.StableRNG(42)).assignments
     ##     fit_labels, mapping = Mycelia.best_label_mapping(shuffled_gamma_labels, fit_labels)
     ##     plt = Mycelia.plot_embeddings(gamma_pca_result.scores;
     ##                    title="GammaPCA-EPCA + KMeans",
@@ -2964,7 +2964,7 @@ Test.@testset "Gamma (strictly positive) Matrix Processing" begin
     ##     test_println("[Gamma] Testing: GammaPCA-EPCA + UMAP + KMeans")
     ##     gamma_pca_result = Mycelia.gamma_pca_epca(clipped_gamma_matrix, k=5)
     ##     umap_model = Mycelia.umap_embed(gamma_pca_result.scores)
-    ##     fit_labels = Clustering.kmeans(umap_model.embedding, n_distributions).assignments
+    ##     fit_labels = Clustering.kmeans(umap_model.embedding, n_distributions; rng = StableRNGs.StableRNG(42)).assignments
     ##     fit_labels, mapping = Mycelia.best_label_mapping(shuffled_gamma_labels, fit_labels)
     ##     plt = Mycelia.plot_embeddings(umap_model.embedding;
     ##                    title="GammaPCA-EPCA + UMAP + KMeans",
@@ -3064,7 +3064,7 @@ Test.@testset "Gaussian (centered, real-valued) Matrix Processing" begin
         gauss_distance_matrix = Mycelia.frequency_matrix_to_euclidean_distance_matrix(shuffled_gauss_matrix)
         ## Classical MDS/PCoA to get coordinates from distance matrix
         pcoa_result = Mycelia.pcoa_from_dist(gauss_distance_matrix)
-        kmeans_labels = Clustering.kmeans(pcoa_result.coordinates, n_distributions).assignments
+        kmeans_labels = Clustering.kmeans(pcoa_result.coordinates, n_distributions; rng = StableRNGs.StableRNG(42)).assignments
         remapped_pred_labels,
         mapping = Mycelia.best_label_mapping(shuffled_gauss_labels, kmeans_labels)
         evaluation_result = Mycelia.evaluate_classification(
@@ -3135,7 +3135,7 @@ Test.@testset "Gaussian (centered, real-valued) Matrix Processing" begin
     Test.@testset "Euclidean Distance + PCoA + KMeans" begin
         test_println("[Gaussian] Testing: Euclidean Distance + PCoA + KMeans")
         pcoa_gauss_result = Mycelia.pcoa_from_dist(Mycelia.frequency_matrix_to_euclidean_distance_matrix(shuffled_gauss_matrix))
-        pcoa_fit_gauss_labels = Clustering.kmeans(pcoa_gauss_result.coordinates, n_distributions).assignments
+        pcoa_fit_gauss_labels = Clustering.kmeans(pcoa_gauss_result.coordinates, n_distributions; rng = StableRNGs.StableRNG(42)).assignments
         pcoa_fit_gauss_labels,
         mapping = Mycelia.best_label_mapping(shuffled_gauss_labels, pcoa_fit_gauss_labels)
         plt = Mycelia.plot_embeddings(pcoa_gauss_result.coordinates;
@@ -3353,7 +3353,7 @@ Test.@testset "Gaussian (centered, real-valued) Matrix Processing" begin
     Test.@testset "GaussianPCA-EPCA + KMeans" begin
         test_println("[Gaussian] Testing: GaussianPCA-EPCA + KMeans")
         gauss_pca_result = Mycelia.gaussian_pca_epca(shuffled_gauss_matrix, k=5)
-        fit_labels = Clustering.kmeans(gauss_pca_result.scores, n_distributions).assignments
+        fit_labels = Clustering.kmeans(gauss_pca_result.scores, n_distributions; rng = StableRNGs.StableRNG(42)).assignments
         fit_labels, mapping = Mycelia.best_label_mapping(shuffled_gauss_labels, fit_labels)
         plt = Mycelia.plot_embeddings(gauss_pca_result.scores;
                        title="GaussianPCA-EPCA + KMeans",
@@ -3436,7 +3436,7 @@ Test.@testset "Gaussian (centered, real-valued) Matrix Processing" begin
         test_println("[Gaussian] Testing: GaussianPCA-EPCA + UMAP + KMeans")
         gauss_pca_result = Mycelia.gaussian_pca_epca(shuffled_gauss_matrix, k=5)
         umap_model = Mycelia.umap_embed(gauss_pca_result.scores)
-        fit_labels = Clustering.kmeans(umap_model.embedding, n_distributions).assignments
+        fit_labels = Clustering.kmeans(umap_model.embedding, n_distributions; rng = StableRNGs.StableRNG(42)).assignments
         fit_labels, mapping = Mycelia.best_label_mapping(shuffled_gauss_labels, fit_labels)
         plt = Mycelia.plot_embeddings(umap_model.embedding;
                        title="GaussianPCA-EPCA + UMAP + KMeans",
@@ -3597,7 +3597,7 @@ Test.@testset "Probability Vector (Compositional) Matrix Processing" begin
         probvec_distance_matrix = Mycelia.frequency_matrix_to_jensen_shannon_distance_matrix(shuffled_dirichlet_matrix)
         ## Classical MDS/PCoA to get coordinates from distance matrix
         pcoa_result = Mycelia.pcoa_from_dist(probvec_distance_matrix)
-        kmeans_labels = Clustering.kmeans(pcoa_result.coordinates, n_distributions).assignments
+        kmeans_labels = Clustering.kmeans(pcoa_result.coordinates, n_distributions; rng = StableRNGs.StableRNG(42)).assignments
         remapped_pred_labels,
         mapping = Mycelia.best_label_mapping(shuffled_dirichlet_labels, kmeans_labels)
         evaluation_result = Mycelia.evaluate_classification(
@@ -3668,7 +3668,7 @@ Test.@testset "Probability Vector (Compositional) Matrix Processing" begin
     Test.@testset "Jensen-Shannon Divergence + PCoA + KMeans" begin
         test_println("[ProbVec] Testing: Jensen-Shannon Divergence + PCoA + KMeans")
         pcoa_probvec_result = Mycelia.pcoa_from_dist(Mycelia.frequency_matrix_to_jensen_shannon_distance_matrix(shuffled_dirichlet_matrix))
-        pcoa_fit_probvec_labels = Clustering.kmeans(pcoa_probvec_result.coordinates, n_distributions).assignments
+        pcoa_fit_probvec_labels = Clustering.kmeans(pcoa_probvec_result.coordinates, n_distributions; rng = StableRNGs.StableRNG(42)).assignments
         pcoa_fit_probvec_labels,
         mapping = Mycelia.best_label_mapping(shuffled_dirichlet_labels, pcoa_fit_probvec_labels)
         plt = Mycelia.plot_embeddings(pcoa_probvec_result.coordinates;

--- a/test/4_assembly/stage0_integration_test.jl
+++ b/test/4_assembly/stage0_integration_test.jl
@@ -1,0 +1,43 @@
+# Unit tests for Stage 0 → corrector integration primitives (td-1do7).
+# The skip mechanism: classify k-mers once, then skip reads with no weak k-mer.
+
+import Test
+import Mycelia
+import FASTX
+
+rec(id, seq) = FASTX.FASTQ.Record(id, seq, String(fill('I', length(seq))))
+
+Test.@testset "Stage 0 skip primitives" begin
+    k = 5
+    clean_seq = "ATGCGTACGTACGT"
+    recs = [rec("clean$i", clean_seq) for i in 1:8]
+    err_seq = "ATGTGTACGTACGT"                       # single substitution at pos 4
+    push!(recs, rec("err1", err_seq))
+    graph = Mycelia.Rhizomorph.build_qualmer_graph(recs, k;
+        dataset_id = "ds", mode = :canonical, memory_profile = :full)
+
+    solid = Mycelia._solid_kmer_set(graph)
+    Test.@test !isempty(solid)
+
+    # The clean read (coverage 9 on every k-mer) has no weak k-mer → skippable.
+    Test.@test Mycelia._read_is_all_solid(rec("c", clean_seq), k, solid)
+    # The error read carries coverage-1 error k-mers → NOT all-solid → corrected.
+    Test.@test !Mycelia._read_is_all_solid(rec("e", err_seq), k, solid)
+    # A read shorter than k has no k-mers → never skipped on absent evidence.
+    Test.@test !Mycelia._read_is_all_solid(rec("s", "ACG"), k, solid)
+    # Empty solid set → never skip.
+    Test.@test !Mycelia._read_is_all_solid(rec("c", clean_seq), k, Set(eltype(solid)[]))
+
+    # Wiring: improve_read_set_likelihood with skip_solid=true runs and returns
+    # every read; the all-solid clean reads pass through unchanged.
+    out_skip, _ = Mycelia.improve_read_set_likelihood(recs, graph, k;
+        graph_mode = :canonical, skip_solid = true)
+    Test.@test length(out_skip) == length(recs)
+    for i in 1:8
+        Test.@test FASTX.sequence(String, out_skip[i]) == clean_seq   # solid ⇒ untouched
+    end
+    # skip_solid=false path still works (no regression).
+    out_noskip, _ = Mycelia.improve_read_set_likelihood(recs, graph, k;
+        graph_mode = :canonical, skip_solid = false)
+    Test.@test length(out_noskip) == length(recs)
+end


### PR DESCRIPTION
The volume-reduction payoff of the staged-correction architecture (epic td-9q84): use the merged Stage 0 classifier to skip the per-read Viterbi decode for reads with no weak k-mer.

## Summary
- `_solid_kmer_set(graph)`: classify k-mers once (default MixtureModel auto-threshold) → set of solid canonical k-mers. Fail-safe: returns all labels (skip nothing) on no evidence.
- `_read_is_all_solid(read, k, solid)`: true iff every read k-mer is solid; false for sub-k/no-kmer reads.
- `improve_read_set_likelihood(...; skip_solid=false)`: OPT-IN (default off → zero regression). When on, skips all-solid reads in both parallel + sequential loops and reports the skip fraction.

## Test Plan
- [x] 15/15 unit tests: skip primitives (clean→skip, error→correct, sub-k→no-skip, empty→no-skip) + wiring (skip_solid true/false both return all reads, solid reads untouched).
- [ ] Full `mycelia_iterative_assemble` benchmark with `skip_solid=true`: measure skip fraction + whether the iterative pipeline completes (follow-up).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional Stage 0 “all-solid” fast-skip (`skip_solid`) to bypass costly per-read likelihood improvement when appropriate (works in both parallel and sequential runs).
  * Added a new Stage 0 completion benchmark script with a toggle to enable/disable solid skipping.
* **Bug Fixes**
  * Prevents incorrect skipping for short reads and reads evaluated against an empty solid set, and ensures non-canonical modes don’t silently skip.
  * Improves reliability of iterative assembly by avoiding a latent scope crash in later iterations.
* **Tests**
  * Added integration coverage validating Stage 0 → corrector skip behavior.
  * Updated clustering tests to be deterministic by using a fixed RNG seed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->