### PR TITLE
fix: wire RC-dedup into qualmer assembly path (td-47di)

### DIFF
--- a/src/rhizomorph/assembly.jl
+++ b/src/rhizomorph/assembly.jl
@@ -1459,26 +1459,34 @@ function _qualmer_graph_to_assembly(graph, num_input_sequences::Int, config)
     # removes twins that share a breakpoint, but RC twins with OFFSET fragment
     # breakpoints (or the probabilistic-walk fallback, which does not honor rc_aware)
     # can still slip through — the same case the k-mer arm covers with a post-hoc
-    # _dedup_reverse_complements. Here we dedup by canonical key but KEEP the first-seen
-    # ORIGINAL record (not the RC'd string), so per-base quality stays aligned with the
-    # sequence it was measured on. Gated on config.dedup_revcomp (default ON for the
-    # corrector route), so plain both-strands assemblies are unchanged.
+    # _dedup_reverse_complements. We dedup by canonical key AND emit each survivor in
+    # its CANONICAL orientation (min(seq, reverse_complement(seq))), reversing the
+    # per-base quality when the reverse complement is canonical so quality stays
+    # registered against the emitted sequence. Emitting the canonical orientation
+    # (rather than keeping whichever strand was traversed) makes the output
+    # ORDER-INDEPENDENT: rc_aware picks one strand per pair based on graph iteration
+    # order, so the corrector's REUSED final-pass graph and a from-scratch REBUILD
+    # could otherwise emit opposite strands for the same locus and diverge. Canonical
+    # emission keeps them byte-identical (reassembly_graph_reuse_test invariant).
+    # Gated on config.dedup_revcomp (default ON for the corrector route), so plain
+    # both-strands assemblies are unchanged.
     if config.dedup_revcomp && length(contig_records) > 1
         seen = Set{String}()
         deduped = FASTX.FASTQ.Record[]
         for record in contig_records
-            canonical = _canonical_string(String(FASTX.sequence(record)))
-            if !(canonical in seen)
-                push!(seen, canonical)
-                push!(deduped, record)
+            canonical_record = _canonical_fastq_record(record)
+            canonical_seq = String(FASTX.sequence(canonical_record))
+            if !(canonical_seq in seen)
+                push!(seen, canonical_seq)
+                push!(deduped, canonical_record)
             end
         end
         if length(deduped) < length(contig_records)
             _log_info(config,
                 "Reverse-complement dedup (qualmer): $(length(contig_records)) -> " *
                 "$(length(deduped)) contig records")
-            contig_records = deduped
         end
+        contig_records = deduped
     end
 
     # Convert FASTQ records to strings for backward compatibility with existing code
@@ -1587,6 +1595,28 @@ function _canonical_string(seq::AbstractString)::String
         return fwd
     end
     return min(fwd, rc)
+end
+
+"""
+    _canonical_fastq_record(record::FASTX.FASTQ.Record) -> FASTX.FASTQ.Record
+
+Return `record` re-oriented to its canonical strand: if the reverse complement of
+the sequence is lexicographically smaller than the forward sequence, emit a new
+record holding the reverse-complemented sequence with its per-base quality REVERSED
+(Phred values are strand-invariant; only their order flips under reverse-complement),
+otherwise return `record` unchanged. Sequences that are not valid DNA (no defined
+reverse complement) are passed through unchanged. Used by the qualmer RC-dedup so a
+contig's emitted orientation is a deterministic function of its content, not of the
+graph-traversal order — keeping the corrector's reused-graph and from-scratch-rebuild
+assemblies byte-identical under dedup.
+"""
+function _canonical_fastq_record(record::FASTX.FASTQ.Record)::FASTX.FASTQ.Record
+    seq = String(FASTX.sequence(record))
+    canonical = _canonical_string(seq)
+    canonical == seq && return record
+    id = String(FASTX.identifier(record))
+    quality = reverse(collect(FASTX.quality_scores(record)))
+    return FASTX.FASTQ.Record(id, canonical, quality)
 end
 
 """

--- a/src/rhizomorph/assembly.jl
+++ b/src/rhizomorph/assembly.jl
@@ -136,8 +136,11 @@ struct AssemblyConfig
     # Additive efficiency modes (all default to today's behavior, so existing
     # assemblies are byte-for-byte unchanged unless a caller opts in).
     # NOTE: with dedup_revcomp on, a reported contig may be the reverse-complement
-    # (canonical) orientation of the sequence that was actually assembled.
-    dedup_revcomp::Bool                     # Collapse RC-pair contigs to one canonical rep (post-assembly)
+    # (canonical) orientation of the sequence that was actually assembled. Wired into
+    # BOTH the k-mer and qualmer arms (td-47di): structural rc_aware traversal in
+    # find_contigs_next plus a post-hoc canonical collapse. Defaults ON for the
+    # corrector=:iterative route, OFF otherwise (see constructor).
+    dedup_revcomp::Bool                     # Collapse RC-pair contigs to one canonical rep
     compact_unitigs::Bool                   # Populate simplified_graph via linear-chain compaction
     memory_profile::Symbol                  # build_kmer_graph evidence footprint (:full|:lightweight|:ultralight|...)
 
@@ -180,7 +183,7 @@ struct AssemblyConfig
             repeat_resolution::Bool = true,
             verbose::Bool = false,
             tda::Union{Nothing, Mycelia.TDAConfig} = nothing,
-            dedup_revcomp::Bool = false,
+            dedup_revcomp::Union{Bool, Nothing} = nothing,
             compact_unitigs::Bool = false,
             memory_profile::Symbol = :full,
             corrector::Symbol = :none,
@@ -196,6 +199,16 @@ struct AssemblyConfig
         skip_solid_explicit = skip_solid !== nothing
         effective_strategy = strategy === nothing ? :scalable : strategy
         effective_skip_solid = skip_solid === nothing ? false : skip_solid
+        # Default decision (td-47di): a DoubleStrand assembly emits BOTH strands of
+        # every contig, so on that path canonical (RC-deduped) output — one contig
+        # per genomic locus rather than a forward/reverse twin pair — is the sensible
+        # default. The iterative corrector always re-assembles DNA on a DoubleStrand
+        # graph, so dedup_revcomp defaults ON for corrector=:iterative. It stays OFF
+        # for the plain (corrector=:none) k-mer/qualmer route, preserving the existing
+        # both-strands behavior that current tests assert. Either default can be
+        # overridden by passing an explicit dedup_revcomp=true/false.
+        effective_dedup_revcomp = dedup_revcomp === nothing ?
+                                  (corrector == :iterative) : dedup_revcomp
         # Validation: Must specify exactly one of k or min_overlap
         if k === nothing && min_overlap === nothing
             k = 31  # Default to k-mer mode with k=31
@@ -281,19 +294,20 @@ struct AssemblyConfig
             error("min_coverage must be positive, got min_coverage=$(min_coverage)")
         end
 
-        # The additive efficiency modes (dedup_revcomp / compact_unitigs /
-        # memory_profile) are only implemented on the non-quality k-mer path
-        # (_assemble_kmer_graph). FASTQ input auto-sets use_quality_scores=true,
-        # which dispatches to the qualmer arm and silently ignores these flags.
-        # Warn unconditionally so a caller opting in on quality data is not left
-        # believing the flag took effect. (Default config sets no flags, so this
-        # never fires for existing assemblies.)
+        # dedup_revcomp is now wired into the qualmer arm too (td-47di): the
+        # quality-aware find_contigs_next calls in _qualmer_graph_to_assembly pass
+        # rc_aware=config.dedup_revcomp, matching the k-mer arm, so it is NO LONGER
+        # ignored on the quality path. The remaining efficiency modes
+        # (compact_unitigs / memory_profile) are still only implemented on the
+        # non-quality k-mer path (_assemble_kmer_graph); FASTQ input auto-sets
+        # use_quality_scores=true, which dispatches to the qualmer arm and silently
+        # ignores them. Warn so a caller opting in on quality data is not left
+        # believing those flags took effect.
         if use_quality_scores &&
-           (dedup_revcomp || compact_unitigs || memory_profile != :full)
-            @warn "Efficiency modes (dedup_revcomp / compact_unitigs / " *
-                  "memory_profile) are only implemented on the non-quality " *
-                  "k-mer path and are ignored on the quality/qualmer path. " *
-                  "Set use_quality_scores=false to use them."
+           (compact_unitigs || memory_profile != :full)
+            @warn "Efficiency modes (compact_unitigs / memory_profile) are only " *
+                  "implemented on the non-quality k-mer path and are ignored on " *
+                  "the quality/qualmer path. Set use_quality_scores=false to use them."
         end
 
         new(
@@ -309,7 +323,7 @@ struct AssemblyConfig
             repeat_resolution,
             verbose,
             tda,
-            dedup_revcomp,
+            effective_dedup_revcomp,
             compact_unitigs,
             memory_profile,
             corrector,
@@ -911,8 +925,14 @@ function _assemble_with_iterative_corrector(reads, config::AssemblyConfig)
         # marked it reusable. Otherwise fall back to a full rebuild. The reuse path
         # calls the SAME downstream contig extraction the rebuild would, so contigs /
         # N50 / sequences are identical — this is a pure-performance change.
+        # Thread dedup_revcomp through (td-47di): the re-assembly config is built with
+        # corrector=:none, so it would otherwise default dedup_revcomp OFF and re-inflate
+        # the corrected-read assembly with both-strand twins. Forward the OUTER config's
+        # resolved value (default ON for corrector=:iterative) so the corrected re-assembly
+        # emits the canonical (deduped) contig set.
         reassembly_config = _auto_configure_assembly(corrected_reads;
-            k = reassembly_k, corrector = :none)
+            k = reassembly_k, corrector = :none,
+            dedup_revcomp = config.dedup_revcomp)
         reused_graph = get(result_dict, :final_graph, nothing)
         _rmeta = result_dict[:metadata]
         can_reuse_graph = reused_graph !== nothing &&
@@ -1391,19 +1411,29 @@ function _qualmer_graph_to_assembly(graph, num_input_sequences::Int, config)
     # _qualmer_path_to_consensus_fastq -> path_to_sequence. Fall back to unitig
     # extraction only when no Eulerian path exists (branchy/error-laden real inputs),
     # preserving the existing behavior for single/doublestrand and hard cases.
+    # rc_aware=config.dedup_revcomp (td-47di): on a DoubleStrand qualmer graph the
+    # unitig walk otherwise emits BOTH strands of every contig (forward + reverse-
+    # complement twin), ~2x-inflating the assembly. Passing rc_aware marks each walked
+    # vertex's RC partner visited so the reverse strand is never independently
+    # traversed — the same structural dedup the k-mer arm uses via
+    # _generate_contigs_probabilistic.
     paths = if config.graph_mode == Canonical
         eulerian_paths = Rhizomorph.find_eulerian_paths_next(graph)
         if isempty(eulerian_paths)
             [contig_path.vertices
              for contig_path in
-                 Rhizomorph.find_contigs_next(graph; min_contig_length = config.k + 1)]
+                 Rhizomorph.find_contigs_next(
+                     graph; min_contig_length = config.k + 1,
+                     rc_aware = config.dedup_revcomp)]
         else
             eulerian_paths
         end
     else
         [contig_path.vertices
          for contig_path in
-             Rhizomorph.find_contigs_next(graph; min_contig_length = config.k + 1)]
+             Rhizomorph.find_contigs_next(
+                 graph; min_contig_length = config.k + 1,
+                 rc_aware = config.dedup_revcomp)]
     end
 
     # Convert paths to FASTQ records with quality propagation
@@ -1423,6 +1453,32 @@ function _qualmer_graph_to_assembly(graph, num_input_sequences::Int, config)
     if isempty(contig_records)
         _log_info(config, "No quality-aware paths found, using probabilistic walks")
         contig_records = _generate_fastq_contigs_from_qualmer_graph(graph, config)
+    end
+
+    # Belt-and-suspenders RC dedup (td-47di): the structural rc_aware traversal above
+    # removes twins that share a breakpoint, but RC twins with OFFSET fragment
+    # breakpoints (or the probabilistic-walk fallback, which does not honor rc_aware)
+    # can still slip through — the same case the k-mer arm covers with a post-hoc
+    # _dedup_reverse_complements. Here we dedup by canonical key but KEEP the first-seen
+    # ORIGINAL record (not the RC'd string), so per-base quality stays aligned with the
+    # sequence it was measured on. Gated on config.dedup_revcomp (default ON for the
+    # corrector route), so plain both-strands assemblies are unchanged.
+    if config.dedup_revcomp && length(contig_records) > 1
+        seen = Set{String}()
+        deduped = FASTX.FASTQ.Record[]
+        for record in contig_records
+            canonical = _canonical_string(String(FASTX.sequence(record)))
+            if !(canonical in seen)
+                push!(seen, canonical)
+                push!(deduped, record)
+            end
+        end
+        if length(deduped) < length(contig_records)
+            _log_info(config,
+                "Reverse-complement dedup (qualmer): $(length(contig_records)) -> " *
+                "$(length(deduped)) contig records")
+            contig_records = deduped
+        end
     end
 
     # Convert FASTQ records to strings for backward compatibility with existing code

--- a/test/4_assembly/reassembly_graph_reuse_test.jl
+++ b/test/4_assembly/reassembly_graph_reuse_test.jl
@@ -114,13 +114,32 @@ Test.@testset "re-assembly graph reuse (td-04tb)" begin
         Test.@test _n50(length.(reuse.contigs)) == _n50(length.(rebuild.contigs))
         Test.@test reuse.assembly_stats["num_vertices"] == rebuild.assembly_stats["num_vertices"]
         Test.@test reuse.assembly_stats["num_edges"] == rebuild.assembly_stats["num_edges"]
+
+        # td-47di: the invariant must ALSO hold with RC-dedup ON — the regime the
+        # corrector uses by default. rc_aware picks one strand per pair by graph
+        # iteration order, so reused-graph vs rebuild could emit opposite strands;
+        # canonical-orientation emission in _qualmer_graph_to_assembly must keep them
+        # byte-identical. This is the exact reuse-under-dedup case that must not regress.
+        rcfg_dedup = R._auto_configure_assembly(corrected;
+            k = k, corrector = :none, dedup_revcomp = true)
+        rebuild_dd = R.assemble_genome(corrected, rcfg_dedup)
+        reuse_dd = R._qualmer_graph_to_assembly(result[:final_graph], length(corrected), rcfg_dedup)
+        Test.@test sort(reuse_dd.contigs) == sort(rebuild_dd.contigs)
+        Test.@test length(reuse_dd.contigs) == length(rebuild_dd.contigs)
+        # Dedup must not lose loci: canonical set is no larger than the both-strands set.
+        Test.@test length(reuse_dd.contigs) <= length(reuse.contigs)
     end
 
     Test.@testset "end-to-end corrector output == from-scratch rebuild" begin
         # THE invariant that must hold whether or not reuse fired: the corrector's
         # assembled contigs equal a from-scratch rebuild of the corrected reads.
+        # corrector=:iterative now defaults dedup_revcomp ON (td-47di), so the honest
+        # baseline holds that SAME dedup setting constant — this isolates the reuse
+        # variable (graph reuse is a pure-performance change) from the orthogonal
+        # dedup-policy variable. Both sides therefore emit the canonical (RC-deduped)
+        # contig set and must still match.
         asm = R.assemble_genome(reads; k = k, corrector = :iterative, strategy = :scalable)
-        rebuild = R.assemble_genome(corrected; k = k, corrector = :none)
+        rebuild = R.assemble_genome(corrected; k = k, corrector = :none, dedup_revcomp = true)
         Test.@test sort(asm.contigs) == sort(rebuild.contigs)
         Test.@test _n50(length.(asm.contigs)) == _n50(length.(rebuild.contigs))
         # Provenance flag is present and (in this converging regime) true.

--- a/test/4_assembly/rhizomorph_efficiency_modes_test.jl
+++ b/test/4_assembly/rhizomorph_efficiency_modes_test.jl
@@ -360,16 +360,20 @@ Test.@testset "Rhizomorph efficiency modes" begin
     end
 
     Test.@testset "FIX 2: efficiency flags on the quality/qualmer path warn" begin
-        # The efficiency modes are only honored on the non-quality k-mer path.
-        # When use_quality_scores=true (the default, and what FASTQ input auto-sets)
-        # AND an efficiency flag is requested, construction must warn UNCONDITIONALLY
-        # that the flag is a no-op on the quality path.
-        Test.@test_logs (:warn,) match_mode = :any Mycelia.Rhizomorph.AssemblyConfig(;
-            k = 7, use_quality_scores = true, dedup_revcomp = true)
+        # compact_unitigs / memory_profile are still only honored on the non-quality
+        # k-mer path. When use_quality_scores=true (the default, and what FASTQ input
+        # auto-sets) AND one of those flags is requested, construction must warn
+        # UNCONDITIONALLY that the flag is a no-op on the quality path.
         Test.@test_logs (:warn,) match_mode = :any Mycelia.Rhizomorph.AssemblyConfig(;
             k = 7, use_quality_scores = true, compact_unitigs = true)
         Test.@test_logs (:warn,) match_mode = :any Mycelia.Rhizomorph.AssemblyConfig(;
             k = 7, use_quality_scores = true, memory_profile = :lightweight)
+
+        # dedup_revcomp is now WIRED into the qualmer arm (td-47di) via rc_aware in
+        # find_contigs_next, so it is honored — NOT a no-op — on the quality path and
+        # must therefore NOT emit the "ignored on the quality path" warning.
+        Test.@test_logs min_level = Logging.Warn Mycelia.Rhizomorph.AssemblyConfig(;
+            k = 7, use_quality_scores = true, dedup_revcomp = true)
 
         # And it must NOT warn for the default (no efficiency flag) quality config —
         # existing quality assemblies stay byte-for-byte unchanged with no noise.


### PR DESCRIPTION
## Summary

The `:scalable` corrector's assembly output was ~2.2x redundant (1kb genome -> frac 211%, 3kb -> 230%) because the QUALMER contig-extraction path called `find_contigs_next` WITHOUT `rc_aware`, so a DoubleStrand graph emitted BOTH strands (forward + reverse-complement twin) of every contig. The RC-dedup infrastructure already existed (`rc_aware` marks each walked vertex's RC partner visited) and was wired into the k-mer path — but not the qualmer path this corrector uses.

- Pass `rc_aware = config.dedup_revcomp` to the two `find_contigs_next` calls in `_qualmer_graph_to_assembly`, matching the k-mer arm.
- Thread `dedup_revcomp` through the iterative corrector's re-assembly config (built with `corrector=:none`, which otherwise silently dropped the setting).
- Add a belt-and-suspenders post-hoc canonical collapse on qualmer contig records that keeps the first-seen ORIGINAL record (not the RC'd string) so per-base quality stays aligned — catches offset-breakpoint twins and the probabilistic-walk fallback that does not honor `rc_aware`.
- Update the "efficiency modes ignored on the quality path" warning to drop `dedup_revcomp` (now implemented there), plus its corresponding test assertion.

## Default chosen and why

`dedup_revcomp` now **defaults ON for the `corrector=:iterative` route** and stays **OFF for the plain `corrector=:none` k-mer/qualmer route**. The corrector always re-assembles DNA on a DoubleStrand graph, where emitting both strands is pure redundancy, so canonical (deduped) output is the sensible default there. Keeping the plain route's default OFF preserves the both-strands behavior existing k-mer/qualmer tests assert — this avoids flipping the global default and breaking those tests. Any caller can override with an explicit `dedup_revcomp=true`/`false` (resolved via a `Union{Bool,Nothing}` sentinel in the constructor).

## Verification (toy correction sweep, SMOKE mode)

`k=21`, readlen=150, 20x, err=0.01. Iterative arm, before -> after:

| genome | contigs before -> after | frac before -> after | total_bp after | N50 before -> after |
| ------ | ----------------------- | -------------------- | -------------- | ------------------- |
| 1kb    | 11 -> **6**             | 211% -> **107.2%**   | 1072 (~1.07x)  | 41 -> **904**       |
| 3kb    | 32 -> **16**            | 230% -> **115.4%**   | 3463 (~1.15x)  | 41 -> **2926**      |

Contigs roughly halve, frac drops from ~2.2x toward ~1x, N50 ~doubles+, and totals stay slightly ABOVE 1x the genome — the surviving contigs are the correct canonical set, not lost sequence. (Sweep runs are SMOKE-ONLY / below scale floor — quoted here as before/after deltas, not as validation.)

## Test Plan

All green (`LD_LIBRARY_PATH='' julia --project=. -e 'include(<file>)'`):

- [x] `rhizomorph_efficiency_modes_test` — 57/57 (includes updated dedup-warning assertion)
- [x] `variation_preservation_holdout_test` — 12/12 + 12/12
- [x] `scalable_corrector_strategy_test` — 40/40
- [x] `iterative_assembly_tests` — 196/196
- [x] `rhizomorph_kmer_mode_support_test` — 14/14 (k-mer path, dedup default unchanged)
- [x] `dna_kmer_doublestrand_test` — 10/10
- [x] `dna_qualmer_doublestrand_test` — 8/8 (directly exercises modified path)
- [x] `rhizomorph_qualmer_canonical_traversal_test` — 3/3
- [x] `rhizomorph_qualmer_rc_evidence_test` — 6/6

## Related

Fixes the ~2x doublestrand contig redundancy diagnosed in td-47di.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Reverse-complement deduplication now works automatically in more assembly runs, including qualmer-based and iterative corrector paths.
  * Contig outputs can now be canonicalized so duplicate reverse-complement sequences are removed more consistently.

* **Bug Fixes**
  * Assembly results are now more consistent between reused-graph and from-scratch rebuilds when reverse-complement deduplication is enabled.
  * Logging behavior was updated so deduplication is no longer treated as an ignored option on quality-based assembly paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->