### PR TITLE
fix: bound short-read Viterbi beam by graph density (td-35ux)

### DIFF
--- a/src/iterative-assembly.jl
+++ b/src/iterative-assembly.jl
@@ -1209,6 +1209,47 @@ function _auto_beam_width(n_observations::Integer)::Int
 end
 
 """
+    _auto_beam_width(n_observations, n_vertices) -> Int
+
+Graph-density-aware size-aware default beam width (td-35ux). The read-length-only
+[`_auto_beam_width`](@ref) keeps the exact/unbounded frontier for any read with
+`n_observations <= _AUTO_BEAM_EXACT_THRESHOLD` (typical short reads). That is
+correct on a sparse graph, but at a dense intermediate k-rung the EXACT retained
+(vertex, strand) frontier grows `O(n_vertices)` per decode depth — i.e.
+`O(genome)` per pass, `O(genome^2)` over the read set — even for a single short
+150 bp read (~15,723 frontier states at 5 kb / k=9, ~2.15 s per read). Long reads
+already dodge this because the read-length rule bounds them; short reads did not,
+which is why only short reads blew up (#376).
+
+This two-arg form bounds the beam to `_AUTO_BEAM_BOUNDED_WIDTH` whenever EITHER
+the read is large (read-length rule) OR the graph is dense
+(`n_vertices > _AUTO_BEAM_BOUNDED_WIDTH`), so a short read on a big graph is
+capped regardless of its length. On a small/sparse graph
+(`n_vertices <= _AUTO_BEAM_BOUNDED_WIDTH`) the exact frontier is already tiny, so
+a small read keeps the exact `typemax(Int)` (ML guarantee preserved). Callers can
+still FORCE exact by passing an explicit `beam_width = typemax(Int)`.
+"""
+function _auto_beam_width(n_observations::Integer, n_vertices::Integer)::Int
+    # Read-length rule first: a large read is bounded no matter the graph.
+    by_length = _auto_beam_width(n_observations)
+    if by_length != typemax(Int)
+        return by_length
+    end
+    # The read is small (exact by read length). If the graph is dense the exact
+    # frontier can still grow O(n_vertices) per depth → O(genome^2) per pass, so
+    # bound it. On a sparse graph the exact frontier is tiny; keep it exact.
+    if n_vertices > _AUTO_BEAM_BOUNDED_WIDTH
+        @info "iterative corrector: short read ($(n_observations) observations) on a " *
+              "dense graph ($(n_vertices) vertices > $(_AUTO_BEAM_BOUNDED_WIDTH)); " *
+              "bounding Viterbi beam_width=$(_AUTO_BEAM_BOUNDED_WIDTH) to keep the " *
+              "retained frontier O(1) instead of O(n_vertices) per depth (td-35ux). " *
+              "Pass beam_width=typemax(Int) to force exact." maxlog = 3
+        return _AUTO_BEAM_BOUNDED_WIDTH
+    end
+    return typemax(Int)
+end
+
+"""
 Improve likelihood of entire read set using current graph and k-mer size.
 Returns updated reads and count of improvements made.
 Uses memory-efficient batch processing for large datasets.
@@ -2383,20 +2424,25 @@ function try_viterbi_path_improvement(read::FASTX.FASTQ.Record,
             observations[i] = Mycelia.QualityObservation(kmer, window)
         end
 
-        # Trustworthy Viterbi (td-ak6w), reconciled with the td-63qy OOM crash:
-        # the decoder is EXACT where tractable and BOUNDED (with a log line) above
-        # a size threshold. `beam_width === nothing` (the default) resolves the
-        # frontier bound PER READ via `_auto_beam_width(length(observations))`:
-        # `typemax(Int)` (never pruned → global maximum-likelihood path) for small
-        # reads, the proven-tractable finite bound for large reads (the unbounded
-        # frontier grows ~unboundedly with read-length depth — 21B allocations on
-        # a 48 kb phage). An explicit `beam_width::Int` (including `typemax(Int)`)
-        # is an OPT-IN override that is honored verbatim — a caller/test can force
-        # exact decoding on every read. This trades the ML guarantee for
-        # tractability ONLY above the threshold, and only under the auto-default;
-        # it never silently changes correctness of an explicit request.
+        # Trustworthy Viterbi (td-ak6w), reconciled with the td-63qy OOM crash and
+        # the td-35ux short-read O(genome^2) frontier blowup: the decoder is EXACT
+        # where tractable and BOUNDED (with a log line) otherwise. `beam_width ===
+        # nothing` (the default) resolves the frontier bound PER READ via the
+        # GRAPH-DENSITY-AWARE `_auto_beam_width(length(observations), Graphs.nv(graph))`:
+        # `typemax(Int)` (never pruned → global maximum-likelihood path) only when
+        # BOTH the read is small AND the graph is sparse; the proven-tractable
+        # finite bound when the read is large (read-length rule, td-63qy) OR the
+        # graph is dense (density rule, td-35ux — a short read on a big graph
+        # otherwise retains an O(n_vertices) frontier at each decode depth). The
+        # graph threaded into this call is the one being decoded, so its vertex
+        # count is exactly the density the frontier can reach. An explicit
+        # `beam_width::Int` (including `typemax(Int)`) is an OPT-IN override honored
+        # verbatim — a caller/test can force exact decoding on every read. This
+        # trades the ML guarantee for tractability only under the auto-default; it
+        # never silently changes correctness of an explicit request.
         effective_beam_width = beam_width === nothing ?
-                               _auto_beam_width(length(observations)) : beam_width
+                               _auto_beam_width(length(observations), Graphs.nv(graph)) :
+                               beam_width
         config = Mycelia.ViterbiCorrectionConfig(
             alphabet = alphabet,
             strand_mode = graph_mode,

--- a/test/4_assembly/viterbi_beam_pruning_test.jl
+++ b/test/4_assembly/viterbi_beam_pruning_test.jl
@@ -113,6 +113,32 @@ Test.@testset "Viterbi corrector beam pruning (td-63qy)" begin
         Test.@test 0 < Mycelia._AUTO_BEAM_BOUNDED_WIDTH < typemax(Int)
     end
 
+    # Graph-density-aware auto-beam (td-35ux): the read-length-only rule left short
+    # reads (n_obs <= threshold) EXACT even on a dense intermediate k-rung, where
+    # the exact retained frontier grows O(n_vertices) per decode depth →
+    # O(genome^2) per pass (~15,723 frontier states / ~2.15 s for one 150 bp read
+    # at 5 kb / k=9). The two-arg form bounds the beam when the graph is dense,
+    # regardless of read length.
+    Test.@testset "graph-density-aware auto-beam (_auto_beam_width, td-35ux)" begin
+        bound = Mycelia._AUTO_BEAM_BOUNDED_WIDTH
+        # Short read (130 observations, below the exact threshold) on a DENSE graph
+        # (2230 vertices > 256): bounded despite the small read length. This is the
+        # #376 short-read blowup case — the exact frontier would grow O(n_vertices).
+        Test.@test Mycelia._auto_beam_width(130, 2230) == bound
+        # Short read on a SPARSE graph (few vertices): stays exact — the exact
+        # frontier is tiny, so the ML guarantee is preserved at no tractability cost.
+        Test.@test Mycelia._auto_beam_width(130, 10) == typemax(Int)
+        Test.@test Mycelia._auto_beam_width(130, bound) == typemax(Int)
+        # Boundary: one vertex past the bounded width flips exact → bounded.
+        Test.@test Mycelia._auto_beam_width(130, bound + 1) == bound
+        # Large read stays bounded no matter how sparse the graph (read-length rule
+        # still dominates — a large read is never exact regardless of density).
+        Test.@test Mycelia._auto_beam_width(
+            Mycelia._AUTO_BEAM_EXACT_THRESHOLD + 1, 10) == bound
+        # A large read on a dense graph is likewise bounded.
+        Test.@test Mycelia._auto_beam_width(48_000, 5000) == bound
+    end
+
     # An explicit beam_width override is honored verbatim by the per-read decoder
     # entry point: passing typemax(Int) forces EXACT decoding regardless of the
     # auto-default, and the correction still completes on a small read.


### PR DESCRIPTION
## Summary

- The `:scalable` iterative corrector's per-read decode resolved its beam width through the **read-length-only** `_auto_beam_width(n_obs)`, which returns `typemax(Int)` (exact/unbounded) for any read at/below the 1024-observation threshold. Typical short reads (150 bp, ~130 observations) therefore always decoded with an **unbounded** beam.
- At a dense intermediate k-rung (k=9) the exact retained (vertex, strand) frontier grows `O(n_vertices)` per decode depth — `O(genome)` per pass, `O(genome^2)` over the read set. A single short read retained thousands of frontier states. Long reads were already bounded by the read-length rule, which is why **only short reads** blew up (#376).
- Adds a graph-density-aware two-arg `_auto_beam_width(n_obs, n_vertices)` and routes the decode call site (`src/iterative-assembly.jl`) through `_auto_beam_width(length(observations), Graphs.nv(graph))`. The beam bounds to the proven-tractable `_AUTO_BEAM_BOUNDED_WIDTH` (256) whenever **either** the read is large (read-length rule, td-63qy) **or** the graph is dense (`n_vertices > 256`).
- A small read on a sparse graph still keeps exact `typemax(Int)` (ML guarantee preserved); an explicit `beam_width` override is still honored verbatim.

## Payoff (readlen=150, k=9, qualmer/singlestrand; 1/2/3 kb)

| genome | nv | frontier BEFORE (exact) | frontier AFTER (bounded) |
| ------ | ---- | ----------------------- | ------------------------ |
| 1 kb   | 3435 | 478  | **256** |
| 2 kb   | 7261 | 1453 | **256** |
| 3 kb   | 11025| 3903 | **256** |

Frontier-scaling alpha (log-log slope of max frontier vs genome length): **1.878 → 0.0** (superlinear O(genome) per-read blowup → constant, genome-independent frontier).

## Quality preserved

- 1 kb `:scalable` (td-nt69 quality-gap fixture, k=21): **14 contigs / N50 925 on BOTH origin/master and this branch — byte-identical** (historical near-complete regime is ~14-21 contigs / N50 ~900). No trade-off: at the k=21 final rung the exact frontier never exceeds 256 so bounding prunes nothing, while the k=9 intermediate rung (where the O(genome^2) blowup lived) caps cleanly.
- `variation_preservation_holdout_test.jl` green (variant preservation held).

## Test Plan

- [x] `viterbi_beam_pruning_test.jl` — 23/23 (adds a density-aware testset incl. `_auto_beam_width(130, 2230) == 256`)
- [x] `variation_preservation_holdout_test.jl` — 12/12 + 12/12
- [x] `scalable_corrector_strategy_test.jl` — 40/40 (incl. td-nt69 1kb quality invariant)
- [x] `scalable_corrector_hard_window_test.jl` — 92/92
- [x] `scalable_corrector_soft_em_test.jl` — 16/16
- [x] `iterative_assembly_tests.jl` — 196/196

## Related

- #376 (short-read profile diagnosis)
- Conflicts with cp/windowed-decode (#378) on `iterative-assembly.jl` if both touch the decode call site — coordinate at merge.
