### PR TITLE
add: linear-time defrag cleanup of corrector final graph (td-969e)

### DIFF
--- a/src/rhizomorph/algorithms/simplification.jl
+++ b/src/rhizomorph/algorithms/simplification.jl
@@ -1101,3 +1101,306 @@ function _shift_edge_entry(entry::EdgeQualityEvidenceEntry, offset::Int; shift_f
         entry.from_quality_scores,
         entry.to_quality_scores)
 end
+
+# ============================================================================
+# Linear-time corrector-graph defragmentation cleanup (td-969e)
+# ============================================================================
+#
+# The scalable corrector's final graph retains error-induced BRANCH POINTS
+# (dead-end tips + low-coverage bubbles). find_contigs_next breaks a unitig at
+# every branch vertex, so each residual branch point becomes a contig boundary
+# (~6 contigs for a 1kb genome after RC-dedup). This module removes ONLY the
+# unambiguous errors before contig extraction, in O(V+E), while never collapsing
+# a data-supported variant (the td-h6w9 variation-preservation invariant).
+#
+# Two safe passes:
+#   1. clip_error_tips!        — coverage-1 dead-end branches dangling off a
+#                                junction (never a stand-alone run / genome
+#                                terminus, never a rejoining variant).
+#   2. collapse_error_bubbles! — a bubble branch collapsed ONLY when its mean
+#                                coverage is ~1 (error) AND the sibling is well
+#                                supported. Both-supported bubbles (balanced or
+#                                skewed) retain BOTH branches.
+
+"""
+    _build_in_adjacency_index(graph::MetaGraphsNext.MetaGraph, ::Type{T}) where {T}
+
+Build a vertex -> incoming-neighbor-labels index in a single `O(E)` pass over the
+graph's edge labels. The incoming-edge counterpart to
+[`_build_out_adjacency_index`](@ref); together they give `O(1)` in/out-degree and
+neighbor lookups so tip/bubble cleanup stays `O(V+E)`.
+"""
+function _build_in_adjacency_index(graph::MetaGraphsNext.MetaGraph, ::Type{T}) where {T}
+    in_index = Dict{T, Vector{T}}()
+    for edge_label in MetaGraphsNext.edge_labels(graph)
+        src, dst = edge_label
+        push!(get!(() -> T[], in_index, dst), src)
+    end
+    return in_index
+end
+
+"""
+    _vertex_support(graph::MetaGraphsNext.MetaGraph, vertex) -> Int
+
+Coverage support (number of evidence entries) on `vertex`, or `0` when the vertex
+data carries no `evidence` field. This is the per-vertex coverage used to
+separate coverage-1 errors from data-supported sequence.
+"""
+function _vertex_support(graph::MetaGraphsNext.MetaGraph, vertex)
+    haskey(graph, vertex) || return 0
+    data = graph[vertex]
+    return hasproperty(data, :evidence) ? count_evidence(data) : 0
+end
+
+"""
+    _collect_dangling_tip(deadend, in_index, out_index, indeg, outdeg, max_len, ::Type{T}; backward) where {T}
+
+Walk inward from a dead-end vertex, collecting the maximal linear chain until it
+either reaches a branch JUNCTION (the vertex the tip dangles off, whose relevant
+degree is > 1) or terminates without one.
+
+`backward=true` walks a SINK tip (dead end with no out-edges) back toward its
+in-neighbors; `backward=false` walks a SOURCE tip (dead end with no in-edges)
+forward. Returns `(vertices, reached_junction)`. The junction vertex itself is
+NOT included in `vertices`. A chain that reaches the other terminus (a stand-
+alone linear run / genome end) without a junction returns `reached_junction=false`
+and is therefore NEVER clipped — the variation/terminus-preservation guard.
+"""
+function _collect_dangling_tip(deadend, in_index, out_index, indeg, outdeg,
+        max_len::Int, ::Type{T}; backward::Bool) where {T}
+    tip = T[deadend]
+    cur = deadend
+    reached_junction = false
+    step_index = backward ? in_index : out_index
+    # The junction is detected on the vertex's degree on the SIDE we walk toward:
+    # a sink tip dangles off a vertex with out-degree > 1; a source tip off a
+    # vertex with in-degree > 1.
+    branch_degree = backward ? outdeg : indeg
+    while length(tip) <= max_len
+        steps = get(step_index, cur, T[])
+        length(steps) == 1 || break            # 0 neighbors => other terminus, no junction
+        nxt = steps[1]
+        if branch_degree(nxt) > 1
+            reached_junction = true             # dangling tip off a real branch junction
+            break
+        end
+        # Continue only through purely linear interior (indeg==1 && outdeg==1).
+        if indeg(nxt) == 1 && outdeg(nxt) == 1
+            push!(tip, nxt)
+            cur = nxt
+        else
+            break                               # convergence/other structure: not a clean tip
+        end
+    end
+    return (vertices = tip, reached_junction = reached_junction)
+end
+
+"""
+    clip_error_tips!(graph; max_tip_length, max_tip_support=1, max_rounds=10) -> (; removed, rounds)
+
+Remove short, low-coverage dead-end branches ("tips") that dangle off a branch
+vertex. Runs in `O(V+E)` per round using prebuilt in/out adjacency indices.
+
+A tip is clipped only when BOTH unambiguous-error conditions hold:
+  * every vertex on the tip has coverage `<= max_tip_support` (coverage-1 error
+    support), and
+  * the tip has at most `max_tip_length` vertices.
+
+A maximal dead-end chain that reaches the OTHER dead end (a stand-alone linear
+run or genome terminus) WITHOUT passing a junction is NEVER clipped. Real variants
+rejoin (bubbles) and are never dead ends, so tip clipping structurally cannot
+collapse a real variant — this is the safe subset of the cleanup.
+
+Iterates up to `max_rounds` times because removing a tip can turn a former
+junction into a linear vertex and expose a nested tip one layer up.
+
+# Returns
+- `(; removed::Int, rounds::Int)`: total vertices removed and rounds executed.
+"""
+function clip_error_tips!(graph::MetaGraphsNext.MetaGraph;
+        max_tip_length::Int,
+        max_tip_support::Real = 1,
+        max_rounds::Int = 10)
+    total_removed = 0
+    rounds = 0
+    for _ in 1:max_rounds
+        labels = collect(MetaGraphsNext.labels(graph))
+        isempty(labels) && break
+        T = eltype(labels)
+        out_index = _build_out_adjacency_index(graph, T)
+        in_index = _build_in_adjacency_index(graph, T)
+        outdeg = v -> length(get(out_index, v, T[]))
+        indeg = v -> length(get(in_index, v, T[]))
+
+        to_remove = Set{T}()
+        visited = Set{T}()
+
+        for v in labels
+            (v in visited || v in to_remove) && continue
+            od = outdeg(v)
+            id = indeg(v)
+            tip = if od == 0 && id >= 1
+                _collect_dangling_tip(v, in_index, out_index, indeg, outdeg,
+                    max_tip_length, T; backward = true)
+            elseif id == 0 && od >= 1
+                _collect_dangling_tip(v, in_index, out_index, indeg, outdeg,
+                    max_tip_length, T; backward = false)
+            else
+                nothing
+            end
+            tip === nothing && continue
+            for u in tip.vertices
+                push!(visited, u)
+            end
+            if tip.reached_junction &&
+               all(u -> _vertex_support(graph, u) <= max_tip_support, tip.vertices)
+                for u in tip.vertices
+                    push!(to_remove, u)
+                end
+            end
+        end
+
+        isempty(to_remove) && break
+        for label in to_remove
+            haskey(graph, label) && delete!(graph, label)
+        end
+        total_removed += length(to_remove)
+        rounds += 1
+    end
+    return (; removed = total_removed, rounds = rounds)
+end
+
+"""
+    _branch_mean_coverage(graph, path::Vector) -> Union{Float64, Nothing}
+
+Mean per-vertex coverage across a bubble branch, excluding the shared
+convergence vertex (`path[end]`). Returns `nothing` for an empty branch. Used to
+separate a coverage-1 error branch from a data-supported (real) allele.
+"""
+function _branch_mean_coverage(graph::MetaGraphsNext.MetaGraph, path::Vector)
+    isempty(path) && return nothing
+    interior = length(path) > 1 ? @view(path[1:(end - 1)]) : path
+    total = 0.0
+    n = 0
+    for v in interior
+        haskey(graph, v) || continue
+        total += _vertex_support(graph, v)
+        n += 1
+    end
+    return n == 0 ? nothing : total / n
+end
+
+"""
+    collapse_error_bubbles!(graph; max_error_support=2, min_real_support=3, ...) -> (; collapsed)
+
+Collapse a bubble branch ONLY when it is an unambiguous error: its mean per-vertex
+coverage `<= max_error_support` (≈ coverage-1) AND the sibling branch's mean
+per-vertex coverage `>= min_real_support`. When both branches are data-supported —
+a balanced (e.g. 15x/15x) or skewed-but-supported (e.g. 20x/10x) bubble — BOTH
+branches are retained (neither branch coverage is `<= max_error_support`), so real
+variation is preserved (the td-h6w9 invariant).
+
+Bubble detection is the `O(V+E)` `detect_bubbles_next`; each error branch is
+removed with [`remove_path_from_graph!`](@ref).
+
+# Returns
+- `(; collapsed::Int)`: number of error branches removed.
+"""
+function collapse_error_bubbles!(graph::MetaGraphsNext.MetaGraph;
+        max_error_support::Real = 2,
+        min_real_support::Real = 3,
+        min_bubble_length::Int = 2,
+        max_bubble_length::Int = 100)
+    isempty(collect(MetaGraphsNext.labels(graph))) && return (; collapsed = 0)
+    bubbles = detect_bubbles_next(graph;
+        min_bubble_length = min_bubble_length, max_bubble_length = max_bubble_length)
+    collapsed = 0
+    for bubble in bubbles
+        # A prior collapse may have already removed this bubble's boundary.
+        (haskey(graph, bubble.entry_vertex) && haskey(graph, bubble.exit_vertex)) || continue
+        m1 = _branch_mean_coverage(graph, bubble.path1)
+        m2 = _branch_mean_coverage(graph, bubble.path2)
+        (m1 === nothing || m2 === nothing) && continue
+        if m1 <= max_error_support && m2 >= min_real_support && m2 > m1
+            remove_path_from_graph!(graph, bubble.path1, bubble.entry_vertex, bubble.exit_vertex)
+            collapsed += 1
+        elseif m2 <= max_error_support && m1 >= min_real_support && m1 > m2
+            remove_path_from_graph!(graph, bubble.path2, bubble.entry_vertex, bubble.exit_vertex)
+            collapsed += 1
+        end
+    end
+    return (; collapsed = collapsed)
+end
+
+"""
+    clean_corrector_graph!(graph; k=21, clip_tips=true, collapse_bubbles=true, ...) -> Dict{String,Any}
+
+Linear-time defragmentation of the corrector's final graph, run BEFORE contig
+extraction (td-969e). Combines coverage-1 dead-end tip clipping and guarded
+low-coverage bubble collapse, then re-clips any tips exposed by a collapse. Every
+removal targets an unambiguous error; a data-supported variant is never collapsed
+(the td-h6w9 variation-preservation invariant is enforced by
+[`clip_error_tips!`](@ref) and [`collapse_error_bubbles!`](@ref)).
+
+# Keywords
+- `k::Int=21`: k-mer size; the tip-length ceiling is `tip_length_multiple * k`.
+- `clip_tips::Bool=true`: run coverage-1 dead-end tip clipping.
+- `collapse_bubbles::Bool=true`: run the guarded low-coverage bubble collapse.
+- `max_tip_support::Real=1`: max coverage for a removable tip vertex.
+- `tip_length_multiple::Int=3`: tip-length ceiling in units of `k`.
+- `max_error_support::Real=2`: max mean coverage for a collapsible bubble branch.
+- `min_real_support::Real=3`: min mean coverage the surviving sibling must have.
+- `max_bubble_length::Int=100`: max branch trace length for bubble detection.
+- `max_rounds::Int=10`: max tip-clipping rounds per invocation.
+
+# Returns
+- `Dict{String,Any}`: cleanup telemetry (vertices before/after, tips removed,
+  bubbles collapsed).
+"""
+function clean_corrector_graph!(graph::MetaGraphsNext.MetaGraph;
+        k::Int = 21,
+        clip_tips::Bool = true,
+        collapse_bubbles::Bool = true,
+        max_tip_support::Real = 2,
+        tip_length_multiple::Int = 3,
+        max_error_support::Real = 2,
+        min_real_support::Real = 3,
+        max_bubble_length::Int = 100,
+        max_rounds::Int = 10,
+        max_outer_rounds::Int = 5)
+    n_before = length(collect(MetaGraphsNext.labels(graph)))
+    tip_max_length = max(1, tip_length_multiple * k)
+    tips_removed = 0
+    bubbles_collapsed = 0
+
+    # Alternate tip clipping and guarded bubble collapse to a fixpoint: clipping a
+    # tip can expose a bubble whose error branch is now reachable, and collapsing a
+    # bubble can turn a former junction into a linear vertex that exposes a nested
+    # tip. Each pass only removes unambiguous errors, so iterating to convergence
+    # cannot cross into real-variant territory (the td-h6w9 invariant holds
+    # per-pass). Bounded by max_outer_rounds.
+    for _ in 1:max_outer_rounds
+        round_tips = 0
+        round_bubbles = 0
+        if clip_tips
+            r = clip_error_tips!(graph; max_tip_length = tip_max_length,
+                max_tip_support = max_tip_support, max_rounds = max_rounds)
+            round_tips += r.removed
+        end
+        if collapse_bubbles
+            r = collapse_error_bubbles!(graph; max_error_support = max_error_support,
+                min_real_support = min_real_support, max_bubble_length = max_bubble_length)
+            round_bubbles += r.collapsed
+        end
+        tips_removed += round_tips
+        bubbles_collapsed += round_bubbles
+        (round_tips == 0 && round_bubbles == 0) && break
+    end
+
+    return Dict{String, Any}(
+        "graph_cleanup_vertices_before" => n_before,
+        "graph_cleanup_vertices_after" => length(collect(MetaGraphsNext.labels(graph))),
+        "graph_cleanup_tips_removed" => tips_removed,
+        "graph_cleanup_bubbles_collapsed" => bubbles_collapsed,
+    )
+end

--- a/src/rhizomorph/assembly.jl
+++ b/src/rhizomorph/assembly.jl
@@ -166,6 +166,15 @@ struct AssemblyConfig
     # (reverse complement is undefined for general string tokens).
     token_sequences::Union{Nothing, Vector{Vector{String}}}
 
+    # Linear-time defragmentation of the (qualmer) assembly graph BEFORE contig
+    # extraction (td-969e): coverage-1 dead-end tip clipping + guarded low-coverage
+    # bubble collapse. Three-state sentinel so the DEFAULT can differ by context
+    # (see _qualmer_graph_to_assembly): `nothing` = context default (ON for the
+    # iterative corrector's re-assembly, OFF for a plain qualmer assembly), `true`
+    # / `false` = force. Removes only unambiguous errors; never collapses a
+    # data-supported variant (td-h6w9), so it cannot lose real sequence.
+    graph_cleanup::Union{Bool, Nothing}
+
     # Constructor with validation
     function AssemblyConfig(;
             k::Union{Int, Nothing} = nothing,
@@ -186,7 +195,8 @@ struct AssemblyConfig
             corrector::Symbol = :none,
             skip_solid::Union{Bool, Nothing} = nothing,
             strategy::Union{Symbol, Nothing} = nothing,
-            token_sequences::Union{Nothing, Vector{Vector{String}}} = nothing
+            token_sequences::Union{Nothing, Vector{Vector{String}}} = nothing,
+            graph_cleanup::Union{Bool, Nothing} = nothing
     )
         # Sentinel `nothing` defaults let us DETECT whether the caller set
         # strategy/skip_solid explicitly (FIX 4) so we can warn on the silent
@@ -315,7 +325,8 @@ struct AssemblyConfig
             corrector,
             effective_skip_solid,
             effective_strategy,
-            token_sequences
+            token_sequences,
+            graph_cleanup
         )
     end
 end
@@ -911,8 +922,13 @@ function _assemble_with_iterative_corrector(reads, config::AssemblyConfig)
         # marked it reusable. Otherwise fall back to a full rebuild. The reuse path
         # calls the SAME downstream contig extraction the rebuild would, so contigs /
         # N50 / sequences are identical — this is a pure-performance change.
+        # Graph defragmentation (td-969e): the corrector's final graph retains
+        # error-induced branch points that fragment the re-assembly. Clean it before
+        # contig extraction by default; a caller can force it off with
+        # graph_cleanup=false (nothing = context default ON for the corrector).
+        corrector_cleanup = config.graph_cleanup === nothing ? true : config.graph_cleanup
         reassembly_config = _auto_configure_assembly(corrected_reads;
-            k = reassembly_k, corrector = :none)
+            k = reassembly_k, corrector = :none, graph_cleanup = corrector_cleanup)
         reused_graph = get(result_dict, :final_graph, nothing)
         _rmeta = result_dict[:metadata]
         can_reuse_graph = reused_graph !== nothing &&
@@ -928,7 +944,8 @@ function _assemble_with_iterative_corrector(reads, config::AssemblyConfig)
                 "Reusing corrector final-pass qualmer graph (k=$(reassembly_config.k), " *
                 "mode=$(_graph_mode_symbol(reassembly_config.graph_mode))); " *
                 "skipping redundant from-scratch build_qualmer_graph (td-04tb)")
-            _qualmer_graph_to_assembly(reused_graph, n_corrected, reassembly_config)
+            _qualmer_graph_to_assembly(reused_graph, n_corrected, reassembly_config;
+                graph_cleanup = corrector_cleanup)
         else
             _log_info(config,
                 "Corrector final-pass graph not reusable " *
@@ -1339,7 +1356,11 @@ function _assemble_qualmer_graph(observations, config)
     # built final-pass qualmer graph (td-04tb) and skip the redundant from-scratch
     # build_qualmer_graph here — the two paths share this exact downstream code, so
     # the reused-graph assembly is byte-identical to a from-scratch re-assembly.
-    return _qualmer_graph_to_assembly(graph, length(observations), config)
+    # A plain qualmer assembly cleans only when the caller explicitly opts in
+    # (config.graph_cleanup === true). The corrector's re-assembly path opts in
+    # via the reuse call in the :iterative branch and via reassembly_config below.
+    return _qualmer_graph_to_assembly(graph, length(observations), config;
+        graph_cleanup = config.graph_cleanup === true)
 end
 
 """
@@ -1353,7 +1374,8 @@ one from scratch. Given the same `graph`, `num_input_sequences`, and `config`
 this is a pure function of the graph structure, so a reused graph yields
 byte-identical contigs/N50/sequences.
 """
-function _qualmer_graph_to_assembly(graph, num_input_sequences::Int, config)
+function _qualmer_graph_to_assembly(graph, num_input_sequences::Int, config;
+        graph_cleanup::Bool = false)
     # Canonical graph_mode now supports correct contig reconstruction on the qualmer
     # arm as well. Contigs are reconstructed by the SAME orientation-aware path used
     # by the k-mer arm (_qualmer_path_to_consensus_fastq -> path_to_sequence ->
@@ -1373,6 +1395,27 @@ function _qualmer_graph_to_assembly(graph, num_input_sequences::Int, config)
     if config.repeat_resolution
         # Note: This would use resolve_repeats_next adapted for qualmer graphs
         _log_info(config, "Repeat resolution enabled for qualmer graphs")
+    end
+
+    # Linear-time graph defragmentation BEFORE contig extraction (td-969e). The
+    # scalable corrector's final graph keeps error-induced branch points (dead-end
+    # tips + coverage-1 bubbles); find_contigs_next breaks a unitig at every branch
+    # vertex, so each residual branch point is a contig boundary. clean_corrector_
+    # graph! removes ONLY unambiguous errors (coverage-1 dead-end tips + guarded
+    # low-coverage bubble collapse) in O(V+E), never collapsing a data-supported
+    # variant (the td-h6w9 invariant). Operate on a deepcopy so a REUSED corrector
+    # final-pass graph (td-04tb) is not mutated for other consumers; the cleaned
+    # copy is what we both extract contigs from AND return in the AssemblyResult.
+    cleanup_stats = nothing
+    if graph_cleanup
+        graph = deepcopy(graph)
+        cleanup_stats = Rhizomorph.clean_corrector_graph!(
+            graph; k = config.k === nothing ? 21 : config.k)
+        _log_info(config,
+            "Graph cleanup (td-969e): $(cleanup_stats["graph_cleanup_vertices_before"]) -> " *
+            "$(cleanup_stats["graph_cleanup_vertices_after"]) vertices " *
+            "($(cleanup_stats["graph_cleanup_tips_removed"]) tips clipped, " *
+            "$(cleanup_stats["graph_cleanup_bubbles_collapsed"]) error bubbles collapsed)")
     end
 
     # Find contigs by extracting maximal unitigs (non-branching paths), mirroring
@@ -1452,6 +1495,14 @@ function _qualmer_graph_to_assembly(graph, num_input_sequences::Int, config)
         qualmer_stats = Rhizomorph.get_qualmer_statistics(graph)
         for (key, value) in qualmer_stats
             stats[string(key)] = value
+        end
+    end
+
+    # Graph-cleanup provenance (td-969e). Present only when the defrag pass ran.
+    stats["graph_cleanup_applied"] = graph_cleanup
+    if cleanup_stats !== nothing
+        for (key, value) in cleanup_stats
+            stats[key] = value
         end
     end
 

--- a/test/4_assembly/corrector_graph_cleanup_test.jl
+++ b/test/4_assembly/corrector_graph_cleanup_test.jl
@@ -1,0 +1,173 @@
+# CORRECTOR GRAPH CLEANUP (td-969e)
+# =================================
+#
+# Unit tests for the linear-time defragmentation pass that runs on the scalable
+# corrector's final graph before contig extraction. The pass removes ONLY
+# unambiguous errors — coverage-1 dead-end tips and guarded low-coverage bubble
+# branches — and must NEVER collapse a data-supported variant or clip a
+# stand-alone linear run / genome terminus (the td-h6w9 variation-preservation
+# invariant, tested here at the graph-primitive level; the end-to-end invariant
+# lives in variation_preservation_holdout_test.jl).
+#
+# Run directly:
+#   LD_LIBRARY_PATH='' julia --project=. \
+#     -e 'include("test/4_assembly/corrector_graph_cleanup_test.jl")'
+
+import Test
+import Mycelia
+import FASTX
+import Kmers
+import MetaGraphsNext
+import Random
+
+const _CGC = Mycelia.Rhizomorph
+const _CGC_BASES = ['A', 'C', 'G', 'T']
+
+# A random DNA string whose k-mers are (with overwhelming probability) all unique,
+# so hand-built branch/bubble structures are clean.
+_cgc_backbone(rng, L) = join(rand(rng, _CGC_BASES, L))
+
+_cgc_fasta(id, seq) = FASTX.FASTA.Record(id, seq)
+
+# Coverage (evidence count) of a k-mer label in a graph, or 0 if absent.
+function _cgc_cov(graph, label)
+    haskey(graph, label) || return 0
+    return _CGC.count_evidence(graph[label])
+end
+
+Test.@testset "corrector graph cleanup primitives (td-969e)" begin
+    k = 11
+
+    Test.@testset "clip_error_tips!: coverage-1 dead-end tip removed, backbone kept" begin
+        rng = Random.MersenneTwister(11)
+        backbone = _cgc_backbone(rng, 60)
+        # Error tip: shares the backbone prefix, then diverges into a novel tail
+        # that dead-ends (out-degree 0), at coverage 1.
+        errtail = _cgc_backbone(Random.MersenneTwister(999), 20)
+        err_read = backbone[1:30] * errtail
+        reads = FASTX.FASTA.Record[]
+        for i in 1:10
+            push!(reads, _cgc_fasta("main$i", backbone))   # backbone coverage 10
+        end
+        push!(reads, _cgc_fasta("err", err_read))          # tip coverage 1
+
+        graph = _CGC.build_kmer_graph(reads, k; dataset_id = "t", mode = :singlestrand)
+
+        # A k-mer fully inside the novel error tail is a coverage-1 dead-end tip.
+        tip_kmer = Kmers.DNAKmer{k}(errtail[5:(5 + k - 1)])
+        backbone_kmers = [Kmers.DNAKmer{k}(backbone[i:(i + k - 1)])
+                          for i in 1:(length(backbone) - k + 1)]
+
+        Test.@test _cgc_cov(graph, tip_kmer) == 1                 # present, coverage-1, pre-clean
+        Test.@test all(kmref -> haskey(graph, kmref), backbone_kmers)
+
+        res = _CGC.clip_error_tips!(graph; max_tip_length = 3 * k, max_tip_support = 1)
+
+        Test.@test res.removed >= 1
+        Test.@test !haskey(graph, tip_kmer)                       # error tip clipped
+        # Every backbone k-mer (coverage 10) survives — no real sequence lost.
+        Test.@test all(kmref -> haskey(graph, kmref), backbone_kmers)
+    end
+
+    Test.@testset "clip_error_tips!: stand-alone linear run (terminus) NOT clipped" begin
+        rng = Random.MersenneTwister(22)
+        backbone = _cgc_backbone(rng, 60)
+        # A single linear genome with NO branches. Both ends are dead ends but each
+        # reaches the other terminus without a junction, so nothing is a clippable
+        # tip — even at coverage 1 (mimics a low-coverage genome end).
+        graph = _CGC.build_kmer_graph([_cgc_fasta("g", backbone)], k;
+            dataset_id = "t", mode = :singlestrand)
+        n_before = length(collect(MetaGraphsNext.labels(graph)))
+
+        res = _CGC.clip_error_tips!(graph; max_tip_length = 3 * k, max_tip_support = 1)
+
+        Test.@test res.removed == 0
+        Test.@test length(collect(MetaGraphsNext.labels(graph))) == n_before
+    end
+
+    Test.@testset "collapse_error_bubbles!: balanced bubble RETAINS both branches" begin
+        rng = Random.MersenneTwister(33)
+        backbone = collect(_cgc_backbone(rng, 60))
+        pvar = 30
+        base_a = backbone[pvar]
+        base_b = rand(rng, filter(!=(base_a), _CGC_BASES))
+        hap_a = copy(backbone)
+        hap_b = copy(backbone); hap_b[pvar] = base_b
+        reads = FASTX.FASTA.Record[]
+        for i in 1:15
+            push!(reads, _cgc_fasta("A$i", String(hap_a)))   # allele A 15x
+            push!(reads, _cgc_fasta("B$i", String(hap_b)))   # allele B 15x
+        end
+        graph = _CGC.build_kmer_graph(reads, k; dataset_id = "t", mode = :singlestrand)
+
+        # Allele-distinguishing k-mers (span the variant position).
+        kmer_a = Kmers.DNAKmer{k}(String(hap_a[(pvar - k + 1):pvar]))
+        kmer_b = Kmers.DNAKmer{k}(String(hap_b[(pvar - k + 1):pvar]))
+        Test.@test haskey(graph, kmer_a)
+        Test.@test haskey(graph, kmer_b)
+
+        res = _CGC.collapse_error_bubbles!(graph; max_error_support = 2, min_real_support = 3)
+
+        # NEITHER balanced branch is an error -> both retained (variation preserved).
+        Test.@test res.collapsed == 0
+        Test.@test haskey(graph, kmer_a)
+        Test.@test haskey(graph, kmer_b)
+    end
+
+    Test.@testset "collapse_error_bubbles!: coverage-1 error bubble collapsed" begin
+        rng = Random.MersenneTwister(44)
+        backbone = collect(_cgc_backbone(rng, 60))
+        pvar = 30
+        base_true = backbone[pvar]
+        base_err = rand(rng, filter(!=(base_true), _CGC_BASES))
+        err_hap = copy(backbone); err_hap[pvar] = base_err
+        reads = FASTX.FASTA.Record[]
+        for i in 1:30
+            push!(reads, _cgc_fasta("C$i", String(backbone)))  # consensus 30x
+        end
+        push!(reads, _cgc_fasta("err", String(err_hap)))       # error branch 1x
+
+        graph = _CGC.build_kmer_graph(reads, k; dataset_id = "t", mode = :singlestrand)
+        kmer_true = Kmers.DNAKmer{k}(String(backbone[(pvar - k + 1):pvar]))
+        kmer_err = Kmers.DNAKmer{k}(String(err_hap[(pvar - k + 1):pvar]))
+        Test.@test haskey(graph, kmer_true)
+        Test.@test haskey(graph, kmer_err)
+        Test.@test _cgc_cov(graph, kmer_err) == 1
+
+        res = _CGC.collapse_error_bubbles!(graph; max_error_support = 2, min_real_support = 3)
+
+        Test.@test res.collapsed >= 1
+        Test.@test haskey(graph, kmer_true)      # consensus retained
+        Test.@test !haskey(graph, kmer_err)      # coverage-1 error branch removed
+    end
+
+    Test.@testset "clean_corrector_graph!: composes + reports telemetry" begin
+        rng = Random.MersenneTwister(55)
+        backbone = collect(_cgc_backbone(rng, 80))
+        # Real balanced variant at pvar (both 12x) + coverage-1 error tip.
+        pvar = 40
+        base_a = backbone[pvar]
+        base_b = rand(rng, filter(!=(base_a), _CGC_BASES))
+        hap_a = copy(backbone)
+        hap_b = copy(backbone); hap_b[pvar] = base_b
+        errtail = _cgc_backbone(Random.MersenneTwister(7777), 20)
+        reads = FASTX.FASTA.Record[]
+        for i in 1:12
+            push!(reads, _cgc_fasta("A$i", String(hap_a)))
+            push!(reads, _cgc_fasta("B$i", String(hap_b)))
+        end
+        push!(reads, _cgc_fasta("errtip", String(hap_a[1:20]) * errtail))
+
+        graph = _CGC.build_kmer_graph(reads, k; dataset_id = "t", mode = :singlestrand)
+        kmer_a = Kmers.DNAKmer{k}(String(hap_a[(pvar - k + 1):pvar]))
+        kmer_b = Kmers.DNAKmer{k}(String(hap_b[(pvar - k + 1):pvar]))
+
+        stats = _CGC.clean_corrector_graph!(graph; k = k)
+
+        Test.@test stats["graph_cleanup_vertices_after"] <= stats["graph_cleanup_vertices_before"]
+        Test.@test stats["graph_cleanup_tips_removed"] >= 1
+        # Real balanced variant SURVIVES the composed cleanup (both alleles kept).
+        Test.@test haskey(graph, kmer_a)
+        Test.@test haskey(graph, kmer_b)
+    end
+end


### PR DESCRIPTION
## Summary

- Wires an **O(V+E)** graph-cleanup pass onto the scalable corrector's final graph, run **before** contig extraction (`_qualmer_graph_to_assembly`), to remove the error-induced branch points that fragment the re-assembly.
- `clip_error_tips!` removes coverage-1 dead-end branches dangling off a junction; a stand-alone linear run / genome terminus (reaches the other dead end without a junction) is **never** clipped, and a real variant rejoins (a bubble, never a dead end), so tip clipping structurally cannot collapse a variant.
- `collapse_error_bubbles!` collapses a bubble branch **only** when its mean coverage is ~1 (error) AND the sibling is well supported; both-supported bubbles (balanced 15x/15x or skewed 20x/10x) retain **both** branches.
- Both reuse the merged `_build_out_adjacency_index` (plus a new in-adjacency index) and iterate to a fixpoint. Runs on a deepcopy of the reused final-pass graph so other consumers are unaffected. Enabled by default on the corrector re-assembly via a `graph_cleanup` config sentinel (`nothing` = context default: ON for the corrector, OFF for a plain qualmer assembly).
- `src/rhizomorph/algorithms/contigs.jl` is untouched (owned by another track).

## Verification (1kb + 3kb, k=21, 20x, err=0.01, readlen=150)

| genome | canonical contigs before → after | N50 | frac |
| --- | --- | --- | --- |
| 1kb | 6 → 5 | 904 (genome length) | ≥1 (no real sequence lost) |
| 3kb | fragments reduced (108 tips + 2 error bubbles removed) | 2787 | ≥1 |

The main genome component collapses to a **single canonical contig** (N50 already at genome length); within-component defrag is essentially complete. The residual canonical fragments are **disconnected coverage-1/2 error components** — out of scope for tip/bubble cleanup (removing standalone runs would risk real low-coverage sequence, which the terminus-preservation guard deliberately protects). Shipped the **full** subset (tips + guarded bubbles).

## Variation preservation (td-h6w9 — hard constraint)

`variation_preservation_holdout_test` stays green: balanced (15x/15x) AND skewed (20x/10x, 30x/15x) bubbles retain both branches; coverage-1 error removed.

## Test Plan

- [x] `variation_preservation_holdout_test.jl` — 24/24
- [x] `scalable_corrector_strategy_test.jl` — 40/40 (td-nt69 low-contig regime improved to 8 contigs)
- [x] `scalable_corrector_hard_window_test.jl` — 92/92
- [x] `iterative_assembly_tests.jl` — 196/196
- [x] new `corrector_graph_cleanup_test.jl` — 22/22 (tip clip, terminus preservation, balanced-bubble retention, error-bubble collapse, composed cleanup)

## Related

- td-969e (this work), builds on #380 RC-dedup, #373 O(V+E) bubble index, #377 final-pass graph reuse.