### PR TITLE
fix: O(V*E) -> O(V+E) bubble detection via out-adjacency index (td-x0k0)

### DIFF
--- a/src/rhizomorph/algorithms/simplification.jl
+++ b/src/rhizomorph/algorithms/simplification.jl
@@ -62,6 +62,46 @@ end
 # ============================================================================
 
 """
+    _build_out_adjacency_index(graph::MetaGraphsNext.MetaGraph, ::Type{T}) where {T}
+
+Build a vertex -> outgoing-neighbor-labels index in a single `O(E)` pass over the
+graph's edge labels.
+
+This replaces the per-vertex `get_out_neighbors` scan (each of which is itself
+`O(E)`) inside bubble detection. Building the index once up front turns the
+detection pass from `O(V*E)` into `O(V+E)`. For any given source vertex the
+neighbor order matches what `get_out_neighbors` would return — both consume
+`MetaGraphsNext.edge_labels(graph)` in the same order — so downstream bubble
+results are identical to the pre-index scan.
+
+# Arguments
+- `graph::MetaGraphsNext.MetaGraph`: Graph to index
+- `T`: Vertex label type
+
+# Returns
+- `Dict{T, Vector{T}}`: Map from each source vertex to its outgoing neighbors
+"""
+function _build_out_adjacency_index(graph::MetaGraphsNext.MetaGraph, ::Type{T}) where {T}
+    out_index = Dict{T, Vector{T}}()
+    for edge_label in MetaGraphsNext.edge_labels(graph)
+        src, dst = edge_label
+        push!(get!(() -> T[], out_index, src), dst)
+    end
+    return out_index
+end
+
+"""
+    _indexed_out_neighbors(out_index::AbstractDict{T, Vector{T}}, vertex) where {T}
+
+Look up the outgoing neighbors of `vertex` in a prebuilt out-adjacency index in
+`O(1)`. Returns an empty vector for vertices with no outgoing edges. Mirrors the
+result of `get_out_neighbors(graph, vertex)` without rescanning the edge set.
+"""
+function _indexed_out_neighbors(out_index::AbstractDict{T, Vector{T}}, vertex) where {T}
+    return haskey(out_index, vertex) ? out_index[vertex] : T[]
+end
+
+"""
     detect_bubbles_next(graph::MetaGraphsNext.MetaGraph; min_bubble_length::Int=2, max_bubble_length::Int=100)
 
 Detect bubble structures (alternative paths) in the assembly graph.
@@ -94,14 +134,20 @@ function detect_bubbles_next(graph::MetaGraphsNext.MetaGraph;
     T = eltype(vertices)
     bubbles = BubbleStructure{T}[]
 
+    # Build the out-adjacency index ONCE in O(E), then reuse it for every
+    # entry-point out-degree check and every forward path trace. This is the
+    # fix for the former O(V*E) scaling: each vertex previously triggered a
+    # full O(E) get_out_neighbors edge scan.
+    out_index = _build_out_adjacency_index(graph, T)
+
     for entry_vertex in vertices
         # Find potential bubble entry points (vertices with out-degree > 1)
-        out_neighbors = get_out_neighbors(graph, entry_vertex)
+        out_neighbors = _indexed_out_neighbors(out_index, entry_vertex)
 
         if length(out_neighbors) >= 2
             # Look for bubbles starting from this vertex
             bubble_candidates = find_bubble_paths(graph, entry_vertex, out_neighbors,
-                min_bubble_length, max_bubble_length)
+                min_bubble_length, max_bubble_length; out_index = out_index)
 
             for bubble in bubble_candidates
                 if is_valid_bubble(graph, bubble)
@@ -193,7 +239,8 @@ candidates = Mycelia.Rhizomorph.find_bubble_paths(graph, vertex, neighbors, 2, 5
 function find_bubble_paths(graph::MetaGraphsNext.MetaGraph,
         entry_vertex::T,
         out_neighbors::Vector,
-        min_length::Int, max_length::Int) where {T}
+        min_length::Int, max_length::Int;
+        out_index::AbstractDict = _build_out_adjacency_index(graph, T)) where {T}
     bubbles = BubbleStructure{T}[]
 
     # Try all pairs of outgoing paths
@@ -202,9 +249,9 @@ function find_bubble_paths(graph::MetaGraphsNext.MetaGraph,
             path1_start = out_neighbors[i]
             path2_start = out_neighbors[j]
 
-            # Find paths from each starting point
-            path1 = find_limited_path(graph, path1_start, max_length)
-            path2 = find_limited_path(graph, path2_start, max_length)
+            # Find paths from each starting point (reuse the shared O(E) index)
+            path1 = find_limited_path(graph, path1_start, max_length; out_index = out_index)
+            path2 = find_limited_path(graph, path2_start, max_length; out_index = out_index)
 
             # Check if paths reconverge
             convergence_point = find_path_convergence(path1, path2)
@@ -256,12 +303,14 @@ Trace a simple path forward from `start_vertex` while the out-degree stays `1`.
 path = Mycelia.Rhizomorph.find_limited_path(graph, vertex, 25)
 ```
 """
-function find_limited_path(graph::MetaGraphsNext.MetaGraph, start_vertex, max_length::Int)
+function find_limited_path(graph::MetaGraphsNext.MetaGraph, start_vertex, max_length::Int;
+        out_index::AbstractDict = _build_out_adjacency_index(
+            graph, eltype(collect(MetaGraphsNext.labels(graph)))))
     path = [start_vertex]
     current = start_vertex
 
     for _ in 1:max_length
-        neighbors = get_out_neighbors(graph, current)
+        neighbors = _indexed_out_neighbors(out_index, current)
         if length(neighbors) == 1
             next_vertex = neighbors[1]
             if next_vertex in path  # Avoid cycles

--- a/test/4_assembly/simplification_test.jl
+++ b/test/4_assembly/simplification_test.jl
@@ -1554,4 +1554,119 @@ Test.@testset "Graph Simplification Helper Coverage" begin
         Test.@test Mycelia.Rhizomorph._suffix_after_overlap("ABC", 2) == "C"
         Test.@test Mycelia.Rhizomorph._suffix_after_overlap("ABC", 5) == ""
     end
+
+    Test.@testset "Indexed bubble detection == naive edge-scan reference" begin
+        # Guards the O(V*E) -> O(V+E) out-adjacency-index optimization: the
+        # indexed detect_bubbles_next MUST return byte-for-byte identical bubbles
+        # to a from-scratch reference that re-scans the edge set per lookup
+        # (get_out_neighbors, unchanged). This is a pure performance fix, so the
+        # detected bubbles/hard vertices must not change.
+
+        # Independent reference implementation using ONLY the O(E)-per-call
+        # get_out_neighbors scan (mirrors the pre-index algorithm exactly).
+        naive_limited_path = function (graph, start_vertex, max_length)
+            path = [start_vertex]
+            current = start_vertex
+            for _ in 1:max_length
+                ns = Mycelia.Rhizomorph.get_out_neighbors(graph, current)
+                if length(ns) == 1
+                    nxt = ns[1]
+                    nxt in path && break
+                    push!(path, nxt)
+                    current = nxt
+                else
+                    break
+                end
+            end
+            return path
+        end
+
+        naive_detect = function (graph; min_bubble_length = 2, max_bubble_length = 100)
+            verts = collect(MetaGraphsNext.labels(graph))
+            T = eltype(verts)
+            bubbles = Mycelia.Rhizomorph.BubbleStructure{T}[]
+            for entry in verts
+                outs = Mycelia.Rhizomorph.get_out_neighbors(graph, entry)
+                length(outs) >= 2 || continue
+                for i in 1:length(outs)
+                    for j in (i + 1):length(outs)
+                        p1 = naive_limited_path(graph, outs[i], max_bubble_length)
+                        p2 = naive_limited_path(graph, outs[j], max_bubble_length)
+                        conv = Mycelia.Rhizomorph.find_path_convergence(p1, p2)
+                        if conv !== nothing &&
+                           length(p1) >= min_bubble_length && length(p2) >= min_bubble_length
+                            ci1 = findfirst(v -> v == conv, p1)
+                            ci2 = findfirst(v -> v == conv, p2)
+                            if ci1 !== nothing && ci2 !== nothing
+                                bp1 = p1[1:ci1]
+                                bp2 = p2[1:ci2]
+                                s1 = Mycelia.Rhizomorph.calculate_path_support(graph, bp1)
+                                s2 = Mycelia.Rhizomorph.calculate_path_support(graph, bp2)
+                                cx = Mycelia.Rhizomorph.calculate_bubble_complexity(bp1, bp2)
+                                b = Mycelia.Rhizomorph.BubbleStructure(
+                                    entry, conv, bp1, bp2, s1, s2, cx)
+                                Mycelia.Rhizomorph.is_valid_bubble(graph, b) && push!(bubbles, b)
+                            end
+                        end
+                    end
+                end
+            end
+            return Mycelia.Rhizomorph.remove_duplicate_bubbles(bubbles)
+        end
+
+        bubble_fields = b -> (b.entry_vertex, b.exit_vertex, b.path1, b.path2,
+            b.path1_support, b.path2_support, b.complexity_score)
+
+        # A collection of small graphs exercising distinct topologies.
+        make_graph = function (verts, edges)
+            g = MetaGraphsNext.MetaGraph(
+                Graphs.DiGraph();
+                label_type = String,
+                vertex_data_type = Mycelia.Rhizomorph.StringVertexData,
+                edge_data_type = Mycelia.Rhizomorph.StringEdgeData
+            )
+            for v in verts
+                g[v] = Mycelia.Rhizomorph.StringVertexData(v)
+            end
+            for (s, d) in edges
+                g[s, d] = Mycelia.Rhizomorph.StringEdgeData(1)
+            end
+            return g
+        end
+
+        graphs = [
+            # simple SNP bubble
+            make_graph(["A", "B", "C", "D"],
+                [("A", "B"), ("A", "C"), ("B", "D"), ("C", "D")]),
+            # asymmetric-length bubble
+            make_graph(["A", "B", "C", "D", "E"],
+                [("A", "B"), ("B", "C"), ("C", "E"), ("A", "D"), ("D", "E")]),
+            # 3-way split
+            make_graph(["A", "B", "C", "D", "E"],
+                [("A", "B"), ("A", "C"), ("A", "D"),
+                    ("B", "E"), ("C", "E"), ("D", "E")]),
+            # linear (no bubble)
+            make_graph(["A", "B", "C", "D"],
+                [("A", "B"), ("B", "C"), ("C", "D")]),
+            # two independent bubbles chained
+            make_graph(["A", "B", "C", "D", "E", "F", "G"],
+                [("A", "B"), ("A", "C"), ("B", "D"), ("C", "D"),
+                    ("D", "E"), ("D", "F"), ("E", "G"), ("F", "G")]),
+        ]
+
+        for g in graphs
+            indexed = Mycelia.Rhizomorph.detect_bubbles_next(
+                g; min_bubble_length = 1, max_bubble_length = 10)
+            reference = naive_detect(g; min_bubble_length = 1, max_bubble_length = 10)
+            Test.@test map(bubble_fields, indexed) == map(bubble_fields, reference)
+        end
+
+        # Also confirm the out-adjacency index reproduces get_out_neighbors exactly.
+        g = graphs[5]
+        idx = Mycelia.Rhizomorph._build_out_adjacency_index(g, String)
+        for v in MetaGraphsNext.labels(g)
+            Test.@test Mycelia.Rhizomorph._indexed_out_neighbors(idx, v) ==
+                       Mycelia.Rhizomorph.get_out_neighbors(g, v)
+        end
+    end
 end


### PR DESCRIPTION
## Summary

- Fixes the `O(V*E)` super-linear term in `detect_bubbles_next` (`src/rhizomorph/algorithms/simplification.jl`), the second-largest super-linear cost in the `:scalable` corrector scaling profile (#372, `_hard_vertex_set` alpha ~2.16).
- Root cause: the detection pass looped all `V` vertices and per vertex called `get_out_neighbors`, which scans all `E` edge labels; `find_limited_path` repeated the same per-step edge scan inside the hot path.
- Fix: build a vertex -> out-neighbors index **once** in a single `O(E)` pass (`_build_out_adjacency_index`) and thread it through `find_bubble_paths` and `find_limited_path`, making detection `O(V+E)`.
- Pure performance change: the index consumes `edge_labels` in the same order as `get_out_neighbors`, so the detected bubbles / hard vertices are identical. `_hard_vertex_set` calls `detect_bubbles_next` once and inherits the speedup with no change to its call site.

## Scaling result

`detect_bubbles_next` on `build_qualmer_graph` fixtures (k=21, 20x, doublestrand):

| genome | V | E | old_s | new_s | identical |
| --- | --- | --- | --- | --- | --- |
| 1000 | 10776 | 11020 | 2.4278 | 0.0019 | yes |
| 2000 | 21090 | 21550 | 11.0633 | 0.0040 | yes |
| 4000 | 42010 | 42942 | 56.2249 | 0.0082 | yes |
| 8000 | 84392 | 86326 | 253.3072 | 0.0205 | yes |

- alpha vs genome length: **2.246 -> 1.139**
- alpha vs E: **2.268 -> 1.151**
- ~12,000x faster at 8000 bp; same bubbles at every size.

## Test Plan

- [x] `test/4_assembly/simplification_test.jl` — green; adds a parity testset asserting indexed detection == a from-scratch edge-scan reference across five topologies, plus an index-vs-`get_out_neighbors` equivalence check.
- [x] `test/4_assembly/graph_algorithms_next.jl` — green (34/34)
- [x] `test/4_assembly/local_path_enumeration_test.jl` — green (47/47)
- [x] `test/4_assembly/rhizomorph_bubbles_and_gfa_test.jl` — green
- [x] `test/4_assembly/scalable_corrector_hard_window_test.jl` — green (92/92; the hard-window gate depends on this)
- [x] `test/4_assembly/variation_preservation_holdout_test.jl` — green (24/24)
- [x] `test/4_assembly/iterative_assembly_tests.jl` — green (196/196)

Scope: touches only `src/rhizomorph/algorithms/simplification.jl` and its test file. Does not touch `path-finding.jl` or the decode.