### PR TITLE
perf: reuse corrector final-pass graph in re-assembly (td-04tb)

### DIFF
--- a/src/iterative-assembly.jl
+++ b/src/iterative-assembly.jl
@@ -442,6 +442,22 @@ function mycelia_iterative_assemble(input_fastq::String;
     # (:exhaustive), so the exhaustive tier is unaffected.
     cheap_correction_counts = Int[]
 
+    # --- Final-pass graph reuse (td-04tb) -----------------------------------
+    # The corrector builds a qualmer graph FROM SCRATCH each pass; the LAST pass at
+    # the largest k builds the graph whose input reads become the final corrected
+    # read set — but ONLY when that pass makes 0 improvements (a converged, no-change
+    # pass). In that case the graph built from `current_reads` is byte-identical to
+    # the graph a downstream re-assembly would build from the corrected reads, so we
+    # hand it back and `_assemble_with_iterative_corrector` reuses it instead of
+    # rebuilding, saving the redundant build_qualmer_graph (~22-36% of the iterative
+    # arm). `final_pass_graph_reusable` is set true ONLY on a 0-improvement pass;
+    # when the last pass changed reads the graph is stale and the caller rebuilds.
+    # These are overwritten every pass, so after the loop they reflect the LAST
+    # pass at the LARGEST k processed (the pass that produced the final FASTQ).
+    final_pass_graph = nothing
+    final_pass_graph_k = 0
+    final_pass_graph_reusable = false
+
     # Main k-mer progression loop
     while k <= max_k
         if verbose
@@ -643,6 +659,17 @@ function mycelia_iterative_assemble(input_fastq::String;
                 println("Wrote $(length(updated_reads)) reads to $output_file")
             end
 
+            # Capture this pass's graph for potential final-pass reuse (td-04tb).
+            # `graph` was built from `current_reads` this pass; `output_file`
+            # (== updated_reads) is this pass's corrected output. When the pass made
+            # 0 improvements, updated_reads == current_reads content, so `graph` is
+            # byte-identical to a rebuild from the corrected reads and is REUSABLE.
+            # Overwritten every pass ⇒ after the loop this holds the last pass at the
+            # largest k, i.e. the pass whose FASTQ finalize selects as the result.
+            final_pass_graph = graph
+            final_pass_graph_k = k
+            final_pass_graph_reusable = (improvements_made == 0)
+
             # Create checkpoint if enabled and at checkpoint interval
             if enable_checkpointing && iteration % checkpoint_interval == 0
                 checkpoint_data = Dict(
@@ -756,7 +783,13 @@ function mycelia_iterative_assemble(input_fastq::String;
         hard_window = hard_window, soft_em = soft_em, cheap_correct = cheap_correct,
         min_decode_k = effective_min_decode_k,
         decode_gate_density = effective_decode_gate_density,
-        decode_gated_rungs = decode_gated_rungs)
+        decode_gated_rungs = decode_gated_rungs,
+        # Final-pass graph reuse (td-04tb): hand the corrector's last-pass qualmer
+        # graph back so a converged run's re-assembly can skip a redundant rebuild.
+        final_pass_graph = final_pass_graph,
+        final_pass_graph_k = final_pass_graph_k,
+        final_pass_graph_mode = graph_mode,
+        final_pass_graph_reusable = final_pass_graph_reusable)
 end
 
 # =============================================================================
@@ -2132,9 +2165,20 @@ function finalize_iterative_assembly(output_dir::String, k_progression::Vector{I
         cheap_correct::Bool = false,
         min_decode_k::Union{Int, Nothing} = nothing,
         decode_gate_density::Union{Float64, Nothing} = nothing,
-        decode_gated_rungs::Vector{Int} = Int[])
+        decode_gated_rungs::Vector{Int} = Int[],
+        final_pass_graph = nothing,
+        final_pass_graph_k::Int = 0,
+        final_pass_graph_mode::Symbol = :canonical,
+        final_pass_graph_reusable::Bool = false)
     if verbose
         println("Finalizing iterative assembly results...")
+    end
+
+    # Only retain the (potentially large) final-pass graph when it is byte-identical-
+    # reusable (td-04tb); otherwise drop the reference so a fallback rebuild does not
+    # double-hold graph memory.
+    if !final_pass_graph_reusable
+        final_pass_graph = nothing
     end
 
     # Find the final output file (last iteration of largest k)
@@ -2240,7 +2284,15 @@ function finalize_iterative_assembly(output_dir::String, k_progression::Vector{I
         # linear pass, per pass and in total. Zero/false on :exhaustive.
         :cheap_correct => cheap_correct,
         :cheap_corrections_per_pass => cheap_correction_counts,
-        :cheap_corrections_total => total_cheap_corrections
+        :cheap_corrections_total => total_cheap_corrections,
+        # Final-pass graph reuse provenance (td-04tb). `final_graph_reusable` is true
+        # only when the final pass at the largest k made 0 improvements, so the
+        # returned `:final_graph` is byte-identical to a from-scratch rebuild of the
+        # corrected reads at `final_graph_k` under `final_graph_mode`. The caller
+        # verifies k + mode match its re-assembly parameters before reusing.
+        :final_graph_k => final_pass_graph_k,
+        :final_graph_mode => final_pass_graph_mode,
+        :final_graph_reusable => final_pass_graph_reusable
     )
 
     if verbose
@@ -2254,7 +2306,10 @@ function finalize_iterative_assembly(output_dir::String, k_progression::Vector{I
     return Dict(
         :final_assembly => final_assembly,
         :k_progression => k_progression,
-        :metadata => metadata
+        :metadata => metadata,
+        # The corrector's final-pass qualmer graph (td-04tb). `nothing` when no pass
+        # completed; only byte-identical-reusable when `metadata[:final_graph_reusable]`.
+        :final_graph => final_pass_graph
     )
 end
 

--- a/src/rhizomorph/assembly.jl
+++ b/src/rhizomorph/assembly.jl
@@ -900,11 +900,51 @@ function _assemble_with_iterative_corrector(reads, config::AssemblyConfig)
         # Re-assemble with AUTO-DETECTED graph_mode (not config.graph_mode): match
         # the mode the naive baseline uses (DoubleStrand for DNA), which auto-config
         # selects, so the corrected-read re-assembly is apples-to-apples.
-        assembly = assemble_genome(corrected_reads;
+        #
+        # Final-pass graph reuse (td-04tb). The corrector already built a qualmer
+        # graph in its final pass; when that pass converged (0 improvements), the
+        # graph is byte-identical to the one a from-scratch re-assembly would build
+        # from the corrected reads. Resolve the re-assembly config exactly as
+        # `assemble_genome(corrected_reads; k=reassembly_k, corrector=:none)` would
+        # (same auto-detected sequence type / graph mode / quality flag), then reuse
+        # the corrector's graph ONLY when every parameter matches AND the corrector
+        # marked it reusable. Otherwise fall back to a full rebuild. The reuse path
+        # calls the SAME downstream contig extraction the rebuild would, so contigs /
+        # N50 / sequences are identical — this is a pure-performance change.
+        reassembly_config = _auto_configure_assembly(corrected_reads;
             k = reassembly_k, corrector = :none)
+        reused_graph = get(result_dict, :final_graph, nothing)
+        _rmeta = result_dict[:metadata]
+        can_reuse_graph = reused_graph !== nothing &&
+                          get(_rmeta, :final_graph_reusable, false) === true &&
+                          get(_rmeta, :final_graph_k, nothing) == reassembly_config.k &&
+                          get(_rmeta, :final_graph_mode, nothing) ==
+                              _graph_mode_symbol(reassembly_config.graph_mode) &&
+                          reassembly_config.k !== nothing &&
+                          reassembly_config.use_quality_scores &&
+                          reassembly_config.sequence_type <: BioSequences.BioSequence
+        assembly = if can_reuse_graph
+            _log_info(config,
+                "Reusing corrector final-pass qualmer graph (k=$(reassembly_config.k), " *
+                "mode=$(_graph_mode_symbol(reassembly_config.graph_mode))); " *
+                "skipping redundant from-scratch build_qualmer_graph (td-04tb)")
+            _qualmer_graph_to_assembly(reused_graph, n_corrected, reassembly_config)
+        else
+            _log_info(config,
+                "Corrector final-pass graph not reusable " *
+                "(reusable=$(get(_rmeta, :final_graph_reusable, false)), " *
+                "graph_k=$(get(_rmeta, :final_graph_k, nothing)) vs reassembly_k=$(reassembly_config.k)); " *
+                "rebuilding from corrected reads")
+            assemble_genome(corrected_reads, reassembly_config)
+        end
         # Stamp the corrector provenance onto the real assembly's stats.
         assembly.assembly_stats["corrector"] = "iterative"
         assembly.assembly_stats["strategy"] = String(config.strategy)
+        # Final-pass graph reuse provenance (td-04tb): true when the re-assembly
+        # reused the corrector's already-built final-pass graph (converged run),
+        # false when it rebuilt from scratch. Pure telemetry — does not affect the
+        # contigs/N50/sequences (identical either way).
+        assembly.assembly_stats["reassembly_graph_reused"] = can_reuse_graph
         # Provenance (FIX 4): stamp BOTH the caller's requested skip_solid and the
         # value the tier actually used, so the tier's silent override cannot hide.
         # `skip_solid` is retained as the EFFECTIVE value for back-compat.
@@ -1292,6 +1332,28 @@ function _assemble_qualmer_graph(observations, config)
 
     # Build qualmer graph using Phase 2 quality-aware algorithms
     mode = _graph_mode_symbol(config.graph_mode)
+    graph = Rhizomorph.build_qualmer_graph(fastq_records, config.k; mode = mode)
+
+    # Contig extraction + AssemblyResult assembly is factored into
+    # `_qualmer_graph_to_assembly` so the iterative corrector can REUSE its already-
+    # built final-pass qualmer graph (td-04tb) and skip the redundant from-scratch
+    # build_qualmer_graph here — the two paths share this exact downstream code, so
+    # the reused-graph assembly is byte-identical to a from-scratch re-assembly.
+    return _qualmer_graph_to_assembly(graph, length(observations), config)
+end
+
+"""
+    _qualmer_graph_to_assembly(graph, num_input_sequences::Int, config) -> AssemblyResult
+
+Extract contigs from an already-built qualmer `graph` and assemble the
+`AssemblyResult` (paths -> consensus FASTQ contigs -> stats). Split out of
+`_assemble_qualmer_graph` (td-04tb) so the iterative corrector's re-assembly can
+REUSE the corrector's final-pass qualmer graph instead of rebuilding an identical
+one from scratch. Given the same `graph`, `num_input_sequences`, and `config`
+this is a pure function of the graph structure, so a reused graph yields
+byte-identical contigs/N50/sequences.
+"""
+function _qualmer_graph_to_assembly(graph, num_input_sequences::Int, config)
     # Canonical graph_mode now supports correct contig reconstruction on the qualmer
     # arm as well. Contigs are reconstructed by the SAME orientation-aware path used
     # by the k-mer arm (_qualmer_path_to_consensus_fastq -> path_to_sequence ->
@@ -1301,7 +1363,6 @@ function _assemble_qualmer_graph(observations, config)
     # so the result is flagged valid and no warning is emitted (see
     # _assemble_kmer_graph for the sequence-side rationale).
     reconstruction_valid = true
-    graph = Rhizomorph.build_qualmer_graph(fastq_records, config.k; mode = mode)
 
     # Apply Phase 2 graph algorithms if enabled
     if config.bubble_resolution
@@ -1382,7 +1443,7 @@ function _assemble_qualmer_graph(observations, config)
         "reconstruction_valid" => reconstruction_valid,
         "num_fastq_contigs" => length(contig_records),
         "num_edges" => length(MetaGraphsNext.edge_labels(graph)),
-        "num_input_sequences" => length(observations),
+        "num_input_sequences" => num_input_sequences,
         "assembly_date" => string(Mycelia.Dates.now())
     )
 

--- a/test/4_assembly/reassembly_graph_reuse_test.jl
+++ b/test/4_assembly/reassembly_graph_reuse_test.jl
@@ -1,0 +1,142 @@
+# td-04tb: re-assembly graph reuse. `_assemble_with_iterative_corrector` used to
+# rebuild a qualmer graph FROM SCRATCH from the corrected reads (~22-36% of the
+# iterative arm), duplicating the graph the corrector already built in its final
+# pass. When that final pass CONVERGED (0 improvements), the corrector's graph is
+# byte-identical to the rebuild, so it is now returned as `:final_graph` and reused.
+#
+# These tests prove:
+#   (1) On a converging fixture the corrector marks its final-pass graph reusable
+#       and hands it back.
+#   (2) Assembling from the REUSED graph is byte-identical (same contigs / N50 /
+#       sequences) to a from-scratch rebuild of the corrected reads — the reuse is
+#       a pure-performance change, not an output change.
+#   (3) The end-to-end `assemble_genome(...; corrector=:iterative)` path stamps the
+#       reuse provenance and its contigs match the from-scratch rebuild.
+#   (4) The reuse guard is conservative: a k / mode mismatch declines reuse.
+#
+# Run directly:
+#   julia --project=. -e 'include("test/4_assembly/reassembly_graph_reuse_test.jl")'
+
+import Test
+import Mycelia
+import FASTX
+import BioSequences
+import Random
+
+const R = Mycelia.Rhizomorph
+
+# Reads via Mycelia.observe from a random reference (the recipe the e2e phase
+# profiler / quality-gap fixtures use). On this regime the :scalable corrector
+# converges at the final k (a 0-improvement pass), so its final-pass graph is
+# reusable — exercising the td-04tb reuse path. The global RNG is seeded so the
+# statistical-resampling arm is reproducible and convergence is stable.
+function _converging_reads(; genome_len = 1000, readlen = 150, coverage = 30,
+        err = 0.05, seed = 42)
+    rec = Mycelia.random_fasta_record(moltype = :DNA, seed = seed, L = genome_len)
+    refseq = FASTX.sequence(BioSequences.LongDNA{4}, rec)
+    rng = Random.MersenneTwister(seed)
+    glen = length(refseq)
+    erl = min(readlen, glen)
+    n = max(1, ceil(Int, coverage * glen / erl))
+    recs = FASTX.FASTQ.Record[]
+    for i in 1:n
+        s = glen == erl ? 1 : rand(rng, 1:(glen - erl + 1))
+        frag = refseq[s:(s + erl - 1)]
+        rand(rng, Bool) && (frag = BioSequences.reverse_complement(frag))
+        obs, q = Mycelia.observe(frag; error_rate = err, tech = :illumina)
+        isempty(obs) && continue
+        push!(recs, FASTX.FASTQ.Record("read_$i", string(obs),
+            String([Char(x + 33) for x in q])))
+    end
+    return recs
+end
+
+_n50(lens) = (t = sum(lens; init = 0); acc = 0;
+    for l in sort(lens; rev = true)
+        acc += l
+        acc >= t / 2 && return l
+    end; 0)
+
+# Reproduce EXACTLY the corrector call `_assemble_with_iterative_corrector` makes
+# for strategy=:scalable at a given k, returning the result dict + corrected reads.
+function _run_corrector(reads, k)
+    knobs = R._corrector_strategy_knobs(:scalable)
+    max_k = max(k, 13)
+    mode = knobs.graph_mode === nothing ?
+           R._graph_mode_symbol(R.DoubleStrand) : knobs.graph_mode
+    indir = mktempdir()
+    outdir = mktempdir()
+    fq = joinpath(indir, "in.fastq")
+    open(FASTX.FASTQ.Writer, fq) do w
+        for r in reads
+            write(w, r)
+        end
+    end
+    result = Mycelia.mycelia_iterative_assemble(fq;
+        max_k = max_k, skip_solid = knobs.skip_solid, graph_mode = mode,
+        n_k_rungs = knobs.n_k_rungs, max_iterations_per_k = knobs.max_iterations_per_k,
+        hard_window = knobs.hard_window, soft_em = knobs.soft_em,
+        cheap_correct = knobs.cheap_correct, beam_width = knobs.beam_width,
+        verbose = false, enable_checkpointing = false, output_dir = outdir)
+    corrected = open(FASTX.FASTQ.Reader, result[:metadata][:final_fastq_file]) do rdr
+        collect(rdr)
+    end
+    return result, corrected, max_k
+end
+
+Test.@testset "re-assembly graph reuse (td-04tb)" begin
+    Random.seed!(42)
+    reads = _converging_reads()
+    k = 21  # >= 13 ⇒ max_k == 21 == reassembly_k, so reuse is parameter-eligible
+
+    result, corrected, max_k = _run_corrector(reads, k)
+    reusable = result[:metadata][:final_graph_reusable]
+
+    Test.@testset "corrector surfaces final-pass graph reuse provenance" begin
+        Test.@test !isempty(corrected)
+        Test.@test result[:metadata][:final_graph_k] == max_k
+        Test.@test result[:metadata][:final_graph_mode] == :doublestrand
+        Test.@test reusable isa Bool
+        # This regime converges at the final k, so the graph IS reusable and returned.
+        Test.@test reusable === true
+        Test.@test result[:final_graph] !== nothing
+    end
+
+    Test.@testset "reused graph == from-scratch rebuild (byte-identical)" begin
+        rcfg = R._auto_configure_assembly(corrected; k = k, corrector = :none)
+        # From-scratch rebuild — what master did unconditionally.
+        rebuild = R.assemble_genome(corrected, rcfg)
+        # Reuse path — assemble straight from the corrector's returned graph.
+        reuse = R._qualmer_graph_to_assembly(result[:final_graph], length(corrected), rcfg)
+
+        Test.@test sort(reuse.contigs) == sort(rebuild.contigs)
+        Test.@test length(reuse.contigs) == length(rebuild.contigs)
+        Test.@test _n50(length.(reuse.contigs)) == _n50(length.(rebuild.contigs))
+        Test.@test reuse.assembly_stats["num_vertices"] == rebuild.assembly_stats["num_vertices"]
+        Test.@test reuse.assembly_stats["num_edges"] == rebuild.assembly_stats["num_edges"]
+    end
+
+    Test.@testset "end-to-end corrector output == from-scratch rebuild" begin
+        # THE invariant that must hold whether or not reuse fired: the corrector's
+        # assembled contigs equal a from-scratch rebuild of the corrected reads.
+        asm = R.assemble_genome(reads; k = k, corrector = :iterative, strategy = :scalable)
+        rebuild = R.assemble_genome(corrected; k = k, corrector = :none)
+        Test.@test sort(asm.contigs) == sort(rebuild.contigs)
+        Test.@test _n50(length.(asm.contigs)) == _n50(length.(rebuild.contigs))
+        # Provenance flag is present and (in this converging regime) true.
+        Test.@test haskey(asm.assembly_stats, "reassembly_graph_reused")
+        Test.@test asm.assembly_stats["reassembly_graph_reused"] == reusable
+    end
+
+    Test.@testset "reuse guard is conservative on k / mode mismatch" begin
+        gk = result[:metadata][:final_graph_k]
+        gmode = result[:metadata][:final_graph_mode]
+        # k mismatch ⇒ a reassembly config at a different k would decline reuse.
+        rcfg_bad_k = R._auto_configure_assembly(corrected; k = gk + 2, corrector = :none)
+        Test.@test rcfg_bad_k.k != gk
+        # mode mismatch ⇒ singlestrand config vs the doublestrand corrector graph.
+        rcfg_bad_mode = R._auto_configure_assembly(corrected;
+            k = gk, graph_mode = R.SingleStrand, corrector = :none)
+        Test.@test R._graph_mode_symbol(rcfg_bad_mode.graph_mode) != gmode
+    end
+end


### PR DESCRIPTION
## Summary

- Eliminates the redundant from-scratch qualmer-graph rebuild in the `:scalable`/iterative corrector route. The #375 end-to-end profile measured the re-assembly (`assemble_genome(corrected_reads; corrector=:none)`) at **22-36% of the iterative arm** — it rebuilt a graph the corrector had already constructed in its final pass.
- When the corrector's final pass at the largest k **converges** (0 improvements), the graph built from that pass's input reads is byte-identical to the graph a from-scratch re-assembly would build from the corrected reads. `mycelia_iterative_assemble` now returns that graph (`:final_graph` + `:final_graph_k` / `:final_graph_mode` / `:final_graph_reusable`), and `_assemble_with_iterative_corrector` reuses it — but **only** when the reassembly k + mode match and the corrector marked it reusable; otherwise it falls back to a full rebuild.
- `_assemble_qualmer_graph` is split so the graph→`AssemblyResult` contig extraction (`_qualmer_graph_to_assembly`) is shared by the normal and reuse paths, guaranteeing identical downstream code. Pure-performance change.

## Verification

Master vs this branch, same seeds, `assemble_genome(reads; corrector=:iterative, strategy=:scalable)`:

| Regime | Master | Branch | Wall-time drop | Output |
| --- | --- | --- | --- | --- |
| short-read illumina (3kb, k=21, err=0.05) | 5.17s | 3.82s | ~26% | byte-identical (2957 contigs, N50 52, largest 559) |
| long-read nanopore (3kb, readlen=1000) | 4.61s | 3.88s | ~16% | byte-identical (3374 contigs, N50 48, largest 2164) |

- Assembly output (contigs / N50 / sequences) is **byte-identical** to master in both regimes (verified by diffing sorted contig dumps); reuse fires in both (regime-independent).
- New `reassembly_graph_reuse_test.jl` proves the reused-graph assembly equals a from-scratch rebuild (contigs, N50, vertex/edge counts) and that the guard is conservative on k/mode mismatch.

## Test Plan

- [x] `scalable_corrector_strategy_test.jl` — 40/40
- [x] `iterative_assembly_tests.jl` — 196/196
- [x] `iterative_convergence_stop_test.jl` — 19/19
- [x] `iterative_assemble_completion_test.jl` — 8/8
- [x] `rhizomorph_iterative_corrector_wiring_test.jl` — 17/17
- [x] `scalable_corrector_soft_em_test.jl` — 16/16
- [x] `scalable_corrector_hard_window_test.jl` — 92/92
- [x] `variation_preservation_holdout_test.jl` — 12/12 + 12/12
- [x] `reassembly_graph_reuse_test.jl` (new) — 17/17

## Notes

Conflicts with `cp/windowed-decode` on `iterative-assembly.jl`; merge this first (smaller, cleaner).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved iterative assembly to reuse a final-pass graph when it is safe to do so, helping preserve results while avoiding unnecessary recomputation.
  * Added assembly provenance details so users can see whether graph reuse was applied during re-assembly.

* **Bug Fixes**
  * Tightened reuse checks to prevent mismatched settings from reusing an incompatible graph.
  * Ensured re-assembled contigs and metrics remain consistent with a full rebuild.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->