### PR TITLE
test: validate universal corrector across non-dsDNA modalities

### DIFF
--- a/test/4_assembly/viterbi_modality_validation_test.jl
+++ b/test/4_assembly/viterbi_modality_validation_test.jl
@@ -1,0 +1,165 @@
+# From the Mycelia base directory, run this test with:
+#
+# ```bash
+# julia --project=. -e 'include("test/4_assembly/viterbi_modality_validation_test.jl")'
+# ```
+#
+# Cross-modality validation for the universal-sequence corrector. Extends the
+# tiny-fixture pattern in viterbi_alphabet_correction_test.jl with:
+#
+#   1. A single-stranded RNA "molecule" fixture (~300 nt) carrying simulated
+#      substitution errors, corrected under mode=:singlestrand with RNA k-mers.
+#   2. A reverse-complement guard test locking the RC-naive contract: an AA
+#      (protein) alphabet asked for :doublestrand or :canonical must throw.
+#   3. A single-strand-vs-canonical discrimination fixture proving the two
+#      strand modes produce DIFFERENT corrected paths (guards against the modes
+#      silently collapsing).
+
+import BioSequences
+import FASTX
+import Kmers
+import Mycelia
+import StableRNGs
+import Test
+
+function _mv_decoded_labels(result::Mycelia.ViterbiCorrectionResult)::Vector{String}
+    decoded = only(result.corrected_observations)
+    return [string(label) for label in decoded]
+end
+
+Test.@testset "Cross-modality Viterbi correction validation" begin
+    Test.@testset "single-stranded RNA molecule (~300nt) recovers substitutions" begin
+        # A single-stranded RNA molecule: one strand, no reverse complement.
+        rng = StableRNGs.StableRNG(1234)
+        bases = ('A', 'C', 'G', 'U')
+        genome = String([bases[rand(rng, 1:4)] for _ in 1:300])
+        rna = BioSequences.LongRNA{4}(genome)
+        records = [FASTX.FASTA.Record("ssRNA_genome", rna)]
+
+        k = 7
+        graph = Mycelia.Rhizomorph.build_kmer_graph(
+            records, k;
+            dataset_id = "ssrna_molecule",
+            mode = :singlestrand,
+            type_hint = :RNA
+        )
+
+        true_kmers = [
+            Kmers.RNAKmer{k}(genome[i:(i + k - 1)])
+            for i in 1:(length(genome) - k + 1)
+        ]
+        expected = [string(kmer) for kmer in true_kmers]
+
+        # Simulate substitution errors at well-separated interior k-mers. Each
+        # error is a single-base substitution at the k-mer's middle position,
+        # surrounded by correct k-mers so the graph forces the true path.
+        observed = copy(true_kmers)
+        error_positions = (40, 120, 200)
+        mid = cld(k, 2)
+        for pos in error_positions
+            original = string(observed[pos])
+            chars = collect(original)
+            chars[mid] = chars[mid] == 'A' ? 'C' : 'A'
+            observed[pos] = Kmers.RNAKmer{k}(String(chars))
+        end
+        # Confirm the corruption actually perturbed the observations.
+        Test.@test any(string(observed[pos]) != expected[pos] for pos in error_positions)
+
+        result = Mycelia.correct_observations(graph, [observed])
+
+        Test.@test result.diagnostics[:alphabet] == :RNA
+        Test.@test result.diagnostics[:strand_mode] == :singlestrand
+        Test.@test _mv_decoded_labels(result) == expected
+    end
+
+    Test.@testset "RC guard: AA alphabet rejects doublestrand and canonical" begin
+        # Amino-acid k-mers are reverse-complement naive; requesting a
+        # double-stranded or canonical decode must throw an ArgumentError.
+        records = [FASTX.FASTA.Record("aa", BioSequences.aa"MKWVTF")]
+        graph = Mycelia.Rhizomorph.build_kmer_graph(
+            records, 3;
+            dataset_id = "aa_rc_guard",
+            mode = :singlestrand,
+            type_hint = :AA
+        )
+        observed = [
+            Kmers.AAKmer{3}("MKW"),
+            Kmers.AAKmer{3}("KWV"),
+            Kmers.AAKmer{3}("WVT"),
+            Kmers.AAKmer{3}("VTF"),
+        ]
+
+        # Sanity: the singlestrand decode is well-formed for the same fixture.
+        ok = Mycelia.correct_observations(graph, [observed])
+        Test.@test ok.diagnostics[:alphabet] == :AA
+        Test.@test ok.diagnostics[:strand_mode] == :singlestrand
+
+        for bad_mode in (:doublestrand, :canonical)
+            local threw = false
+            local message = ""
+            try
+                Mycelia.correct_observations(
+                    graph,
+                    [observed];
+                    config = Mycelia.ViterbiCorrectionConfig(strand_mode = bad_mode)
+                )
+            catch err
+                threw = true
+                Test.@test err isa ArgumentError
+                message = sprint(showerror, err)
+            end
+            Test.@test threw
+            Test.@test occursin("requires a DNA/RNA alphabet", message)
+            Test.@test occursin("reverse-complement naive", message)
+            Test.@test occursin("alphabet AA", message)
+        end
+    end
+
+    Test.@testset "ssDNA vs canonical produce different corrected paths" begin
+        # The same sequence's k-mers, corrected under :singlestrand vs
+        # :canonical, must yield different label paths. If the two modes
+        # collapsed into one, these paths would be identical.
+        records = [FASTX.FASTA.Record("dna", BioSequences.dna"ATGCGT")]
+
+        # Single-strand: forward-oriented k-mers; one corrupted (TGA<-TGC).
+        graph_ss = Mycelia.Rhizomorph.build_kmer_graph(
+            records, 3; dataset_id = "disc_ss", mode = :singlestrand
+        )
+        observed_ss = [
+            Kmers.DNAKmer{3}("ATG"),
+            Kmers.DNAKmer{3}("TGA"),
+            Kmers.DNAKmer{3}("GCG"),
+            Kmers.DNAKmer{3}("CGT"),
+        ]
+        result_ss = Mycelia.correct_observations(graph_ss, [observed_ss])
+        labels_ss = _mv_decoded_labels(result_ss)
+
+        # Canonical: the canonical k-mers of the same sequence; one corrupted
+        # (CCC<-CGC). Expected labels are the canonical forms.
+        graph_cn = Mycelia.Rhizomorph.build_kmer_graph(
+            records, 3; dataset_id = "disc_cn", mode = :canonical
+        )
+        canonical_labels = [
+            Kmers.DNAKmer{3}("ACG"),
+            Kmers.DNAKmer{3}("CGC"),
+            Kmers.DNAKmer{3}("GCA"),
+            Kmers.DNAKmer{3}("CAT"),
+        ]
+        observed_cn = [
+            canonical_labels[1],
+            Kmers.DNAKmer{3}("CCC"),
+            canonical_labels[3],
+            canonical_labels[4],
+        ]
+        result_cn = Mycelia.correct_observations(graph_cn, [observed_cn])
+        labels_cn = _mv_decoded_labels(result_cn)
+        expected_cn = [string(BioSequences.canonical(label)) for label in canonical_labels]
+
+        Test.@test result_ss.diagnostics[:strand_mode] == :singlestrand
+        Test.@test result_cn.diagnostics[:strand_mode] == :canonical
+        Test.@test labels_ss == ["ATG", "TGC", "GCG", "CGT"]
+        Test.@test labels_cn == expected_cn
+        # The load-bearing assertion: the two modes do NOT collapse.
+        Test.@test labels_ss != labels_cn
+    end
+end

--- a/test/4_assembly/viterbi_sentencepiece_correction_test.jl
+++ b/test/4_assembly/viterbi_sentencepiece_correction_test.jl
@@ -1,0 +1,184 @@
+# From the Mycelia base directory, run this test with:
+#
+# ```bash
+# julia --project=. -e 'include("test/4_assembly/viterbi_sentencepiece_correction_test.jl")'
+# ```
+#
+# Optional real-SentencePiece leg (requires the conda `sentencepiece_env`):
+# ```bash
+# MYCELIA_RUN_EXTERNAL=true julia --project=. -e 'include("test/4_assembly/viterbi_sentencepiece_correction_test.jl")'
+# ```
+#
+# Wires the SentencePiece -> token-graph -> Viterbi-corrector pipeline that the
+# cross-modality audit flagged as the one genuinely-untested universal claim.
+#
+# The always-on leg uses hand-built ASCII token sequences that mimic
+# SentencePiece subword pieces so the token-graph -> corrector seam is exercised
+# in default CI without the external `sentencepiece_env`. The gated leg trains a
+# real tiny model, encodes sentences, and runs the same pipeline end-to-end.
+#
+# Finding 1 (recorded during authoring): `build_token_graph` produces
+# `StringVertexData` vertices (in the corrector's accepted vertex-data union) and
+# `StringEdgeData` edges (in the variable-length-edge union). The token graph is
+# therefore classified as TEXT / variable-length and threads through
+# `correct_observations` unchanged — NO core (viterbi-next.jl) or
+# string-graphs.jl edge-data fix was needed.
+#
+# Finding 2 (follow-on, do NOT fix here — viterbi-next.jl is owned elsewhere):
+# the TEXT emission model in viterbi-next.jl indexes token strings by BYTE, so a
+# token containing a multibyte UTF-8 character throws `StringIndexError`. Real
+# SentencePiece emits the U+2581 ("▁", 3 bytes) word-boundary marker on
+# word-initial pieces, so a raw token graph built from unstripped pieces trips
+# this. The gated leg below strips U+2581 before graph construction as a
+# workaround; a proper fix (character-aware indexing in the emission model)
+# belongs in the correction-core track.
+
+import Mycelia
+import Test
+
+# SentencePiece prints this 3-byte marker before word-initial pieces; stripped
+# for the correction path because the TEXT emission model is byte-indexed (see
+# Finding 2 in the header).
+const _SP_WORD_BOUNDARY = "▁"
+
+function _sp_decoded_labels(result::Mycelia.ViterbiCorrectionResult)::Vector{String}
+    decoded = only(result.corrected_observations)
+    return [string(label) for label in decoded]
+end
+
+Test.@testset "SentencePiece token-graph Viterbi correction" begin
+    Test.@testset "token-graph -> corrector wiring (simulated pieces)" begin
+        # ASCII subword pieces (SentencePiece-style, boundary marker stripped).
+        # Two sentences share the interior token so the graph is a genuine
+        # (non-trivial) token adjacency graph, not a single linear chain.
+        token_sequences = [
+            ["the", "quick", "brown", "fox", "jumps"],
+            ["the", "lazy", "brown", "dog", "sleeps"],
+        ]
+        graph = Mycelia.Rhizomorph.build_token_graph(
+            token_sequences; dataset_id = "sp_tokens"
+        )
+
+        # The wiring facts the corrector relies on to classify the token graph.
+        Test.@test Mycelia._correction_vertex_data_type(graph) ==
+                   Mycelia.Rhizomorph.StringVertexData
+        Test.@test Mycelia._correction_edge_data_type(graph) ==
+                   Mycelia.Rhizomorph.StringEdgeData
+
+        # Corrupt exactly ONE interior token with a same-length substitution
+        # ("brown" -> "brawn"). Start and end tokens stay valid graph vertices.
+        observed = ["the", "quick", "brawn", "fox", "jumps"]
+        result = Mycelia.correct_observations(graph, [observed])
+
+        Test.@test result.diagnostics[:alphabet] == :TEXT
+        Test.@test result.diagnostics[:strand_mode] == :singlestrand
+        Test.@test result.diagnostics[:emission_model] == :alphabet_parameterized
+        Test.@test result.diagnostics[:transition_model] == :normalized_overlap_length
+        # The corrupted token is restored to "brown".
+        Test.@test _sp_decoded_labels(result) ==
+                   ["the", "quick", "brown", "fox", "jumps"]
+    end
+
+    Test.@testset "TEXT token graph rejects reverse-complement strand modes" begin
+        # Tokens are reverse-complement naive: a doublestrand/canonical request
+        # must throw (locks the RC-naive contract for the token-graph path too).
+        toks = [["alpha", "beta", "gamma"]]
+        graph = Mycelia.Rhizomorph.build_token_graph(toks; dataset_id = "sp_rc_guard")
+        Test.@test_throws ArgumentError Mycelia.correct_observations(
+            graph,
+            [["alpha", "beta", "gamma"]];
+            config = Mycelia.ViterbiCorrectionConfig(strand_mode = :doublestrand)
+        )
+    end
+
+    # ------------------------------------------------------------------
+    # Gated real-SentencePiece leg: trains a tiny model, encodes sentences,
+    # builds the token graph from the encoded pieces, corrupts one token, and
+    # asserts the pipeline runs and (for a linear token path) restores it.
+    # ------------------------------------------------------------------
+    run_all = lowercase(get(ENV, "MYCELIA_RUN_ALL", "false")) == "true"
+    run_external = run_all ||
+                   lowercase(get(ENV, "MYCELIA_RUN_EXTERNAL", "false")) == "true"
+
+    if run_external && Mycelia._check_sentencepiece_installed()
+        Test.@testset "real SentencePiece encode -> token-graph -> correction" begin
+            # A small corpus whose word-level tokens repeat across sentences so
+            # a word-model vocabulary is learnable at tiny scale.
+            corpus_sentences = [
+                "the quick brown fox jumps over the lazy dog",
+                "the lazy brown dog sleeps under the quick fox",
+                "a quick brown fox and a lazy brown dog",
+            ]
+            corpus_file = tempname() * ".txt"
+            model_prefix = tempname()
+            try
+                write(corpus_file, join(corpus_sentences, "\n") * "\n")
+                trained = Mycelia.train_sentencepiece_model(
+                    input_file = corpus_file,
+                    model_prefix = model_prefix,
+                    vocab_size = 32,
+                    model_type = :word
+                )
+                Test.@test isfile(trained.model_file)
+
+                encoded = Mycelia.encode_sentencepiece(
+                    model_file = trained.model_file,
+                    input = corpus_sentences,
+                    output_format = :pieces
+                )
+                Test.@test encoded isa Vector{Vector{String}}
+                # Strip the U+2581 word-boundary marker: the TEXT emission model
+                # is byte-indexed and throws on multibyte pieces (Finding 2).
+                token_sequences = [
+                    [replace(piece, _SP_WORD_BOUNDARY => "") for piece in pieces]
+                    for pieces in encoded
+                ]
+                token_sequences = [
+                    filter(!isempty, seq) for seq in token_sequences
+                ]
+
+                graph = Mycelia.Rhizomorph.build_token_graph(
+                    token_sequences; dataset_id = "sp_real_tokens"
+                )
+                Test.@test Mycelia._correction_vertex_data_type(graph) ==
+                           Mycelia.Rhizomorph.StringVertexData
+
+                # Pick a sentence whose token path has no repeated token (a
+                # linear chain) so the corrupted-token restoration is
+                # deterministic.
+                linear_idx = findfirst(
+                    seq -> length(seq) >= 3 && length(unique(seq)) == length(seq),
+                    token_sequences
+                )
+                if linear_idx === nothing
+                    # Still assert the pipeline runs end-to-end on the whole set.
+                    result = Mycelia.correct_observations(graph, token_sequences)
+                    Test.@test result.diagnostics[:alphabet] == :TEXT
+                else
+                    path_tokens = token_sequences[linear_idx]
+                    mid = cld(length(path_tokens), 2)
+                    original = path_tokens[mid]
+                    # Same-length substitution: flip the final character to a
+                    # different ASCII letter, guaranteeing an off-graph token.
+                    last_char = original[end]
+                    replacement = last_char == 'z' ? 'y' : 'z'
+                    corrupted_token = original[1:(end - 1)] * string(replacement)
+                    corrupted = copy(path_tokens)
+                    corrupted[mid] = corrupted_token
+
+                    result = Mycelia.correct_observations(graph, [corrupted])
+                    Test.@test result.diagnostics[:alphabet] == :TEXT
+                    Test.@test _sp_decoded_labels(result) == path_tokens
+                end
+            finally
+                isfile(corpus_file) && rm(corpus_file)
+                isfile(model_prefix * ".model") && rm(model_prefix * ".model")
+                isfile(model_prefix * ".vocab") && rm(model_prefix * ".vocab")
+            end
+        end
+    else
+        Test.@testset "real SentencePiece leg (skipped)" begin
+            Test.@test_skip "Set MYCELIA_RUN_EXTERNAL=true with sentencepiece_env installed"
+        end
+    end
+end


### PR DESCRIPTION
## Summary

Adds run-the-corrector-and-assert coverage (beads td-2pt1 + td-ej3z) for the modalities the cross-modality audit flagged as untested or only mode-tested. No correction-core or assembly changes — pure new tests under `test/4_assembly/`.

- **`viterbi_sentencepiece_correction_test.jl`** — wires the SentencePiece → token-graph → Viterbi-corrector pipeline (the one genuinely-untested universal claim). `build_token_graph` produces `StringVertexData` vertices (accepted vertex-data union) and `StringEdgeData` edges (variable-length-edge union), so the token graph classifies as TEXT / variable-length and threads through `correct_observations` **unchanged — no core fix needed**. An always-on leg corrupts one token and asserts restoration; a gated (`MYCELIA_RUN_EXTERNAL`) leg trains a real tiny model, encodes sentences, and runs the same path.
- **`viterbi_modality_validation_test.jl`** — (1) a ~300 nt single-stranded RNA molecule fixture with simulated substitution errors, recovered under `mode=:singlestrand` with RNA k-mers; (2) an AA reverse-complement guard test (`:doublestrand`/`:canonical` must throw); (3) a single-strand-vs-canonical discrimination fixture proving the two strand modes produce **different** corrected paths (guards against silent mode collapse).

## Modalities now with run-the-corrector-and-assert coverage

| Modality | Coverage added |
| --- | --- |
| TEXT via SentencePiece token graph | corrupt-and-restore (new pipeline wiring) |
| ssRNA (~300 nt molecule) | multi-substitution recovery, `mode=:singlestrand` |
| AA `:doublestrand`/`:canonical` | RC-naive guard throw |
| ssDNA vs canonical | different-corrected-path discrimination |

## Finding for a follow-on (not fixed here)

The TEXT emission model in `src/viterbi-next.jl` (owned by the correction-core track) indexes token strings by **byte** and throws `StringIndexError` on multibyte UTF-8 pieces — including the U+2581 word-boundary marker that real SentencePiece emits on word-initial pieces. The gated real-SentencePiece leg strips U+2581 before graph construction as a workaround. A proper fix (character-aware indexing in the emission model) belongs in the correction-core track, so `viterbi-next.jl` was intentionally left untouched.

## Test plan

- `julia --project=. -e 'include("test/4_assembly/viterbi_sentencepiece_correction_test.jl")'` → 8 pass, 1 broken (expected `@test_skip` for the gated external leg)
- `julia --project=. -e 'include("test/4_assembly/viterbi_modality_validation_test.jl")'` → 21 pass
- Ran alongside sibling `viterbi_*` / `token_graph` / `string_variable` suites in a shared session (mimics runtests' single-module inclusion): all pass, no name collisions.
- Both files are auto-discovered by the `include_all_tests(test/4_assembly)` sweep and are pure-Julia (no external tooling required by default).