### PR TITLE
Restore the graph-as-HMM correction core (emission, trustworthy Viterbi, soft-EM scaffold)

### DIFF
--- a/src/iterative-assembly.jl
+++ b/src/iterative-assembly.jl
@@ -626,7 +626,8 @@ function improve_read_set_likelihood(reads::Vector{<:FASTX.FASTQ.Record}, graph,
         batch_size::Int = 10000,
         enable_parallel::Bool = false,
         graph_mode::Symbol = :canonical,
-        skip_solid::Bool = false)::Tuple{Vector{FASTX.FASTQ.Record}, Int}
+        skip_solid::Bool = false,
+        beam_width::Int = typemax(Int))::Tuple{Vector{FASTX.FASTQ.Record}, Int}
     total_reads = length(reads)
     updated_reads = Vector{FASTX.FASTQ.Record}(undef, total_reads)
     improvements_made = 0
@@ -670,7 +671,8 @@ function improve_read_set_likelihood(reads::Vector{<:FASTX.FASTQ.Record}, graph,
                     skip_flags[i] = true
                 else
                     improved_read,
-                    was_improved = improve_read_likelihood(read, graph, k; graph_mode = graph_mode)
+                    was_improved = improve_read_likelihood(
+                        read, graph, k; graph_mode = graph_mode, beam_width = beam_width)
                     batch_results[i] = (improved_read, was_improved)
                 end
             end
@@ -692,7 +694,8 @@ function improve_read_set_likelihood(reads::Vector{<:FASTX.FASTQ.Record}, graph,
                     continue
                 end
                 improved_read,
-                was_improved = improve_read_likelihood(read, graph, k; graph_mode = graph_mode)
+                was_improved = improve_read_likelihood(
+                    read, graph, k; graph_mode = graph_mode, beam_width = beam_width)
                 updated_reads[batch_start + i - 1] = improved_read
 
                 if was_improved
@@ -734,7 +737,8 @@ Improve likelihood of a single read using maximum likelihood path finding.
 Returns improved read and boolean indicating if improvement was made.
 """
 function improve_read_likelihood(read::FASTX.FASTQ.Record, graph, k::Int;
-        graph_mode::Symbol = :canonical)::Tuple{FASTX.FASTQ.Record, Bool}
+        graph_mode::Symbol = :canonical,
+        beam_width::Int = typemax(Int))::Tuple{FASTX.FASTQ.Record, Bool}
     # Extract sequence and quality
     original_seq = FASTX.sequence(String, read)
     original_qual = FASTX.quality(read)
@@ -745,9 +749,10 @@ function improve_read_likelihood(read::FASTX.FASTQ.Record, graph, k::Int;
         return read, false
     end
 
-    # Find optimal path through graph using enhanced statistical path improvement
+    # Find optimal path through graph via the exact-by-default trustworthy Viterbi.
     improved_read,
-    likelihood_improvement = find_optimal_sequence_path(read, graph, k; graph_mode = graph_mode)
+    likelihood_improvement = find_optimal_sequence_path(
+        read, graph, k; graph_mode = graph_mode, beam_width = beam_width)
 
     # Only update if significant improvement
     if likelihood_improvement > 0.01  # Threshold for meaningful improvement
@@ -778,39 +783,33 @@ function find_optimal_sequence_path(sequence::AbstractString, quality, graph, k:
 end
 
 function find_optimal_sequence_path(read::FASTX.FASTQ.Record, graph, k::Int;
-        graph_mode::Symbol = :canonical)::Tuple{FASTX.FASTQ.Record, Float64}
-    # Enhanced Statistical Path Improvement (Phase 5.2b)
-    # Integrates iterative assembly with existing Viterbi algorithms from viterbi-next.jl
-
+        graph_mode::Symbol = :canonical,
+        beam_width::Int = typemax(Int))::Tuple{FASTX.FASTQ.Record, Float64}
+    # Trustworthy Viterbi (graph-as-HMM correction core, td-ak6w). Trust the
+    # maximum-likelihood path or report no improvement. The prior heuristic
+    # fallback cascade (0.01 abandon-threshold -> statistical resampling -> local
+    # edits) is removed from the correctness path: a "corrected" read must lie on
+    # an ML graph path, not on an off-path heuristic that may not correspond to
+    # any real traversal. `try_statistical_path_resampling` and
+    # `try_local_path_improvements` remain DEFINED as opt-in comparison baselines
+    # (and for direct callers/tests) but are no longer invoked here.
     original_likelihood = calculate_read_likelihood(read, graph, k; graph_mode = graph_mode)
 
-    # Option 1: Use Viterbi algorithm for full path optimization
-    viterbi_result = try_viterbi_path_improvement(read, graph, k; graph_mode = graph_mode)
-    if viterbi_result !== nothing
-        viterbi_read, viterbi_likelihood = viterbi_result
-        viterbi_improvement = viterbi_likelihood - original_likelihood
-
-        # If Viterbi shows significant improvement, use it
-        if viterbi_improvement > 0.01
-            return viterbi_read, viterbi_improvement
-        end
+    viterbi_result = try_viterbi_path_improvement(
+        read, graph, k; graph_mode = graph_mode, beam_width = beam_width)
+    if viterbi_result === nothing
+        # Viterbi could not decode (empty observation set, ArgumentError, etc.):
+        # report no improvement rather than falling back to a heuristic path.
+        return read, 0.0
     end
 
-    # Option 2: Statistical resampling for alternative paths
-    statistical_result = try_statistical_path_resampling(read, graph, k; graph_mode = graph_mode)
-    if statistical_result !== nothing
-        stat_read, stat_likelihood = statistical_result
-        stat_improvement = stat_likelihood - original_likelihood
-
-        # If statistical resampling shows improvement, use it
-        if stat_improvement > 0.01
-            return stat_read, stat_improvement
-        end
-    end
-
-    # Option 3: Local heuristic improvements (fallback)
-    return try_local_path_improvements(
-        read, graph, k, original_likelihood; graph_mode = graph_mode)
+    viterbi_read, viterbi_likelihood = viterbi_result
+    improvement = viterbi_likelihood - original_likelihood
+    # Accept the ML path only when it is at least as likely as the original; a
+    # non-positive delta means the ML path is not an improvement, so report none
+    # (never return a strictly-worse read). This is the ADR's "trust the ML path
+    # or report no improvement", NOT the removed 0.01 minimum-magnitude threshold.
+    return improvement > 0.0 ? (viterbi_read, improvement) : (read, 0.0)
 end
 
 """
@@ -1433,7 +1432,8 @@ Returns (improved_read, likelihood) or nothing if no improvement.
 function try_viterbi_path_improvement(read::FASTX.FASTQ.Record,
         graph,
         k::Int;
-        graph_mode::Symbol = :canonical)::Union{Tuple{FASTX.FASTQ.Record, Float64}, Nothing}
+        graph_mode::Symbol = :canonical,
+        beam_width::Int = typemax(Int))::Union{Tuple{FASTX.FASTQ.Record, Float64}, Nothing}
     try
         sequence_string = FASTX.sequence(String, read)
         alphabet = Mycelia.detect_alphabet(sequence_string)
@@ -1459,11 +1459,19 @@ function try_viterbi_path_improvement(read::FASTX.FASTQ.Record,
             observations[i] = Mycelia.QualityObservation(kmer, window)
         end
 
+        # Trustworthy Viterbi (td-ak6w): the decoder is EXACT by default
+        # (`beam_width = typemax(Int)` — the frontier is never pruned, so the
+        # returned path is the global maximum-likelihood path). `beam_width` is a
+        # documented OPT-IN scaling knob: pass a finite value to bound the
+        # (vertex, strand) frontier on very long reads / branchy graphs (it can
+        # otherwise grow ~unboundedly with read-length depth — 21B allocations on
+        # a 48 kb phage, td-63qy) at the cost of dropping the ML guarantee. It is
+        # NOT a default that silently changes correctness.
         config = Mycelia.ViterbiCorrectionConfig(
             alphabet = alphabet,
             strand_mode = graph_mode,
             max_steps = length(observations) - 1,
-            beam_width = 256
+            beam_width = beam_width
         )
         correction = Mycelia.correct_observations(graph, [observations]; config = config)
         corrected_path = only(correction.corrected_observations)

--- a/src/iterative-assembly.jl
+++ b/src/iterative-assembly.jl
@@ -1684,6 +1684,68 @@ function try_local_path_improvements(
     return FASTX.sequence(String, improved_record), improvement
 end
 
+# ============================================================================
+# Soft-EM M-step accumulation hook (SCAFFOLD, td-e70t)
+# ============================================================================
+#
+# See the design note over `SoftEdgeWeightAccumulator` in
+# `src/rhizomorph/core/evidence-functions.jl`. This is the correction-side hook
+# that turns a read's competing decoded paths into probability-weighted edge
+# evidence: each candidate path's RESPONSIBILITY (posterior over the read's own
+# candidate set) is accumulated onto the edges it traverses. Summed over reads,
+# the accumulator holds soft edge weights in which error edges — traversed only
+# by rare, low-probability paths — accrue little weight and decay below the
+# `generate_alternative_qualmer_paths` `weight > 0.01` gate WITHOUT tip-clipping.
+#
+# NOT yet called from `mycelia_iterative_assemble`: emergent coalescence also
+# needs the qualmer graph rebuild / transition weighting to CONSUME these soft
+# weights instead of raw coverage counts, which is outside the correction-core
+# file boundary (the td-e70t follow-on). This hook is deliberately additive and
+# side-effect-free so wiring it in cannot destabilize the current EM loop until
+# the M-step consumption lands.
+
+"""
+    _decoded_path_edges(result) -> Vector
+
+Ordered `(src_label, dst_label)` edge tuples of a decoded Viterbi path, or an
+empty vector when the result carries no path.
+"""
+function _decoded_path_edges(result::Mycelia.Rhizomorph.ViterbiDecodingResult)
+    labels = _decoded_path_labels(result)
+    labels === nothing && return Tuple{Any, Any}[]
+    return Tuple{Any, Any}[(labels[i], labels[i + 1]) for i in 1:(length(labels) - 1)]
+end
+
+"""
+    accumulate_soft_em_edge_weights!(accumulator, candidate_paths) -> accumulator
+
+Soft-EM M-step seam (td-e70t scaffold). Given a single read's competing decoded
+paths (`ViterbiDecodingResult`s, each with a `.score` log-likelihood and a
+`.path`), compute each path's responsibility by softmax-normalizing its score
+against the candidate set (`Mycelia.Rhizomorph.path_responsibility`) and
+accumulate that responsibility onto the edges it traverses
+(`Mycelia.Rhizomorph.accumulate_path_probability!`).
+
+With a single argmax path per read the responsibility is `1.0` (soft weight ==
+hard count); the softening emerges once several candidate paths per read compete
+(e.g. from `generate_alternative_qualmer_paths`), which is the regime the
+follow-on wires into the iteration loop.
+"""
+function accumulate_soft_em_edge_weights!(
+        accumulator::Mycelia.Rhizomorph.SoftEdgeWeightAccumulator,
+        candidate_paths
+)
+    scores = Float64[result.score for result in candidate_paths if isfinite(result.score)]
+    isempty(scores) && return accumulator
+    for result in candidate_paths
+        isfinite(result.score) || continue
+        responsibility = Mycelia.Rhizomorph.path_responsibility(result.score, scores)
+        Mycelia.Rhizomorph.accumulate_path_probability!(
+            accumulator, _decoded_path_edges(result), responsibility)
+    end
+    return accumulator
+end
+
 """
 Generate alternative qualmer paths through the graph using quality-aware probabilistic sampling.
 """

--- a/src/iterative-assembly.jl
+++ b/src/iterative-assembly.jl
@@ -237,6 +237,12 @@ function mycelia_iterative_assemble(input_fastq::String;
         skip_solid::Bool = false)
     start_time = time()
 
+    # Accumulates swallowed decode failures (structural / un-k-merizable) across
+    # every k and iteration so a systematically-broken corrector that reports
+    # "0 improvements" is visible in the result metadata rather than passing as
+    # "nothing to fix". See CorrectorDiagnostics.
+    corrector_diagnostics = CorrectorDiagnostics()
+
     # -- Convergence + k-ladder tuning knobs (td-q70n) -------------------------
     #
     # Two literature-backed speedups for the iterative corrector:
@@ -404,6 +410,11 @@ function mycelia_iterative_assemble(input_fastq::String;
             if verbose
                 println("Processing reads for likelihood improvements...")
             end
+            # `beam_width` is intentionally NOT passed here: the shipping path uses
+            # the size-aware auto-beam default (exact where tractable, bounded on
+            # large reads) so the production assembler cannot OOM-crash (td-63qy).
+            # `corrector_diagnostics` accumulates swallowed decode failures across
+            # every k and iteration and is surfaced in the result metadata.
             updated_reads,
             improvements_made = improve_read_set_likelihood(
                 current_reads, graph, k,
@@ -411,7 +422,8 @@ function mycelia_iterative_assemble(input_fastq::String;
                 batch_size = batch_size,
                 enable_parallel = enable_parallel,
                 graph_mode = graph_mode,
-                skip_solid = skip_solid
+                skip_solid = skip_solid,
+                diagnostics = corrector_diagnostics
             )
 
             # Calculate iteration metrics
@@ -552,7 +564,8 @@ function mycelia_iterative_assemble(input_fastq::String;
 
     # Finalize iterative assembly
     return finalize_iterative_assembly(
-        output_dir, k_progression, iteration_history, total_runtime, verbose = verbose)
+        output_dir, k_progression, iteration_history, total_runtime,
+        verbose = verbose, diagnostics = corrector_diagnostics)
 end
 
 # =============================================================================
@@ -616,10 +629,81 @@ function _read_is_all_solid(read::FASTX.FASTQ.Record, k::Int, solid_kmers::Abstr
     return saw_kmer
 end
 
+# ------------------------------------------------------------------------------
+# Corrector diagnostics + size-aware auto-beam (review: robustness blockers)
+# ------------------------------------------------------------------------------
+
+"""
+    CorrectorDiagnostics()
+
+Thread-safe tally of decode outcomes the per-read corrector would otherwise
+swallow SILENTLY. When `try_viterbi_path_improvement` fails to decode a read it
+returns `nothing` and the read passes through uncorrected; without this tally a
+SYSTEMATICALLY broken corrector — empty graph, alphabet-inference miss, config
+error, or a read that cannot be k-merized — reports `0/N improvements` as if it
+had actually run and found nothing to fix. Counters are `Threads.Atomic` so the
+parallel (`@threads`) read loop increments them race-free.
+
+- `structural_errors`  : `ArgumentError` from the decoder (empty graph,
+  alphabet-inference miss, config error). Means "the decoder could not run",
+  NOT "the decoder ran and found no gain".
+- `unkmerizable_reads` : `BioSequences.EncodeError` — a read carrying an
+  ambiguous base (e.g. `N`) that the 2-bit k-mer iterator cannot encode. The
+  read is SKIPPED (passes through uncorrected), never crashed on.
+"""
+mutable struct CorrectorDiagnostics
+    structural_errors::Threads.Atomic{Int}
+    unkmerizable_reads::Threads.Atomic{Int}
+end
+CorrectorDiagnostics() = CorrectorDiagnostics(Threads.Atomic{Int}(0), Threads.Atomic{Int}(0))
+
+# Previously-proven-tractable finite beam (td-63qy: beam 256 completed on the
+# 48 kb phage that OOM-crashed — ~21B allocations — at the unbounded typemax
+# default). A read whose observation count is at/below the threshold keeps the
+# EXACT maximum-likelihood guarantee (its frontier is small); above the threshold
+# the frontier is bounded so the SHIPPING assembler cannot OOM-crash.
+const _AUTO_BEAM_BOUNDED_WIDTH = 256
+# Heuristic cutoff on a read's observation (k-mer) count. Typical short reads
+# (Illumina, up to a few hundred bp) stay exact; long reads (PacBio/ONT, or the
+# 48 kb-scale inputs behind td-63qy) get bounded. This is NOT a correctness
+# constant: it only trades exactness for tractability, and only ABOVE the line.
+const _AUTO_BEAM_EXACT_THRESHOLD = 1024
+
+"""
+    _auto_beam_width(n_observations) -> Int
+
+Size-aware default beam width reconciling the ADR's "exact by default" with the
+td-63qy OOM crash. Returns `typemax(Int)` (exact — the unbounded frontier
+preserves the ML guarantee) when `n_observations <= _AUTO_BEAM_EXACT_THRESHOLD`,
+and the bounded `_AUTO_BEAM_BOUNDED_WIDTH` above it, emitting a one-line `@info`
+when it bounds so the exactness→tractability switch is visible in the log.
+Callers can still FORCE exact on a large read by passing an explicit
+`beam_width = typemax(Int)`.
+"""
+function _auto_beam_width(n_observations::Integer)::Int
+    if n_observations <= _AUTO_BEAM_EXACT_THRESHOLD
+        return typemax(Int)
+    end
+    @info "iterative corrector: read has $(n_observations) observations " *
+          "(> $(_AUTO_BEAM_EXACT_THRESHOLD)); bounding Viterbi beam_width=" *
+          "$(_AUTO_BEAM_BOUNDED_WIDTH) to stay tractable (exact ML would risk OOM, " *
+          "td-63qy). Pass beam_width=typemax(Int) to force exact." maxlog = 3
+    return _AUTO_BEAM_BOUNDED_WIDTH
+end
+
 """
 Improve likelihood of entire read set using current graph and k-mer size.
 Returns updated reads and count of improvements made.
 Uses memory-efficient batch processing for large datasets.
+
+`beam_width` defaults to `nothing` (size-aware auto-beam per read via
+`_auto_beam_width`): exact ML where the read is small enough to be tractable,
+a bounded frontier on large reads so the SHIPPING assembler cannot OOM-crash
+(td-63qy). Pass an explicit `Int` (including `typemax(Int)`) to override — a
+caller/test passing `beam_width = typemax(Int)` still gets exact decoding on
+every read. Swallowed structural/un-k-merizable decode failures are tallied into
+`diagnostics` (auto-created if not supplied) and a high swallowed fraction is
+`@warn`ed so a run that silently corrected nothing is visible.
 """
 function improve_read_set_likelihood(reads::Vector{<:FASTX.FASTQ.Record}, graph, k::Int;
         verbose::Bool = false,
@@ -627,7 +711,13 @@ function improve_read_set_likelihood(reads::Vector{<:FASTX.FASTQ.Record}, graph,
         enable_parallel::Bool = false,
         graph_mode::Symbol = :canonical,
         skip_solid::Bool = false,
-        beam_width::Int = typemax(Int))::Tuple{Vector{FASTX.FASTQ.Record}, Int}
+        beam_width::Union{Int, Nothing} = nothing,
+        diagnostics::Union{Nothing, CorrectorDiagnostics} = nothing)::Tuple{Vector{FASTX.FASTQ.Record}, Int}
+    diag = diagnostics === nothing ? CorrectorDiagnostics() : diagnostics
+    # Snapshot so the per-call @warn reflects THIS pass's swallowed fraction even
+    # when `diag` is a shared accumulator threaded across many passes.
+    struct_before = diag.structural_errors[]
+    unk_before = diag.unkmerizable_reads[]
     total_reads = length(reads)
     updated_reads = Vector{FASTX.FASTQ.Record}(undef, total_reads)
     improvements_made = 0
@@ -672,7 +762,8 @@ function improve_read_set_likelihood(reads::Vector{<:FASTX.FASTQ.Record}, graph,
                 else
                     improved_read,
                     was_improved = improve_read_likelihood(
-                        read, graph, k; graph_mode = graph_mode, beam_width = beam_width)
+                        read, graph, k; graph_mode = graph_mode,
+                        beam_width = beam_width, diagnostics = diag)
                     batch_results[i] = (improved_read, was_improved)
                 end
             end
@@ -695,7 +786,8 @@ function improve_read_set_likelihood(reads::Vector{<:FASTX.FASTQ.Record}, graph,
                 end
                 improved_read,
                 was_improved = improve_read_likelihood(
-                    read, graph, k; graph_mode = graph_mode, beam_width = beam_width)
+                    read, graph, k; graph_mode = graph_mode,
+                    beam_width = beam_width, diagnostics = diag)
                 updated_reads[batch_start + i - 1] = improved_read
 
                 if was_improved
@@ -729,6 +821,25 @@ function improve_read_set_likelihood(reads::Vector{<:FASTX.FASTQ.Record}, graph,
         end
     end
 
+    # Surface swallowed decode failures for THIS pass (see CorrectorDiagnostics):
+    # a systematically broken corrector otherwise reports 0 improvements as if it
+    # ran. Distinguish "every read failed structurally" (the corrector is not
+    # running at all) from a merely-high swallowed fraction.
+    struct_swallowed = diag.structural_errors[] - struct_before
+    unk_swallowed = diag.unkmerizable_reads[] - unk_before
+    swallowed = struct_swallowed + unk_swallowed
+    if total_reads > 0 && swallowed > 0
+        frac = swallowed / total_reads
+        if struct_swallowed == total_reads
+            @warn "iterative corrector: EVERY read failed to decode with a structural " *
+                  "error (empty graph / alphabet-inference miss / config error) — the " *
+                  "corrector is not running; 0 improvements is NOT 'nothing to fix'." total_reads structural_errors = struct_swallowed
+        elseif frac >= 0.5
+            @warn "iterative corrector: high swallowed-decode fraction; many reads " *
+                  "passed through uncorrected (not conflated with 'no likelihood gain')." total_reads structural_errors = struct_swallowed unkmerizable_reads = unk_swallowed fraction = round(frac, digits = 3)
+        end
+    end
+
     return updated_reads, improvements_made
 end
 
@@ -738,7 +849,8 @@ Returns improved read and boolean indicating if improvement was made.
 """
 function improve_read_likelihood(read::FASTX.FASTQ.Record, graph, k::Int;
         graph_mode::Symbol = :canonical,
-        beam_width::Int = typemax(Int))::Tuple{FASTX.FASTQ.Record, Bool}
+        beam_width::Union{Int, Nothing} = nothing,
+        diagnostics::Union{Nothing, CorrectorDiagnostics} = nothing)::Tuple{FASTX.FASTQ.Record, Bool}
     # Extract sequence and quality
     original_seq = FASTX.sequence(String, read)
     original_qual = FASTX.quality(read)
@@ -749,10 +861,21 @@ function improve_read_likelihood(read::FASTX.FASTQ.Record, graph, k::Int;
         return read, false
     end
 
-    # Find optimal path through graph via the exact-by-default trustworthy Viterbi.
+    # Find optimal path through graph via the trustworthy Viterbi. `beam_width`
+    # defaults to `nothing` = size-aware auto-beam (exact where tractable, bounded
+    # above the threshold to avoid the td-63qy OOM); an explicit Int overrides it.
+    #
+    # Two-gate design (intentional, not a narrative/code mismatch): the inner
+    # `find_optimal_sequence_path` gates on `improvement > 0.0` (accept the ML path
+    # only when it is at least as likely as the original — never return a strictly
+    # worse read), while THIS function additionally requires `> 0.01` so a
+    # negligible likelihood wiggle is not counted as a real correction. The two
+    # thresholds serve different jobs (correctness floor vs. meaningful-change
+    # floor) and compose deliberately.
     improved_read,
     likelihood_improvement = find_optimal_sequence_path(
-        read, graph, k; graph_mode = graph_mode, beam_width = beam_width)
+        read, graph, k; graph_mode = graph_mode,
+        beam_width = beam_width, diagnostics = diagnostics)
 
     # Only update if significant improvement
     if likelihood_improvement > 0.01  # Threshold for meaningful improvement
@@ -784,7 +907,8 @@ end
 
 function find_optimal_sequence_path(read::FASTX.FASTQ.Record, graph, k::Int;
         graph_mode::Symbol = :canonical,
-        beam_width::Int = typemax(Int))::Tuple{FASTX.FASTQ.Record, Float64}
+        beam_width::Union{Int, Nothing} = nothing,
+        diagnostics::Union{Nothing, CorrectorDiagnostics} = nothing)::Tuple{FASTX.FASTQ.Record, Float64}
     # Trustworthy Viterbi (graph-as-HMM correction core, td-ak6w). Trust the
     # maximum-likelihood path or report no improvement. The prior heuristic
     # fallback cascade (0.01 abandon-threshold -> statistical resampling -> local
@@ -793,13 +917,33 @@ function find_optimal_sequence_path(read::FASTX.FASTQ.Record, graph, k::Int;
     # any real traversal. `try_statistical_path_resampling` and
     # `try_local_path_improvements` remain DEFINED as opt-in comparison baselines
     # (and for direct callers/tests) but are no longer invoked here.
-    original_likelihood = calculate_read_likelihood(read, graph, k; graph_mode = graph_mode)
+    #
+    # `calculate_read_likelihood` k-merizes the read with the 2-bit iterator and
+    # runs BEFORE the decoder, so an un-k-merizable read (ambiguous base, e.g. `N`)
+    # throws `BioSequences.EncodeError` HERE, not in `try_viterbi_path_improvement`.
+    # Treat it identically: SKIP the read (pass through uncorrected) + count, so a
+    # single N-containing read never crashes the (threaded) corrector (td-63qy
+    # family). Returning before the decoder means each such read is tallied once.
+    original_likelihood = try
+        calculate_read_likelihood(read, graph, k; graph_mode = graph_mode)
+    catch error
+        if error isa BioSequences.EncodeError
+            diagnostics === nothing ||
+                Threads.atomic_add!(diagnostics.unkmerizable_reads, 1)
+            return read, 0.0
+        end
+        rethrow()
+    end
 
     viterbi_result = try_viterbi_path_improvement(
-        read, graph, k; graph_mode = graph_mode, beam_width = beam_width)
+        read, graph, k; graph_mode = graph_mode,
+        beam_width = beam_width, diagnostics = diagnostics)
     if viterbi_result === nothing
-        # Viterbi could not decode (empty observation set, ArgumentError, etc.):
-        # report no improvement rather than falling back to a heuristic path.
+        # Viterbi could not decode (empty observation set, structural error, or an
+        # un-k-merizable read): report no improvement rather than falling back to a
+        # heuristic path. Genuine decode FAILURES (vs. "no observations") are
+        # tallied in `diagnostics` inside try_viterbi_path_improvement so they are
+        # not silently conflated with "the ML path had no gain".
         return read, 0.0
     end
 
@@ -1286,7 +1430,8 @@ Finalize iterative assembly by combining results from all k-mer sizes and iterat
 """
 function finalize_iterative_assembly(output_dir::String, k_progression::Vector{Int},
         iteration_history::Dict{Int, Vector{Dict{Symbol, Any}}},
-        total_runtime::Float64; verbose::Bool = true)
+        total_runtime::Float64; verbose::Bool = true,
+        diagnostics::Union{Nothing, CorrectorDiagnostics} = nothing)
     if verbose
         println("Finalizing iterative assembly results...")
     end
@@ -1313,6 +1458,14 @@ function finalize_iterative_assembly(output_dir::String, k_progression::Vector{I
         final_assembly = String[]
     end
 
+    # Swallowed-decode tally (structural / un-k-merizable). Surfaced on the result
+    # so a caller can detect a corrector that reported 0 improvements because it
+    # never actually ran, distinct from "ran and found nothing to fix".
+    corrector_errors = diagnostics === nothing ?
+                       Dict(:structural => 0, :unkmerizable => 0) :
+                       Dict(:structural => diagnostics.structural_errors[],
+        :unkmerizable => diagnostics.unkmerizable_reads[])
+
     # Create comprehensive metadata
     metadata = Dict(
         :total_runtime => total_runtime,
@@ -1323,6 +1476,7 @@ function finalize_iterative_assembly(output_dir::String, k_progression::Vector{I
         :final_fastq_file => final_fastq,
         :output_directory => output_dir,
         :iteration_history => iteration_history,
+        :corrector_errors => corrector_errors,
         :assembly_type => "iterative_maximum_likelihood",
         :version => "Phase_5.2a"
     )
@@ -1433,12 +1587,17 @@ function try_viterbi_path_improvement(read::FASTX.FASTQ.Record,
         graph,
         k::Int;
         graph_mode::Symbol = :canonical,
-        beam_width::Int = typemax(Int))::Union{Tuple{FASTX.FASTQ.Record, Float64}, Nothing}
+        beam_width::Union{Int, Nothing} = nothing,
+        diagnostics::Union{Nothing, CorrectorDiagnostics} = nothing)::Union{Tuple{FASTX.FASTQ.Record, Float64}, Nothing}
     try
         sequence_string = FASTX.sequence(String, read)
         alphabet = Mycelia.detect_alphabet(sequence_string)
         sequence_type = Mycelia.alphabet_to_biosequence_type(alphabet)
         sequence = Mycelia.extract_typed_sequence(read, sequence_type)
+        # NOTE: `_record_kmer_iterator` uses a 2-bit (unambiguous) k-mer iterator,
+        # so `collect` here throws `BioSequences.EncodeError` on a read carrying an
+        # ambiguous base (e.g. a single `N`). That is handled as a SKIP-with-count
+        # in the catch below, NOT a crash of the (threaded) batch (td-63qy family).
         kmers = collect(Mycelia._record_kmer_iterator(sequence_type, k, sequence))
         if isempty(kmers)
             return nothing
@@ -1459,19 +1618,25 @@ function try_viterbi_path_improvement(read::FASTX.FASTQ.Record,
             observations[i] = Mycelia.QualityObservation(kmer, window)
         end
 
-        # Trustworthy Viterbi (td-ak6w): the decoder is EXACT by default
-        # (`beam_width = typemax(Int)` — the frontier is never pruned, so the
-        # returned path is the global maximum-likelihood path). `beam_width` is a
-        # documented OPT-IN scaling knob: pass a finite value to bound the
-        # (vertex, strand) frontier on very long reads / branchy graphs (it can
-        # otherwise grow ~unboundedly with read-length depth — 21B allocations on
-        # a 48 kb phage, td-63qy) at the cost of dropping the ML guarantee. It is
-        # NOT a default that silently changes correctness.
+        # Trustworthy Viterbi (td-ak6w), reconciled with the td-63qy OOM crash:
+        # the decoder is EXACT where tractable and BOUNDED (with a log line) above
+        # a size threshold. `beam_width === nothing` (the default) resolves the
+        # frontier bound PER READ via `_auto_beam_width(length(observations))`:
+        # `typemax(Int)` (never pruned → global maximum-likelihood path) for small
+        # reads, the proven-tractable finite bound for large reads (the unbounded
+        # frontier grows ~unboundedly with read-length depth — 21B allocations on
+        # a 48 kb phage). An explicit `beam_width::Int` (including `typemax(Int)`)
+        # is an OPT-IN override that is honored verbatim — a caller/test can force
+        # exact decoding on every read. This trades the ML guarantee for
+        # tractability ONLY above the threshold, and only under the auto-default;
+        # it never silently changes correctness of an explicit request.
+        effective_beam_width = beam_width === nothing ?
+                               _auto_beam_width(length(observations)) : beam_width
         config = Mycelia.ViterbiCorrectionConfig(
             alphabet = alphabet,
             strand_mode = graph_mode,
             max_steps = length(observations) - 1,
-            beam_width = beam_width
+            beam_width = effective_beam_width
         )
         correction = Mycelia.correct_observations(graph, [observations]; config = config)
         corrected_path = only(correction.corrected_observations)
@@ -1491,6 +1656,22 @@ function try_viterbi_path_improvement(read::FASTX.FASTQ.Record,
         return (improved_record, improved_likelihood)
     catch error
         if error isa ArgumentError
+            # STRUCTURAL decode failure (empty graph, alphabet-inference miss,
+            # config error). Swallow as "no improvement" so one broken read does
+            # not abort the (threaded) batch — but COUNT it so a run that silently
+            # corrected nothing is visible (not conflated with "decoder ran, no
+            # gain"). See CorrectorDiagnostics + the per-pass @warn.
+            diagnostics === nothing ||
+                Threads.atomic_add!(diagnostics.structural_errors, 1)
+            return nothing
+        elseif error isa BioSequences.EncodeError
+            # UN-K-MERIZABLE read: the 2-bit k-mer iterator throws EncodeError (NOT
+            # ArgumentError) on an ambiguous base (e.g. a single `N` in an Illumina
+            # read). Treat as a SKIP — the read passes through uncorrected — and
+            # count it, rather than rethrowing and crashing the whole threaded
+            # corrector on one N-containing read (td-63qy family).
+            diagnostics === nothing ||
+                Threads.atomic_add!(diagnostics.unkmerizable_reads, 1)
             return nothing
         end
         rethrow()

--- a/src/iterative-assembly.jl
+++ b/src/iterative-assembly.jl
@@ -1439,17 +1439,26 @@ function try_viterbi_path_improvement(read::FASTX.FASTQ.Record,
         alphabet = Mycelia.detect_alphabet(sequence_string)
         sequence_type = Mycelia.alphabet_to_biosequence_type(alphabet)
         sequence = Mycelia.extract_typed_sequence(read, sequence_type)
-        observations = collect(Mycelia._record_kmer_iterator(sequence_type, k, sequence))
-        if isempty(observations)
+        kmers = collect(Mycelia._record_kmer_iterator(sequence_type, k, sequence))
+        if isempty(kmers)
             return nothing
         end
 
+        # Restore the emission model (graph-as-HMM correction core, td-jqdf): the
+        # read's per-base Phred quality is the emission P(observed | hidden). The
+        # k-mer at index `i` spans read positions `i:(i+k-1)`, so wrap it with that
+        # per-base window (clamped to bounds) instead of discarding the quality and
+        # letting the emission fall back to the graph's population-average quality.
         quality_scores = collect(FASTX.quality_scores(read))
-        # Bound the exact-Viterbi frontier: without a finite beam the reachable
-        # (vertex, strand) set grows ~unboundedly with read length on real graphs
-        # and the corrector explodes (21B allocations / crash on a 48 kb phage —
-        # td-63qy). 256 keeps enough candidates to preserve correction quality
-        # while making the corrector tractable at read scale; tune via benchmark.
+        n_qual = length(quality_scores)
+        observations = Vector{Mycelia.QualityObservation}(undef, length(kmers))
+        for (i, kmer) in enumerate(kmers)
+            lo = clamp(i, 1, n_qual)
+            hi = clamp(i + k - 1, 1, n_qual)
+            window = UInt8.(@view quality_scores[lo:hi])
+            observations[i] = Mycelia.QualityObservation(kmer, window)
+        end
+
         config = Mycelia.ViterbiCorrectionConfig(
             alphabet = alphabet,
             strand_mode = graph_mode,

--- a/src/rhizomorph/assembly.jl
+++ b/src/rhizomorph/assembly.jl
@@ -904,9 +904,12 @@ function _prepare_observations(reads)
     elseif reads isa Vector{<:FASTX.FASTA.Record}
         return reads
     elseif reads isa Vector{<:FASTX.FASTQ.Record}
-        # Convert FASTQ to FASTA records
-        return [FASTX.FASTA.Record(FASTX.FASTQ.identifier(record), FASTX.FASTQ.sequence(record))
-                for record in reads]
+        # PRESERVE FASTQ records (do NOT strip quality). FASTQ input always routes to
+        # the quality-aware paths (use_quality_scores=true → qualmer / quality-biosequence),
+        # which consume per-base quality; stripping to FASTA here forced the downstream
+        # _prepare_fastq_observations to re-inject placeholder Q40 (td-tps5). FASTA input
+        # (which legitimately lacks quality) still flows through the FASTA branch above.
+        return reads
     else
         throw(ArgumentError("Unsupported reads format: $(typeof(reads))"))
     end

--- a/src/rhizomorph/assembly.jl
+++ b/src/rhizomorph/assembly.jl
@@ -1384,34 +1384,48 @@ Convert observations to FASTQ records for quality processing.
 """
 function _prepare_fastq_observations(observations)
     fastq_records = FASTX.FASTQ.Record[]
+    # Mirror `_write_reads_to_fastq`: any FASTA (quality-less) input that gets a
+    # placeholder Q40 must be SURFACED once per call, never silently substituted.
+    # A degenerate uniform-Q40 model makes the corrector's decisions
+    # coverage-driven only, so a silent substitution masks that the quality model
+    # is inert (review: silent Q40).
+    placeholder_used = false
 
     for (i, obs) in enumerate(observations)
         # Handle different observation formats
         if obs isa FASTX.FASTQ.Record
             push!(fastq_records, obs)
         elseif obs isa FASTX.FASTA.Record
-            # Convert FASTA to FASTQ with default quality (assume high quality)
+            # Convert FASTA to FASTQ with placeholder quality (Q40).
             seq = FASTX.FASTA.sequence(obs)
-            qual = repeat('I', length(seq))  # Quality score 40 (high quality)
+            qual = repeat('I', length(seq))  # Phred+33 'I' == Q40 placeholder
             record = FASTX.FASTQ.Record(FASTX.FASTA.identifier(obs), seq, qual)
             push!(fastq_records, record)
+            placeholder_used = true
         elseif obs isa Tuple && length(obs) >= 1
             # Handle tuple format like (record, index) or (record, other_data)
             record = obs[1]
             if record isa FASTX.FASTQ.Record
                 push!(fastq_records, record)
             elseif record isa FASTX.FASTA.Record
-                # Convert FASTA to FASTQ with default quality
+                # Convert FASTA to FASTQ with placeholder quality (Q40).
                 seq = FASTX.FASTA.sequence(record)
-                qual = repeat('I', length(seq))  # Quality score 40 (high quality)
+                qual = repeat('I', length(seq))  # Phred+33 'I' == Q40 placeholder
                 fastq_record = FASTX.FASTQ.Record(FASTX.FASTA.identifier(record), seq, qual)
                 push!(fastq_records, fastq_record)
+                placeholder_used = true
             else
                 @warn "Unsupported record type in tuple: $(typeof(record))"
             end
         else
             @warn "Unsupported observation type: $(typeof(obs))"
         end
+    end
+
+    if placeholder_used
+        @warn "corrector: observation input lacked per-base quality (FASTA / quality-less); " *
+              "assigned placeholder Q40. The corrector's quality model is degenerate (uniform) " *
+              "for these reads — its decisions become coverage-driven only."
     end
 
     return fastq_records

--- a/src/rhizomorph/assembly.jl
+++ b/src/rhizomorph/assembly.jl
@@ -862,6 +862,20 @@ end
 
 """
 Prepare observations from various input formats (FASTA/FASTQ records or file paths).
+
+Quality note (graph-as-HMM correction redesign,
+`docs/design/2026-07-06-graph-as-hmm-correction-redesign.md`): this helper
+normalizes to FASTA records, which DROPS per-base quality. That is intentional
+for the naive k-mer / string / n-gram graph builders, which do not consume
+quality. The iterative CORRECTOR does NOT use this path — it preserves real
+FASTQ quality end-to-end via `_write_reads_to_fastq` (FASTQ written verbatim;
+FASTA flagged quality-absent with a warning, never silently Q40) and the per-read
+per-base emission wrapping in `try_viterbi_path_improvement`. The remaining gap is
+the qualmer GRAPH builder (`_assemble_qualmer_graph`), which currently receives
+these quality-stripped observations and then re-injects a Q40 placeholder in
+`_prepare_fastq_observations`; giving it real FASTQ quality requires routing raw
+reads through the `assemble_genome` dispatch (a separate track) rather than this
+FASTA-normalizing helper.
 """
 function _prepare_observations(reads)
     if reads isa Vector{String}

--- a/src/rhizomorph/core/evidence-functions.jl
+++ b/src/rhizomorph/core/evidence-functions.jl
@@ -606,6 +606,113 @@ function compute_edge_coverage(edge)
 end
 
 # ============================================================================
+# Soft-EM edge weighting (SCAFFOLD, td-e70t)
+# ============================================================================
+#
+# Design note (graph-as-HMM correction redesign). Today the M-step is a HARD
+# assignment: `compute_edge_weight` returns `count_total_observations(edge)` — a
+# raw integer coverage count — and each EM iteration rebuilds the graph from the
+# corrected *sequences*. The graph keeps no path-probability memory, so cleaning
+# only happens because corrected reads stop emitting error k-mers, not because
+# low-probability edges decay on their own.
+#
+# The soft-EM thesis replaces the hard count with probability-weighted evidence:
+# after Viterbi returns a path + likelihood, the path's RESPONSIBILITY (posterior
+# probability, normalized against competing paths) is accumulated onto each edge
+# it traverses. Summing responsibilities over all reads gives a soft, real-valued
+# edge weight. Error edges — traversed only by low-probability paths — accumulate
+# little weight and fall below the emergent-cleaning gate
+# (`generate_alternative_qualmer_paths`' `weight > 0.01` filter), so they decay
+# across iterations WITHOUT explicit tip-clipping. Cleaning becomes an emergent
+# property of the EM rather than a bolted-on heuristic.
+#
+# This block is the ACCUMULATION HOOK (the primitive + math). The remaining work
+# to reach emergent coalescence is to make the M-step CONSUME these soft weights
+# instead of rebuilding from hard sequences — that lives in the qualmer graph
+# rebuild (`build_qualmer_graph`) / `_get_valid_transitions` weighting, which is
+# outside the correction-core file boundary and is tracked as the follow-on for
+# td-e70t. The full-pipeline acceptance (1 kb toy coalesces to ~1 contig; error
+# edge weight decreases across iterations) is encoded as a skipped test until the
+# M-step consumption is wired.
+
+"""
+    SoftEdgeWeightAccumulator
+
+Probability-weighted (soft) edge-evidence accumulator for soft-EM correction
+(td-e70t scaffold). Maps an edge identity (e.g. an ordered `(src_label,
+dst_label)` tuple) to the sum of the responsibilities of the decoded paths that
+traversed it. Unlike `count_total_observations` (a hard integer count), the
+accumulated value is a real-valued soft weight in which a low-probability error
+edge contributes proportionally little.
+"""
+struct SoftEdgeWeightAccumulator
+    weights::Dict{Any, Float64}
+end
+
+SoftEdgeWeightAccumulator() = SoftEdgeWeightAccumulator(Dict{Any, Float64}())
+
+"""
+    accumulate_path_probability!(acc, path_edges, probability)
+
+Accumulate a single decoded path's `probability` (its responsibility / posterior
+weight, in `[0, 1]`) onto every edge in `path_edges` (the soft E->M update). Edges
+shared by many high-probability paths accrue large weight; edges visited only by
+rare, low-probability (error) paths accrue little, so they decay relative to the
+true consensus edges across EM iterations. Returns `acc`.
+"""
+function accumulate_path_probability!(
+        acc::SoftEdgeWeightAccumulator,
+        path_edges,
+        probability::Real
+)
+    p = Float64(probability)
+    for edge_id in path_edges
+        acc.weights[edge_id] = get(acc.weights, edge_id, 0.0) + p
+    end
+    return acc
+end
+
+"""
+    soft_edge_weight(acc, edge_id; prior=0.0)
+
+The soft (probability-weighted) weight for `edge_id`: the accumulated path
+responsibility, or `prior` when no soft evidence exists yet. This is the
+probability-weighted replacement for `compute_edge_weight`'s raw coverage count;
+the M-step consumes it so that emergent cleaning (low-weight error edges falling
+below the `generate_alternative_qualmer_paths` gate) replaces heuristic
+tip-clipping.
+"""
+function soft_edge_weight(
+        acc::SoftEdgeWeightAccumulator,
+        edge_id;
+        prior::Real = 0.0
+)::Float64
+    return get(acc.weights, edge_id, Float64(prior))
+end
+
+"""
+    path_responsibility(path_logp, competing_logps)
+
+Convert a decoded path's log-likelihood into a responsibility (posterior weight)
+by normalizing against the log-likelihoods of the competing paths for the same
+read, via a numerically-stable softmax:
+`exp(path_logp - logsumexp(competing_logps))`. When a read yields a single
+decoded path this is `1.0`; when several paths compete the mass splits by
+relative likelihood — the soft assignment that distinguishes soft-EM from the
+current hard argmax rebuild.
+"""
+function path_responsibility(
+        path_logp::Real,
+        competing_logps::AbstractVector{<:Real}
+)::Float64
+    isempty(competing_logps) && return 1.0
+    m = maximum(competing_logps)
+    isfinite(m) || return 0.0
+    denom = sum(exp(Float64(lp) - m) for lp in competing_logps)
+    return exp(Float64(path_logp) - m) / denom
+end
+
+# ============================================================================
 # Lightweight Type Overloads
 #
 # These methods enable lightweight vertex/edge types to satisfy the same

--- a/src/rhizomorph/core/evidence-functions.jl
+++ b/src/rhizomorph/core/evidence-functions.jl
@@ -700,6 +700,13 @@ read, via a numerically-stable softmax:
 decoded path this is `1.0`; when several paths compete the mass splits by
 relative likelihood — the soft assignment that distinguishes soft-EM from the
 current hard argmax rebuild.
+
+# Precondition
+`path_logp` MUST itself be one of `competing_logps` (the softmax normalizer is the
+full competing set INCLUDING the decoded path). If `path_logp` is omitted from the
+denominator the numerator can exceed the denominator and the "responsibility"
+returns `> 1.0`, which is not a posterior weight. The assertion below enforces
+this rather than silently returning an out-of-range value.
 """
 function path_responsibility(
         path_logp::Real,
@@ -708,6 +715,11 @@ function path_responsibility(
     isempty(competing_logps) && return 1.0
     m = maximum(competing_logps)
     isfinite(m) || return 0.0
+    # Precondition: the decoded path is part of the competing set it is normalized
+    # against (see docstring). Guard with a tolerance for float round-trips.
+    @assert any(lp -> isapprox(Float64(lp), Float64(path_logp); atol = 1e-9), competing_logps) (
+        "path_responsibility: path_logp=$(path_logp) must be included in competing_logps " *
+        "(the softmax denominator); otherwise the responsibility can exceed 1.0.")
     denom = sum(exp(Float64(lp) - m) for lp in competing_logps)
     return exp(Float64(path_logp) - m) / denom
 end

--- a/src/viterbi-next.jl
+++ b/src/viterbi-next.jl
@@ -200,6 +200,55 @@ const _VITERBI_VARIABLE_LENGTH_EDGE_DATA = Union{
 }
 
 """
+An observation unit that carries the READ's own per-base Phred quality window
+alongside the observed k-mer.
+
+This is the central seam that restores the graph-as-HMM emission model
+(`docs/design/2026-07-06-graph-as-hmm-correction-redesign.md`). Bare k-mer
+observations force the emission to fall back to the graph vertex's
+population-average quality (or a uniform `error_rate`), so `P(observed | hidden)`
+loses the *observed* — it measures the graph's confidence in a k-mer rather than
+the read's confidence in its base. Wrapping each k-mer with the read's per-base
+Phred (`quality_scores[idx-k+1:idx]` for the k-mer ending at read index `idx`)
+makes `_viterbi_direct_quality_scores` return the read's real quality, so a
+low-quality read base yields a higher tolerance for correcting toward the graph,
+and a high-quality base resists it.
+
+`quality_scores` stores RAW Phred values (as returned by `FASTX.quality_scores`),
+not ASCII-encoded scores, so the emission consumes them directly without the
+ambiguous ASCII-vs-Phred decode heuristic.
+"""
+struct QualityObservation{KmerT}
+    kmer::KmerT
+    quality_scores::Vector{UInt8}
+end
+
+# The observed-unit accessors used by the emission chain. Bare-k-mer behavior is
+# preserved by delegating to the wrapped k-mer, so wrapping only ADDS the read's
+# per-base quality without changing string/alphabet resolution.
+_viterbi_unit_string(unit::QualityObservation)::String = _viterbi_unit_string(unit.kmer)
+
+function _infer_viterbi_alphabet(unit::QualityObservation)::Union{Nothing, Symbol}
+    return _infer_viterbi_alphabet(unit.kmer)
+end
+
+# QualityObservation stores RAW Phred; return it verbatim (no ASCII decode), which
+# is both correct and unambiguous for high-quality reads (Phred >= 33 would
+# otherwise be misread as ASCII-offset by the generic `Any` heuristic).
+function _viterbi_direct_quality_scores(
+        unit::QualityObservation
+)::Union{Nothing, Vector{Float64}}
+    return isempty(unit.quality_scores) ? nothing : Float64.(unit.quality_scores)
+end
+
+# For graph-label comparisons (start-candidate matching, target resolution) the
+# emission-carrying wrapper must be transparent: unwrap to the underlying k-mer so
+# the decode stays as targeted/efficient as it was for bare k-mers. Emission
+# scoring still receives the full `QualityObservation`.
+_viterbi_label_unit(unit) = unit
+_viterbi_label_unit(unit::QualityObservation) = unit.kmer
+
+"""
 $(DocStringExtensions.TYPEDSIGNATURES)
 
 Correct observations against a graph with a swappable emission model.
@@ -897,7 +946,8 @@ function _viterbi_correct_observation(
     label_type = eltype(labels)
     start_observed = first(observation)
     target_vertex = _emission_target_vertex(graph, observation, config, alphabet, strand_mode)
-    start_candidates = _viterbi_start_candidates(labels, start_observed, alphabet, strand_mode)
+    start_candidates = _viterbi_start_candidates(
+        labels, _viterbi_label_unit(start_observed), alphabet, strand_mode)
 
     diagnostics = Dict{Symbol, Any}(
         :algorithm => :viterbi_emission_correct_observation,
@@ -1085,6 +1135,15 @@ function _emission_target_vertex(
     if config.target_vertex !== nothing
         return config.target_vertex
     end
+    # NOTE: deliberately do NOT unwrap a QualityObservation here. Pinning the
+    # decode's endpoint to the read's observed last k-mer would forbid correcting
+    # it — if that k-mer is an in-graph error (present from other reads' errors),
+    # the ML path would be forced onto the error instead of the higher-likelihood
+    # true vertex. Leaving the endpoint free (target === nothing for wrapped
+    # observations) lets the ML path + per-base emission choose it, which is the
+    # whole point of the correction core. The start (below) is still anchored for
+    # efficiency, since a read's first k-mer is a reasonable, usually-correct
+    # threading anchor and falls back to all labels when absent from the graph.
     candidate = last(observation)
     labels = collect(MetaGraphsNext.labels(graph))
     if candidate in labels

--- a/src/viterbi-next.jl
+++ b/src/viterbi-next.jl
@@ -214,13 +214,38 @@ makes `_viterbi_direct_quality_scores` return the read's real quality, so a
 low-quality read base yields a higher tolerance for correcting toward the graph,
 and a high-quality base resists it.
 
-`quality_scores` stores RAW Phred values (as returned by `FASTX.quality_scores`),
-not ASCII-encoded scores, so the emission consumes them directly without the
-ambiguous ASCII-vs-Phred decode heuristic.
+!!! warning "RAW Phred, not ASCII Phred+33"
+    `quality_scores` stores RAW Phred values (integer quality, as returned by
+    `FASTX.quality_scores` — e.g. `0x28` == Q40), NOT ASCII-encoded Phred+33
+    bytes (where Q40 is the byte `'I'` == `0x49` == 73). This type deliberately
+    bypasses the generic ASCII-vs-Phred decode heuristic used elsewhere and
+    consumes the bytes verbatim (see `_viterbi_direct_quality_scores`). A caller
+    that passes ASCII Phred+33 bytes here would inflate every quality by ~33
+    (Q40 read as Q73), collapsing the emission model. Always construct with the
+    integer quality window (`FASTX.quality_scores(read)`), never the ASCII
+    quality string.
+
+The inner constructor enforces the one hard invariant — a non-empty quality
+window. An empty window makes `_viterbi_direct_quality_scores` return `nothing`,
+which silently drops the read's own quality and falls the emission back to the
+graph's population-average quality; guarding here surfaces that as an error at
+the construction site instead of a silent degradation deep in the decoder. (No
+ASCII-detection heuristic is added on purpose: raw-Phred and ASCII-Phred ranges
+overlap, so any such heuristic would misfire — the doc invariant above plus this
+non-empty guard is the deliberate, non-fragile contract.)
 """
 struct QualityObservation{KmerT}
     kmer::KmerT
     quality_scores::Vector{UInt8}
+
+    function QualityObservation(kmer::KmerT,
+            quality_scores::AbstractVector{UInt8}) where {KmerT}
+        isempty(quality_scores) && throw(ArgumentError(
+            "QualityObservation requires a non-empty RAW-Phred quality window; an " *
+            "empty window would silently fall the emission back to the graph's " *
+            "population-average quality (see the RAW-Phred invariant in the docstring)."))
+        return new{KmerT}(kmer, quality_scores)
+    end
 end
 
 # The observed-unit accessors used by the emission chain. Bare-k-mer behavior is

--- a/test/4_assembly/iterative_assembly_tests.jl
+++ b/test/4_assembly/iterative_assembly_tests.jl
@@ -618,4 +618,51 @@ Test.@testset "Iterative Assembly Tests" begin
             end
         end
     end
+
+    Test.@testset "N-read skip + swallowed-decode diagnostics (td-63qy family)" begin
+        # A read carrying an ambiguous base (N) cannot be 2-bit k-merized;
+        # FwDNAMers throws BioSequences.EncodeError (NOT ArgumentError). The
+        # corrector must SKIP such a read (pass it through uncorrected) and COUNT
+        # it, never crash the (threaded) batch on one N-containing read.
+        clean_seqs = [
+            "ATCGATCGATCGATCGATCG",
+            "TCGATCGATCGATCGATCGA",
+            "CGATCGATCGATCGATCGAT"
+        ]
+        clean_records = [FASTX.FASTQ.Record("clean$i", seq, repeat("I", length(seq)))
+                         for (i, seq) in enumerate(clean_seqs)]
+        k = 7
+        graph = Mycelia.Rhizomorph.build_qualmer_graph(
+            clean_records, k; dataset_id = "nread", mode = :canonical)
+
+        n_read = FASTX.FASTQ.Record("with_n", "ATCGATCGATNGATCGATCG", repeat("I", 20))
+
+        # Direct decoder call: returns nothing (skip) + counts, never throws.
+        diag = Mycelia.CorrectorDiagnostics()
+        result = Mycelia.try_viterbi_path_improvement(
+            n_read, graph, k; graph_mode = :canonical, diagnostics = diag)
+        Test.@test result === nothing
+        Test.@test diag.unkmerizable_reads[] == 1
+        Test.@test diag.structural_errors[] == 0
+
+        # Single-read path: improve_read_likelihood must not crash on the N read.
+        diag_single = Mycelia.CorrectorDiagnostics()
+        improved_read,
+        was_improved = Mycelia.improve_read_likelihood(
+            n_read, graph, k; graph_mode = :canonical, diagnostics = diag_single)
+        Test.@test was_improved == false
+        Test.@test FASTX.sequence(String, improved_read) == "ATCGATCGATNGATCGATCG"
+        Test.@test diag_single.unkmerizable_reads[] == 1
+
+        # End-to-end batch mixing an N read with clean reads completes (no crash);
+        # the N read passes through uncorrected and is tallied.
+        mixed = vcat(clean_records, [n_read])
+        diag_batch = Mycelia.CorrectorDiagnostics()
+        updated,
+        _ = Mycelia.improve_read_set_likelihood(
+            mixed, graph, k; graph_mode = :canonical, diagnostics = diag_batch)
+        Test.@test length(updated) == length(mixed)
+        Test.@test FASTX.sequence(String, updated[end]) == "ATCGATCGATNGATCGATCG"
+        Test.@test diag_batch.unkmerizable_reads[] == 1
+    end
 end

--- a/test/4_assembly/quality_observation_emission_test.jl
+++ b/test/4_assembly/quality_observation_emission_test.jl
@@ -1,0 +1,118 @@
+# CHECKPOINT test for the graph-as-HMM correction core (td-jqdf / td-tps5):
+# the Viterbi emission must respond to the READ's per-base Phred quality, carried
+# by `Mycelia.QualityObservation`, not just the graph's population-average quality.
+#
+# Two levels of evidence:
+#   1. Emission logp: the SAME observed k-mer against the SAME graph node yields a
+#      DIFFERENT emission log-probability when the read base at the mismatch is
+#      low-quality vs high-quality (low quality => smaller mismatch penalty).
+#   2. Correction decision: the SAME observed error k-mer is corrected toward the
+#      well-supported graph vertex when the read base is low-quality, but kept when
+#      the read base is high-quality — a decision driven purely by per-read quality.
+#
+# Run directly:
+#   julia --project=. -e 'include("test/4_assembly/quality_observation_emission_test.jl")'
+
+import BioSequences
+import FASTX
+import Kmers
+import Mycelia
+import Test
+
+function _quality_record(
+        identifier::AbstractString,
+        sequence::AbstractString,
+        phred::AbstractVector{<:Integer}
+)::FASTX.FASTQ.Record
+    quality = String([Char(score + 33) for score in phred])
+    return FASTX.FASTQ.Record(identifier, sequence, quality)
+end
+
+function _decoded_strings(result::Mycelia.ViterbiCorrectionResult)::Vector{String}
+    return [string(label) for label in only(result.corrected_observations)]
+end
+
+Test.@testset "QualityObservation per-read emission (td-jqdf / td-tps5)" begin
+    Test.@testset "wrapper accessors delegate to the k-mer and expose raw Phred" begin
+        qo = Mycelia.QualityObservation(Kmers.DNAKmer{3}("TGA"), UInt8[40, 30, 2])
+        # string + alphabet resolution see through the wrapper to the k-mer
+        Test.@test Mycelia._viterbi_unit_string(qo) == "TGA"
+        Test.@test Mycelia._infer_viterbi_alphabet(qo) == :DNA
+        # raw Phred is returned verbatim (no ASCII decode heuristic)
+        Test.@test Mycelia._viterbi_direct_quality_scores(qo) == Float64[40.0, 30.0, 2.0]
+        # label-comparison unwraps to the k-mer; bare units pass through unchanged
+        Test.@test Mycelia._viterbi_label_unit(qo) == Kmers.DNAKmer{3}("TGA")
+        Test.@test Mycelia._viterbi_label_unit(Kmers.DNAKmer{3}("TGA")) ==
+                   Kmers.DNAKmer{3}("TGA")
+    end
+
+    Test.@testset "same k-mer + node: low-Q base gives a higher emission logp than high-Q" begin
+        observed = Kmers.DNAKmer{3}("TGA")
+        node = Kmers.DNAKmer{3}("TGC")  # mismatch only at the last base
+
+        qo_low = Mycelia.QualityObservation(observed, UInt8[40, 40, 2])
+        qo_high = Mycelia.QualityObservation(observed, UInt8[40, 40, 40])
+
+        logp_low = Mycelia.default_viterbi_emission_logp(
+            qo_low,
+            node,
+            :DNA;
+            quality = Mycelia._viterbi_direct_quality_scores(qo_low),
+            error_rate = 0.01
+        )
+        logp_high = Mycelia.default_viterbi_emission_logp(
+            qo_high,
+            node,
+            :DNA;
+            quality = Mycelia._viterbi_direct_quality_scores(qo_high),
+            error_rate = 0.01
+        )
+
+        # A low-quality read base at the mismatch means "I don't trust this base",
+        # so observing TGA when the truth is TGC is cheap; a high-quality base makes
+        # the same mismatch expensive. The emission therefore MUST respond to the
+        # read's per-base quality.
+        Test.@test logp_low > logp_high
+    end
+
+    Test.@testset "correction decision flips on per-read quality alone" begin
+        # A graph with a well-supported truth vertex (TGC) and a weakly-supported
+        # error branch (TGA) reachable from the same predecessor (ATG).
+        records = FASTX.FASTQ.Record[]
+        for index in 1:30
+            push!(records, _quality_record("truth_$index", "ATGC", [40, 40, 40, 40]))
+        end
+        for index in 1:3
+            push!(records, _quality_record("variant_$index", "ATGA", [40, 40, 40, 40]))
+        end
+        graph = Mycelia.Rhizomorph.build_qualmer_graph(
+            records,
+            3;
+            dataset_id = "quality_observation_decision",
+            mode = :singlestrand
+        )
+
+        anchor = Mycelia.QualityObservation(Kmers.DNAKmer{3}("ATG"), UInt8[40, 40, 40])
+
+        # SAME observed error k-mer TGA; only the read's per-base quality differs.
+        low_quality = [
+            anchor,
+            Mycelia.QualityObservation(Kmers.DNAKmer{3}("TGA"), UInt8[2, 2, 2])
+        ]
+        high_quality = [
+            anchor,
+            Mycelia.QualityObservation(Kmers.DNAKmer{3}("TGA"), UInt8[40, 40, 40])
+        ]
+
+        low_result = Mycelia.correct_observations(graph, [low_quality])
+        high_result = Mycelia.correct_observations(graph, [high_quality])
+
+        # Low-quality error base => trust the well-supported graph vertex => correct
+        # TGA -> TGC. High-quality base => keep the read's TGA. The decision is
+        # driven entirely by per-read quality on an identical observed k-mer.
+        Test.@test _decoded_strings(low_result) == ["ATG", "TGC"]
+        Test.@test _decoded_strings(high_result) == ["ATG", "TGA"]
+        Test.@test _decoded_strings(low_result) != _decoded_strings(high_result)
+        Test.@test only(low_result.paths).diagnostics[:emission_scoring] == :quality_aware
+    end
+end

--- a/test/4_assembly/rhizomorph_assembly_helpers_test.jl
+++ b/test/4_assembly/rhizomorph_assembly_helpers_test.jl
@@ -20,8 +20,12 @@ Test.@testset "Rhizomorph Assembly Helpers" begin
     Test.@testset "Observation preparation" begin
         fastq_reads = [FASTX.FASTQ.Record("read1", "ATCG", "IIII")]
         observations = Mycelia.Rhizomorph._prepare_observations(fastq_reads)
-        Test.@test observations[1] isa FASTX.FASTA.Record
-        Test.@test FASTX.FASTA.sequence(observations[1]) == "ATCG"
+        # In-memory FASTQ is PRESERVED (not stripped to FASTA): FASTQ input routes to
+        # the quality-aware paths, which consume per-base quality (td-tps5). Stripping
+        # here previously forced a placeholder-Q40 re-injection downstream.
+        Test.@test observations[1] isa FASTX.FASTQ.Record
+        Test.@test FASTX.sequence(String, observations[1]) == "ATCG"
+        Test.@test collect(FASTX.quality_scores(observations[1])) == fill(UInt8(40), 4)  # 'I' == Q40, quality retained
 
         mktempdir() do dir
             fasta_path = joinpath(dir, "reads.fasta")

--- a/test/4_assembly/soft_em_edge_weight_scaffold_test.jl
+++ b/test/4_assembly/soft_em_edge_weight_scaffold_test.jl
@@ -1,0 +1,125 @@
+# SCAFFOLD test for soft-EM edge weighting (td-e70t).
+#
+# The graph-as-HMM correction redesign replaces the hard-count M-step
+# (`compute_edge_weight` == raw coverage) with probability-weighted evidence:
+# after Viterbi decodes a read, each candidate path's RESPONSIBILITY (posterior
+# over the read's candidate set) is accumulated onto its edges. Error edges,
+# traversed only by rare low-probability paths, accrue little soft weight and
+# decay below the emergent-cleaning gate WITHOUT tip-clipping.
+#
+# What lands here: the accumulation PRIMITIVE + the correction-side hook, proven
+# at the unit level (passing tests below). What does NOT land yet: making the
+# qualmer graph rebuild / transition weighting CONSUME these soft weights so the
+# full pipeline coalesces a 1 kb toy to ~1 contig across EM iterations — that
+# M-step consumption is outside the correction-core file boundary and is the
+# td-e70t follow-on. The full-pipeline acceptance is therefore a skipped test.
+#
+# Run directly:
+#   julia --project=. -e 'include("test/4_assembly/soft_em_edge_weight_scaffold_test.jl")'
+
+import BioSequences
+import FASTX
+import Kmers
+import Mycelia
+import Test
+
+Test.@testset "Soft-EM edge weighting scaffold (td-e70t)" begin
+    Test.@testset "path_responsibility softmax normalization" begin
+        # A single candidate path owns all the responsibility.
+        Test.@test Mycelia.Rhizomorph.path_responsibility(-3.2, Float64[-3.2]) ≈ 1.0
+        # Competing paths split responsibility by relative likelihood; the sum is 1.
+        logps = Float64[-1.0, -2.0, -5.0]
+        rs = [Mycelia.Rhizomorph.path_responsibility(lp, logps) for lp in logps]
+        Test.@test sum(rs) ≈ 1.0
+        Test.@test rs[1] > rs[2] > rs[3]          # higher logp => more responsibility
+        # A far-lower-likelihood (error) path gets vanishing responsibility.
+        Test.@test Mycelia.Rhizomorph.path_responsibility(-20.0, Float64[-1.0, -20.0]) < 1e-6
+    end
+
+    Test.@testset "accumulator sums path responsibilities onto edges" begin
+        acc = Mycelia.Rhizomorph.SoftEdgeWeightAccumulator()
+        true_edge = ("ATG", "TGC")
+        error_edge = ("ATG", "TGA")
+        Mycelia.Rhizomorph.accumulate_path_probability!(acc, [true_edge], 0.9)
+        Mycelia.Rhizomorph.accumulate_path_probability!(acc, [error_edge], 0.1)
+        Mycelia.Rhizomorph.accumulate_path_probability!(acc, [true_edge], 0.95)
+
+        Test.@test Mycelia.Rhizomorph.soft_edge_weight(acc, true_edge) ≈ 1.85
+        Test.@test Mycelia.Rhizomorph.soft_edge_weight(acc, error_edge) ≈ 0.1
+        # Unseen edge falls back to the prior.
+        Test.@test Mycelia.Rhizomorph.soft_edge_weight(acc, ("X", "Y"); prior = 0.0) == 0.0
+        # The error edge is already far below the emergent-cleaning gate (0.01 per
+        # read of responsibility); the true edge dominates.
+        Test.@test Mycelia.Rhizomorph.soft_edge_weight(acc, error_edge) <
+                   Mycelia.Rhizomorph.soft_edge_weight(acc, true_edge)
+    end
+
+    Test.@testset "error-edge soft weight decreases across (simulated) EM iterations" begin
+        # Simulate the E->M loop at the primitive level: each iteration a read
+        # offers a TRUE path and an ERROR path. As correction sharpens the graph
+        # across iterations, the error path's relative likelihood falls (the gap
+        # widens), so its per-iteration responsibility -- the soft weight it
+        # deposits -- monotonically decreases. This is the decay mechanism that,
+        # once the M-step consumes it, drives emergent cleaning.
+        true_edge = ("ATG", "TGC")
+        error_edge = ("ATG", "TGA")
+        true_logp = -1.0
+        error_contributions = Float64[]
+        for iteration in 1:5
+            error_logp = true_logp - Float64(iteration)   # gap widens each iteration
+            candidate_logps = Float64[true_logp, error_logp]
+            acc = Mycelia.Rhizomorph.SoftEdgeWeightAccumulator()
+            Mycelia.Rhizomorph.accumulate_path_probability!(
+                acc, [true_edge],
+                Mycelia.Rhizomorph.path_responsibility(true_logp, candidate_logps))
+            Mycelia.Rhizomorph.accumulate_path_probability!(
+                acc, [error_edge],
+                Mycelia.Rhizomorph.path_responsibility(error_logp, candidate_logps))
+            push!(error_contributions, Mycelia.Rhizomorph.soft_edge_weight(acc, error_edge))
+        end
+        # Strictly monotone decrease of the error edge's accumulated soft weight.
+        Test.@test all(diff(error_contributions) .< 0)
+        Test.@test error_contributions[end] < error_contributions[1]
+    end
+
+    Test.@testset "hook accumulates real decoded paths (responsibility 1 for single path)" begin
+        records = FASTX.FASTQ.Record[]
+        for index in 1:20
+            push!(records, FASTX.FASTQ.Record(
+                "truth_$index", "ATGCA", String(fill('I', 5))))
+        end
+        graph = Mycelia.Rhizomorph.build_qualmer_graph(
+            records, 3; dataset_id = "soft_em_scaffold", mode = :singlestrand)
+
+        observation = [
+            Mycelia.QualityObservation(Kmers.DNAKmer{3}("ATG"), UInt8[40, 40, 40]),
+            Mycelia.QualityObservation(Kmers.DNAKmer{3}("TGC"), UInt8[40, 40, 40]),
+            Mycelia.QualityObservation(Kmers.DNAKmer{3}("GCA"), UInt8[40, 40, 40])
+        ]
+        result = Mycelia.correct_observations(graph, [observation])
+
+        edges = Mycelia._decoded_path_edges(only(result.paths))
+        Test.@test !isempty(edges)
+
+        acc = Mycelia.Rhizomorph.SoftEdgeWeightAccumulator()
+        Mycelia.accumulate_soft_em_edge_weights!(acc, result.paths)
+        # A single argmax path per read => responsibility 1.0 on every traversed
+        # edge (soft weight == hard count in the degenerate single-candidate case).
+        for edge in edges
+            Test.@test Mycelia.Rhizomorph.soft_edge_weight(acc, edge) ≈ 1.0
+        end
+    end
+
+    Test.@testset "FULL-PIPELINE ACCEPTANCE (skipped until M-step consumes soft weights)" begin
+        # td-e70t acceptance: running mycelia_iterative_assemble on a clean ~1 kb
+        # toy should coalesce the qualmer graph toward ~1 contig across EM
+        # iterations, and the summed soft weight of error edges should DECREASE
+        # across iterations, WITHOUT any explicit tip/bubble removal. This requires
+        # the qualmer graph rebuild / transition weighting to consume the soft
+        # weights produced by `accumulate_soft_em_edge_weights!` in place of raw
+        # coverage counts -- the follow-on that lives outside the correction-core
+        # file boundary. Skipped (not @test false) so it documents the target
+        # without failing CI on unlanded work.
+        Test.@test_skip false
+    end
+end

--- a/test/4_assembly/viterbi_beam_pruning_test.jl
+++ b/test/4_assembly/viterbi_beam_pruning_test.jl
@@ -94,4 +94,39 @@ Test.@testset "Viterbi corrector beam pruning (td-63qy)" begin
         Test.@test_throws ArgumentError Mycelia.ViterbiCorrectionConfig(beam_width=0)
         Test.@test_throws ArgumentError Mycelia.ViterbiCorrectionConfig(beam_width=-4)
     end
+
+    # Size-aware auto-beam (td-63qy): the SHIPPING corrector default must stay
+    # exact on small reads (preserving the ML guarantee) yet bound the frontier on
+    # large reads so it cannot OOM-crash (~21B allocations on a 48 kb phage).
+    Test.@testset "size-aware auto-beam default (_auto_beam_width)" begin
+        # Small read (observation count at/below the threshold): stays EXACT.
+        Test.@test Mycelia._auto_beam_width(1) == typemax(Int)
+        Test.@test Mycelia._auto_beam_width(300) == typemax(Int)
+        Test.@test Mycelia._auto_beam_width(Mycelia._AUTO_BEAM_EXACT_THRESHOLD) ==
+                   typemax(Int)
+        # Large read (above the threshold): BOUNDED to the proven-tractable width.
+        Test.@test Mycelia._auto_beam_width(Mycelia._AUTO_BEAM_EXACT_THRESHOLD + 1) ==
+                   Mycelia._AUTO_BEAM_BOUNDED_WIDTH
+        Test.@test Mycelia._auto_beam_width(48_000) == Mycelia._AUTO_BEAM_BOUNDED_WIDTH
+        # The bounded width is a finite, positive, previously-proven value (256).
+        Test.@test Mycelia._AUTO_BEAM_BOUNDED_WIDTH == 256
+        Test.@test 0 < Mycelia._AUTO_BEAM_BOUNDED_WIDTH < typemax(Int)
+    end
+
+    # An explicit beam_width override is honored verbatim by the per-read decoder
+    # entry point: passing typemax(Int) forces EXACT decoding regardless of the
+    # auto-default, and the correction still completes on a small read.
+    Test.@testset "explicit beam_width override forces exact on the decoder entry" begin
+        records = [FASTX.FASTQ.Record("r", "ATGCGT", repeat("I", 6))]
+        graph = Mycelia.Rhizomorph.build_qualmer_graph(
+            records, 3; dataset_id="beam_override", mode=:singlestrand)
+        read = FASTX.FASTQ.Record("q", "ATGCGT", repeat("I", 6))
+        # Explicit exact override.
+        forced = Mycelia.try_viterbi_path_improvement(
+            read, graph, 3; graph_mode=:singlestrand, beam_width=typemax(Int))
+        Test.@test forced isa Union{Tuple{FASTX.FASTQ.Record, Float64}, Nothing}
+        # Auto default (nothing) also completes on this small read.
+        auto = Mycelia.try_viterbi_path_improvement(read, graph, 3; graph_mode=:singlestrand)
+        Test.@test auto isa Union{Tuple{FASTX.FASTQ.Record, Float64}, Nothing}
+    end
 end


### PR DESCRIPTION
Implements the CORE SPINE of the graph-as-HMM correction redesign (ADR
`docs/design/2026-07-06-graph-as-hmm-correction-redesign.md`; beads
td-jqdf / td-tps5 / td-ak6w / td-e70t). Each stage is a separate commit.

## Summary

- **Stage 1 — Emission = per-read per-base quality (td-jqdf) + quality flow (td-tps5).**
  The emission chain already consumed a `.quality_scores` property, but
  `try_viterbi_path_improvement` collected the read's Phred and then discarded
  it, passing bare k-mers — so emission fell back to the graph vertex's
  population-average quality (`P(observed | hidden)` lost the *observed*). Adds
  `QualityObservation` (wraps each k-mer with the read's per-base Phred window,
  positions `i:(i+k-1)`) + dispatch so string/alphabet resolution and
  direct-quality extraction see through the wrapper, returning RAW Phred (no
  ambiguous ASCII decode). Start-candidate matching unwraps to the k-mer (keeps
  the decode targeted); the decode ENDPOINT is left free so an in-graph error
  k-mer can be corrected rather than pinned. Documents the naive/qualmer
  graph-builder quality gap in `_prepare_observations` (the corrector itself
  preserves FASTQ end-to-end via `_write_reads_to_fastq`, which already writes
  FASTQ verbatim and warns — never silently Q40 — on FASTA).

- **Stage 2 — Trustworthy Viterbi (td-ak6w).** Removes the 0.01 abandon-threshold
  and the heuristic fallback cascade (statistical resampling -> local edits) from
  `find_optimal_sequence_path`: it now trusts the ML path or reports no
  improvement (never a strictly-worse read). Flips the hardcoded `beam_width=256`
  to the exact default `typemax(Int)` and exposes `beam_width` as a documented
  opt-in scaling knob threaded through the correction call chain. The removed
  helpers remain defined as opt-in baselines.

- **Stage 3 — Soft-EM (td-e70t), SCAFFOLD.** Lands the probability-weighted
  accumulation primitive (`SoftEdgeWeightAccumulator`,
  `accumulate_path_probability!`, `soft_edge_weight`, `path_responsibility`) and
  the correction-side M-step seam (`accumulate_soft_em_edge_weights!`). The
  primitive's decay behavior is proven at the unit level. The full emergent
  coalescence (M-step consuming soft weights so a 1 kb toy coalesces to ~1 contig
  without tip-clipping) requires the qualmer graph rebuild — outside the
  correction-core file boundary — and is encoded as a skipped acceptance test.

## Test Plan

- [x] `test/4_assembly/quality_observation_emission_test.jl` — new; emission
  responds to per-read quality (10 pass).
- [x] `test/4_assembly/soft_em_edge_weight_scaffold_test.jl` — new; soft-weight
  primitive + decay (13 pass, 1 skipped acceptance).
- [x] `rhizomorph_iterative_corrector_wiring_test.jl` (17), `iterative_assemble_completion_test.jl` (8),
  `iterative_assembly_tests.jl` (187), `iterative_convergence_stop_test.jl` (19),
  `viterbi_beam_pruning_test.jl` (8), `iterative_assembly_helpers_test.jl` (12) — green.
- [x] `viterbi_quality_emission_test.jl` (8), `viterbi_maximum_likelihood_corrector_test.jl` (3),
  `viterbi_cross_product_correction_test.jl` (171), `viterbi_strand_correction_test.jl` (31),
  `viterbi_fixed_length_graph_correction_test.jl` (11), `sequence_graphs_next.jl` (51) — no regressions.

## Notes / caveats

- **Soft-EM is a scaffold (status partial for that track).** The accumulation
  hook + primitives land and are unit-tested; wiring the M-step consumption to
  achieve emergent coalescence is a follow-on outside the owned file boundary.
- The ADR file (`docs/design/2026-07-06-graph-as-hmm-correction-redesign.md`)
  lives on a parallel branch (`cp/graph-cleaning-and-quality`), not on master, so
  the Stage-3 design note is embedded in the scaffold code/tests rather than
  appended to the ADR to avoid a cross-branch conflict.
- Do NOT merge — awaiting review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added quality-aware Viterbi read correction, using per-base quality windows to influence emission scoring and correction outcomes.
  * Introduced soft-EM support for probability-weighted evidence accumulation across candidate decoded paths.
  * Added diagnostics reporting for swallowed decode issues and unk-merizable reads, including batch-level metadata.
* **Bug Fixes**
  * Improved handling of ambiguous reads (e.g., containing N), preventing crashes and keeping such reads uncorrected.
  * Tightened path selection to rely on ML Viterbi results only, with size-aware automatic beam sizing and `beam_width` overrides.
* **Tests**
  * Added coverage for N-skip diagnostics, quality-aware emission behavior, soft-EM edge weighting, and auto-beam pruning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->