### PR TITLE
add: low-k decode gating for the scalable corrector (td-9h5r)

### DIFF
--- a/src/iterative-assembly.jl
+++ b/src/iterative-assembly.jl
@@ -165,6 +165,17 @@ function _next_k_in_progression(current_k::Int, max_k::Int,
     return isempty(larger) ? current_k : minimum(larger)
 end
 
+# Default ADAPTIVE low-k decode-gate density threshold (td-9h5r): if, at a given
+# k-rung, the post-Stage-0 hard-window gate would still send AT LEAST this fraction
+# of reads to the expensive per-read graph-Viterbi decode, the gate is judged
+# NON-DISCRIMINATING (it is not reducing decode volume) and the whole decode is
+# skipped for that pass — the reads fall back on Stage 0 cheap correction +
+# skip-solid, and the whole-read Viterbi is deferred to higher, selective rungs
+# where the gate actually filters. 0.90 leaves a genuinely selective low-k decode
+# (e.g. a gate that skips ~40-60% of reads) ON, and only gates the dense-graph
+# "decode almost everything" pathology the #370 profile flagged.
+const _DEFAULT_DECODE_GATE_DENSITY = 0.90
+
 """
 Estimate memory usage for a graph with a given number of k-mers.
 Provides a rough estimate for memory monitoring.
@@ -238,7 +249,9 @@ function mycelia_iterative_assemble(input_fastq::String;
         hard_window::Bool = false,
         soft_em::Bool = false,
         cheap_correct::Bool = false,
-        beam_width::Union{Int, Nothing} = nothing)
+        beam_width::Union{Int, Nothing} = nothing,
+        min_decode_k::Union{Int, Nothing} = nothing,
+        decode_gate_density::Union{Float64, Nothing} = nothing)
     start_time = time()
 
     # Accumulates swallowed decode failures (structural / un-k-merizable) across
@@ -373,6 +386,51 @@ function mycelia_iterative_assemble(input_fastq::String;
         println("K-mer ladder (coarse progression): $(k_schedule)")
     end
 
+    # -- Low-k decode gating (td-9h5r) -----------------------------------------
+    # The finding (PR #370 profile): the per-read graph-Viterbi decode is 57-78% of
+    # every :scalable iteration — the dominant runtime term — yet at LOW k the graph
+    # is dense (nearly every k-mer sits on a bubble/repeat vertex), so the
+    # hard-window gate cannot discriminate and flags essentially EVERY read for a
+    # full whole-read decode. That is correction Stage 0's cheap linear pass already
+    # largely did. Two composable gates cut that wasted volume; BOTH still BUILD the
+    # graph and run Stage 0 cheap correction + skip-solid, deferring only the
+    # expensive whole-read Viterbi to higher, selective rungs:
+    #
+    #   (1) ADAPTIVE (default): at a rung whose post-Stage-0 hard-window decode
+    #       fraction would be >= `decode_gate_density`, the gate is non-
+    #       discriminating (it would decode ~everything → no volume reduction), so
+    #       the whole decode is skipped for that pass. This fires EXACTLY on the
+    #       dense-low-k pathology and is a NO-OP where the gate genuinely filters
+    #       (so a load-bearing selective low-k decode is preserved). Measured
+    #       post-Stage-0 inside improve_read_set_likelihood (raw-read density is
+    #       uninformative — Stage 0 clears most apparent hardness first).
+    #   (2) EXPLICIT floor: `min_decode_k` hard-gates every rung `k < min_decode_k`
+    #       (the LoRMA-style "start the graph-decode ladder higher" lever). Off by
+    #       default; deterministic, for tuning/tests.
+    #
+    # Both are gated behind the `:scalable` tier (only active when `hard_window` is
+    # true), so the `:exhaustive` tier (hard_window=false) is BYTE-IDENTICAL.
+    effective_min_decode_k = hard_window ? min_decode_k : nothing
+    # Adaptive-gate density threshold (fraction of reads the hard-window gate would
+    # still decode after Stage 0 above which the gate counts as non-discriminating).
+    # Default 0.90 on :scalable; `nothing` (or the exhaustive tier) disables it.
+    effective_decode_gate_density = hard_window ?
+                                    (decode_gate_density === nothing ?
+                                     _DEFAULT_DECODE_GATE_DENSITY : decode_gate_density) :
+                                    nothing
+    if verbose && (effective_min_decode_k !== nothing ||
+                   effective_decode_gate_density !== nothing)
+        println("Low-k decode gating (td-9h5r): " *
+                (effective_min_decode_k !== nothing ?
+                 "explicit floor min_decode_k=$(effective_min_decode_k); " : "") *
+                (effective_decode_gate_density !== nothing ?
+                 "adaptive gate-off when post-Stage-0 decode fraction >= " *
+                 "$(effective_decode_gate_density). " : "") *
+                "Gated rungs rely on Stage 0 cheap correction + skip-solid.")
+    end
+    # Telemetry: the k-rungs whose per-read decode was gated OFF (low-k skip).
+    decode_gated_rungs = Int[]
+
     # Hard-window skip telemetry (td-nn6l): the fraction of reads the hard-window
     # gate passed through WITHOUT a decode, recorded PER PASS (across every k and
     # iteration) so the run metadata can surface min/mean/max, not just the last
@@ -469,9 +527,22 @@ function mycelia_iterative_assemble(input_fastq::String;
             # orientation, so the gate works on both :canonical and :doublestrand
             # (:scalable now runs :doublestrand). Only :singlestrand — which has no
             # RC vertices and is not a corrector target — is excluded.
-            hard_vertices = (hard_window && graph_mode != :singlestrand) ?
+            # Low-k decode gating (td-9h5r) — EXPLICIT floor. Below
+            # `effective_min_decode_k` the per-read graph-Viterbi decode is skipped
+            # for EVERY read this pass. Stage 0 cheap correction + skip-solid still
+            # run below. Only active on the :scalable tier (hard_window=true), so
+            # :exhaustive is byte-identical. The ADAPTIVE gate (density-based) is
+            # decided inside improve_read_set_likelihood — it needs the post-Stage-0
+            # decode fraction — and is reported back via `pass_decode_gated`.
+            explicit_floor_gated = effective_min_decode_k !== nothing &&
+                                   k < effective_min_decode_k
+            # Building the hard-vertex set is pointless when the explicit floor
+            # already gates the decode off; the adaptive gate needs it, though, so
+            # build it whenever the floor is NOT gating and hard_window is on.
+            hard_vertices = (hard_window && !explicit_floor_gated &&
+                             graph_mode != :singlestrand) ?
                             _hard_vertex_set(graph, k) : nothing
-            if hard_window && graph_mode == :singlestrand
+            if hard_window && !explicit_floor_gated && graph_mode == :singlestrand
                 @warn "hard_window gating is not supported for graph_mode=:singlestrand; " *
                       "disabling (decoding all non-solid reads)." graph_mode maxlog = 1
             end
@@ -500,6 +571,7 @@ function mycelia_iterative_assemble(input_fastq::String;
             improvements_made = 0
             pass_skip_fraction = 0.0
             pass_cheap_corrections = 0
+            pass_decode_gated = false
             try
                 if soft_em && prev_soft_weights !== nothing
                     Mycelia.Rhizomorph.register_soft_edge_weights!(graph, prev_soft_weights)
@@ -507,7 +579,8 @@ function mycelia_iterative_assemble(input_fastq::String;
                 updated_reads,
                 improvements_made,
                 pass_skip_fraction,
-                pass_cheap_corrections = improve_read_set_likelihood(
+                pass_cheap_corrections,
+                pass_decode_gated = improve_read_set_likelihood(
                     current_reads, graph, k,
                     verbose = verbose,
                     batch_size = batch_size,
@@ -518,6 +591,8 @@ function mycelia_iterative_assemble(input_fastq::String;
                     beam_width = beam_width,
                     soft_weights = current_soft_weights,
                     hard_vertices = hard_vertices,
+                    decode_enabled = !explicit_floor_gated,
+                    decode_gate_density = effective_decode_gate_density,
                     diagnostics = corrector_diagnostics
                 )
             finally
@@ -525,6 +600,12 @@ function mycelia_iterative_assemble(input_fastq::String;
             end
             push!(skip_fractions, pass_skip_fraction)
             push!(cheap_correction_counts, pass_cheap_corrections)
+            # Record a rung whose per-read decode was gated OFF (explicit floor OR
+            # adaptive density gate) — telemetry surfaced in the run metadata.
+            if (explicit_floor_gated || pass_decode_gated) &&
+               (isempty(decode_gated_rungs) || last(decode_gated_rungs) != k)
+                push!(decode_gated_rungs, k)
+            end
             # Carry this iteration's soft edge memory forward: it becomes the next
             # EM iteration's M-step input (registered onto the next graph). `nothing`
             # on :exhaustive (no soft-EM) so that tier stays byte-identical.
@@ -672,7 +753,10 @@ function mycelia_iterative_assemble(input_fastq::String;
         verbose = verbose, diagnostics = corrector_diagnostics,
         skip_fractions = skip_fractions,
         cheap_correction_counts = cheap_correction_counts,
-        hard_window = hard_window, soft_em = soft_em, cheap_correct = cheap_correct)
+        hard_window = hard_window, soft_em = soft_em, cheap_correct = cheap_correct,
+        min_decode_k = effective_min_decode_k,
+        decode_gate_density = effective_decode_gate_density,
+        decode_gated_rungs = decode_gated_rungs)
 end
 
 # =============================================================================
@@ -1143,6 +1227,25 @@ k-mers overlap the "hard" vertex set (bubbles / repeats / weak k-mers); every
 other read passes through untouched. Composes with `skip_solid` — a read is
 decoded only when it is NOT all-solid AND (no hard set, or it touches one).
 
+`decode_enabled` (td-9h5r): when `false`, the per-read graph-Viterbi decode is
+skipped for EVERY read this pass (skip_fraction == 1.0) — the EXPLICIT low-k decode
+floor. Stage 0 cheap correction still runs first (on `work_reads`), so simple
+errors are still fixed; only the expensive whole-read Viterbi is deferred to higher
+k-rungs. Defaults to `true`; the `:scalable` k-ladder sets it `false` below
+`min_decode_k`.
+
+`decode_gate_density` (td-9h5r): the ADAPTIVE low-k decode gate. When non-`nothing`
+and a hard-window gate is active, the pass measures the post-Stage-0 fraction of
+reads the gate would still decode; if that is `>= decode_gate_density` the gate is
+NON-DISCRIMINATING (the dense-low-k "gate skips nothing" pathology) and the whole
+decode is skipped for the pass. A genuinely selective low-k decode (gate skips a
+meaningful fraction) is left ON. `nothing` (default / `:exhaustive`) disables it.
+
+Returns `(updated_reads, improvements_made, skip_fraction, cheap_corrections,
+decode_gated)` where `decode_gated` is `true` iff the per-read decode was gated OFF
+for this pass (explicit floor OR adaptive density). Callers destructuring only the
+first two/three/four values are unaffected.
+
 `soft_weights` (td-e70t): when non-`nothing`, each decoded read's ML path
 accumulates edge responsibilities into it (the soft-EM E-step). Accumulation is
 NOT thread-safe, so supplying it forces sequential processing for this pass.
@@ -1154,13 +1257,15 @@ linear scan so the expensive graph Viterbi is reserved for genuine ambiguity
 (bubbles/repeats). The decode then operates on the cheaply-corrected reads. Only
 enabled on the :scalable tier.
 
-Returns `(updated_reads, improvements_made, skip_fraction, cheap_corrections)`
-where `skip_fraction` is the fraction of reads passed through WITHOUT a decode
-(solid + hard-window skips) and `cheap_corrections` is the number of bases fixed
-by the Stage 0 pass. The graph-Viterbi decode fraction is `1 - skip_fraction`.
-`improvements_made` counts BOTH cheap corrections and decode-accepted corrections
-so per-k convergence sees Stage 0 progress. Callers destructuring only the first
-two or three values are unaffected.
+Returns `(updated_reads, improvements_made, skip_fraction, cheap_corrections,
+decode_gated)` where `skip_fraction` is the fraction of reads passed through WITHOUT
+a decode (solid + hard-window skips, plus the whole set when the low-k decode gate
+fires) and `cheap_corrections` is the number of bases fixed by the Stage 0 pass. The
+graph-Viterbi decode fraction is `1 - skip_fraction`. `improvements_made` counts
+BOTH cheap corrections and decode-accepted corrections so per-k convergence sees
+Stage 0 progress. `decode_gated` is `true` iff the per-read decode was gated OFF for
+the whole pass (low-k gate, td-9h5r). Callers destructuring only the first
+two/three/four values are unaffected.
 """
 function improve_read_set_likelihood(reads::Vector{<:FASTX.FASTQ.Record}, graph, k::Int;
         verbose::Bool = false,
@@ -1172,8 +1277,10 @@ function improve_read_set_likelihood(reads::Vector{<:FASTX.FASTQ.Record}, graph,
         beam_width::Union{Int, Nothing} = nothing,
         soft_weights::Union{Nothing, Mycelia.Rhizomorph.SoftEdgeWeightAccumulator} = nothing,
         hard_vertices::Union{Nothing, AbstractSet} = nothing,
+        decode_enabled::Bool = true,
+        decode_gate_density::Union{Float64, Nothing} = nothing,
         diagnostics::Union{Nothing, CorrectorDiagnostics} = nothing)::Tuple{
-        Vector{FASTX.FASTQ.Record}, Int, Float64, Int}
+        Vector{FASTX.FASTQ.Record}, Int, Float64, Int, Bool}
     diag = diagnostics === nothing ? CorrectorDiagnostics() : diagnostics
     # Snapshot so the per-call @warn reflects THIS pass's swallowed fraction even
     # when `diag` is a shared accumulator threaded across many passes.
@@ -1225,8 +1332,9 @@ function improve_read_set_likelihood(reads::Vector{<:FASTX.FASTQ.Record}, graph,
     # hard vertex. Both are volume-reduction skips and both count toward the
     # reported skip fraction. `solid_kmers` may be populated for cheap correction
     # even when skip_solid is off, so the all-solid skip is gated on `skip_solid`
-    # explicitly. Returns true ⇒ skip.
-    _skip_this_read = read -> begin
+    # explicitly. Returns true ⇒ skip. Stage 0 has ALREADY run above (on
+    # `work_reads`), so this predicate sees the cheaply-corrected reads.
+    _gate_skip = read -> begin
         (skip_solid && solid_kmers !== nothing &&
              _read_is_all_solid(read, k, solid_kmers; graph_mode = graph_mode)) &&
             return true
@@ -1235,6 +1343,44 @@ function improve_read_set_likelihood(reads::Vector{<:FASTX.FASTQ.Record}, graph,
             return true
         return false
     end
+
+    # Precompute per-read skip decisions ONCE (cheap k-mer-membership checks) so the
+    # adaptive low-k gate can measure the natural decode fraction and the decode loop
+    # can reuse the same flags (no double evaluation).
+    base_skip_flags = Vector{Bool}(undef, total_reads)
+    @inbounds for i in 1:total_reads
+        base_skip_flags[i] = _gate_skip(work_reads[i])
+    end
+    natural_decode_fraction = total_reads > 0 ?
+                              count(!, base_skip_flags) / total_reads : 0.0
+
+    # -- Low-k decode gating (td-9h5r) -----------------------------------------
+    # `decode_enabled == false` (EXPLICIT floor `min_decode_k`): skip the per-read
+    # graph-Viterbi decode for EVERY read this pass. Stage 0 cheap correction has
+    # already run (on `work_reads`), so error correction still happens; only the
+    # expensive whole-read Viterbi is deferred to higher, selective k-rungs.
+    #
+    # ADAPTIVE density gate: even with `decode_enabled`, if the hard-window gate
+    # would still send >= `decode_gate_density` of reads to the decode (i.e. it is
+    # NON-DISCRIMINATING — the dense-low-k pathology where "the gate skips nothing"),
+    # skip the whole decode too: the gate is not reducing volume, so the decode is
+    # ~pure waste Stage 0 + the selective higher rungs recover. Requires an active
+    # hard-window gate (`hard_vertices !== nothing`) — with no gate there is no
+    # discrimination signal to act on, so the decode runs as before.
+    adaptive_gated = decode_enabled && decode_gate_density !== nothing &&
+                     hard_vertices !== nothing &&
+                     natural_decode_fraction >= decode_gate_density
+    pass_decode_off = !decode_enabled || adaptive_gated
+    if verbose && adaptive_gated
+        println("  Low-k decode gate (td-9h5r): hard-window gate non-discriminating " *
+                "at k=$k (would decode $(round(natural_decode_fraction * 100, digits=1))% " *
+                ">= $(round(decode_gate_density * 100, digits=1))%); skipping decode " *
+                "this pass (Stage 0 + higher-k rungs recover).")
+    end
+
+    # Final per-read skip decision: all reads skip when the pass decode is gated off;
+    # otherwise use the precomputed gate flags.
+    _skip_this_read_at = i -> pass_decode_off || base_skip_flags[i]
 
     # Soft-EM accumulation into `soft_weights` is not thread-safe (shared Dict),
     # so a soft-EM pass runs sequentially. Otherwise honor the caller's request.
@@ -1266,7 +1412,7 @@ function improve_read_set_likelihood(reads::Vector{<:FASTX.FASTQ.Record}, graph,
             skip_flags = fill(false, length(batch_reads))
             Threads.@threads for i in eachindex(batch_reads)
                 read = batch_reads[i]
-                if _skip_this_read(read)
+                if _skip_this_read_at(batch_start + i - 1)
                     batch_results[i] = (read, false)   # skip the decode
                     skip_flags[i] = true
                 else
@@ -1290,7 +1436,7 @@ function improve_read_set_likelihood(reads::Vector{<:FASTX.FASTQ.Record}, graph,
             # Sequential processing (also the soft-EM path: accumulation into
             # `soft_weights` happens per-read inside improve_read_likelihood).
             for (i, read) in enumerate(batch_reads)
-                if _skip_this_read(read)
+                if _skip_this_read_at(batch_start + i - 1)
                     updated_reads[batch_start + i - 1] = read   # skip the decode
                     skipped_reads += 1
                     continue
@@ -1328,10 +1474,11 @@ function improve_read_set_likelihood(reads::Vector{<:FASTX.FASTQ.Record}, graph,
     if verbose
         total_improvement_rate = improvements_made / total_reads * 100
         println("  Total improvements: $improvements_made/$total_reads ($(round(total_improvement_rate, digits=1))%)")
-        if skip_solid || hard_vertices !== nothing
+        if skip_solid || hard_vertices !== nothing || pass_decode_off
             println("  Skipped (no decode): $skipped_reads/$total_reads ($(round(skip_fraction * 100, digits=1))%)")
             decode_fraction = 1.0 - skip_fraction
-            println("  Graph-Viterbi decode fraction: $(round(decode_fraction * 100, digits=1))%")
+            gated = pass_decode_off ? " [low-k decode gated OFF, td-9h5r]" : ""
+            println("  Graph-Viterbi decode fraction: $(round(decode_fraction * 100, digits=1))%$(gated)")
         end
         if cheap_correct
             println("  Stage 0 cheap corrections (this pass): $cheap_corrections")
@@ -1358,7 +1505,8 @@ function improve_read_set_likelihood(reads::Vector{<:FASTX.FASTQ.Record}, graph,
         end
     end
 
-    return updated_reads, improvements_made, skip_fraction, cheap_corrections
+    return updated_reads, improvements_made, skip_fraction, cheap_corrections,
+    pass_decode_off
 end
 
 """
@@ -1963,7 +2111,10 @@ function finalize_iterative_assembly(output_dir::String, k_progression::Vector{I
         cheap_correction_counts::Vector{Int} = Int[],
         hard_window::Bool = false,
         soft_em::Bool = false,
-        cheap_correct::Bool = false)
+        cheap_correct::Bool = false,
+        min_decode_k::Union{Int, Nothing} = nothing,
+        decode_gate_density::Union{Float64, Nothing} = nothing,
+        decode_gated_rungs::Vector{Int} = Int[])
     if verbose
         println("Finalizing iterative assembly results...")
     end
@@ -2049,6 +2200,12 @@ function finalize_iterative_assembly(output_dir::String, k_progression::Vector{I
         # iteration's graph, so unsupported error edges decay while supported
         # variation is retained. `false` on the exhaustive tier (soft-EM off there).
         :soft_em => (soft_em ? "v2-competing-paths-floor" : false),
+        # Low-k decode gating (td-9h5r): the explicit floor (if any), the adaptive
+        # density threshold, and the specific rungs whose per-read decode was gated
+        # OFF (explicit floor OR adaptive). `nothing`/empty on the exhaustive tier.
+        :min_decode_k => min_decode_k,
+        :decode_gate_density => decode_gate_density,
+        :decode_gated_rungs => decode_gated_rungs,
         :last_skip_fraction => last_skip_fraction,
         :skip_fraction_per_pass => skip_fractions,
         :skip_fraction_min => skip_min,

--- a/test/4_assembly/low_k_decode_gating_test.jl
+++ b/test/4_assembly/low_k_decode_gating_test.jl
@@ -1,0 +1,203 @@
+# LOW-K DECODE GATING (td-9h5r)
+# =============================
+#
+# The per-read graph-Viterbi decode is the dominant runtime term of the :scalable
+# corrector (57-78% of every iteration in the #370 profile). At LOW k the graph is
+# dense — nearly every k-mer sits on a bubble/repeat vertex — so the hard-window
+# gate cannot discriminate and flags essentially every read for a full whole-read
+# decode, correction Stage 0's cheap linear pass already largely did. This gates
+# that wasted low-k decode volume WITHOUT touching the decode algorithm itself, via
+# two composable levers, BOTH gated behind the :scalable tier (hard_window=true) so
+# :exhaustive stays byte-identical:
+#
+#   (1) EXPLICIT floor  — `min_decode_k`: skip the decode for every rung k < floor
+#       (deterministic; "start the graph-decode ladder at a higher k").
+#   (2) ADAPTIVE gate   — `decode_gate_density`: skip the decode for a pass whose
+#       post-Stage-0 hard-window decode fraction would be >= the threshold (the gate
+#       is non-discriminating). A genuinely selective low-k decode stays ON.
+#
+# WHAT IS ASSERTED
+#   * `_read_set` explicit floor: decode_enabled=false ⇒ the whole pass is gated
+#     (skip_fraction == 1.0, decode_gated == true), but Stage 0 cheap corrections
+#     still happen (error correction is not disabled, only the Viterbi is deferred).
+#   * `_read_set` adaptive gate: a NON-discriminating hard set (covers ~all reads)
+#     with a density threshold below 1.0 gates the pass; a SELECTIVE hard set (few
+#     reads) does NOT gate even at the same threshold (the load-bearing decode is
+#     preserved).
+#   * Integration: mycelia_iterative_assemble with hard_window=true + a high
+#     min_decode_k gates the low rungs and surfaces `decode_gated_rungs`.
+#   * :exhaustive byte-identical: with hard_window=false the gating knobs are
+#     IGNORED — an explicit min_decode_k / decode_gate_density produces identical
+#     corrected output to the ungated run.
+#
+# Run directly:
+#   LD_LIBRARY_PATH='' julia --project=. \
+#     -e 'include("test/4_assembly/low_k_decode_gating_test.jl")'
+
+import Test
+import Mycelia
+import FASTX
+import Random
+
+const _LK_BASES = ['A', 'C', 'G', 'T']
+
+function _lk_reads(rng, ref; n_reads = 120, readlen = 80)
+    reflen = length(ref)
+    records = FASTX.FASTQ.Record[]
+    for i in 1:n_reads
+        s = rand(rng, 1:(reflen - readlen + 1))
+        seq = ref[s:(s + readlen - 1)]
+        push!(records, FASTX.FASTQ.Record("r$i", seq, String(fill('I', readlen))))
+    end
+    return records
+end
+
+Test.@testset "low-k decode gating (td-9h5r)" begin
+    R = Mycelia.Rhizomorph
+
+    Test.@testset "explicit floor: decode_enabled=false gates the whole pass" begin
+        rng = Random.MersenneTwister(101)
+        ref = join(rand(rng, _LK_BASES, 1000))
+        # Inject single-substitution errors so Stage 0 has simple errors to fix.
+        reads = _lk_reads(rng, ref; n_reads = 150)
+        for i in 1:20
+            s = rand(rng, 1:921)
+            seq = collect(ref[s:(s + 79)])
+            seq[40] = rand(rng, filter(!=(seq[40]), _LK_BASES))
+            push!(reads, FASTX.FASTQ.Record("e$i", String(seq), String(fill('I', 80))))
+        end
+        k = 13
+        graph = R.build_qualmer_graph(reads, k; mode = :canonical)
+        hard = Mycelia._hard_vertex_set(graph, k)
+
+        # decode_enabled=false ⇒ every read skips the decode; Stage 0 still runs.
+        _out, imp, skip, cheap, gated = Mycelia.improve_read_set_likelihood(
+            reads, graph, k; graph_mode = :canonical, skip_solid = true,
+            cheap_correct = true, hard_vertices = hard, decode_enabled = false)
+        Test.@test gated == true
+        Test.@test skip == 1.0                 # nothing decoded
+        Test.@test cheap >= 0                  # Stage 0 still allowed to run
+        Test.@test imp == cheap                # all improvements are cheap-correction
+
+        # decode_enabled=true (no adaptive threshold) ⇒ normal, decode runs.
+        _o2, _i2, skip2, _c2, gated2 = Mycelia.improve_read_set_likelihood(
+            reads, graph, k; graph_mode = :canonical, skip_solid = true,
+            cheap_correct = true, hard_vertices = hard, decode_enabled = true)
+        Test.@test gated2 == false
+        Test.@test skip2 < 1.0                 # at least some reads reached the decode
+    end
+
+    Test.@testset "adaptive gate: fires on a non-discriminating hard set only" begin
+        rng = Random.MersenneTwister(202)
+        ref = join(rand(rng, _LK_BASES, 800))
+        reads = _lk_reads(rng, ref; n_reads = 120)
+        k = 13
+        graph = R.build_qualmer_graph(reads, k; mode = :canonical)
+        all_labels = collect(R.MetaGraphsNext.labels(graph))
+
+        # NON-discriminating hard set: EVERY vertex is "hard" ⇒ every read with a
+        # k-mer would decode ⇒ natural decode fraction ~1.0. A density threshold
+        # below that must gate the pass.
+        hard_all = Set(all_labels)
+        _o, _i, skip_all, _c, gated_all = Mycelia.improve_read_set_likelihood(
+            reads, graph, k; graph_mode = :canonical, skip_solid = false,
+            cheap_correct = false, hard_vertices = hard_all,
+            decode_gate_density = 0.90)
+        Test.@test gated_all == true
+        Test.@test skip_all == 1.0
+
+        # Same non-discriminating hard set but NO threshold ⇒ NOT gated (decodes).
+        _o2, _i2, skip_none, _c2, gated_none = Mycelia.improve_read_set_likelihood(
+            reads, graph, k; graph_mode = :canonical, skip_solid = false,
+            cheap_correct = false, hard_vertices = hard_all,
+            decode_gate_density = nothing)
+        Test.@test gated_none == false
+        Test.@test skip_none < 1.0
+
+        # SELECTIVE hard set: only a couple of vertices are hard ⇒ few reads decode
+        # ⇒ natural decode fraction is LOW ⇒ the adaptive gate must NOT fire even at
+        # the same 0.90 threshold (a load-bearing selective decode is preserved).
+        hard_few = Set(all_labels[1:min(2, length(all_labels))])
+        _o3, _i3, skip_few, _c3, gated_few = Mycelia.improve_read_set_likelihood(
+            reads, graph, k; graph_mode = :canonical, skip_solid = false,
+            cheap_correct = false, hard_vertices = hard_few,
+            decode_gate_density = 0.90)
+        Test.@test gated_few == false
+        Test.@test skip_few > 0.0              # most reads skipped (few are hard)
+    end
+
+    Test.@testset "adaptive gate requires an active hard-window gate" begin
+        # With no hard set (hard_vertices=nothing) there is no discrimination signal,
+        # so the adaptive gate is inert regardless of the threshold — the decode runs
+        # as before (this keeps the gate from firing on a skip_solid-only pass).
+        rng = Random.MersenneTwister(303)
+        ref = join(rand(rng, _LK_BASES, 800))
+        reads = _lk_reads(rng, ref; n_reads = 100)
+        k = 13
+        graph = R.build_qualmer_graph(reads, k; mode = :canonical)
+        _o, _i, _skip, _c, gated = Mycelia.improve_read_set_likelihood(
+            reads, graph, k; graph_mode = :canonical, skip_solid = false,
+            cheap_correct = false, hard_vertices = nothing,
+            decode_gate_density = 0.10)
+        Test.@test gated == false
+    end
+
+    Test.@testset "integration: explicit floor gates low rungs (:scalable)" begin
+        rng = Random.MersenneTwister(404)
+        ref = join(rand(rng, _LK_BASES, 1500))
+        reads = _lk_reads(rng, ref; n_reads = 200, readlen = 100)
+        tmp = mktempdir()
+        fq = joinpath(tmp, "in.fastq")
+        Mycelia.write_fastq(records = reads, filename = fq)
+
+        # Force the graph-decode ladder to start at the top rung: a high min_decode_k
+        # (>= the largest rung) gates every lower rung. hard_window=true ⇒ :scalable.
+        res = Mycelia.mycelia_iterative_assemble(fq;
+            max_k = 21, skip_solid = true, graph_mode = :doublestrand,
+            n_k_rungs = 3, max_iterations_per_k = 2, hard_window = true,
+            soft_em = false, cheap_correct = true, beam_width = nothing,
+            min_decode_k = 1000, verbose = false, enable_checkpointing = false,
+            output_dir = joinpath(tmp, "out"))
+        meta = res[:metadata]
+        Test.@test meta[:min_decode_k] == 1000
+        # Every processed rung is below 1000 ⇒ all are gated.
+        Test.@test !isempty(meta[:decode_gated_rungs])
+        Test.@test Set(meta[:decode_gated_rungs]) == Set(res[:k_progression])
+        # Every pass skipped the whole decode ⇒ skip fraction 1.0 throughout.
+        Test.@test all(==(1.0), meta[:skip_fraction_per_pass])
+    end
+
+    Test.@testset ":exhaustive is byte-identical (gating knobs ignored)" begin
+        # hard_window=false ⇒ the :exhaustive tier. The low-k gating knobs must be
+        # NO-OPS: a run with an aggressive min_decode_k + density threshold must
+        # produce byte-identical corrected reads to the ungated run.
+        rng = Random.MersenneTwister(505)
+        ref = join(rand(rng, _LK_BASES, 600))
+        reads = _lk_reads(rng, ref; n_reads = 60, readlen = 80)
+        tmp = mktempdir()
+        fq = joinpath(tmp, "in.fastq")
+        Mycelia.write_fastq(records = reads, filename = fq)
+
+        run_corrector = (; min_decode_k, decode_gate_density, out) ->
+            Mycelia.mycelia_iterative_assemble(fq;
+                max_k = 17, skip_solid = false, graph_mode = :canonical,
+                n_k_rungs = 3, max_iterations_per_k = 2, hard_window = false,
+                soft_em = false, cheap_correct = false, beam_width = typemax(Int),
+                min_decode_k = min_decode_k, decode_gate_density = decode_gate_density,
+                verbose = false, enable_checkpointing = false, output_dir = out)
+
+        r_plain = run_corrector(; min_decode_k = nothing, decode_gate_density = nothing,
+            out = joinpath(tmp, "plain"))
+        r_gated = run_corrector(; min_decode_k = 1000, decode_gate_density = 0.10,
+            out = joinpath(tmp, "gated"))
+
+        seqs(res) = [FASTX.sequence(String, r) for r in
+                     open(FASTX.FASTQ.Reader, res[:metadata][:final_fastq_file]) do rd
+                         collect(rd)
+                     end]
+        Test.@test seqs(r_plain) == seqs(r_gated)
+        # And the exhaustive tier records NO gating (byte-identical passthrough).
+        Test.@test r_gated[:metadata][:min_decode_k] === nothing
+        Test.@test isempty(r_gated[:metadata][:decode_gated_rungs])
+    end
+end


### PR DESCRIPTION
## Summary

The per-read graph-Viterbi decode is the dominant runtime term of the `:scalable` corrector (57-78% of every iteration in the #370 profile). This adds **low-k decode gating** to cut wasted decode VOLUME without touching the decode algorithm itself. All changes are gated behind the `:scalable` tier (`hard_window=true`); the `:exhaustive` tier is **byte-identical**.

Two composable levers, both in `src/iterative-assembly.jl`:

- **Adaptive gate (default, self-tuning)** — `decode_gate_density` (0.90): at a rung whose post-Stage-0 hard-window decode fraction would be `>=` the threshold, the gate is *non-discriminating* (it would decode ~everything → no volume reduction), so the whole decode is skipped for that pass. Reads fall back on Stage 0 cheap correction + skip-solid; the whole-read Viterbi is deferred to higher, selective rungs. A genuinely selective low-k decode is left ON.
- **Explicit floor** — `min_decode_k`: hard-gate every rung `k < floor` (the "start the graph-decode ladder higher" lever). Off by default; deterministic for tuning/tests.

Telemetry (`min_decode_k`, `decode_gate_density`, `decode_gated_rungs`) is surfaced in the corrector metadata; `improve_read_set_likelihood` returns a 5th `decode_gated` tuple element (existing 2-4-value destructures unaffected).

## Empirical finding (which approach + why)

Fixtures: 1kb / 3kb / 5kb, err=0.01, 20x, 100bp.

**The bead's dense-low-k pathology ("gate decodes 200/200 at low k") does not reproduce on current code.** Stage 0 cheap correction + skip-solid (merged after the #370 profile) already eliminated it. Measured post-Stage-0 decode fraction per k:

| k | 3 | 5 | 7 | 9 | 11 | 13 | 15 | 17 | 19 | 21 |
|---|---|---|---|---|----|----|----|----|----|----|
| decode frac (1kb) | 0.00 | 0.23 | 0.36 | 0.44 | 0.47 | 0.49 | 0.52 | 0.55 | 0.57 | 0.58 |

The lowest rungs (k≤5) are fully skipped by skip-solid (decode 0%); the decode fraction then *increases* with k and never reaches 90%. So chosen approach = **the adaptive gate** (option c/a hybrid: gate only when the gate is genuinely non-discriminating), which correctly **never fires** on these fixtures.

**Verification (per the payoff checklist):**
- Per-rung decode fraction before/after (1kb ladder `[3,9,21]`): `[0.0, 0.435, 0.175, 0.06]` → **identical** under the adaptive default (`decode_gated_rungs = []`).
- Runtime: unchanged (no gating triggered); the pathology the bead targeted is already mitigated.
- **Quality preserved:** 14 contigs / N50 925 (baseline: 14 / 925) — not regressed toward naive's 474/33.
- `variation_preservation_holdout_test.jl` still passes.

**Fallback reported (per the bead's instruction):** forcing low-k gating via an explicit floor (decode only at the top rung) cuts corrector runtime ~50% but regresses contigs **14 → 53** (N50 preserved at 906), confirming the residual low-k (k=9, 43.5%) decode is discriminating and load-bearing — Stage 0 alone cannot replace it. The gate therefore ships as a safe guardrail that fires only on genuine non-discrimination, plus the operator floor.

## Test Plan

- [x] `test/4_assembly/low_k_decode_gating_test.jl` (new, 20 assertions): explicit floor gates the whole pass (skip=1.0, decode_gated=true) while Stage 0 still runs; adaptive gate fires on a non-discriminating hard set and NOT on a selective one; adaptive gate inert without an active hard-window gate; integration gates low rungs and surfaces `decode_gated_rungs`; **:exhaustive byte-identical** (gating knobs ignored → identical corrected output).
- [x] Regression suites pass: `scalable_corrector_strategy_test`, `scalable_corrector_hard_window_test`, `scalable_corrector_soft_em_test`, `stage0_cheap_correction_test`, `stage0_integration_test`, `variation_preservation_holdout_test`, `iterative_assembly_tests`.

## Scope

Owns only `src/iterative-assembly.jl` (k-ladder + skip/hard-window gate) + the new test. Complements GPU-batching the residual per-decode cost (separate lever).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable low-k decode gating controls to iterative assembly, including a minimum decode k, adaptive gate density, and beam width options.
  * Added telemetry in run metadata to show which k-rungs skipped whole-read decoding.

* **Bug Fixes**
  * Improved decoding behavior so low-k passes can be skipped automatically under defined gating conditions without affecting unaffected runs.
  * Preserved existing results when hard-window gating is off, even if gating settings are provided.

* **Tests**
  * Added coverage for explicit and adaptive decode gating behavior, plus an end-to-end check for gated and ungated assembly runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->