### PR TITLE
add: activate soft-EM v2 competing-paths corrector (td-e70t)

### DIFF
--- a/src/iterative-assembly.jl
+++ b/src/iterative-assembly.jl
@@ -246,19 +246,21 @@ function mycelia_iterative_assemble(input_fastq::String;
     # "nothing to fix". See CorrectorDiagnostics.
     corrector_diagnostics = CorrectorDiagnostics()
 
-    # -- Soft-EM registry hygiene (td-e70t, v1 record-only) --------------------
-    # Soft-EM v1 is a RECORD-ONLY scaffold: the E-step accumulates per-edge path
-    # responsibilities (for the future v2 competing-paths M-step) but the pipeline
-    # NEVER calls `register_soft_edge_weights!`, so `compute_edge_weight` always
-    # returns raw coverage counts and the identity-keyed soft-weight registry MUST
-    # stay empty for this whole run. Defensively clear it at entry so no prior
-    # crash mid-registration (a direct unit-test primitive call, or a future v2
-    # path) can leak soft weights into this correction, then assert the invariant
-    # (belt-and-suspenders). The registry is reserved for v2.
+    # -- Soft-EM registry hygiene (td-e70t, v2 competing-paths) ----------------
+    # Soft-EM v2 ACTIVATES the M-step: within each k's EM loop, iteration N's
+    # per-edge path responsibilities are REGISTERED onto iteration N+1's graph so
+    # `compute_edge_weight` returns the probability-weighted (soft) evidence — the
+    # feedback loop that lets unsupported (error) edges decay while data-supported
+    # variation is retained. Registration is always paired with `clear!` in a
+    # try/finally INSIDE the loop, so the process-global registry is EMPTY at
+    # corrector entry (and between iterations). Defensively clear it here so no
+    # prior crash mid-registration (a direct unit-test primitive call, an aborted
+    # run) can leak soft weights into this correction, then assert the invariant
+    # (belt-and-suspenders).
     Mycelia.Rhizomorph.clear_soft_edge_weights!()
     @assert isempty(Mycelia.Rhizomorph._SOFT_EDGE_WEIGHT_REGISTRY) (
-        "soft-EM registry must be empty at corrector entry (v1 is record-only; " *
-        "the pipeline never registers soft weights)")
+        "soft-EM registry must be empty at corrector entry (registration is scoped " *
+        "to each EM iteration and always cleared in a try/finally)")
 
     # -- Convergence + k-ladder tuning knobs (td-q70n) -------------------------
     #
@@ -395,6 +397,13 @@ function mycelia_iterative_assemble(input_fastq::String;
         # crash that prevented the pipeline from completing past the first k).
         current_reads = FASTX.FASTQ.Record[]
 
+        # Soft-EM M-step memory (td-e70t v2): the PREVIOUS EM iteration's soft
+        # edge-weight accumulator, registered onto THIS iteration's freshly-built
+        # graph so the decode consumes probability-weighted (decayed) edges. Reset
+        # to `nothing` at each new k — accumulator keys are (src,dst) k-mer-label
+        # tuples, so weights from a different k never match and must not carry over.
+        prev_soft_weights = nothing
+
         # Iterative improvement loop for current k
         while iteration <= max_iterations_per_k
             if verbose
@@ -429,19 +438,17 @@ function mycelia_iterative_assemble(input_fastq::String;
                 break
             end
 
-            # --- Soft-EM E-step accumulation (td-e70t, v1 RECORD-ONLY) --------
-            # v1 is a DORMANT scaffold: a fresh accumulator tallies THIS pass's
-            # decoded-path responsibilities (the E-step), but the pipeline does NOT
-            # consume it — `register_soft_edge_weights!` is deliberately NOT called,
-            # so `compute_edge_weight` always returns raw coverage counts and the
-            # graph is never soft-reweighted. This keeps the accumulation machinery
-            # live and exercised (recording path probabilities for the future v2
-            # competing-paths M-step) while removing v1's uncontrolled perturbation:
-            # a single-path decode makes every responsibility 1.0 and hard-skipped
-            # reads never accumulate, so consuming the accumulator would mix
-            # DECODED-SUBSET coverage with raw counts on unvisited edges — an
-            # uncontrolled reweighting, not principled soft-EM. Only allocated under
-            # soft-EM so :exhaustive threads `nothing`.
+            # --- Soft-EM E-step accumulator (td-e70t, v2 COMPETING-PATHS) -----
+            # A fresh accumulator tallies THIS pass's per-edge responsibilities. In
+            # v2 the E-step enumerates COMPETING candidate paths per decoded read
+            # (k-shortest paths between the read's decoded endpoints) and splits the
+            # responsibility across them by a stable softmax over their path
+            # log-probabilities — so a data-supported branch keeps high mass while
+            # an unsupported (error) branch accrues little. This accumulator is then
+            # REGISTERED onto the NEXT iteration's graph (the M-step below), closing
+            # the loop that makes error edges decay across EM iterations. Only
+            # allocated under soft-EM so :exhaustive threads `nothing` and is
+            # byte-for-byte unchanged.
             current_soft_weights = soft_em ?
                                    Mycelia.Rhizomorph.SoftEdgeWeightAccumulator() : nothing
 
@@ -466,26 +473,46 @@ function mycelia_iterative_assemble(input_fastq::String;
             # OOM-crash (td-63qy); :exhaustive passes typemax(Int) to force exact.
             # `corrector_diagnostics` accumulates swallowed decode failures across
             # every k and iteration and is surfaced in the result metadata.
-            updated_reads,
-            improvements_made,
-            pass_skip_fraction = improve_read_set_likelihood(
-                current_reads, graph, k,
-                verbose = verbose,
-                batch_size = batch_size,
-                enable_parallel = enable_parallel,
-                graph_mode = graph_mode,
-                skip_solid = skip_solid,
-                beam_width = beam_width,
-                soft_weights = current_soft_weights,
-                hard_vertices = hard_vertices,
-                diagnostics = corrector_diagnostics
-            )
+            # --- Soft-EM M-step consumption (td-e70t, v2) --------------------
+            # Register the PREVIOUS EM iteration's soft edge weights onto THIS
+            # freshly-built graph so `compute_edge_weight` (and thus the Viterbi
+            # transition scoring AND the competing-path enumeration in the E-step)
+            # consumes the decayed, probability-weighted edges instead of raw
+            # counts. Paired with `clear!` in a `finally` so the process-global
+            # registry never leaks past this iteration — including on :exhaustive,
+            # where `soft_em` is false, nothing is registered, and the decode is
+            # byte-identical. `updated_reads` / `improvements_made` /
+            # `pass_skip_fraction` are assigned in the `try` (Julia `try` shares the
+            # enclosing scope) and consumed below.
+            updated_reads = current_reads
+            improvements_made = 0
+            pass_skip_fraction = 0.0
+            try
+                if soft_em && prev_soft_weights !== nothing
+                    Mycelia.Rhizomorph.register_soft_edge_weights!(graph, prev_soft_weights)
+                end
+                updated_reads,
+                improvements_made,
+                pass_skip_fraction = improve_read_set_likelihood(
+                    current_reads, graph, k,
+                    verbose = verbose,
+                    batch_size = batch_size,
+                    enable_parallel = enable_parallel,
+                    graph_mode = graph_mode,
+                    skip_solid = skip_solid,
+                    beam_width = beam_width,
+                    soft_weights = current_soft_weights,
+                    hard_vertices = hard_vertices,
+                    diagnostics = corrector_diagnostics
+                )
+            finally
+                Mycelia.Rhizomorph.clear_soft_edge_weights!()
+            end
             push!(skip_fractions, pass_skip_fraction)
-            # Soft-EM v1 is record-only: `current_soft_weights` was populated by the
-            # E-step but is deliberately NOT registered/consumed, so there is nothing
-            # to clear from the registry (it stayed empty) and no cross-iteration
-            # carry-forward — the accumulator is dropped once recorded. The v2
-            # competing-paths M-step will consume it.
+            # Carry this iteration's soft edge memory forward: it becomes the next
+            # EM iteration's M-step input (registered onto the next graph). `nothing`
+            # on :exhaustive (no soft-EM) so that tier stays byte-identical.
+            prev_soft_weights = soft_em ? current_soft_weights : nothing
 
             # Calculate iteration metrics
             iteration_time = time() - iteration_start
@@ -1750,10 +1777,11 @@ function finalize_iterative_assembly(output_dir::String, k_progression::Vector{I
         :hard_window => hard_window,
         :hard_read_gate => hard_window,
         :windowed_decode => false,
-        # Soft-EM v1 is RECORD-ONLY (E-step accumulates, M-step does NOT consume),
-        # so report a scaffold marker rather than a bare `true` that would imply
-        # active soft reweighting (FIX 1/5). `false` on the exhaustive tier.
-        :soft_em => (soft_em ? "scaffold-v1-record-only" : false),
+        # Soft-EM v2 ACTIVE: E-step enumerates competing paths and the M-step
+        # registers the resulting soft edge weights onto the next EM iteration's
+        # graph (`register_soft_edge_weights!`), so error edges decay across
+        # iterations. `false` on the exhaustive tier (soft-EM off there).
+        :soft_em => (soft_em ? "v2-competing-paths" : false),
         :last_skip_fraction => last_skip_fraction,
         :skip_fraction_per_pass => skip_fractions,
         :skip_fraction_min => skip_min,
@@ -1926,13 +1954,22 @@ function try_viterbi_path_improvement(read::FASTX.FASTQ.Record,
             return nothing
         end
 
-        # Soft-EM E-step (td-e70t): accumulate this read's decoded ML path edges
-        # onto the shared accumulator. With a single argmax path per read the
-        # responsibility is 1.0 (soft weight == hard count); the softening emerges
-        # once competing paths per read are wired (v2). Additive + guarded so it
-        # cannot perturb the :exhaustive path (soft_weights === nothing there).
+        # Soft-EM E-step (td-e70t v2): build this read's COMPETING candidate paths
+        # (the observed read path + quality-aware alternative qualmer paths that
+        # substitute high-support k-mers at low-confidence positions) and split the
+        # responsibility across them by a stable softmax over their per-read
+        # sequence log-likelihoods, accumulating each path's edges weighted by its
+        # share. A data-supported branch keeps high mass; an unsupported (error)
+        # branch — whose low-coverage k-mers depress its likelihood — accrues little
+        # and decays across EM iterations (the M-step registers this accumulator
+        # onto the next graph, and rebuilding from the corrected reads drops the
+        # error k-mers entirely). Additive + guarded so it cannot perturb the
+        # :exhaustive path (soft_weights === nothing there); degenerates to the
+        # single observed path at responsibility 1.0 when no distinct alternative
+        # exists.
         if soft_weights !== nothing
-            accumulate_soft_em_edge_weights!(soft_weights, correction.paths)
+            accumulate_competing_paths!(
+                soft_weights, read, graph, k; graph_mode = graph_mode)
         end
 
         corrected_sequence = Mycelia.Rhizomorph.path_to_sequence(corrected_path, graph)
@@ -2158,7 +2195,7 @@ function try_local_path_improvements(
 end
 
 # ============================================================================
-# Soft-EM M-step accumulation hook (SCAFFOLD, td-e70t)
+# Soft-EM M-step accumulation hook (ACTIVE, td-e70t v2 competing-paths)
 # ============================================================================
 #
 # See the design note over `SoftEdgeWeightAccumulator` in
@@ -2168,20 +2205,27 @@ end
 # candidate set) is accumulated onto the edges it traverses. Summed over reads,
 # the accumulator holds soft edge weights in which error edges — traversed only
 # by rare, low-probability paths — accrue little weight and decay below the
-# `generate_alternative_qualmer_paths` `weight > 0.01` gate WITHOUT tip-clipping.
+# emergent-cleaning gate WITHOUT tip-clipping.
 #
-# v1 status — E-step WIRED (record-only), M-step NOT wired. Under `soft_em=true`
-# this hook IS called per decode from `try_viterbi_path_improvement`, so the
-# accumulator records decoded-path responsibilities each pass. But the pipeline
-# deliberately does NOT consume them: `register_soft_edge_weights!` is never
-# called from `mycelia_iterative_assemble`, so `compute_edge_weight` always
-# returns raw coverage counts and the graph is never soft-reweighted. Emergent
-# coalescence needs the M-step to consume these weights (and, before that, the
-# v2 competing-paths E-step so responsibilities stop being a degenerate 1.0),
-# which is the tracked td-e70t follow-on. Keeping the E-step live but the M-step
-# dormant avoids v1's uncontrolled reweighting (single-path 1.0 responsibilities
-# + hard-skipped reads never accumulating would mix decoded-subset coverage with
-# raw counts) while exercising the recording machinery for v2.
+# v2 status — E-step AND M-step both WIRED. Under `soft_em=true`:
+#   * E-step: `accumulate_competing_paths!` (below) builds each decoded read's
+#     COMPETING candidate paths — the observed read path and a consensus
+#     alternative re-routed through the best-supported sibling branch — then
+#     softmax-splits the responsibility across them by their normalized-transition
+#     log-probability, so a real branch keeps high mass and an unsupported (error)
+#     branch gets little.
+#   * M-step: `mycelia_iterative_assemble` registers the accumulator onto the NEXT
+#     EM iteration's graph (`register_soft_edge_weights!`), so `compute_edge_weight`
+#     returns the decayed soft weight and the next iteration's transition scoring
+#     is biased away from the error edge — a positive feedback loop that drives the
+#     error edge's weight strictly down across iterations.
+# This is the CORRECT activation of the v1 scaffold: v1 was record-only because a
+# single-ML-path decode makes every responsibility a degenerate 1.0 (soft weight
+# == raw count), so consuming it was an uncontrolled perturbation. v2's genuine
+# responsibility split makes consumption principled. The decay is RESPONSIBILITY-
+# based (unsupported edges decay), never coverage-ratio-based: a balanced real
+# variant (het/paralog bubble) has BOTH branches at high responsibility and both
+# are RETAINED — the td-h6w9 variation-preservation invariant.
 
 """
     _decoded_path_edges(result) -> Vector
@@ -2198,17 +2242,18 @@ end
 """
     accumulate_soft_em_edge_weights!(accumulator, candidate_paths) -> accumulator
 
-Soft-EM M-step seam (td-e70t scaffold). Given a single read's competing decoded
-paths (`ViterbiDecodingResult`s, each with a `.score` log-likelihood and a
-`.path`), compute each path's responsibility by softmax-normalizing its score
-against the candidate set (`Mycelia.Rhizomorph.path_responsibility`) and
-accumulate that responsibility onto the edges it traverses
+Soft-EM E-step core. Given a single read's competing decoded paths
+(`ViterbiDecodingResult`s, each with a `.score` log-likelihood and a `.path`),
+compute each path's responsibility by softmax-normalizing its score against the
+candidate set (`Mycelia.Rhizomorph.path_responsibility`) and accumulate that
+responsibility onto the edges it traverses
 (`Mycelia.Rhizomorph.accumulate_path_probability!`).
 
-With a single argmax path per read the responsibility is `1.0` (soft weight ==
-hard count); the softening emerges once several candidate paths per read compete
-(e.g. from `generate_alternative_qualmer_paths`), which is the regime the
-follow-on wires into the iteration loop.
+A path whose `.score` is non-finite (`-Inf` for a zero-probability path) is
+excluded from the softmax denominator and contributes nothing. With a single
+candidate the responsibility is `1.0` (soft weight == hard count); the softening
+comes from `accumulate_competing_paths!`, which supplies several candidate paths
+per read.
 """
 function accumulate_soft_em_edge_weights!(
         accumulator::Mycelia.Rhizomorph.SoftEdgeWeightAccumulator,
@@ -2221,6 +2266,225 @@ function accumulate_soft_em_edge_weights!(
         responsibility = Mycelia.Rhizomorph.path_responsibility(result.score, scores)
         Mycelia.Rhizomorph.accumulate_path_probability!(
             accumulator, _decoded_path_edges(result), responsibility)
+    end
+    return accumulator
+end
+
+"""
+    _graph_oriented_edges(labels, graph) -> Vector{Tuple}
+
+Turn an ordered list of vertex `labels` into the `(src, dst)` edge tuples in the
+ORIENTATION the graph actually stores them (checking both directions), skipping
+any consecutive pair with no edge in `graph`. Keying the accumulator in the
+graph's own orientation is what lets `register_soft_edge_weights!` — which
+iterates `MetaGraphsNext.edge_labels(graph)` — find and consume the soft weight.
+A candidate substitution that is not a real graph traversal contributes no edge.
+"""
+function _graph_oriented_edges(labels, graph)
+    edges = Tuple{Any, Any}[]
+    for i in 1:(length(labels) - 1)
+        a, b = labels[i], labels[i + 1]
+        if MetaGraphsNext.haskey(graph, a, b)
+            push!(edges, (a, b))
+        elseif MetaGraphsNext.haskey(graph, b, a)
+            push!(edges, (b, a))
+        end
+    end
+    return edges
+end
+
+# The observed read path, resolved to graph vertex labels (canonical where the
+# graph is canonical). Empty when no k-mer of the read resolves onto the graph.
+function _read_resolved_labels(read::FASTX.FASTQ.Record, graph, k::Int; graph_mode::Symbol)
+    labels = Any[]
+    for (qmer, _pos) in qualmers_unambiguous(read, k)
+        resolved = _resolve_qualmer_for_graph(graph, qmer; graph_mode = graph_mode)
+        resolved === nothing || push!(labels, resolved.kmer)
+    end
+    return labels
+end
+
+# Soft-weight-aware edge weight between two vertex labels in either stored
+# orientation, or `nothing` when they are not adjacent. `compute_edge_weight`
+# consults the soft-edge registry, so an edge the M-step decayed reads back its
+# decayed weight here — the cross-iteration feedback that sharpens the split.
+function _edge_weight_between(graph, a, b)
+    if MetaGraphsNext.haskey(graph, a, b)
+        return Float64(Mycelia.Rhizomorph.compute_edge_weight(graph[a, b]))
+    elseif MetaGraphsNext.haskey(graph, b, a)
+        return Float64(Mycelia.Rhizomorph.compute_edge_weight(graph[b, a]))
+    end
+    return nothing
+end
+
+# All labels adjacent to `a` (either orientation), deduplicated. Used both as the
+# transition normalizer support and as the branch-candidate set.
+function _incident_labels(graph, a)
+    ns = Any[]
+    for n in MetaGraphsNext.outneighbor_labels(graph, a)
+        push!(ns, n)
+    end
+    for n in MetaGraphsNext.inneighbor_labels(graph, a)
+        push!(ns, n)
+    end
+    return unique(ns)
+end
+
+# Sum of the soft-weight-aware edge weights on every edge incident to `a` — the
+# denominator that turns a raw edge weight into a normalized transition
+# probability. Normalizing here is what counts a single branch decision ONCE
+# (internal edges of a linear run normalize to ~0.5 on BOTH competing branches
+# and cancel in the responsibility softmax), so a real but skewed variant is
+# retained rather than collapsed like a raw coverage-ratio prune would.
+function _incident_weight_sum(graph, a)
+    total = 0.0
+    for x in _incident_labels(graph, a)
+        w = _edge_weight_between(graph, a, x)
+        w === nothing || (total += w)
+    end
+    return total
+end
+
+# Normalized-transition log-probability of a label path: sum of log(w(a,b)/S(a)).
+# Returns -Inf if any consecutive pair is non-adjacent or zero-weight, so an
+# invalid candidate is dropped by the softmax `isfinite` guard.
+function _path_transition_logscore(labels, graph)
+    total = 0.0
+    for i in 2:length(labels)
+        a, b = labels[i - 1], labels[i]
+        w = _edge_weight_between(graph, a, b)
+        (w === nothing || w <= 0.0) && return -Inf
+        s = _incident_weight_sum(graph, a)
+        s <= 0.0 && return -Inf
+        total += log(w / s)
+    end
+    return total
+end
+
+# Generate ONE competing alternative to `observed` by re-routing its first
+# clearly-weak branch through the highest-weight sibling and walking greedily
+# until rejoining `observed`. Returns the spliced label path, or `nothing` when
+# no weak branch exists (a linear region, or a balanced variant whose sibling is
+# not strictly better — which is retained, not competed away). Bounded by the
+# observed length so it always terminates.
+function _consensus_alternative(observed, graph)
+    n = length(observed)
+    n < 3 && return nothing
+    firstpos = Dict{Any, Int}()
+    for i in 1:n
+        haskey(firstpos, observed[i]) || (firstpos[observed[i]] = i)
+    end
+    for i in 1:(n - 1)
+        a, b = observed[i], observed[i + 1]
+        w_ab = _edge_weight_between(graph, a, b)
+        w_ab === nothing && continue
+        best_x, best_w = nothing, w_ab
+        for x in _incident_labels(graph, a)
+            x == b && continue
+            (i > 1 && x == observed[i - 1]) && continue
+            wx = _edge_weight_between(graph, a, x)
+            wx === nothing && continue
+            if wx > best_w
+                best_w, best_x = wx, x
+            end
+        end
+        best_x === nothing && continue   # no strictly-better sibling ⇒ not weak
+        # Greedy highest-weight walk from the sibling until we rejoin `observed`
+        # at or after position i+1.
+        mid = Any[best_x]
+        prev, cur = a, best_x
+        rejoin = get(firstpos, best_x, 0) >= i + 1 ? firstpos[best_x] : 0
+        steps = 0
+        while rejoin == 0 && steps < n
+            steps += 1
+            nxt, nxt_w = nothing, 0.0
+            for y in _incident_labels(graph, cur)
+                y == prev && continue
+                y in mid && continue
+                wy = _edge_weight_between(graph, cur, y)
+                wy === nothing && continue
+                if wy > nxt_w
+                    nxt_w, nxt = wy, y
+                end
+            end
+            nxt === nothing && break
+            if get(firstpos, nxt, 0) >= i + 1
+                rejoin = firstpos[nxt]
+                break
+            end
+            push!(mid, nxt)
+            prev, cur = cur, nxt
+        end
+        if rejoin >= i + 1
+            return vcat(observed[1:i], mid, observed[rejoin:end])
+        end
+    end
+    return nothing
+end
+
+"""
+    accumulate_competing_paths!(accumulator, read, graph, k; graph_mode) -> accumulator
+
+Soft-EM v2 competing-paths E-step for ONE read (td-e70t). Builds the read's
+COMPETING candidate paths — the observed read path and (when the observed path
+takes a weak branch) a consensus alternative re-routed through the best-supported
+sibling (`_consensus_alternative`) — scores each by its normalized-transition
+log-probability on the graph (`_path_transition_logscore`, which reads the
+soft-weight-aware `compute_edge_weight`), converts the scores to responsibilities
+with a stable softmax (`Mycelia.Rhizomorph.path_responsibility`), and accumulates
+each candidate's graph-oriented edges weighted by its responsibility.
+
+Why normalized transition probability (not a raw coverage ratio, and not a
+per-k-mer coverage sum): normalization counts each branch DECISION once — the
+divergence edge carries the coverage contrast (error 1x vs consensus 30x ⇒
+responsibility ≈ 0.03) while the deterministic internal edges normalize to ~0.5
+on both competing branches and cancel in the softmax. So a real but SKEWED
+variant (say 10x vs 20x) keeps responsibility ≈ 0.33 and is RETAINED, whereas an
+unsupported error decays — the responsibility-based decay the td-h6w9 invariant
+requires. `compute_edge_weight` reads the M-step's registered soft weights, so an
+edge the previous EM iteration decayed scores even lower this iteration (the
+feedback loop). A balanced variant produces no strictly-better sibling, so no
+alternative is generated and the observed path keeps responsibility 1.0 (both
+alleles are retained through their own reads). Never throws (guarded), so the
+decode is always safe.
+"""
+function accumulate_competing_paths!(
+        accumulator::Mycelia.Rhizomorph.SoftEdgeWeightAccumulator,
+        read::FASTX.FASTQ.Record,
+        graph,
+        k::Int;
+        graph_mode::Symbol = :canonical
+)
+    observed = _read_resolved_labels(read, graph, k; graph_mode = graph_mode)
+    isempty(observed) && return accumulator
+
+    alternative = try
+        _consensus_alternative(observed, graph)
+    catch
+        nothing
+    end
+
+    if alternative === nothing || alternative == observed
+        # No genuine competition: the observed path owns all responsibility.
+        Mycelia.Rhizomorph.accumulate_path_probability!(
+            accumulator, _graph_oriented_edges(observed, graph), 1.0)
+        return accumulator
+    end
+
+    candidate_paths = (observed, alternative)
+    scores = Float64[_path_transition_logscore(labels, graph) for labels in candidate_paths]
+    finite = Float64[s for s in scores if isfinite(s)]
+    if isempty(finite)
+        # Fall back to the observed path if scoring degenerated.
+        Mycelia.Rhizomorph.accumulate_path_probability!(
+            accumulator, _graph_oriented_edges(observed, graph), 1.0)
+        return accumulator
+    end
+    for (idx, labels) in enumerate(candidate_paths)
+        isfinite(scores[idx]) || continue
+        responsibility = Mycelia.Rhizomorph.path_responsibility(scores[idx], finite)
+        Mycelia.Rhizomorph.accumulate_path_probability!(
+            accumulator, _graph_oriented_edges(labels, graph), responsibility)
     end
     return accumulator
 end

--- a/test/4_assembly/scalable_corrector_soft_em_test.jl
+++ b/test/4_assembly/scalable_corrector_soft_em_test.jl
@@ -1,18 +1,18 @@
-# Stage 2 (td-e70t): soft-EM edge-memory PRIMITIVES. After each successful Viterbi
-# decode the ML path's edges accumulate responsibility (1.0 for the single argmax
-# path) into a SoftEdgeWeightAccumulator; `register_soft_edge_weights!` can then
-# re-weight a graph so `compute_edge_weight` returns probability-weighted evidence
-# instead of raw coverage counts, reverting byte-for-byte after `clear!`. This
-# test exercises those primitives at the UNIT level.
+# Soft-EM edge-memory tests (td-e70t) — v2 competing-paths ACTIVE. The E-step
+# splits each read's responsibility across COMPETING candidate paths (the observed
+# read path vs a consensus alternative re-routed through the best-supported
+# sibling) and accumulates each path's edges weighted by its responsibility into a
+# SoftEdgeWeightAccumulator. `register_soft_edge_weights!` then re-weights a graph
+# so `compute_edge_weight` returns the probability-weighted evidence instead of raw
+# coverage counts, reverting byte-for-byte after `clear!` — the M-step consumption
+# the shipped pipeline (`mycelia_iterative_assemble`) now performs each EM
+# iteration.
 #
-# IMPORTANT (v1 is RECORD-ONLY): the shipped pipeline (`mycelia_iterative_assemble`)
-# runs the E-step accumulation but does NOT consume it — it never calls
-# `register_soft_edge_weights!`, so `compute_edge_weight` always returns raw counts
-# and the graph is never soft-reweighted (see the FIX-1 note in
-# src/iterative-assembly.jl). Registration/consumption is a v2-reserved capability;
-# this file tests the primitives directly (not the pipeline) so they are ready for
-# the v2 competing-paths M-step. With a single argmax path per read, responsibility
-# is always 1.0 (soft weight == hard count); v2 softens it via competing paths.
+# On CLEAN data (no bubbles) there is no competing branch, so responsibility is
+# 1.0 (soft weight == hard count); on error-bearing data the observed error branch
+# gets a fractional responsibility and its soft weight decays. This file exercises
+# the primitives + the pipeline E-step; the strict cross-iteration decay-below-gate
+# is asserted in soft_em_edge_weight_scaffold_test.jl.
 #
 # Run directly:
 #   julia --project=. -e 'include("test/4_assembly/scalable_corrector_soft_em_test.jl")'
@@ -38,7 +38,7 @@ function _toy_fastq_records(rng; reflen = 1000, n_reads = 120, readlen = 80, err
     return records
 end
 
-Test.@testset "scalable corrector soft-EM v1 (td-e70t)" begin
+Test.@testset "scalable corrector soft-EM v2 (td-e70t)" begin
     R = Mycelia.Rhizomorph
 
     Test.@testset "registry consumption + byte-identical revert" begin
@@ -73,30 +73,31 @@ Test.@testset "scalable corrector soft-EM v1 (td-e70t)" begin
         Test.@test R.compute_edge_weight(edge_data) == raw    # byte-identical revert
     end
 
-    Test.@testset "decode pass populates the accumulator (responsibility 1.0)" begin
+    Test.@testset "clean-data decode pass: no competition ⇒ responsibility 1.0" begin
+        # On error-free reads the qualmer graph has (essentially) no bubbles, so the
+        # v2 competing-paths E-step finds no consensus alternative for any read and
+        # every read's observed path owns all responsibility (1.0). The accumulated
+        # soft weights are therefore sums of unit responsibilities ⇒ integer-valued
+        # and >= 1 (soft weight == hard coverage count in the no-competition case).
         reads = _toy_fastq_records(Random.MersenneTwister(5); n_reads = 80, err = 0.0)
         graph = R.build_qualmer_graph(reads, 13; mode = :canonical)
         acc = R.SoftEdgeWeightAccumulator()
         _updated, _n,
         _skip = Mycelia.improve_read_set_likelihood(
             reads, graph, 13; graph_mode = :canonical, soft_weights = acc)
-        # The E-step accumulated ML-path edges: non-empty, and every soft weight is
-        # a sum of unit (1.0) responsibilities ⇒ integer-valued and >= 1.
         Test.@test !isempty(acc.weights)
         Test.@test all(w -> w >= 1.0 && isapprox(w, round(w)), values(acc.weights))
     end
 
     Test.@testset "rare (error) edge soft weight is non-increasing across iterations" begin
-        # Two manual EM iterations. Iteration 2's graph is re-weighted from
-        # iteration 1's accumulator (the M-step consumption), then decoded on the
-        # CORRECTED reads. The probability-memory / decay property is AGGREGATE in
-        # v1 (responsibility is always 1.0, so a single edge's soft weight is just
-        # its ML-path coverage and can rise if a read is corrected onto it): the
-        # rare-edge (error) POPULATION shrinks. We assert both the count of rare
-        # edges and their total tail mass are non-increasing.
-        #
-        # v1 CAVEAT: full coalescence to ~1 contig (and strict per-edge decay)
-        # needs the v2 competing-paths E-step; this asserts the v1 aggregate trend.
+        # Two manual EM iterations mirroring the pipeline: iteration 2's graph is
+        # rebuilt from the CORRECTED reads and re-weighted from iteration 1's
+        # accumulator (the M-step consumption), then re-decoded. Under v2 the
+        # competing-paths E-step gives error branches fractional responsibility, and
+        # the feedback loop + rebuild shrink the rare-edge (error) POPULATION: we
+        # assert both the count of rare edges and their total tail mass are
+        # non-increasing across the two iterations. (The strict per-edge
+        # decay-below-gate is asserted in soft_em_edge_weight_scaffold_test.jl.)
         reads = _toy_fastq_records(Random.MersenneTwister(9); n_reads = 150, err = 0.008)
         k = 13
         rare_threshold = 2.0   # <=2 supporting ML paths ⇒ error-like edge

--- a/test/4_assembly/scalable_corrector_strategy_test.jl
+++ b/test/4_assembly/scalable_corrector_strategy_test.jl
@@ -51,9 +51,10 @@ Test.@testset "scalable corrector strategy fork (td-fuo8)" begin
         sc = R._corrector_strategy_knobs(:scalable)
         # Scalable = coarse 3-rung ladder, low iteration cap, all volume/quality
         # gates on, size-aware auto-beam (nothing). `soft_em=true` is the ENGINE
-        # switch that runs the record-only E-step (accumulate responsibilities);
-        # the pipeline does NOT consume them (v1), which the surfaced provenance
-        # flag ("scaffold-v1-record-only") reflects — asserted end-to-end below.
+        # switch that runs the v2 competing-paths E-step (split responsibilities)
+        # AND the M-step (register soft weights onto the next iteration's graph);
+        # the surfaced provenance flag ("v2-competing-paths") reflects the active
+        # soft reweighting — asserted end-to-end below.
         Test.@test sc.n_k_rungs == 3
         Test.@test sc.max_iterations_per_k == 2
         Test.@test sc.skip_solid == true
@@ -83,9 +84,9 @@ Test.@testset "scalable corrector strategy fork (td-fuo8)" begin
         # Per-hard-region windowed decode is scaffolded (hard reads decoded WHOLE),
         # so the honest flag is false even on :scalable (FIX 5).
         Test.@test sc.assembly_stats["windowed_decode"] == false
-        # soft-EM v1 is RECORD-ONLY (E-step records, M-step does not consume), so
-        # the surfaced provenance is a scaffold marker, never a bare `true` (FIX 1/5).
-        Test.@test sc.assembly_stats["soft_em"] == "scaffold-v1-record-only"
+        # soft-EM v2 is ACTIVE (competing-paths E-step + M-step consumption), so
+        # the surfaced provenance names the active engine, never a bare `true`.
+        Test.@test sc.assembly_stats["soft_em"] == "v2-competing-paths"
         Test.@test sc.assembly_stats["skip_solid"] == true
         # Skip fraction is a real fraction in [0, 1].
         skip = sc.assembly_stats["skip_fraction"]

--- a/test/4_assembly/soft_em_edge_weight_scaffold_test.jl
+++ b/test/4_assembly/soft_em_edge_weight_scaffold_test.jl
@@ -1,18 +1,18 @@
-# SCAFFOLD test for soft-EM edge weighting (td-e70t).
+# Soft-EM edge weighting tests (td-e70t) — v2 competing-paths ACTIVE.
 #
 # The graph-as-HMM correction redesign replaces the hard-count M-step
 # (`compute_edge_weight` == raw coverage) with probability-weighted evidence:
-# after Viterbi decodes a read, each candidate path's RESPONSIBILITY (posterior
-# over the read's candidate set) is accumulated onto its edges. Error edges,
-# traversed only by rare low-probability paths, accrue little soft weight and
-# decay below the emergent-cleaning gate WITHOUT tip-clipping.
+# each competing candidate path's RESPONSIBILITY (posterior over the read's
+# candidate set) is accumulated onto its edges. Error edges, traversed only by
+# low-probability paths, accrue little soft weight and decay below the
+# emergent-cleaning gate WITHOUT tip-clipping.
 #
-# What lands here: the accumulation PRIMITIVE + the correction-side hook, proven
-# at the unit level (passing tests below). What does NOT land yet: making the
-# qualmer graph rebuild / transition weighting CONSUME these soft weights so the
-# full pipeline coalesces a 1 kb toy to ~1 contig across EM iterations — that
-# M-step consumption is outside the correction-core file boundary and is the
-# td-e70t follow-on. The full-pipeline acceptance is therefore a skipped test.
+# This file exercises the accumulation PRIMITIVES (softmax responsibility,
+# accumulator, single-path hook) at the unit level AND the v2 activation: the
+# final testset drives the competing-paths E-step + the M-step consumption
+# feedback loop end-to-end (register soft weights -> compute_edge_weight decays ->
+# next iteration's responsibility sharpens) and asserts a tracked error edge's
+# soft weight strictly decreases across EM iterations below the 0.01 gate.
 #
 # Run directly:
 #   julia --project=. -e 'include("test/4_assembly/soft_em_edge_weight_scaffold_test.jl")'
@@ -21,6 +21,7 @@ import BioSequences
 import FASTX
 import Kmers
 import Mycelia
+import Random
 import Test
 
 Test.@testset "Soft-EM edge weighting scaffold (td-e70t)" begin
@@ -110,16 +111,75 @@ Test.@testset "Soft-EM edge weighting scaffold (td-e70t)" begin
         end
     end
 
-    Test.@testset "FULL-PIPELINE ACCEPTANCE (skipped until M-step consumes soft weights)" begin
-        # td-e70t acceptance: running mycelia_iterative_assemble on a clean ~1 kb
-        # toy should coalesce the qualmer graph toward ~1 contig across EM
-        # iterations, and the summed soft weight of error edges should DECREASE
-        # across iterations, WITHOUT any explicit tip/bubble removal. This requires
-        # the qualmer graph rebuild / transition weighting to consume the soft
-        # weights produced by `accumulate_soft_em_edge_weights!` in place of raw
-        # coverage counts -- the follow-on that lives outside the correction-core
-        # file boundary. Skipped (not @test false) so it documents the target
-        # without failing CI on unlanded work.
-        Test.@test_skip false
+    Test.@testset "ERROR-EDGE DECAY across EM iterations (v2 competing paths, td-e70t)" begin
+        # td-e70t acceptance, now ACTIVE (v2). Controlled fixture: a random backbone
+        # at high coverage plus ONE coverage-1 error read. The single substitution
+        # creates coverage-1 error k-mers/edges while every consensus edge is
+        # high-coverage. The v2 competing-paths E-step
+        # (`accumulate_competing_paths!`) gives the error branch a small
+        # responsibility (a genuine split — v1 was always 1.0), and REGISTERING that
+        # soft weight (the M-step) makes `compute_edge_weight` return the decayed
+        # value, so the next iteration's transition scoring sharpens the split
+        # further — a positive feedback loop. We isolate the loop by re-accumulating
+        # on the SAME reads across iterations (stable edge identity) and assert the
+        # tracked error edge's soft weight decreases strictly and falls below the
+        # 0.01 emergent-cleaning gate, WITHOUT any explicit tip/bubble removal.
+        R = Mycelia.Rhizomorph
+        bases = ['A', 'C', 'G', 'T']
+        rng = Random.MersenneTwister(7)
+        L, cov, readlen, errpos, kk = 300, 25, 100, 150, 13
+        backbone = collect(join(rand(rng, bases, L)))
+        reads = FASTX.FASTQ.Record[]
+        qual = String(fill('I', readlen))
+        for i in 1:cov
+            s = rand(rng, 1:(L - readlen + 1))
+            push!(reads, FASTX.FASTQ.Record("c$i", String(backbone[s:(s + readlen - 1)]), qual))
+        end
+        errseq = copy(backbone)
+        errseq[errpos] = rand(rng, filter(!=(errseq[errpos]), bases))
+        s0 = errpos - readlen ÷ 2
+        push!(reads, FASTX.FASTQ.Record("err", String(errseq[s0:(s0 + readlen - 1)]), qual))
+
+        graph = R.build_qualmer_graph(reads, kk; mode = :canonical)
+        err_edges = [(a, b) for (a, b) in R.MetaGraphsNext.edge_labels(graph)
+                     if R.count_total_observations(graph[a, b]) == 1]
+        Test.@test !isempty(err_edges)
+
+        # Iteration 1 E-step (raw weights).
+        acc1 = R.SoftEdgeWeightAccumulator()
+        for rd in reads
+            Mycelia.accumulate_competing_paths!(acc1, rd, graph, kk; graph_mode = :canonical)
+        end
+        # v2 genuinely SPLITS: at least one error edge received a fractional (<1)
+        # responsibility because a consensus alternative outscored the observed
+        # error branch. (v1's single-path decode made every responsibility 1.0.)
+        competed = [(e, acc1.weights[e]) for e in err_edges
+                    if haskey(acc1.weights, e) && acc1.weights[e] < 1.0]
+        Test.@test !isempty(competed)
+        tracked = last(sort(competed; by = x -> x[2]))[1]   # largest still-competed edge
+
+        # Feedback iterations: register the previous accumulator (M-step), then
+        # re-accumulate; `compute_edge_weight` now reads the decayed soft weight.
+        trace = Float64[acc1.weights[tracked]]
+        prev = acc1
+        for _ in 1:4
+            acc = R.SoftEdgeWeightAccumulator()
+            try
+                R.register_soft_edge_weights!(graph, prev)
+                for rd in reads
+                    Mycelia.accumulate_competing_paths!(acc, rd, graph, kk; graph_mode = :canonical)
+                end
+            finally
+                R.clear_soft_edge_weights!()   # never leak the process-global registry
+            end
+            push!(trace, get(acc.weights, tracked, 0.0))
+            prev = acc
+        end
+        # Strictly decreasing across EM iterations, and below the 0.01 gate.
+        Test.@test all(diff(trace) .< 0)
+        Test.@test trace[end] < 0.01
+        # Registry cleared ⇒ the raw coverage count is restored byte-for-byte.
+        Test.@test R.compute_edge_weight(graph[tracked...]) ==
+                   R.count_total_observations(graph[tracked...])
     end
 end


### PR DESCRIPTION
## Summary

Activates the previously **record-only** soft-EM scaffold (td-e70t) into a working competing-paths corrector. v1 was dormant because a single-ML-path decode makes every path responsibility a degenerate `1.0` (soft weight == raw coverage), so consuming it was an uncontrolled perturbation. v2 makes the responsibilities genuinely split.

All new behavior is gated behind `strategy=:scalable` + `soft_em`; `strategy=:exhaustive` threads `soft_em=false` and stays byte-identical.

- **E-step (`accumulate_competing_paths!`)** builds each decoded read's competing candidate paths — the observed read path vs a consensus alternative re-routed through the best-supported sibling branch — and splits responsibility across them by a stable softmax over their **normalized-transition** log-probabilities. Normalizing counts each branch decision once, so a real but skewed variant (10x vs 20x → responsibility ≈ 0.33) is **retained** while an unsupported error branch (1x vs 30x → ≈ 0.03) decays. Responsibility-based, never a raw coverage-ratio prune.
- **M-step consumption re-enabled**: each EM iteration registers the previous iteration's soft edge weights onto the freshly-built graph (`register_soft_edge_weights!`), so `compute_edge_weight` returns the decayed weight and the next iteration's transition scoring is biased away from the error edge — a feedback loop that drives error-edge weight strictly down. `register`/`clear` are paired in `try/finally`; the empty-at-entry assert is preserved; provenance stamp moves `scaffold-v1-record-only` → `v2-competing-paths`.
- Ownership limited to `src/iterative-assembly.jl` + tests (evidence-functions.jl primitives were already complete and unchanged).

## Test Plan

Run under `LD_LIBRARY_PATH='' julia --project=.`:

- [x] `soft_em_edge_weight_scaffold_test.jl` (18/18) — new **error-edge-decay** test: a tracked error edge's soft weight decreases strictly across EM iterations `[0.112, 0.022, 0.005, 0.001, 0.0002]` and falls below the 0.01 gate.
- [x] `variation_preservation_holdout_test.jl` (td-h6w9) — **green** (11 pass + 1 broken): balanced het retained, only the unsupported error removable by the exhaustive tier.
- [x] `scalable_corrector_soft_em_test.jl` (12/12), `scalable_corrector_strategy_test.jl` (33/33, provenance `v2-competing-paths`, both tiers reach a real `AssemblyResult`).
- [x] `iterative_assemble_completion_test.jl` (8/8), `scalable_corrector_hard_window_test.jl`, `stage0_integration_test.jl`, `iterative_convergence_stop_test.jl`, `rhizomorph_iterative_corrector_wiring_test.jl`, `viterbi_beam_pruning_test.jl`, `iterative_assembly_tests.jl` — all pass.
- [x] `:exhaustive` unchanged (soft-EM structurally bypassed).

## Related

- td-e70t (soft-EM edge/node weights from path probabilities)
- td-h6w9 (variation-preservation holdout — gating invariant, stays green)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Soft-EM assembly now uses competing path evidence during iterations, improving how ambiguous reads contribute to graph correction.
  * Assembly run metadata now reports the active Soft-EM mode more clearly.

* **Bug Fixes**
  * Soft-edge weights are now safely reset between iterations, including on errors.
  * Error-edge influence is updated across iterations more consistently, helping weak erroneous edges decay over time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->