### PR TITLE
feat: wire iterative+skip corrector into assemble_genome (opt-in, td-k6oc)

### DIFF
--- a/src/rhizomorph/assembly.jl
+++ b/src/rhizomorph/assembly.jl
@@ -140,6 +140,11 @@ struct AssemblyConfig
     compact_unitigs::Bool                   # Populate simplified_graph via linear-chain compaction
     memory_profile::Symbol                  # build_kmer_graph evidence footprint (:full|:lightweight|:ultralight|...)
 
+    # Optional read-correction front-end (opt-in; default :none preserves today's
+    # single-k-from-uncorrected-reads behavior byte-for-byte).
+    corrector::Symbol                       # :none (default) or :iterative (mycelia_iterative_assemble)
+    skip_solid::Bool                        # When corrector=:iterative, skip already-solid/clean reads
+
     # Constructor with validation
     function AssemblyConfig(;
             k::Union{Int, Nothing} = nothing,
@@ -156,7 +161,9 @@ struct AssemblyConfig
             tda::Union{Nothing, Mycelia.TDAConfig} = nothing,
             dedup_revcomp::Bool = false,
             compact_unitigs::Bool = false,
-            memory_profile::Symbol = :full
+            memory_profile::Symbol = :full,
+            corrector::Symbol = :none,
+            skip_solid::Bool = false
     )
         # Validation: Must specify exactly one of k or min_overlap
         if k === nothing && min_overlap === nothing
@@ -179,6 +186,12 @@ struct AssemblyConfig
         _valid_memory_profiles = (:full, :lightweight, :ultralight, :lightweight_quality, :ultralight_quality)
         if !(memory_profile in _valid_memory_profiles)
             error("memory_profile must be one of $(_valid_memory_profiles), got :$(memory_profile)")
+        end
+
+        # Validation: corrector front-end must be a recognized mode
+        _valid_correctors = (:none, :iterative)
+        if !(corrector in _valid_correctors)
+            error("corrector must be one of $(_valid_correctors), got :$(corrector)")
         end
 
         # Validation: Parameter ranges
@@ -225,7 +238,9 @@ struct AssemblyConfig
             tda,
             dedup_revcomp,
             compact_unitigs,
-            memory_profile
+            memory_profile,
+            corrector,
+            skip_solid
         )
     end
 end
@@ -531,6 +546,13 @@ end
 Type-stable main assembly function that dispatches based on configuration.
 """
 function assemble_genome(reads, config::AssemblyConfig)
+    # Opt-in read-correction front-end. The default (corrector=:none) falls
+    # through to the byte-identical single-k pipeline below; only an explicit
+    # corrector=:iterative diverts to the iterative+skip corrector.
+    if config.corrector == :iterative
+        return _assemble_with_iterative_corrector(reads, config)
+    end
+
     _log_info(config, "Starting unified genome assembly", config.sequence_type,
         config.graph_mode, config.k, config.min_overlap)
 
@@ -565,6 +587,100 @@ function assemble_genome(reads, config::AssemblyConfig)
 
     _log_info(config, "Assembly completed: $(length(result.contigs)) contigs generated")
     return result
+end
+
+"""
+Write assembly input `reads` to a FASTQ file at `path` for the iterative
+corrector, which consumes a FASTQ file path. Handles FASTQ records (written
+verbatim), FASTA records and file paths (assigned a placeholder max quality,
+since the corrector requires per-base quality strings).
+"""
+function _write_reads_to_fastq(reads, path::String)
+    _placeholder_qual(n) = repeat("I", n)  # Phred+33 'I' == Q40
+    open(path, "w") do io
+        writer = FASTX.FASTQ.Writer(io)
+        if reads isa Vector{String}
+            for file_path in reads
+                if endswith(file_path, ".fastq") || endswith(file_path, ".fq")
+                    open(FASTX.FASTQ.Reader, file_path) do reader
+                        for record in reader
+                            write(writer, record)
+                        end
+                    end
+                else
+                    open(FASTX.FASTA.Reader, file_path) do reader
+                        for record in reader
+                            seq = FASTX.FASTA.sequence(String, record)
+                            write(writer, FASTX.FASTQ.Record(
+                                FASTX.FASTA.identifier(record), seq, _placeholder_qual(length(seq))))
+                        end
+                    end
+                end
+            end
+        else
+            for record in reads
+                if record isa FASTX.FASTQ.Record
+                    write(writer, record)
+                elseif record isa FASTX.FASTA.Record
+                    seq = FASTX.FASTA.sequence(String, record)
+                    write(writer, FASTX.FASTQ.Record(
+                        FASTX.FASTA.identifier(record), seq, _placeholder_qual(length(seq))))
+                else
+                    error("Unsupported read type for iterative corrector: $(typeof(record))")
+                end
+            end
+        end
+        close(writer)
+    end
+    return path
+end
+
+"""
+Route assembly through `Mycelia.mycelia_iterative_assemble` (the iterative +
+skip-solid maximum-likelihood corrector) and wrap its Dict result in an
+`AssemblyResult`.
+
+v0 return shape: the corrector returns a Dict with `:final_assembly`
+(Vector of sequence strings), `:k_progression`, and `:metadata`. We map
+`:final_assembly` directly onto `AssemblyResult.contigs` and stash the
+corrector's `:k_progression` / `:metadata` under `assembly_stats`. No graph is
+produced by this path, so `graph`/`simplified_graph` are `nothing` and the
+result is marked `gfa_compatible=false`.
+"""
+function _assemble_with_iterative_corrector(reads, config::AssemblyConfig)
+    _log_info(config, "Routing assembly through iterative corrector (corrector=:iterative)")
+
+    input_dir = mktempdir()
+    output_dir = mktempdir()
+    temp_fastq = joinpath(input_dir, "corrector_input.fastq")
+    _write_reads_to_fastq(reads, temp_fastq)
+
+    # The corrector's k-progression needs a sane floor; honor the config's k when
+    # it is at least the floor, otherwise use the floor (13).
+    max_k = config.k === nothing ? 13 : max(config.k, 13)
+
+    result_dict = Mycelia.mycelia_iterative_assemble(
+        temp_fastq;
+        max_k = max_k,
+        skip_solid = config.skip_solid,
+        graph_mode = _graph_mode_symbol(config.graph_mode),
+        verbose = false,
+        enable_checkpointing = false,
+        output_dir = output_dir
+    )
+
+    contigs = collect(String, result_dict[:final_assembly])
+    contig_names = ["corrected_contig_$(i)" for i in 1:length(contigs)]
+    assembly_stats = Dict{String, Any}(
+        "corrector" => "iterative",
+        "skip_solid" => config.skip_solid,
+        "k_progression" => result_dict[:k_progression],
+        "corrector_metadata" => result_dict[:metadata]
+    )
+
+    _log_info(config, "Iterative corrector produced $(length(contigs)) contigs")
+    return AssemblyResult(contigs, contig_names;
+        assembly_stats = assembly_stats, gfa_compatible = false)
 end
 
 """

--- a/src/rhizomorph/assembly.jl
+++ b/src/rhizomorph/assembly.jl
@@ -597,6 +597,7 @@ since the corrector requires per-base quality strings).
 """
 function _write_reads_to_fastq(reads, path::String)
     _placeholder_qual(n) = repeat("I", n)  # Phred+33 'I' == Q40
+    placeholder_used = Ref(false)
     open(path, "w") do io
         writer = FASTX.FASTQ.Writer(io)
         if reads isa Vector{String}
@@ -611,6 +612,7 @@ function _write_reads_to_fastq(reads, path::String)
                     open(FASTX.FASTA.Reader, file_path) do reader
                         for record in reader
                             seq = FASTX.FASTA.sequence(String, record)
+                            placeholder_used[] = true
                             write(writer, FASTX.FASTQ.Record(
                                 FASTX.FASTA.identifier(record), seq, _placeholder_qual(length(seq))))
                         end
@@ -623,6 +625,7 @@ function _write_reads_to_fastq(reads, path::String)
                     write(writer, record)
                 elseif record isa FASTX.FASTA.Record
                     seq = FASTX.FASTA.sequence(String, record)
+                    placeholder_used[] = true
                     write(writer, FASTX.FASTQ.Record(
                         FASTX.FASTA.identifier(record), seq, _placeholder_qual(length(seq))))
                 else
@@ -631,6 +634,11 @@ function _write_reads_to_fastq(reads, path::String)
             end
         end
         close(writer)
+    end
+    if placeholder_used[]
+        @warn "corrector=:iterative: input lacked per-base quality (FASTA / quality-less); " *
+              "assigned placeholder Q40. The corrector's quality model is degenerate (uniform) " *
+              "for these reads — its decisions become coverage-driven only."
     end
     return path
 end
@@ -650,37 +658,48 @@ result is marked `gfa_compatible=false`.
 function _assemble_with_iterative_corrector(reads, config::AssemblyConfig)
     _log_info(config, "Routing assembly through iterative corrector (corrector=:iterative)")
 
-    input_dir = mktempdir()
-    output_dir = mktempdir()
-    temp_fastq = joinpath(input_dir, "corrector_input.fastq")
-    _write_reads_to_fastq(reads, temp_fastq)
-
-    # The corrector's k-progression needs a sane floor; honor the config's k when
-    # it is at least the floor, otherwise use the floor (13).
+    # The corrector is k-mer based; a min_overlap-only config has no k, so the
+    # k-progression floors at 13 and min_overlap is not used — surface that rather
+    # than silently drop the OLC intent (review Important #3).
+    if config.k === nothing
+        @warn "corrector=:iterative is k-mer based; min_overlap is ignored and the k-progression floors at 13."
+    end
     max_k = config.k === nothing ? 13 : max(config.k, 13)
 
-    result_dict = Mycelia.mycelia_iterative_assemble(
-        temp_fastq;
-        max_k = max_k,
-        skip_solid = config.skip_solid,
-        graph_mode = _graph_mode_symbol(config.graph_mode),
-        verbose = false,
-        enable_checkpointing = false,
-        output_dir = output_dir
-    )
+    input_dir = mktempdir()
+    output_dir = mktempdir()
+    try
+        temp_fastq = joinpath(input_dir, "corrector_input.fastq")
+        _write_reads_to_fastq(reads, temp_fastq)
 
-    contigs = collect(String, result_dict[:final_assembly])
-    contig_names = ["corrected_contig_$(i)" for i in 1:length(contigs)]
-    assembly_stats = Dict{String, Any}(
-        "corrector" => "iterative",
-        "skip_solid" => config.skip_solid,
-        "k_progression" => result_dict[:k_progression],
-        "corrector_metadata" => result_dict[:metadata]
-    )
+        result_dict = Mycelia.mycelia_iterative_assemble(
+            temp_fastq;
+            max_k = max_k,
+            skip_solid = config.skip_solid,
+            graph_mode = _graph_mode_symbol(config.graph_mode),
+            verbose = false,
+            enable_checkpointing = false,
+            output_dir = output_dir
+        )
 
-    _log_info(config, "Iterative corrector produced $(length(contigs)) contigs")
-    return AssemblyResult(contigs, contig_names;
-        assembly_stats = assembly_stats, gfa_compatible = false)
+        contigs = collect(String, result_dict[:final_assembly])
+        contig_names = ["corrected_contig_$(i)" for i in 1:length(contigs)]
+        assembly_stats = Dict{String, Any}(
+            "corrector" => "iterative",
+            "skip_solid" => config.skip_solid,
+            "k_progression" => result_dict[:k_progression],
+            "corrector_metadata" => result_dict[:metadata]
+        )
+
+        _log_info(config, "Iterative corrector produced $(length(contigs)) contigs")
+        return AssemblyResult(contigs, contig_names;
+            assembly_stats = assembly_stats, gfa_compatible = false)
+    finally
+        # Prompt cleanup so repeated assemblies in a long-lived process do not leak
+        # the input FASTQ + corrector output dirs until process exit (review #2).
+        rm(input_dir; recursive = true, force = true)
+        rm(output_dir; recursive = true, force = true)
+    end
 end
 
 """

--- a/test/4_assembly/rhizomorph_iterative_corrector_wiring_test.jl
+++ b/test/4_assembly/rhizomorph_iterative_corrector_wiring_test.jl
@@ -1,0 +1,69 @@
+# Wiring test: the iterative+skip corrector must be reachable through the public
+# assemble_genome interface via the opt-in `corrector=:iterative` keyword, while
+# the default path (`corrector=:none`) stays on the existing single-k pipeline.
+#
+# Guards td-k6oc: previously mycelia_iterative_assemble was only callable from
+# benchmarks; AssemblyConfig now threads `corrector`/`skip_solid` and
+# assemble_genome routes to it. This test proves (a) the opt-in path runs to
+# completion and returns non-empty contigs, and (b) the default path is
+# untouched (no corrector metadata, still produces contigs).
+#
+# Run directly:
+#   julia --project=. -e 'include("test/4_assembly/rhizomorph_iterative_corrector_wiring_test.jl")'
+
+import Test
+import Mycelia
+import FASTX
+import Random
+
+const _BASES = ['A', 'C', 'G', 'T']
+
+# ~50-100 fragmented FASTQ reads from a ~1 kb reference (mirrors the known-good
+# toy input used by iterative_assemble_completion_test.jl, but returns records so
+# they flow through the assemble_genome front door rather than a file path).
+function _toy_fastq_records(rng; reflen = 1000, n_reads = 80, readlen = 80, err = 0.01)
+    ref = join(rand(rng, _BASES, reflen))
+    records = FASTX.FASTQ.Record[]
+    for i in 1:n_reads
+        s = rand(rng, 1:(reflen - readlen + 1))
+        seq = collect(ref[s:(s + readlen - 1)])
+        for j in 1:readlen
+            rand(rng) < err && (seq[j] = rand(rng, filter(!=(seq[j]), _BASES)))
+        end
+        push!(records, FASTX.FASTQ.Record("r$i", String(seq), String(fill('I', readlen))))
+    end
+    return records
+end
+
+Test.@testset "assemble_genome iterative corrector wiring (td-k6oc)" begin
+    reads = _toy_fastq_records(Random.MersenneTwister(42))
+
+    Test.@testset "config threads corrector/skip_solid + validates" begin
+        cfg = Mycelia.Rhizomorph.AssemblyConfig(k = 13, corrector = :iterative, skip_solid = true)
+        Test.@test cfg.corrector == :iterative
+        Test.@test cfg.skip_solid == true
+        # default preserves today's behavior
+        Test.@test Mycelia.Rhizomorph.AssemblyConfig(k = 13).corrector == :none
+        Test.@test Mycelia.Rhizomorph.AssemblyConfig(k = 13).skip_solid == false
+        # invalid corrector is rejected
+        Test.@test_throws Exception Mycelia.Rhizomorph.AssemblyConfig(k = 13, corrector = :bogus)
+    end
+
+    Test.@testset "corrector=:iterative runs end-to-end, non-empty contigs" begin
+        result = Mycelia.Rhizomorph.assemble_genome(reads; k = 13, corrector = :iterative)
+        Test.@test result isa Mycelia.Rhizomorph.AssemblyResult
+        Test.@test !isempty(result.contigs)
+        Test.@test all(!isempty, result.contigs)
+        # corrector provenance is recorded
+        Test.@test get(result.assembly_stats, "corrector", nothing) == "iterative"
+        Test.@test haskey(result.assembly_stats, "k_progression")
+    end
+
+    Test.@testset "default (corrector=:none) path is unchanged" begin
+        result = Mycelia.Rhizomorph.assemble_genome(reads; k = 13)
+        Test.@test result isa Mycelia.Rhizomorph.AssemblyResult
+        Test.@test !isempty(result.contigs)
+        # default path never touches the corrector -> no corrector metadata
+        Test.@test !haskey(result.assembly_stats, "corrector")
+    end
+end


### PR DESCRIPTION
Makes the now-completing, volume-reducing iterative corrector reachable from the public assemble_genome interface (was benchmark/test-only).

## Summary
- AssemblyConfig: opt-in corrector::Symbol=:none + skip_solid::Bool=false, validated (:none|:iterative).
- assemble_genome(reads, config): when corrector=:iterative, writes reads to a temp FASTQ, calls mycelia_iterative_assemble(max_k=max(config.k,13), skip_solid=...), wraps :final_assembly into AssemblyResult. Default :none path byte-identical (guarded early).

## Caveats (v0)
- FASTA/non-FASTQ inputs get placeholder Q40 quality (corrector needs per-base quality); FASTQ is lossless.
- corrector result has no graph → gfa_compatible=false; :k_progression + metadata under assembly_stats.
- max_iterations_per_k not exposed (corrector default).

## Test Plan
- [x] 13/13 assertions: config threading + invalid-symbol rejection; corrector=:iterative completes + non-empty contigs; default path unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional iterative read-correction mode for genome assembly.
  * Users can now choose the correction mode and control whether a solid-read filtering step is skipped.

* **Bug Fixes**
  * Improved assembly routing so the selected correction mode is applied consistently.
  * Preserved the existing default assembly behavior when the new option is not enabled.

* **Tests**
  * Added coverage for the new iterative path, configuration validation, and default-path behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->