### PR TITLE
fix: run :scalable corrector on doublestrand, recovering the quality regime (td-nt69)

### DIFF
--- a/src/iterative-assembly.jl
+++ b/src/iterative-assembly.jl
@@ -456,10 +456,15 @@ function mycelia_iterative_assemble(input_fastq::String;
             # entry/exit/interior, high-out-degree/repeat-like, or weak/non-solid
             # k-mer). Easy reads pass through untouched, cutting decode volume
             # ~85-95% on clean data. Off unless `hard_window=true` (:scalable).
-            hard_vertices = (hard_window && graph_mode == :canonical) ?
+            # Mode-agnostic (td-nt69): `_hard_vertex_set` operates on graph
+            # vertices/edges and `should_decode_read` matches reads in their observed
+            # orientation, so the gate works on both :canonical and :doublestrand
+            # (:scalable now runs :doublestrand). Only :singlestrand — which has no
+            # RC vertices and is not a corrector target — is excluded.
+            hard_vertices = (hard_window && graph_mode != :singlestrand) ?
                             _hard_vertex_set(graph, k) : nothing
-            if hard_window && graph_mode != :canonical
-                @warn "hard_window gating is only supported for graph_mode=:canonical; " *
+            if hard_window && graph_mode == :singlestrand
+                @warn "hard_window gating is not supported for graph_mode=:singlestrand; " *
                       "disabling (decoding all non-solid reads)." graph_mode maxlog = 1
             end
 
@@ -683,21 +688,37 @@ function _solid_kmer_set(graph;
     return solid
 end
 
-"""
-    _read_is_all_solid(read, k, solid_kmers) -> Bool
+# Mode-aware lookup key for classification/gating (td-nt69). `solid_kmers` /
+# `hard_vertices` are graph VERTEX LABELS, so the key that a read's observed k-mer
+# maps to depends on how the graph was built:
+#   :canonical    → labels are canonical k-mers, so canonicalize the read k-mer.
+#   :doublestrand → both a k-mer and its RC are SEPARATE vertices, so the read
+#                   traverses its observed-orientation k-mer; use it as-is.
+#   :singlestrand → no RC vertices; use the observed k-mer as-is.
+# Classification is coverage-based and therefore mode-agnostic: under
+# :doublestrand each strand-vertex still separates real (≈half-coverage) from
+# error (coverage-1) k-mers, so the solid/hard sets remain valid.
+@inline function _lookup_key(kmer, graph_mode::Symbol)
+    return graph_mode == :canonical ? BioSequences.canonical(kmer) : kmer
+end
 
-True iff every canonical k-mer of `read` is in `solid_kmers` (⇒ no weak region ⇒
-the read needs no correction and can skip the decode). A read with no k-mers
-(shorter than k, or fully ambiguous) returns `false` so it is never skipped on the
-basis of absent evidence.
 """
-function _read_is_all_solid(read::FASTX.FASTQ.Record, k::Int, solid_kmers::AbstractSet)
+    _read_is_all_solid(read, k, solid_kmers; graph_mode) -> Bool
+
+True iff every k-mer of `read` (resolved to its graph label via `_lookup_key`) is
+in `solid_kmers` (⇒ no weak region ⇒ the read needs no correction and can skip the
+decode). A read with no k-mers (shorter than k, or fully ambiguous) returns
+`false` so it is never skipped on the basis of absent evidence. Works on both
+`:canonical` and `:doublestrand` graphs (td-nt69).
+"""
+function _read_is_all_solid(read::FASTX.FASTQ.Record, k::Int, solid_kmers::AbstractSet;
+        graph_mode::Symbol = :canonical)
     isempty(solid_kmers) && return false
     sequence = FASTX.sequence(BioSequences.LongDNA{4}, read)
     saw_kmer = false
     for (kmer, _) in Kmers.UnambiguousDNAMers{k}(sequence)
         saw_kmer = true
-        (BioSequences.canonical(kmer) in solid_kmers) || return false
+        (_lookup_key(kmer, graph_mode) in solid_kmers) || return false
     end
     return saw_kmer
 end
@@ -717,11 +738,13 @@ end
 # :exhaustive path never calls it and is byte-identical.
 # ------------------------------------------------------------------------------
 
-# Canonical k-mer at 1-based read position `i` (bases [i, i+k-1]) of an ACGT-only
-# char vector, comparable against the `_solid_kmer_set` labels. The read is
-# pre-screened for ambiguity by the caller so this construction cannot throw.
-@inline function _canonical_kmer_at(chars::Vector{Char}, k::Int, i::Int)
-    return BioSequences.canonical(Kmers.DNAKmer{k}(String(@view chars[i:(i + k - 1)])))
+# Graph-label lookup key for the k-mer at 1-based read position `i` (bases
+# [i, i+k-1]) of an ACGT-only char vector, comparable against the `_solid_kmer_set`
+# labels. Mode-aware (td-nt69): canonicalized under :canonical, observed
+# orientation under :doublestrand / :singlestrand. The read is pre-screened for
+# ambiguity by the caller so this construction cannot throw.
+@inline function _lookup_kmer_at(chars::Vector{Char}, k::Int, i::Int, graph_mode::Symbol)
+    return _lookup_key(Kmers.DNAKmer{k}(String(@view chars[i:(i + k - 1)])), graph_mode)
 end
 
 """
@@ -740,9 +763,12 @@ left untouched for the graph decode, so Stage 0 never collapses real variation.
 
 Reads shorter than `k`, reads with ambiguous bases (e.g. `N`), and reads with no
 weak run are returned unchanged with a 0 count. Returns the (possibly rewritten)
-record and the number of bases corrected.
+record and the number of bases corrected. `graph_mode` selects the solid-set
+lookup key (canonicalized under :canonical, observed orientation otherwise —
+td-nt69).
 """
-function _stage0_correct_read(read::FASTX.FASTQ.Record, k::Int, solid_kmers::AbstractSet)
+function _stage0_correct_read(read::FASTX.FASTQ.Record, k::Int, solid_kmers::AbstractSet;
+        graph_mode::Symbol = :canonical)
     seq_str = FASTX.sequence(String, read)
     n = length(seq_str)
     n < k && return read, 0
@@ -756,7 +782,7 @@ function _stage0_correct_read(read::FASTX.FASTQ.Record, k::Int, solid_kmers::Abs
     nkmers = n - k + 1
     solid = Vector{Bool}(undef, nkmers)
     @inbounds for i in 1:nkmers
-        solid[i] = _canonical_kmer_at(chars, k, i) in solid_kmers
+        solid[i] = _lookup_kmer_at(chars, k, i, graph_mode) in solid_kmers
     end
 
     n_corr = 0
@@ -797,7 +823,7 @@ function _stage0_correct_read(read::FASTX.FASTQ.Record, k::Int, solid_kmers::Abs
                     chars[p] = base
                     ok = true
                     for j in lo_j:hi_j
-                        if !(_canonical_kmer_at(chars, k, j) in solid_kmers)
+                        if !(_lookup_kmer_at(chars, k, j, graph_mode) in solid_kmers)
                             ok = false
                             break
                         end
@@ -846,12 +872,12 @@ without a solid reference every k-mer looks weak and there is no trustworthy
 neighbor to correct toward, so nothing is changed.
 """
 function _stage0_cheap_correct(reads::Vector{<:FASTX.FASTQ.Record}, k::Int,
-        solid_kmers::AbstractSet)
+        solid_kmers::AbstractSet; graph_mode::Symbol = :canonical)
     total = 0
     isempty(solid_kmers) && return collect(reads), 0
     corrected = Vector{FASTX.FASTQ.Record}(undef, length(reads))
     for (idx, read) in enumerate(reads)
-        rec, n = _stage0_correct_read(read, k, solid_kmers)
+        rec, n = _stage0_correct_read(read, k, solid_kmers; graph_mode = graph_mode)
         corrected[idx] = rec
         total += n
     end
@@ -867,19 +893,21 @@ end
 # ------------------------------------------------------------------------------
 
 """
-    should_decode_read(read, k, hard_vertices) -> Bool
+    should_decode_read(read, k, hard_vertices; graph_mode) -> Bool
 
-True iff any canonical k-mer of `read` is a member of `hard_vertices` (the
-bubble / repeat-like / weak-k-mer set). Reads that touch no hard vertex have no
-region worth decoding and are passed through untouched. Mirrors
-`_read_is_all_solid`'s canonical k-mer iteration so the two gates compose on the
-same `:canonical` graph. An empty `hard_vertices` means "no gate" ⇒ decode.
+True iff any k-mer of `read` (resolved to its graph label via `_lookup_key`) is a
+member of `hard_vertices` (the bubble / repeat-like / weak-k-mer set). Reads that
+touch no hard vertex have no region worth decoding and are passed through
+untouched. Mirrors `_read_is_all_solid`'s k-mer iteration so the two gates compose
+on the same graph. Works on both `:canonical` and `:doublestrand` graphs
+(td-nt69). An empty `hard_vertices` means "no gate" ⇒ decode.
 """
-function should_decode_read(read::FASTX.FASTQ.Record, k::Int, hard_vertices::AbstractSet)
+function should_decode_read(read::FASTX.FASTQ.Record, k::Int, hard_vertices::AbstractSet;
+        graph_mode::Symbol = :canonical)
     isempty(hard_vertices) && return true
     sequence = FASTX.sequence(BioSequences.LongDNA{4}, read)
     for (kmer, _) in Kmers.UnambiguousDNAMers{k}(sequence)
-        (BioSequences.canonical(kmer) in hard_vertices) && return true
+        (_lookup_key(kmer, graph_mode) in hard_vertices) && return true
     end
     return false
 end
@@ -903,9 +931,11 @@ ambiguity — a bubble/superbubble (competing balanced alleles) or a repeat-like
 high-out-degree vertex. Those are the true ~5–15%. A weak k-mer flanked by solid
 neighbors is no longer "hard"; it is an error Stage 0 either already corrected or
 left as genuinely ambiguous (in which case it typically also sits in a bubble and
-is caught by clause 1). Intended for `:canonical` graphs (matches the skip gate);
-only reached on the :scalable tier (`hard_window=true`), so :exhaustive is
-unaffected.
+is caught by clause 1). Operates directly on the graph vertices/edges, so it is
+mode-agnostic (works on `:canonical` and `:doublestrand` graphs — on a
+doublestrand graph a bubble/repeat is flagged on both strands, and reads are
+matched in their observed orientation by `should_decode_read`; td-nt69). Only
+reached on the :scalable tier (`hard_window=true`), so :exhaustive is unaffected.
 """
 function _hard_vertex_set(graph, k::Int)
     labels = collect(MetaGraphsNext.labels(graph))
@@ -1128,19 +1158,20 @@ function improve_read_set_likelihood(reads::Vector{<:FASTX.FASTQ.Record}, graph,
     # solid has no weak region to correct and skips the per-read decode. Opt-in
     # (default off) so existing callers are unchanged. `solid_kmers === nothing`
     # ⇒ correct every read as before.
-    # The skip helpers canonicalize read k-mers, so they are only valid on a
-    # :canonical graph; on any other mode disable the skip (correct all) rather
-    # than mis-match strands and wrongly skip (review I1/I2 graph_mode).
-    if skip_solid && graph_mode != :canonical
-        @warn "skip_solid is only supported for graph_mode=:canonical; disabling skip (correcting all reads)." graph_mode
+    # td-nt69: the skip/cheap-correct helpers resolve read k-mers to their graph
+    # label via `_lookup_key` (canonicalized under :canonical, observed orientation
+    # under :doublestrand), so they are valid on BOTH modes — classification is
+    # coverage-based and mode-agnostic. :scalable now runs :doublestrand. Only
+    # :singlestrand (no RC vertices, not a corrector target) is excluded.
+    if skip_solid && graph_mode == :singlestrand
+        @warn "skip_solid is not supported for graph_mode=:singlestrand; disabling skip (correcting all reads)." graph_mode
     end
-    if cheap_correct && graph_mode != :canonical
-        @warn "cheap_correct is only supported for graph_mode=:canonical; disabling Stage 0 cheap correction." graph_mode
+    if cheap_correct && graph_mode == :singlestrand
+        @warn "cheap_correct is not supported for graph_mode=:singlestrand; disabling Stage 0 cheap correction." graph_mode
     end
     # Classify k-mers once if EITHER the skip-solid gate OR the Stage 0 cheap
-    # corrector needs the solid set (both canonicalize read k-mers ⇒ :canonical
-    # only). Compute once, share both consumers.
-    need_solid = (skip_solid || cheap_correct) && graph_mode == :canonical
+    # corrector needs the solid set. Compute once, share both consumers.
+    need_solid = (skip_solid || cheap_correct) && graph_mode != :singlestrand
     solid_kmers = need_solid ? _solid_kmer_set(graph) : nothing
 
     # Stage 0 CHEAP correction (td-bjnt): fix simple single-substitution errors
@@ -1149,8 +1180,9 @@ function improve_read_set_likelihood(reads::Vector{<:FASTX.FASTQ.Record}, graph,
     # cheaply-corrected reads. Gated on :scalable (cheap_correct=true, canonical).
     cheap_corrections = 0
     work_reads = reads
-    if cheap_correct && graph_mode == :canonical && solid_kmers !== nothing
-        work_reads, cheap_corrections = _stage0_cheap_correct(reads, k, solid_kmers)
+    if cheap_correct && graph_mode != :singlestrand && solid_kmers !== nothing
+        work_reads, cheap_corrections = _stage0_cheap_correct(reads, k, solid_kmers;
+            graph_mode = graph_mode)
         improvements_made += cheap_corrections
         if verbose && cheap_corrections > 0
             println("  Stage 0 cheap correction: fixed $cheap_corrections base(s) " *
@@ -1166,9 +1198,11 @@ function improve_read_set_likelihood(reads::Vector{<:FASTX.FASTQ.Record}, graph,
     # even when skip_solid is off, so the all-solid skip is gated on `skip_solid`
     # explicitly. Returns true ⇒ skip.
     _skip_this_read = read -> begin
-        (skip_solid && solid_kmers !== nothing && _read_is_all_solid(read, k, solid_kmers)) &&
+        (skip_solid && solid_kmers !== nothing &&
+             _read_is_all_solid(read, k, solid_kmers; graph_mode = graph_mode)) &&
             return true
-        (hard_vertices !== nothing && !should_decode_read(read, k, hard_vertices)) &&
+        (hard_vertices !== nothing &&
+             !should_decode_read(read, k, hard_vertices; graph_mode = graph_mode)) &&
             return true
         return false
     end

--- a/src/rhizomorph/assembly.jl
+++ b/src/rhizomorph/assembly.jl
@@ -245,11 +245,11 @@ struct AssemblyConfig
         # FIX 4 (silent-default + skip_solid-override provenance). corrector=:iterative
         # now DEFAULTS to strategy=:scalable, which is a materially different engine
         # than the prior corrector route (coarse ladder / low iteration cap /
-        # skip-solid / canonical / hard-read gate). Announce the default once so a
-        # caller relying on old behavior is not silently switched.
+        # skip-solid / doublestrand graph mode / hard-read gate). Announce the default
+        # once so a caller relying on old behavior is not silently switched.
         if corrector == :iterative && !strategy_explicit
             @warn "corrector=:iterative now defaults to strategy=:scalable — a coarse " *
-                  "k-ladder + low iteration cap with skip-solid, canonical graph mode, " *
+                  "k-ladder + low iteration cap with skip-solid, doublestrand graph mode, " *
                   "and hard-read gating enabled. This is NOT the prior corrector " *
                   "behavior; pass strategy=:exhaustive for the maximum-sensitivity " *
                   "exact-ML engine, or strategy=:scalable to silence this warning." maxlog = 1
@@ -740,10 +740,14 @@ routing can be unit-tested without running the (slow) corrector.
   skip-solid volume reduction, Stage 0 cheap k-mer-spectrum correction (td-bjnt,
   linear single-substitution fix before the decode), hard-read gating (Stage 3,
   now narrowed to bubble/repeat vertices only), soft-EM edge memory (Stage 2,
-  record-only v1), and the size-aware auto-beam (`beam_width=nothing`).
+  record-only v1), the size-aware auto-beam (`beam_width=nothing`), and
+  `graph_mode=:doublestrand` (td-nt69 — canonical was over-constrained by the skip
+  machinery and was the cause of the quality gap; the skip/classification is
+  coverage-based and mode-agnostic).
 - `:exhaustive` — maximum-sensitivity EXACT-ML tier: prime-by-prime k-walk
   (`n_k_rungs=nothing`), 10 iterations/k, no skip, no hard-window, no soft-EM,
-  and an exact UNBOUNDED (`typemax(Int)`) Viterbi beam. This is NOT a reproduction
+  `graph_mode=nothing` (derive from `config.graph_mode`, byte-identical
+  passthrough), and an exact UNBOUNDED (`typemax(Int)`) Viterbi beam. This is NOT a reproduction
   of the prior corrector default: master's corrector route used the size-aware
   auto-beam (`beam_width=nothing`, bounded on large reads), so forcing an exact
   unbounded beam here reintroduces the td-63qy OOM ABOVE the auto-beam threshold.
@@ -759,7 +763,17 @@ function _corrector_strategy_knobs(strategy::Symbol)
             hard_window = true,
             soft_em = true,
             cheap_correct = true,  # Stage 0 linear k-mer-spectrum correction (td-bjnt)
-            beam_width = nothing   # size-aware auto-beam (bounded on huge reads)
+            beam_width = nothing,  # size-aware auto-beam (bounded on huge reads)
+            # graph_mode=:doublestrand (td-nt69): forcing :canonical was THE cause of
+            # the :scalable quality gap. On a controlled 1kb fixture, flipping ONLY
+            # canonical→doublestrand (all other knobs held) collapses 197→16 contigs
+            # and lifts N50 43→891 — the historical near-complete regime. Canonical
+            # was forced only because the skip machinery was (wrongly) wired to
+            # require it; the k-mer classification is coverage-based and mode-agnostic
+            # (each vertex + its RC are separate doublestrand vertices, still
+            # separable by coverage), so skip_solid + hard_window work under
+            # :doublestrand too — the naive contig path stays valid.
+            graph_mode = :doublestrand
         )
     elseif strategy == :exhaustive
         return (
@@ -769,7 +783,10 @@ function _corrector_strategy_knobs(strategy::Symbol)
             hard_window = false,
             soft_em = false,
             cheap_correct = false,  # exact-ML tier: no cheap pre-correction
-            beam_width = typemax(Int)  # exact ML decode
+            beam_width = typemax(Int),  # exact ML decode
+            # nothing ⇒ derive the corrector graph_mode from config.graph_mode below,
+            # keeping :exhaustive a byte-identical passthrough of prior behavior.
+            graph_mode = nothing
         )
     else
         error("unknown corrector strategy :$(strategy); expected :scalable or :exhaustive")
@@ -791,9 +808,8 @@ td-zru6). Corrector provenance (`corrector`, `strategy`, `skip_solid`,
 `assembly_stats`.
 
 The re-assembly deliberately lets `assemble_genome` auto-detect its graph mode
-(DoubleStrand for DNA) rather than inheriting `config.graph_mode`: the corrector
-needs `:canonical` for skip-solid, but the naive contig path is invalid under
-`:canonical`. Corrected reads are FASTQ, so the re-assembly runs the same
+(DoubleStrand for DNA) rather than inheriting `config.graph_mode`. Corrected
+reads are FASTQ, so the re-assembly runs the same
 quality-aware (qualmer) path a naive `assemble_genome` on FASTQ reads would —
 i.e. it mirrors the naive-on-FASTQ baseline, keeping the comparison apples-to-
 apples.
@@ -826,13 +842,15 @@ function _assemble_with_iterative_corrector(reads, config::AssemblyConfig)
         # soft-EM. The per-tier knobs live in _corrector_strategy_knobs so the
         # routing is unit-testable without running the corrector.
         knobs = _corrector_strategy_knobs(config.strategy)
-        # The :scalable gates (skip-solid + hard-window) canonicalize read k-mers,
-        # so they REQUIRE :canonical (mycelia_iterative_assemble's own default);
-        # forcing config.graph_mode (DoubleStrand for DNA) would silently disable
-        # both gates. :exhaustive keeps today's config-derived mode so it stays a
-        # byte-identical passthrough.
-        corrector_graph_mode = config.strategy == :scalable ?
-                               :canonical : _graph_mode_symbol(config.graph_mode)
+        # td-nt69: :scalable now runs the corrector on a :doublestrand graph
+        # (`knobs.graph_mode == :doublestrand`). Forcing :canonical was THE cause of
+        # the quality gap — the skip machinery was over-constrained to require it,
+        # but skip-solid + hard-window classification is coverage-based and
+        # mode-agnostic, so both gates stay ACTIVE under :doublestrand and the naive
+        # contig path stays valid. :exhaustive threads `knobs.graph_mode === nothing`
+        # ⇒ derive from config.graph_mode, a byte-identical passthrough.
+        corrector_graph_mode = knobs.graph_mode === nothing ?
+                               _graph_mode_symbol(config.graph_mode) : knobs.graph_mode
         result_dict = Mycelia.mycelia_iterative_assemble(
             temp_fastq;
             max_k = max_k,
@@ -879,10 +897,9 @@ function _assemble_with_iterative_corrector(reads, config::AssemblyConfig)
         end
         _log_info(config, "Corrected $(n_corrected) reads; re-assembling them (corrector=:none)")
         reassembly_k = config.k === nothing ? max_k : config.k
-        # Re-assemble with AUTO-DETECTED graph_mode (not config.graph_mode): the
-        # corrector needs :canonical for skip_solid, but the naive graph path emits
-        # invalid contigs under :canonical, so the re-assembly must use the mode the
-        # naive baseline uses (DoubleStrand for DNA), which auto-config selects.
+        # Re-assemble with AUTO-DETECTED graph_mode (not config.graph_mode): match
+        # the mode the naive baseline uses (DoubleStrand for DNA), which auto-config
+        # selects, so the corrected-read re-assembly is apples-to-apples.
         assembly = assemble_genome(corrected_reads;
             k = reassembly_k, corrector = :none)
         # Stamp the corrector provenance onto the real assembly's stats.

--- a/test/4_assembly/scalable_corrector_strategy_test.jl
+++ b/test/4_assembly/scalable_corrector_strategy_test.jl
@@ -14,6 +14,7 @@
 import Test
 import Mycelia
 import FASTX
+import BioSequences
 import Random
 
 const _BASES = ['A', 'C', 'G', 'T']
@@ -28,6 +29,30 @@ function _toy_fastq_records(rng; reflen = 1000, n_reads = 80, readlen = 80, err 
             rand(rng) < err && (seq[j] = rand(rng, filter(!=(seq[j]), _BASES)))
         end
         push!(records, FASTX.FASTQ.Record("r$i", String(seq), String(fill('I', readlen))))
+    end
+    return records
+end
+
+# 1kb quality-gap fixture (mirrors benchmarking/quality_gap_diagnostic.jl): reads
+# sampled from BOTH strands and passed through Mycelia.observe at err=0.01, so the
+# corrector runs on a realistic double-stranded read set. Used by the td-nt69
+# doublestrand-recovery testset below.
+function _qgd_reads(; genome_len = 1000, readlen = 100, coverage = 20,
+        err = 0.01, seed = 42)
+    rec = Mycelia.random_fasta_record(moltype = :DNA, seed = seed, L = genome_len)
+    refseq = FASTX.sequence(BioSequences.LongDNA{4}, rec)
+    rng = Random.MersenneTwister(seed)
+    glen = length(refseq)
+    n_reads = max(1, ceil(Int, coverage * glen / readlen))
+    records = FASTX.FASTQ.Record[]
+    for i in 1:n_reads
+        start = rand(rng, 1:(glen - readlen + 1))
+        frag = refseq[start:(start + readlen - 1)]
+        rand(rng, Bool) && (frag = BioSequences.reverse_complement(frag))
+        obs_seq, quals = Mycelia.observe(frag; error_rate = err, tech = :illumina)
+        isempty(obs_seq) && continue
+        qstr = String([Char(q + 33) for q in quals])
+        push!(records, FASTX.FASTQ.Record("read_$(i)", string(obs_seq), qstr))
     end
     return records
 end
@@ -47,6 +72,9 @@ Test.@testset "scalable corrector strategy fork (td-fuo8)" begin
         Test.@test ex.hard_window == false
         Test.@test ex.soft_em == false
         Test.@test ex.beam_width == typemax(Int)
+        # td-nt69: :exhaustive derives its corrector graph_mode from
+        # config.graph_mode (nothing ⇒ derive), a byte-identical passthrough.
+        Test.@test ex.graph_mode === nothing
 
         sc = R._corrector_strategy_knobs(:scalable)
         # Scalable = coarse 3-rung ladder, low iteration cap, all volume/quality
@@ -60,6 +88,11 @@ Test.@testset "scalable corrector strategy fork (td-fuo8)" begin
         Test.@test sc.hard_window == true
         Test.@test sc.soft_em == true
         Test.@test sc.beam_width === nothing
+        # td-nt69: :scalable runs the corrector on a :doublestrand graph. Forcing
+        # :canonical was THE cause of the quality gap (skip machinery was over-
+        # constrained to require it); the classification is coverage-based and
+        # mode-agnostic, so skip stays active under :doublestrand.
+        Test.@test sc.graph_mode == :doublestrand
 
         Test.@test_throws Exception R._corrector_strategy_knobs(:bogus)
     end
@@ -107,5 +140,47 @@ Test.@testset "scalable corrector strategy fork (td-fuo8)" begin
         # No explicit strategy ⇒ scalable.
         res = R.assemble_genome(reads; k = 13, corrector = :iterative)
         Test.@test res.assembly_stats["strategy"] == "scalable"
+    end
+
+    Test.@testset ":scalable doublestrand recovers low-contig regime (td-nt69)" begin
+        # THE quality fix. On the same 1kb fixture the quality-gap diagnostic used
+        # (err=0.01, ~20x, 100bp), the previously-forced :canonical corrector
+        # shattered the re-assembly to ~197 contigs / N50 43. Running the corrector
+        # on :doublestrand (all other :scalable knobs held) recovers the historical
+        # near-complete regime (~14-21 contigs / N50 ~900), WITH the skip gate still
+        # active. This is an invariant (regime recovery + skip-active), not a golden
+        # contig count, so the thresholds are deliberately loose.
+        reads = _qgd_reads()
+        asm = R.assemble_genome(reads; k = 21, corrector = :iterative, strategy = :scalable)
+
+        n_contigs = length(asm.contigs)
+        lens = sort(length.(asm.contigs); rev = true)
+        total = sum(lens; init = 0)
+        # N50 (contig length at which cumulative coverage reaches half the total).
+        n50 = 0
+        acc = 0
+        for l in lens
+            acc += l
+            if acc >= total / 2
+                n50 = l
+                break
+            end
+        end
+        skip_fraction = get(asm.assembly_stats, "skip_fraction", 0.0)
+
+        Test.@info "td-nt69 doublestrand recovery" n_contigs n50 largest = (isempty(lens) ? 0 : lens[1]) skip_fraction skip_solid = asm.assembly_stats["skip_solid"] hard_window = asm.assembly_stats["hard_window"]
+
+        # RECOVERED low-contig regime: nowhere near the ~197 canonical shatter.
+        # Loose upper bound (observed ~14) that still fails hard on a regression to
+        # the fragmented canonical behavior.
+        Test.@test n_contigs <= 40
+        # High N50 — the historical near-complete regime was ~891-903; require a
+        # large jump over the canonical N50 of 43.
+        Test.@test n50 >= 400
+        # Skip MUST stay ACTIVE under :doublestrand (the whole point: the fix does
+        # not disable the volume-reduction gate, it just runs it on the right graph).
+        Test.@test skip_fraction > 0.0
+        Test.@test asm.assembly_stats["skip_solid"] == true
+        Test.@test asm.assembly_stats["hard_window"] == true
     end
 end


### PR DESCRIPTION
## Summary

- `:scalable` forcing `graph_mode=:canonical` was **THE** cause of the assembly quality gap isolated by the PR #367 diagnostic. On a controlled 1kb fixture (err=0.01, ~20x, 100bp), the canonical route shattered the re-assembly to ~197 contigs / N50 43, versus the historical near-complete DoubleStrand regime (~16-21 contigs / N50 ~900).
- Canonical was forced only because the skip machinery (skip-solid + hard-window + Stage 0 cheap-correct) was wired to require it — an over-constraint. K-mer classification is coverage-based and mode-agnostic (a k-mer and its RC are separate doublestrand vertices, still coverage-separable from errors), so the gates work unchanged on doublestrand.
- All changes are gated behind `strategy=:scalable`; **`:exhaustive` is byte-identical** (its corrector `graph_mode` still derives from `config.graph_mode`).

## Changes

- **`src/rhizomorph/assembly.jl`** — `_corrector_strategy_knobs(:scalable)` now carries `graph_mode=:doublestrand`; `:exhaustive` carries `graph_mode=nothing` (derive from config, unchanged). `_assemble_with_iterative_corrector` consumes `knobs.graph_mode` instead of hardcoding `:canonical` for `:scalable`.
- **`src/iterative-assembly.jl`** — un-constrain the skip-solid / hard-window / Stage 0 gates from `graph_mode==:canonical`. A mode-aware `_lookup_key` resolves each read k-mer to its graph vertex label (canonicalized under `:canonical`, observed orientation under `:doublestrand`). `_read_is_all_solid`, `should_decode_read`, `_stage0_correct_read` / `_stage0_cheap_correct` (via renamed `_lookup_kmer_at`) thread `graph_mode`. Only `:singlestrand` (no RC vertices, not a corrector target) is excluded.
- **test** — assert `:scalable` knob `graph_mode==:doublestrand` and `:exhaustive==nothing`; end-to-end assertion that `:scalable` on the 1kb fixture recovers the low-contig regime (≤40 contigs, N50≥400) with the skip gate still active.

## Verification (1kb fixture, err=0.01, ~20x, 100bp)

| metric | canonical (before) | doublestrand (this PR) |
| --- | --- | --- |
| contigs | ~197 | **14** |
| N50 | 43 | **925** |
| skip_fraction | — | **0.94 (skip ACTIVE)** |

`skip_solid_effective=true`, `hard_window=true` — the skip gate stays active on doublestrand.

## Test Plan

- [x] `variation_preservation_holdout_test.jl` — 12/12 (variation preserved, coverage-1 error still removed)
- [x] `scalable_corrector_strategy_test.jl` — 40/40 (incl. new doublestrand-recovery assertions)
- [x] `scalable_corrector_hard_window_test.jl` — 92/92
- [x] `scalable_corrector_soft_em_test.jl`, `iterative_assembly_helpers_test.jl`, `rhizomorph_iterative_corrector_wiring_test.jl`, `stage0_*` — pass
- [x] `iterative_assembly_tests.jl` — 196/196

## Related

- Builds directly on the PR #367 quality-gap diagnostic (merged).
- NOTE: conflicts with `cp/softem-v2-floor` (#366) on `iterative-assembly.jl`; this is the priority quality fix and should merge first.