### PR TITLE
test: Stage 0 benchmark regression guards — skip-floor + hidden-proxy correlation (td-gz51)

### DIFF
--- a/benchmarking/stage0_classification_matrix.jl
+++ b/benchmarking/stage0_classification_matrix.jl
@@ -164,6 +164,40 @@ function main()
                 lpad(f(m.prec), 8), lpad(f(m.bal_acc), 9), lpad(f(m.auc), 8))
     end
 
+    # ---- Score-correlation confound guard (td-gz51) -------------------------
+    # The coverage-only arm (FixedCoverageThreshold, score = coverage) and the
+    # quality-only arm (QualityThreshold, score = mean Phred) are NOMINALLY
+    # independent signals. If accumulated "quality" is secretly a proxy for
+    # coverage (the C1 confound), the two continuous score vectors become
+    # near-perfectly correlated — the tell-tale of a hidden proxy. This prints a
+    # prominent WARNING when |Pearson r| exceeds the threshold. Non-breaking:
+    # correct data (partial-signal quality model) sits well below it.
+    corr_threshold = getenv("MYCELIA_S0_CORR_WARN", 0.98)
+    selftest_bad = get(ENV, "MYCELIA_S0_SELFTEST_BAD", "false") in ("1", "true")
+    cov_scores = Float64[classifications["FixedCoverageThreshold"].scores[l] for l in labels]
+    qual_scores = if selftest_bad
+        # feed the coverage vector as the "quality" vector to force r ≈ 1.0 and
+        # prove the warning fires (verification only; off by default).
+        println("[SELFTEST] using coverage scores as quality scores to force correlation ≈ 1.0")
+        copy(cov_scores)
+    else
+        Float64[classifications["QualityThreshold"].scores[l] for l in labels]
+    end
+    r = Statistics.cor(cov_scores, qual_scores)
+    println("\n--- Score-correlation confound guard ---")
+    println("Pearson r(coverage-only score, quality-only score) = ",
+            round(r; digits = 4), "  (warn if |r| > ", corr_threshold, ")")
+    if isfinite(r) && abs(r) > corr_threshold
+        println("!!! WARNING: coverage-only and quality-only scores are near-perfectly " *
+                "correlated (|r| = $(round(abs(r); digits = 4)) > $(corr_threshold)).")
+        println("!!! Nominally-independent signals should NOT track this tightly — this is " *
+                "the tell-tale of a hidden proxy (e.g. accumulated 'quality' is secretly " *
+                "coverage, the C1 confound). Inspect the quality evidence path before " *
+                "trusting the fused arms.")
+    else
+        println("OK: independent signals are not collinear (no hidden-proxy tell-tale).")
+    end
+
     outdir = joinpath(@__DIR__, "results"); mkpath(outdir)
     config = Dict("reflen" => REFLEN, "coverage" => COVERAGE, "readlen" => READLEN,
                   "error_rate" => ERROR_RATE, "k" => K, "seed" => SEED)

--- a/benchmarking/stage0_completion_benchmark.jl
+++ b/benchmarking/stage0_completion_benchmark.jl
@@ -20,7 +20,58 @@ const ERR      = getenv("MYCELIA_S0C_ERR", 0.01)
 const MAXK     = getenv("MYCELIA_S0C_MAXK", 19)
 const SEED     = getenv("MYCELIA_S0C_SEED", 42)
 const SKIP     = get(ENV, "MYCELIA_S0C_SKIP", "true") == "true"
+# Regression guard (td-gz51): a FLOOR on the Stage 0 skip fraction. The skip is
+# what lets the iterative corrector complete at scale — if a regression silently
+# disables it (classifier returns all-weak, inverted no-evidence fallback), the
+# pipeline still finishes, just far slower, so a wall-clock benchmark would NOT
+# catch it. This asserts that at every k >= 5 the reported skip fraction stays
+# above the floor, turning a silent skip regression into a benchmark FAILURE.
+const SKIP_FLOOR = getenv("MYCELIA_S0C_SKIP_FLOOR", 30.0)  # percent
+# k below this is exempt: at tiny k almost every read has a weak k-mer, so a low
+# skip fraction there is expected, not a regression.
+const SKIP_FLOOR_MIN_K = getenv("MYCELIA_S0C_SKIP_FLOOR_MIN_K", 5)
+# Self-test hook: inject a synthetic k=7 skip=0/100 record to prove the floor
+# assertion actually fires (verification only; off by default, non-breaking).
+const SELFTEST_BAD = get(ENV, "MYCELIA_S0C_SELFTEST_BAD", "false") in ("1", "true")
 const BASES = ['A', 'C', 'G', 'T']
+
+"""Run `f` with stdout captured line-by-line while still echoing live to the
+real stdout, and return the captured lines (so the verbose Stage 0 output can be
+parsed for the skip-fraction guard without silencing the benchmark)."""
+function run_capturing_stdout(f)
+    real_out = stdout
+    rd, wr = redirect_stdout()
+    lines = String[]
+    reader = @async for ln in eachline(rd)
+        println(real_out, ln)   # live passthrough
+        push!(lines, ln)
+    end
+    try
+        f()
+    finally
+        redirect_stdout(real_out)
+        close(wr)
+        wait(reader)
+    end
+    return lines
+end
+
+"""Parse captured verbose output into (k, skipped, total) records, associating
+each "Stage 0 skipped" line with the most recently announced k."""
+function parse_skip_records(lines::Vector{String})
+    records = Tuple{Int, Int, Int}[]
+    current_k = 0
+    for ln in lines
+        mk = match(r"for k=(\d+)", ln)
+        mk === nothing || (current_k = parse(Int, mk.captures[1]))
+        mb = match(r"Building qualmer graph with k=(\d+)", ln)
+        mb === nothing || (current_k = parse(Int, mb.captures[1]))
+        ms = match(r"Stage 0 skipped \(all-solid, no decode\): (\d+)/(\d+)", ln)
+        ms === nothing && continue
+        push!(records, (current_k, parse(Int, ms.captures[1]), parse(Int, ms.captures[2])))
+    end
+    return records
+end
 
 function simulate_fastq(path)
     rng = Random.MersenneTwister(SEED)
@@ -50,16 +101,54 @@ function main()
     println("=== Stage 0 completion benchmark ===")
     println("reflen=$REFLEN cov=$COVERAGE readlen=$READLEN err=$ERR max_k=$MAXK seed=$SEED skip_solid=$SKIP reads=$n_reads")
     t0 = time()
-    Mycelia.mycelia_iterative_assemble(fastq;
-        max_k = MAXK,
-        skip_solid = SKIP,
-        verbose = true,
-        enable_parallel = true,
-        enable_checkpointing = false,
-        output_dir = joinpath(outdir, "asm"))
+    captured = run_capturing_stdout() do
+        Mycelia.mycelia_iterative_assemble(fastq;
+            max_k = MAXK,
+            skip_solid = SKIP,
+            verbose = true,
+            enable_parallel = true,
+            enable_checkpointing = false,
+            output_dir = joinpath(outdir, "asm"))
+    end
     elapsed = time() - t0
     println("=== COMPLETED in $(round(elapsed; digits = 1))s (skip_solid=$SKIP) ===")
-    println("(skip fraction is reported per iteration in the verbose output above)")
+
+    # ---- Skip-fraction floor guard (td-gz51) --------------------------------
+    # Only meaningful when the skip was actually requested; with skip off the
+    # source prints no "Stage 0 skipped" lines and there is nothing to guard.
+    records = parse_skip_records(captured)
+    if SELFTEST_BAD
+        push!(records, (7, 0, 100))
+        println("[SELFTEST] injected synthetic k=7 skip=0/100 record to prove the floor assertion fires")
+    end
+    if SKIP
+        guarded = filter(r -> r[1] >= SKIP_FLOOR_MIN_K && r[3] > 0, records)
+        println("\n--- Stage 0 skip-fraction guard (floor = $(SKIP_FLOOR)% for k >= $(SKIP_FLOOR_MIN_K)) ---")
+        violations = String[]
+        if isempty(guarded)
+            push!(violations,
+                "no Stage 0 skip records observed for k >= $(SKIP_FLOOR_MIN_K) while skip_solid=true " *
+                "(the skip may be silently disabled)")
+        else
+            for (k, skipped, total) in guarded
+                frac = skipped / total * 100
+                status = frac >= SKIP_FLOOR ? "OK " : "LOW"
+                println("  [$status] k=$k skip=$skipped/$total ($(round(frac; digits = 1))%)")
+                frac < SKIP_FLOOR && push!(violations,
+                    "k=$k skip fraction $(round(frac; digits = 1))% < floor $(SKIP_FLOOR)%")
+            end
+        end
+        if !isempty(violations)
+            println("\n=== GUARD FAILED: Stage 0 skip fraction below floor ===")
+            for v in violations
+                println("  - $v")
+            end
+            error("Stage 0 skip-fraction floor guard failed: " * join(violations, "; "))
+        end
+        println("=== GUARD PASSED: all k >= $(SKIP_FLOOR_MIN_K) skip fractions >= $(SKIP_FLOOR)% ===")
+    else
+        println("(skip_solid=false — skip-fraction guard not applicable this run)")
+    end
 end
 
 main()


### PR DESCRIPTION
Two cheap standing invariants that would have auto-caught this session's confounds. Benchmarking-only (no src changes).

## Summary
- completion benchmark: fails if skip fraction at any k>=5 drops below 30% (catches a silently-disabled skip).
- classification matrix: warns if coverage-only vs quality-only score Pearson r>0.98 (the hidden-proxy tell — the C1 confound).

## Test Plan
- [x] Both pass on correct data (no false trigger), both fire on env-gated synthetic bad cases (skip=0 → exit 1; identical scores → r=1.0 warning).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added safeguards that flag suspicious metric patterns and unusual benchmark behavior.
  * Benchmark runs now warn when two score sets are nearly identical and when expected skipping rates drop too low.
* **Chores**
  * Added optional self-test modes to help verify the new safeguards during validation.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->