### PR TITLE
add: wire token/SentencePiece graph into assemble_genome

### DIFF
--- a/src/rhizomorph/assembly.jl
+++ b/src/rhizomorph/assembly.jl
@@ -15,6 +15,7 @@ Assembly method enumeration for unified interface.
     StringGraph      # String graph assembly (simplified from N-gram graphs)
     BioSequenceGraph # BioSequence graph assembly (simplified from K-mer graphs)
     QualityBioSequenceGraph # Quality-aware BioSequence graph assembly (simplified from Qualmer graphs)
+    TokenGraph       # Token graph assembly (SentencePiece/word-token sequences, SingleStrand only)
 
     # Hybrid approaches
     HybridOLC        # Hybrid OLC + qualmer graph approach
@@ -145,6 +146,12 @@ struct AssemblyConfig
     corrector::Symbol                       # :none (default) or :iterative (mycelia_iterative_assemble)
     skip_solid::Bool                        # When corrector=:iterative, skip already-solid/clean reads
 
+    # Optional pre-tokenized input (opt-in; default `nothing` preserves the
+    # read-driven pipeline). When supplied, assemble_genome routes to the token
+    # graph and IGNORES `reads` — the tokens ARE the input. SingleStrand only
+    # (reverse complement is undefined for general string tokens).
+    token_sequences::Union{Nothing, Vector{Vector{String}}}
+
     # Constructor with validation
     function AssemblyConfig(;
             k::Union{Int, Nothing} = nothing,
@@ -163,7 +170,8 @@ struct AssemblyConfig
             compact_unitigs::Bool = false,
             memory_profile::Symbol = :full,
             corrector::Symbol = :none,
-            skip_solid::Bool = false
+            skip_solid::Bool = false,
+            token_sequences::Union{Nothing, Vector{Vector{String}}} = nothing
     )
         # Validation: Must specify exactly one of k or min_overlap
         if k === nothing && min_overlap === nothing
@@ -180,6 +188,13 @@ struct AssemblyConfig
         end
         if sequence_type == String && (graph_mode == DoubleStrand || graph_mode == Canonical)
             error("String sequences can only use SingleStrand mode (reverse complement undefined for general strings)")
+        end
+
+        # Validation: token-graph input is SingleStrand only. Tokens are opaque
+        # strings (SentencePiece pieces / words) with no defined reverse
+        # complement, so DoubleStrand/Canonical are meaningless for them.
+        if token_sequences !== nothing && graph_mode != SingleStrand
+            error("token_sequences requires SingleStrand mode (reverse complement undefined for string tokens)")
         end
 
         # Validation: memory_profile must be one recognized by build_kmer_graph
@@ -240,7 +255,8 @@ struct AssemblyConfig
             compact_unitigs,
             memory_profile,
             corrector,
-            skip_solid
+            skip_solid,
+            token_sequences
         )
     end
 end
@@ -551,6 +567,15 @@ function assemble_genome(reads, config::AssemblyConfig)
     # corrector=:iterative diverts to the iterative+skip corrector.
     if config.corrector == :iterative
         return _assemble_with_iterative_corrector(reads, config)
+    end
+
+    # Token-graph route. When the caller supplies pre-tokenized sequences, the
+    # tokens ARE the input and `reads` is ignored — token assembly is driven by
+    # config.token_sequences, not by loaded read observations. SingleStrand only
+    # (enforced in the AssemblyConfig constructor).
+    if config.token_sequences !== nothing
+        _log_info(config, "Routing to token graph assembly (token_sequences supplied)")
+        return _assemble_token_graph(config.token_sequences, config)
     end
 
     _log_info(config, "Starting unified genome assembly", config.sequence_type,
@@ -1644,6 +1669,70 @@ function _assemble_ngram_graph(observations, config)
         "vertex_type" => "unicode_character_vectors",
         "k" => config.k,
         "num_input_sequences" => length(observations),
+        "assembly_date" => string(Mycelia.Dates.now())
+    )
+
+    return AssemblyResult(contigs, contig_names; graph = graph, assembly_stats = stats)
+end
+
+"""
+Token graph assembly implementation (variable-length SentencePiece/word-token
+analysis).
+
+Assembles pre-tokenized sequences (e.g. SentencePiece pieces or whitespace
+tokens) into contigs. It builds a token graph over the String token labels,
+finds an Eulerian path when one exists (or, when it does not, the maximal linear
+contigs), and reconstructs each contig by joining that path's token labels with
+`token_separator`.
+
+Modeled on `_assemble_ngram_graph`, with one deliberate difference: token
+vertices are whole opaque strings, not fixed-length character windows, so the
+character-overlap reconstruction used by `path_to_sequence` /
+`generate_contig_sequence` (append only the last char of each subsequent vertex)
+is wrong here. Instead the ordered token labels are joined directly. Tokens are
+SingleStrand only — reverse complement is undefined for general string tokens —
+so no reverse-complement handling is performed.
+"""
+function _assemble_token_graph(
+        token_sequences::Vector{Vector{String}}, config;
+        token_separator::AbstractString = " "
+)
+    _log_info(config, "Using token graph assembly strategy (variable-length token analysis)")
+
+    graph = Rhizomorph.build_token_graph(token_sequences)
+
+    # Fast path: a single Eulerian traversal covering every edge, if one exists.
+    paths = Rhizomorph.find_eulerian_paths_next(graph)
+    contigs = String[]
+    for path in paths
+        if length(path) > 1
+            push!(contigs, join(path, token_separator))
+        end
+    end
+
+    # Fallback: emit maximal linear contigs (token label paths). `min_contig_length`
+    # is measured against find_contigs_next's character-overlap string, so use 1
+    # to keep short token contigs (single-token paths included).
+    if isempty(contigs)
+        contig_paths = Rhizomorph.find_contigs_next(graph; min_contig_length = 1)
+        for contig in contig_paths
+            if !isempty(contig.vertices)
+                push!(contigs, join(contig.vertices, token_separator))
+            end
+        end
+    end
+
+    contig_names = ["token_contig_$i" for i in 1:length(contigs)]
+
+    stats = Dict{String, Any}(
+        "method" => "TokenGraph",
+        "graph_type" => "variable_length",
+        "vertex_type" => "string_tokens",
+        "token_separator" => String(token_separator),
+        "graph_mode" => string(config.graph_mode),
+        "num_vertices" => length(MetaGraphsNext.labels(graph)),
+        "num_edges" => length(MetaGraphsNext.edge_labels(graph)),
+        "num_input_sequences" => length(token_sequences),
         "assembly_date" => string(Mycelia.Dates.now())
     )
 

--- a/test/4_assembly/token_graph_assembly_test.jl
+++ b/test/4_assembly/token_graph_assembly_test.jl
@@ -1,0 +1,112 @@
+# From the Mycelia base directory, run the tests with:
+#
+# ```bash
+# julia --project=. -e 'include("test/4_assembly/token_graph_assembly_test.jl")'
+# ```
+#
+# And to turn this file into a jupyter notebook, run:
+# ```bash
+# julia --project=. -e 'import Literate; Literate.notebook("test/4_assembly/token_graph_assembly_test.jl", "test/4_assembly", execute=false)'
+# ```
+
+## If running Literate notebook, ensure the package is activated:
+## import Pkg
+## if isinteractive()
+##     Pkg.activate(joinpath(@__DIR__, "..", ".."))
+## end
+## using Revise
+
+# Token Graph Assembly - end-to-end through assemble_genome
+#
+# Exercises the TokenGraph route: pre-tokenized SentencePiece/word-token
+# sequences are supplied via AssemblyConfig.token_sequences and assembled
+# directly (reads are ignored). SingleStrand only.
+
+import Test
+import Mycelia
+import MetaGraphsNext
+
+Test.@testset "Token Graph Assembly (assemble_genome route)" begin
+    Test.@testset "TokenGraph enum member exists" begin
+        Test.@test Mycelia.Rhizomorph.TokenGraph isa Mycelia.Rhizomorph.AssemblyMethod
+    end
+
+    Test.@testset "config validation: token_sequences requires SingleStrand" begin
+        toks = [["the", "cat", "sat"]]
+        # DoubleStrand (the default) must be rejected for tokens.
+        Test.@test_throws ErrorException Mycelia.Rhizomorph.AssemblyConfig(;
+            token_sequences = toks,
+            graph_mode = Mycelia.Rhizomorph.DoubleStrand)
+        # SingleStrand constructs cleanly and stores the tokens.
+        cfg_ok = Mycelia.Rhizomorph.AssemblyConfig(;
+            token_sequences = toks,
+            graph_mode = Mycelia.Rhizomorph.SingleStrand)
+        Test.@test cfg_ok.token_sequences == toks
+    end
+
+    Test.@testset "default config has token_sequences === nothing" begin
+        cfg = Mycelia.Rhizomorph.AssemblyConfig()
+        Test.@test cfg.token_sequences === nothing
+    end
+
+    Test.@testset "end-to-end linear token assembly" begin
+        # A single linear chain: the -> quick -> brown -> fox -> jumps.
+        token_sequences = [["the", "quick", "brown", "fox", "jumps"]]
+
+        config = Mycelia.Rhizomorph.AssemblyConfig(;
+            token_sequences = token_sequences,
+            graph_mode = Mycelia.Rhizomorph.SingleStrand)
+
+        # reads are ignored when token_sequences is supplied; pass an empty vector.
+        result = Mycelia.Rhizomorph.assemble_genome(String[], config)
+
+        Test.@test result isa Mycelia.Rhizomorph.AssemblyResult
+        Test.@test Mycelia.Rhizomorph.has_graph_structure(result)
+        Test.@test result.graph isa MetaGraphsNext.MetaGraph
+
+        # 5 distinct tokens -> 5 vertices, 4 edges.
+        Test.@test length(collect(MetaGraphsNext.labels(result.graph))) == 5
+        Test.@test length(collect(MetaGraphsNext.edge_labels(result.graph))) == 4
+
+        # At least one contig, names aligned, and stats stamped.
+        Test.@test !isempty(result.contigs)
+        Test.@test length(result.contigs) == length(result.contig_names)
+        Test.@test result.assembly_stats["method"] == "TokenGraph"
+        Test.@test result.assembly_stats["num_input_sequences"] == 1
+
+        # A valid linear assembly recovers the full ordered token string via the
+        # Eulerian fast path, joined by the default separator.
+        Test.@test "the quick brown fox jumps" in result.contigs
+
+        # Structural consistency check passes.
+        report = Mycelia.Rhizomorph.validate_assembly_structure(result)
+        Test.@test isempty(report["issues"])
+    end
+
+    Test.@testset "shared tokens across multiple sequences" begin
+        # Two sequences sharing a prefix token exercise the multi-sequence path
+        # and the branching-graph contig fallback.
+        token_sequences = [
+            ["the", "cat", "sat"],
+            ["the", "dog", "ran"]
+        ]
+
+        config = Mycelia.Rhizomorph.AssemblyConfig(;
+            token_sequences = token_sequences,
+            graph_mode = Mycelia.Rhizomorph.SingleStrand)
+
+        result = Mycelia.Rhizomorph.assemble_genome(String[], config)
+
+        Test.@test result isa Mycelia.Rhizomorph.AssemblyResult
+        Test.@test Mycelia.Rhizomorph.has_graph_structure(result)
+        # 5 distinct tokens: the, cat, sat, dog, ran.
+        Test.@test length(collect(MetaGraphsNext.labels(result.graph))) == 5
+        Test.@test !isempty(result.contigs)
+        Test.@test length(result.contigs) == length(result.contig_names)
+        # Contigs are token strings; every emitted token appears somewhere.
+        joined = join(result.contigs, " ")
+        for tok in ["the", "cat", "sat", "dog", "ran"]
+            Test.@test occursin(tok, joined)
+        end
+    end
+end


### PR DESCRIPTION
## Summary

- Adds a `TokenGraph` route to the unified `assemble_genome` interface so pre-tokenized inputs (SentencePiece pieces, whitespace/word tokens) can be assembled without dropping down to `build_token_graph` and reimplementing traversal by hand.
- New opt-in `token_sequences::Union{Nothing,Vector{Vector{String}}}` field on `AssemblyConfig` (default `nothing`) — the read-driven pipeline is byte-for-byte unchanged when unset.
- `assemble_genome(reads, config)` gains a dispatch arm that routes to a new `_assemble_token_graph` whenever `token_sequences` is supplied (`reads` are then ignored — the tokens are the input).
- `_assemble_token_graph` mirrors `_assemble_ngram_graph` (Eulerian fast path -> maximal-linear-contig fallback) but joins the ordered token labels with a separator rather than the character-overlap reconstruction used for fixed-length n-gram windows, which would corrupt whole-token vertices.
- SingleStrand only — reverse complement is undefined for opaque string tokens — enforced in the `AssemblyConfig` constructor.

## Test Plan

- New `test/4_assembly/token_graph_assembly_test.jl` assembles token sequences end-to-end through `assemble_genome` and asserts a valid `AssemblyResult` with a graph, correct vertex/edge counts, recovered ordered-token contig, config validation (DoubleStrand rejected), and default `token_sequences === nothing`.
- Run: `LD_LIBRARY_PATH='' julia --project=. -e 'include("test/4_assembly/token_graph_assembly_test.jl")'` -> 25/25 pass.

## Related

- Bead td-gmlu

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new token-based genome assembly mode for single-strand inputs.
  * You can now provide token sequences directly for assembly, alongside or instead of read-based input.
  * Assembly results now include token-graph contigs and summary details for this mode.

* **Bug Fixes**
  * Added validation to prevent token-based assembly in unsupported double-strand mode.
  * When token sequences are provided, the assembly flow now uses them consistently and ignores reads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->