### PR TITLE
fix: iterative route must correct-then-reassemble (not return corrected reads as contigs) (td-zru6)

### DIFF
--- a/src/rhizomorph/assembly.jl
+++ b/src/rhizomorph/assembly.jl
@@ -688,18 +688,32 @@ function _assemble_with_iterative_corrector(reads, config::AssemblyConfig)
             output_dir = output_dir
         )
 
-        contigs = collect(String, result_dict[:final_assembly])
-        contig_names = ["corrected_contig_$(i)" for i in 1:length(contigs)]
-        assembly_stats = Dict{String, Any}(
-            "corrector" => "iterative",
-            "skip_solid" => config.skip_solid,
-            "k_progression" => result_dict[:k_progression],
-            "corrector_metadata" => result_dict[:metadata]
-        )
-
-        _log_info(config, "Iterative corrector produced $(length(contigs)) contigs")
-        return AssemblyResult(contigs, contig_names;
-            assembly_stats = assembly_stats, gfa_compatible = false)
+        # mycelia_iterative_assemble is a read CORRECTOR: its :final_assembly is the
+        # corrected READS, not an assembly. Re-assemble the corrected reads through
+        # the naive path so assemble_genome returns real contigs + a graph —
+        # otherwise downstream (QUAST, GFA) would treat raw corrected reads as an
+        # assembly, which is not an apples-to-apples assembly result (td-zru6).
+        corrected_fastq = get(result_dict[:metadata], :final_fastq_file, nothing)
+        if corrected_fastq === nothing || !isfile(corrected_fastq)
+            error("iterative corrector produced no final corrected FASTQ to re-assemble")
+        end
+        corrected_reads = collect(FASTX.FASTQ.Reader(open(corrected_fastq)))
+        n_corrected = length(corrected_reads)
+        _log_info(config, "Corrected $(n_corrected) reads; re-assembling them (corrector=:none)")
+        reassembly_k = config.k === nothing ? max_k : config.k
+        # Re-assemble with AUTO-DETECTED graph_mode (not config.graph_mode): the
+        # corrector needs :canonical for skip_solid, but the naive graph path emits
+        # invalid contigs under :canonical, so the re-assembly must use the mode the
+        # naive baseline uses (DoubleStrand for DNA), which auto-config selects.
+        assembly = assemble_genome(corrected_reads;
+            k = reassembly_k, corrector = :none)
+        # Stamp the corrector provenance onto the real assembly's stats.
+        assembly.assembly_stats["corrector"] = "iterative"
+        assembly.assembly_stats["skip_solid"] = config.skip_solid
+        assembly.assembly_stats["k_progression"] = result_dict[:k_progression]
+        assembly.assembly_stats["corrected_read_count"] = n_corrected
+        _log_info(config, "Re-assembled corrected reads into $(length(assembly.contigs)) contigs")
+        return assembly
     finally
         # Prompt cleanup so repeated assemblies in a long-lived process do not leak
         # the input FASTQ + corrector output dirs until process exit (review #2).

--- a/src/rhizomorph/assembly.jl
+++ b/src/rhizomorph/assembly.jl
@@ -645,15 +645,24 @@ end
 
 """
 Route assembly through `Mycelia.mycelia_iterative_assemble` (the iterative +
-skip-solid maximum-likelihood corrector) and wrap its Dict result in an
-`AssemblyResult`.
+skip-solid maximum-likelihood corrector), then RE-ASSEMBLE the corrected reads
+into a real `AssemblyResult`.
 
-v0 return shape: the corrector returns a Dict with `:final_assembly`
-(Vector of sequence strings), `:k_progression`, and `:metadata`. We map
-`:final_assembly` directly onto `AssemblyResult.contigs` and stash the
-corrector's `:k_progression` / `:metadata` under `assembly_stats`. No graph is
-produced by this path, so `graph`/`simplified_graph` are `nothing` and the
-result is marked `gfa_compatible=false`.
+`mycelia_iterative_assemble` is a read CORRECTOR: its `:final_assembly` is the
+corrected READS (not contigs). This function reads the corrected FASTQ back and
+re-assembles it through the naive path (`assemble_genome(...; corrector=:none)`),
+so the returned `AssemblyResult` has real contigs + graph (`gfa_compatible=true`)
+— NOT raw corrected reads (that v0 shortcut made QUAST comparisons invalid,
+td-zru6). Corrector provenance (`corrector`, `skip_solid`, `k_progression`,
+`corrected_read_count`) is stamped onto the re-assembly's `assembly_stats`.
+
+The re-assembly deliberately lets `assemble_genome` auto-detect its graph mode
+(DoubleStrand for DNA) rather than inheriting `config.graph_mode`: the corrector
+needs `:canonical` for skip-solid, but the naive contig path is invalid under
+`:canonical`. Corrected reads are FASTQ, so the re-assembly runs the same
+quality-aware (qualmer) path a naive `assemble_genome` on FASTQ reads would —
+i.e. it mirrors the naive-on-FASTQ baseline, keeping the comparison apples-to-
+apples.
 """
 function _assemble_with_iterative_corrector(reads, config::AssemblyConfig)
     _log_info(config, "Routing assembly through iterative corrector (corrector=:iterative)")
@@ -694,11 +703,28 @@ function _assemble_with_iterative_corrector(reads, config::AssemblyConfig)
         # otherwise downstream (QUAST, GFA) would treat raw corrected reads as an
         # assembly, which is not an apples-to-apples assembly result (td-zru6).
         corrected_fastq = get(result_dict[:metadata], :final_fastq_file, nothing)
-        if corrected_fastq === nothing || !isfile(corrected_fastq)
-            error("iterative corrector produced no final corrected FASTQ to re-assemble")
+        if corrected_fastq === nothing
+            error("iterative corrector metadata is missing the :final_fastq_file key; " *
+                  "keys=$(collect(keys(result_dict[:metadata])))")
+        elseif !isfile(corrected_fastq)
+            error("iterative corrector :final_fastq_file points at a nonexistent path: " *
+                  "$(corrected_fastq) (output_dir=$(output_dir))")
         end
-        corrected_reads = collect(FASTX.FASTQ.Reader(open(corrected_fastq)))
+        # Eager `collect` inside a do-block: materializes ALL corrected reads into
+        # memory (load-bearing — the finally-block rm's output_dir, so a lazy reader
+        # would hit a deleted file) AND closes the stream (no leaked fd across many
+        # assemblies, and closes on a malformed-FASTQ throw too).
+        corrected_reads = open(FASTX.FASTQ.Reader, corrected_fastq) do reader
+            collect(reader)
+        end
         n_corrected = length(corrected_reads)
+        # A corrector that silently ate every read (empty/header-only FASTQ) would
+        # otherwise flow into assemble_genome([]) → a 0-contig "successful" assembly.
+        # Fail loud instead of handing downstream a silently-empty assembly.
+        if n_corrected == 0
+            error("iterative corrector produced 0 corrected reads (from $(corrected_fastq)); " *
+                  "refusing to return an empty assembly")
+        end
         _log_info(config, "Corrected $(n_corrected) reads; re-assembling them (corrector=:none)")
         reassembly_k = config.k === nothing ? max_k : config.k
         # Re-assemble with AUTO-DETECTED graph_mode (not config.graph_mode): the
@@ -712,6 +738,10 @@ function _assemble_with_iterative_corrector(reads, config::AssemblyConfig)
         assembly.assembly_stats["skip_solid"] = config.skip_solid
         assembly.assembly_stats["k_progression"] = result_dict[:k_progression]
         assembly.assembly_stats["corrected_read_count"] = n_corrected
+        if isempty(assembly.contigs)
+            @warn "corrector=:iterative re-assembled $(n_corrected) corrected reads into 0 " *
+                  "contigs — the corrected read set did not assemble."
+        end
         _log_info(config, "Re-assembled corrected reads into $(length(assembly.contigs)) contigs")
         return assembly
     finally

--- a/test/4_assembly/rhizomorph_iterative_corrector_wiring_test.jl
+++ b/test/4_assembly/rhizomorph_iterative_corrector_wiring_test.jl
@@ -49,7 +49,7 @@ Test.@testset "assemble_genome iterative corrector wiring (td-k6oc)" begin
         Test.@test_throws Exception Mycelia.Rhizomorph.AssemblyConfig(k = 13, corrector = :bogus)
     end
 
-    Test.@testset "corrector=:iterative runs end-to-end, non-empty contigs" begin
+    Test.@testset "corrector=:iterative re-assembles corrected reads (not raw reads)" begin
         result = Mycelia.Rhizomorph.assemble_genome(reads; k = 13, corrector = :iterative)
         Test.@test result isa Mycelia.Rhizomorph.AssemblyResult
         Test.@test !isempty(result.contigs)
@@ -57,6 +57,18 @@ Test.@testset "assemble_genome iterative corrector wiring (td-k6oc)" begin
         # corrector provenance is recorded
         Test.@test get(result.assembly_stats, "corrector", nothing) == "iterative"
         Test.@test haskey(result.assembly_stats, "k_progression")
+        # REGRESSION GUARD (td-zru6): these distinguish a real re-assembly from the
+        # v0 "return corrected reads as contigs" bug — all of them were false/absent
+        # under v0, so the old bug can no longer pass this test silently.
+        Test.@test result.gfa_compatible == true            # v0 was false (no graph)
+        Test.@test result.graph !== nothing                 # v0 produced no graph
+        Test.@test haskey(result.assembly_stats, "corrected_read_count")
+        # Behavioral guard: a real assembly does not pass reads through 1:1, so the
+        # contig set is not identical to the corrected read set. (Count alone is not
+        # an invariant — a fragmented DBG can yield more unitigs than reads — so
+        # compare the actual sequences, not the counts.)
+        corrected_seqs = Set(FASTX.sequence(String, r) for r in reads)
+        Test.@test Set(result.contigs) != corrected_seqs
     end
 
     Test.@testset "default (corrector=:none) path is unchanged" begin


### PR DESCRIPTION
The real-genome validation (td-wlfq) surfaced a root issue in the v0 corrector wiring (#350).

## The bug
`mycelia_iterative_assemble` is a read **corrector** — its `:final_assembly` is the corrected **reads**, not assembled contigs. The #350 wiring returned those reads AS `assemble_genome`'s contigs, so `assemble_genome(corrector=:iterative)` never actually assembled anything. This made any QUAST comparison invalid: raw corrected reads naturally cover more of a genome than a fragmented assembly, so the earlier "naive 63.3% vs iterative 97.5% genome fraction" was reads-vs-assembly (retracted).

## The fix
After correction, read the corrected FASTQ and **re-assemble** it through the naive path (`corrector=:none`), returning a real `AssemblyResult` with contigs + graph. Corrector provenance (`corrector`, `skip_solid`, `k_progression`, `corrected_read_count`) is stamped onto the assembly stats.

## graph_mode subtlety
The corrector needs `:canonical` for `skip_solid`, but the naive contig path emits invalid contigs under `:canonical`. So the re-assembly **auto-detects** its graph mode (DoubleStrand for DNA — the mode the naive baseline uses) rather than inheriting `config.graph_mode`.

## Test Plan
- [x] 13/13 `rhizomorph_iterative_corrector_wiring_test.jl` pass (57.8s) — re-assembly returns non-empty contigs, `corrector=iterative` provenance stamped, `k_progression` present; default `corrector=:none` path unchanged.
- [ ] Follow-up (td-wlfq): re-run the real-genome validation as a fair assembly-vs-assembly comparison.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Iterative correction now returns a full assembled result with graph output instead of just passing through corrected reads.
  * Added validation for corrected-read output and clearer handling when no corrected reads are produced.
  * Assembly results now include additional provenance details, such as correction progress and read counts.
  * Improved regression coverage to ensure iterative correction produces genuine re-assembly results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->