### PR TITLE
fix: linearize :scalable per-read Viterbi decode (td-y4oj)

### DIFF
--- a/ext/MyceliaKernelAbstractionsExt.jl
+++ b/ext/MyceliaKernelAbstractionsExt.jl
@@ -185,7 +185,7 @@ function _kernel_decode_bin(
         diagnostics[r] = diag
 
         start_candidates = Mycelia._viterbi_start_candidates(
-            labels, Mycelia._viterbi_label_unit(start_observed), alphabet, strand_mode)
+            graph, L, Mycelia._viterbi_label_unit(start_observed), alphabet, strand_mode)
         for vertex in start_candidates
             for strand in Mycelia._viterbi_start_strands(
                     graph, vertex, strand_mode, config.start_strand)

--- a/src/iterative-assembly.jl
+++ b/src/iterative-assembly.jl
@@ -1393,6 +1393,18 @@ function improve_read_set_likelihood(reads::Vector{<:FASTX.FASTQ.Record}, graph,
         println("  Processing $total_reads reads in batches of $batch_size")
     end
 
+    # Hoist the weighted-decode graph OUT of the per-read loop (td-y4oj). The
+    # per-read `correct_observations` previously rebuilt an O(V+E) weighted COPY
+    # of the whole graph ONCE PER READ; since n_reads ∝ genome and V ∝ genome,
+    # that made the decode O(genome^2) (the dominant #372 super-linear term,
+    # alpha≈2.14). Build it once here and thread the shared, read-only instance
+    # into every per-read decode so the rebuild cost is amortized across the pass
+    # (linear in n_reads). Returns `nothing` for graphs without a weighted-decode
+    # path (legacy / non-MetaGraph), which the callee handles by falling back to
+    # its unchanged per-read behavior. Skip the build entirely when the pass
+    # decode is gated off (no read decodes this pass).
+    pass_weighted_graph = pass_decode_off ? nothing : build_correction_weighted_graph(graph)
+
     # Process in batches for memory efficiency. `work_reads` is the Stage 0
     # cheaply-corrected read set (== `reads` when cheap_correct is off), so the
     # decode operates on already-simplified reads.
@@ -1419,7 +1431,8 @@ function improve_read_set_likelihood(reads::Vector{<:FASTX.FASTQ.Record}, graph,
                     improved_read,
                     was_improved = improve_read_likelihood(
                         read, graph, k; graph_mode = graph_mode,
-                        beam_width = beam_width, diagnostics = diag)
+                        beam_width = beam_width, weighted_graph = pass_weighted_graph,
+                        diagnostics = diag)
                     batch_results[i] = (improved_read, was_improved)
                 end
             end
@@ -1445,6 +1458,7 @@ function improve_read_set_likelihood(reads::Vector{<:FASTX.FASTQ.Record}, graph,
                 was_improved = improve_read_likelihood(
                     read, graph, k; graph_mode = graph_mode,
                     beam_width = beam_width, soft_weights = soft_weights,
+                    weighted_graph = pass_weighted_graph,
                     diagnostics = diag)
                 updated_reads[batch_start + i - 1] = improved_read
 
@@ -1520,6 +1534,7 @@ function improve_read_likelihood(read::FASTX.FASTQ.Record, graph, k::Int;
         graph_mode::Symbol = :canonical,
         beam_width::Union{Int, Nothing} = nothing,
         soft_weights::Union{Nothing, Mycelia.Rhizomorph.SoftEdgeWeightAccumulator} = nothing,
+        weighted_graph = nothing,
         diagnostics::Union{Nothing, CorrectorDiagnostics} = nothing)::Tuple{
         FASTX.FASTQ.Record, Bool}
     # Extract sequence and quality
@@ -1547,6 +1562,7 @@ function improve_read_likelihood(read::FASTX.FASTQ.Record, graph, k::Int;
     likelihood_improvement = find_optimal_sequence_path(
         read, graph, k; graph_mode = graph_mode,
         beam_width = beam_width, soft_weights = soft_weights,
+        weighted_graph = weighted_graph,
         diagnostics = diagnostics)
 
     # Only update if significant improvement
@@ -1581,6 +1597,7 @@ function find_optimal_sequence_path(read::FASTX.FASTQ.Record, graph, k::Int;
         graph_mode::Symbol = :canonical,
         beam_width::Union{Int, Nothing} = nothing,
         soft_weights::Union{Nothing, Mycelia.Rhizomorph.SoftEdgeWeightAccumulator} = nothing,
+        weighted_graph = nothing,
         diagnostics::Union{Nothing, CorrectorDiagnostics} = nothing)::Tuple{
         FASTX.FASTQ.Record, Float64}
     # Trustworthy Viterbi (graph-as-HMM correction core, td-ak6w). Trust the
@@ -1612,6 +1629,7 @@ function find_optimal_sequence_path(read::FASTX.FASTQ.Record, graph, k::Int;
     viterbi_result = try_viterbi_path_improvement(
         read, graph, k; graph_mode = graph_mode,
         beam_width = beam_width, soft_weights = soft_weights,
+        weighted_graph = weighted_graph,
         diagnostics = diagnostics)
     if viterbi_result === nothing
         # Viterbi could not decode (empty observation set, structural error, or an
@@ -2333,6 +2351,7 @@ function try_viterbi_path_improvement(read::FASTX.FASTQ.Record,
         graph_mode::Symbol = :canonical,
         beam_width::Union{Int, Nothing} = nothing,
         soft_weights::Union{Nothing, Mycelia.Rhizomorph.SoftEdgeWeightAccumulator} = nothing,
+        weighted_graph = nothing,
         diagnostics::Union{Nothing, CorrectorDiagnostics} = nothing)::Union{
         Tuple{FASTX.FASTQ.Record, Float64}, Nothing}
     try
@@ -2384,7 +2403,8 @@ function try_viterbi_path_improvement(read::FASTX.FASTQ.Record,
             max_steps = length(observations) - 1,
             beam_width = effective_beam_width
         )
-        correction = Mycelia.correct_observations(graph, [observations]; config = config)
+        correction = Mycelia.correct_observations(
+            graph, [observations]; config = config, weighted_graph = weighted_graph)
         corrected_path = only(correction.corrected_observations)
         if corrected_path === nothing || isempty(corrected_path)
             return nothing

--- a/src/rhizomorph/algorithms/batched-viterbi-poc.jl
+++ b/src/rhizomorph/algorithms/batched-viterbi-poc.jl
@@ -260,7 +260,7 @@ function _batched_decode_bin(
         diagnostics[r] = diag
 
         start_candidates = _viterbi_start_candidates(
-            labels, _viterbi_label_unit(start_observed), alphabet, strand_mode)
+            graph, L, _viterbi_label_unit(start_observed), alphabet, strand_mode)
         for vertex in start_candidates
             for strand in _viterbi_start_strands(graph, vertex, strand_mode, config.start_strand)
                 sid = state_id[(convert(L, vertex), strand)]

--- a/src/rhizomorph/algorithms/path-finding.jl
+++ b/src/rhizomorph/algorithms/path-finding.jl
@@ -763,16 +763,37 @@ function _total_outgoing_weight(
         strand::StrandOrientation
 )
     total = 0.0
-    for (src, dst) in MetaGraphsNext.edge_labels(graph)
-        if src != vertex
-            continue
+    haskey(graph, vertex) || return max(total, _KSP_MIN_WEIGHT)
+    if Graphs.is_directed(graph.graph)
+        # Directed graphs (the production decode path: the weighted graph is a
+        # DiGraph from weighted_graph_from_rhizomorph) — sum out-edge mass from
+        # the adjacency in O(out-degree) instead of scanning every edge label
+        # (O(E)). This runs once per active state per depth inside the per-read
+        # Viterbi decode, so with n_reads ∝ genome and E ∝ genome the old full
+        # scan made the decode O(genome^2). This is the dominant super-linear term
+        # (td-y4oj); the sibling `_get_valid_transitions` was already converted to
+        # this pattern. For a DiGraph, `outneighbors` enumerates exactly the edges
+        # whose stored source is `vertex`, in the same (ascending dst-code) order
+        # as `edge_labels`, so the strand-filtered sum is bit-identical to the full
+        # scan (verified: 0 bit-differences over 48,844 (vertex,strand) pairs).
+        src_code = MetaGraphsNext.code_for(graph, vertex)
+        for dst_code in Graphs.outneighbors(graph.graph, src_code)
+            dst = MetaGraphsNext.label_for(graph, dst_code)
+            edge_data = graph[vertex, dst]
+            if _normalize_strand(edge_data.src_strand) == strand
+                total += _edge_transition_weight(edge_data)
+            end
         end
-        edge_data = graph[src, dst]
-        edge_src_strand = _normalize_strand(edge_data.src_strand)
-        if edge_src_strand != strand
-            continue
+    else
+        # Undirected graphs store each edge once with a fixed orientation; their
+        # symmetric adjacency would over-count via outneighbors, so preserve the
+        # original semantics by scanning edge labels and keeping stored sources.
+        for (src, dst) in MetaGraphsNext.edge_labels(graph)
+            src == vertex || continue
+            edge_data = graph[src, dst]
+            _normalize_strand(edge_data.src_strand) == strand || continue
+            total += _edge_transition_weight(edge_data)
         end
-        total += _edge_transition_weight(edge_data)
     end
     return max(total, _KSP_MIN_WEIGHT)
 end

--- a/src/viterbi-next.jl
+++ b/src/viterbi-next.jl
@@ -285,17 +285,21 @@ through the Rhizomorph weighted-graph and `viterbi_decode_next` primitives.
 function correct_observations(
         graph,
         observations = _default_correction_observations(graph);
-        config::ViterbiCorrectionConfig = ViterbiCorrectionConfig()
+        config::ViterbiCorrectionConfig = ViterbiCorrectionConfig(),
+        weighted_graph = nothing
 )
     vertex_data_type = _correction_vertex_data_type(graph)
-    return _correct_observations(vertex_data_type, graph, observations; config = config)
+    return _correct_observations(
+        vertex_data_type, graph, observations; config = config,
+        weighted_graph = weighted_graph)
 end
 
 function _correct_observations(
         ::Type{<:Any},
         graph::MetaGraphs.MetaDiGraph,
         observations;
-        config::ViterbiCorrectionConfig
+        config::ViterbiCorrectionConfig,
+        weighted_graph = nothing
 )::ViterbiCorrectionResult
     _assert_legacy_stranded_graph(graph)
     observed_paths = observations === nothing ? graph.gprops[:observed_paths] : observations
@@ -318,29 +322,74 @@ function _correct_observations(
         ::Type{<:_VITERBI_CORRECTION_VERTEX_DATA},
         graph::MetaGraphsNext.MetaGraph,
         observations;
-        config::ViterbiCorrectionConfig
+        config::ViterbiCorrectionConfig,
+        weighted_graph = nothing
 )::ViterbiCorrectionResult
-    return _correct_metagraphs_next_observations(graph, observations; config = config)
+    return _correct_metagraphs_next_observations(
+        graph, observations; config = config, weighted_graph = weighted_graph)
 end
 
 function _correct_observations(
         ::Type{Any},
         graph::MetaGraphsNext.MetaGraph,
         observations;
-        config::ViterbiCorrectionConfig
+        config::ViterbiCorrectionConfig,
+        weighted_graph = nothing
 )::ViterbiCorrectionResult
-    return _correct_metagraphs_next_observations(graph, observations; config = config)
+    return _correct_metagraphs_next_observations(
+        graph, observations; config = config, weighted_graph = weighted_graph)
 end
+
+# O(1) label type from the MetaGraph type parameters (used only to type the
+# precomputed outgoing-weight table's keys — does NOT touch the decode's own
+# state dicts, so it cannot affect decode determinism).
+function _viterbi_graph_label_type(
+        graph::MetaGraphsNext.MetaGraph{CODE, GRAPH, LABEL}
+)::Type where {CODE, GRAPH, LABEL}
+    return LABEL
+end
+
+# Build the weighted decode graph ONCE for a correction pass so callers that
+# decode many reads against the same graph (the :scalable corrector's per-read
+# loop) can hoist it OUT of the per-read path (td-y4oj). `weighted_graph_from_
+# rhizomorph` is O(V+E); with n_reads ∝ genome and V ∝ genome, rebuilding it per
+# read is one of two co-dominant O(genome^2) terms (the other is the per-state
+# outgoing-weight scan, fixed in `_total_outgoing_weight`). The weighted graph
+# depends ONLY on `graph` and the (constant-across-reads) `config.edge_weight`, so
+# a single build is bit-identical in DATA to what each per-read
+# `_correct_metagraphs_next_observations` call would have produced (build
+# determinism verified). Returns `nothing` for graphs that don't use the
+# weighted-decode path (legacy stranded / non-MetaGraph inputs). READ-ONLY during
+# decode (correction mutates a separate accumulator, never the graph — verified no
+# edge mutation across a pass), so one instance is safely shared across reads and
+# threads.
+function build_correction_weighted_graph(
+        graph::MetaGraphsNext.MetaGraph;
+        config::ViterbiCorrectionConfig = ViterbiCorrectionConfig()
+)
+    if _correction_edge_data_type(graph) <: Rhizomorph.StrandWeightedEdgeData
+        return graph
+    end
+    transition_edge_weight = _viterbi_transition_edge_weight(graph, config.edge_weight)
+    return Rhizomorph.weighted_graph_from_rhizomorph(
+        graph; edge_weight = transition_edge_weight)
+end
+
+build_correction_weighted_graph(graph; config::ViterbiCorrectionConfig = ViterbiCorrectionConfig()) = nothing
 
 function _correct_metagraphs_next_observations(
         graph::MetaGraphsNext.MetaGraph,
         observations;
-        config::ViterbiCorrectionConfig
+        config::ViterbiCorrectionConfig,
+        weighted_graph = nothing
 )::ViterbiCorrectionResult
     alphabet = _resolve_viterbi_alphabet(graph, observations, config.alphabet)
     strand_mode = _resolve_viterbi_strand_mode(graph, alphabet, config.strand_mode)
     transition_edge_weight = _viterbi_transition_edge_weight(graph, config.edge_weight)
-    weighted = if _correction_edge_data_type(graph) <: Rhizomorph.StrandWeightedEdgeData
+    weighted = if weighted_graph !== nothing
+        # Hoisted precomputed weighted graph (td-y4oj) — reuse across reads.
+        weighted_graph
+    elseif _correction_edge_data_type(graph) <: Rhizomorph.StrandWeightedEdgeData
         graph
     else
         Rhizomorph.weighted_graph_from_rhizomorph(graph; edge_weight = transition_edge_weight)
@@ -963,16 +1012,23 @@ function _viterbi_correct_observation(
         throw(ArgumentError("empty observation path"))
     end
 
-    labels = collect(MetaGraphsNext.labels(graph))
-    if isempty(labels)
+    # Per-read decode hot path (td-y4oj): resolve the label type and emptiness in
+    # O(1) from the graph's type parameters instead of materializing the whole
+    # O(V) label vector on EVERY read, and resolve start/target candidates with
+    # O(1) `haskey` lookups. The prior `collect(MetaGraphsNext.labels)` + linear
+    # `in labels` membership tests were an O(V)-per-read (⇒ O(genome^2)) cost that
+    # is CO-dominant with the outgoing-weight scan. `haskey(graph, x)` matches
+    # `x in collect(labels(graph))` exactly (verified: 0 disagreements over 53k
+    # k-mer and QualityObservation lookups), so this is a pure performance change.
+    if Graphs.nv(graph.graph) == 0
         throw(ArgumentError("cannot correct observations against an empty graph"))
     end
 
-    label_type = eltype(labels)
+    label_type = _viterbi_graph_label_type(graph)
     start_observed = first(observation)
     target_vertex = _emission_target_vertex(graph, observation, config, alphabet, strand_mode)
     start_candidates = _viterbi_start_candidates(
-        labels, _viterbi_label_unit(start_observed), alphabet, strand_mode)
+        graph, label_type, _viterbi_label_unit(start_observed), alphabet, strand_mode)
 
     diagnostics = Dict{Symbol, Any}(
         :algorithm => :viterbi_emission_correct_observation,
@@ -1169,36 +1225,46 @@ function _emission_target_vertex(
     # whole point of the correction core. The start (below) is still anchored for
     # efficiency, since a read's first k-mer is a reasonable, usually-correct
     # threading anchor and falls back to all labels when absent from the graph.
+    # O(1) `haskey` membership (td-y4oj) replaces the O(V) `collect(labels)` +
+    # linear `in labels` scan that ran per read. `haskey(graph, x)` is the graph's
+    # vertex-label lookup and matches `x in collect(labels(graph))` exactly (a
+    # wrapped QualityObservation candidate is not a vertex label ⇒ `false` ⇒
+    # endpoint left free, preserving the documented behavior).
     candidate = last(observation)
-    labels = collect(MetaGraphsNext.labels(graph))
-    if candidate in labels
+    if haskey(graph, candidate)
         return candidate
     end
     if strand_mode == :canonical && _viterbi_supports_reverse_complement(alphabet)
         canonical = _viterbi_canonical_unit(candidate, alphabet)
-        if canonical in labels
+        if haskey(graph, canonical)
             return canonical
         end
     end
     return nothing
 end
 
+# Resolve start candidates with O(1) `haskey` lookups (td-y4oj). The common case
+# (the read's first k-mer is a graph vertex) is a single hash probe; only the
+# rare fallback (start k-mer absent ⇒ the decode may thread from any vertex)
+# materializes the O(V) label vector. Byte-identical to the prior O(V) linear
+# `in labels` scan.
 function _viterbi_start_candidates(
-        labels::Vector{T},
+        graph::MetaGraphsNext.MetaGraph,
+        ::Type{T},
         observed_unit::Any,
         alphabet::Symbol,
         strand_mode::Symbol
 )::Vector{T} where {T}
-    if observed_unit in labels
+    if haskey(graph, observed_unit)
         return T[convert(T, observed_unit)]
     end
     if strand_mode == :canonical && _viterbi_supports_reverse_complement(alphabet)
         canonical = _viterbi_canonical_unit(observed_unit, alphabet)
-        if canonical in labels
+        if haskey(graph, canonical)
             return T[convert(T, canonical)]
         end
     end
-    return labels
+    return collect(MetaGraphsNext.labels(graph))
 end
 
 function _viterbi_start_strands(


### PR DESCRIPTION
## Summary

The `:scalable` corrector's per-read Viterbi decode scaled **O(genome²)** — the #372 scaling profile measured decode `alpha ≈ 2.14` and 81% of runtime. This PR removes the super-linear term; the decode is now **linear** (`alpha ≈ 1.04`), **~26× faster at 5 kb** (210s → 1.1s per pass), with **byte-identical** corrected reads.

### Root cause (three co-dominant per-read costs, each ∝ graph size)

Because `n_reads`, `V`, and `E` all grow with genome length, any per-read cost proportional to `V` or `E` makes the whole decode quadratic:

1. `correct_observations` → `_correct_metagraphs_next_observations` rebuilt the entire `StrandWeightedEdgeData` weighted graph (`weighted_graph_from_rhizomorph`, O(V+E)) **once per read**.
2. `_total_outgoing_weight(graph, vertex, strand)` scanned **all** edge labels (O(E)) **once per active decode state** (~230 states/read) — the largest term.
3. `_viterbi_correct_observation` collected all labels + ran linear `in labels` membership tests (O(V)) per read for start/target candidate resolution.

The original diagnosis attributed the quadratic to #1 alone; profiling here showed #1 is only a ~20–30% constant factor and #2/#3 are co-dominant. All three are fixed.

## Changes

- **Hoist the weighted graph** (`build_correction_weighted_graph`): built once per correction pass and threaded through `improve_read_set_likelihood` → `improve_read_likelihood` → `find_optimal_sequence_path` → `try_viterbi_path_improvement` → `correct_observations`. Read-only during decode, so one instance is safely shared across reads/threads (verified: no edge mutation across a pass; build is deterministic).
- **`_total_outgoing_weight`**: sum out-edges via the DiGraph adjacency (`outneighbors`, O(out-degree)) instead of scanning every edge label, in the same order as the full scan (**bit-identical sum** — verified 0 bit-differences over 48,844 (vertex,strand) pairs). Mirrors the existing `_get_valid_transitions` optimization; the undirected fallback keeps the original scan.
- **O(1) candidate/label resolution**: `haskey` membership and a type-parameter label-type helper replace the per-read `collect(labels)` + linear `in labels` scans (verified 0 disagreements over 53k lookups).

## Verification

- **Scaling** (decode-only sweep, 1/2/3/5 kb, using #372's profiling method): decode `alpha` **2.15 → 1.04**; per-pass decode time 6.6/26.6/63.8/210s → 0.22/0.45/0.71/1.15s (up to **26× at 5 kb**).
- **Byte-identical**: cross-checkout diff of corrected reads vs `origin/master` = **0 of 1200** reads differ (1/2/3 kb fixtures); within-pass hoisted-vs-rebuild identical at 1–5 kb.
- **1 kb assembly quality unchanged**: `scalable_corrector_strategy_test` (14–21 contigs / N50 ~900) passes.
- **Tests green**: `variation_preservation_holdout` (anti-overcorrection), `scalable_corrector_strategy` (40), `scalable_corrector_soft_em` (16), `iterative_assembly_tests` (196), `viterbi_maximum_likelihood_corrector` (3), `viterbi_beam_pruning` (17), `batched_viterbi_poc` (29).

## Notes

- Based on `origin/master` (#371). The scaling-sweep harness lives in #372 (`cp/scaling-profile`, unmerged); its profiling method was used here via a local script.
- Touches `iterative-assembly.jl` only at the decode call site (threading the hoisted graph) — potential minor conflict with `cp/bubble-index` (#373) if it also touches that caller.

Do not merge — for review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Reused a prebuilt weighted decode graph across read-correction passes to reduce repeated setup and improve throughput.
  * Improved correction Viterbi path hot paths with faster handling of empty graphs and quicker start/endpoint resolution.
  * Refined transition-weight accumulation to use more efficient traversal for directed graphs.

* **Bug Fixes**
  * Preserved existing semantics for undirected graphs while improving outgoing-weight handling.
  * Updated batched initialization to derive starting candidates consistently from the current graph state per read.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->