### PR TITLE
add: prune disconnected error components in corrector cleanup (td-byva)

### DIFF
--- a/src/rhizomorph/algorithms/simplification.jl
+++ b/src/rhizomorph/algorithms/simplification.jl
@@ -1332,46 +1332,233 @@ function collapse_error_bubbles!(graph::MetaGraphsNext.MetaGraph;
     return (; collapsed = collapsed)
 end
 
+# ----------------------------------------------------------------------------
+# Disconnected error-component pruning (td-byva)
+# ----------------------------------------------------------------------------
+#
+# clip_error_tips!/collapse_error_bubbles! only touch structure WITHIN a
+# component (dangling tips off a junction, error branches of a bubble). After
+# RC-dedup + those passes the main genome collapses to a single full-length
+# contig, but the graph still carries standalone DISCONNECTED components — small
+# coverage-1/2 islands of sequencing-error k-mers that never joined the main
+# path. Each is its own contig at extraction, so a 1kb genome can extract ~5
+# contigs (1 real + ~4 error islands) and a 48kb genome ~98 (1 real + ~97).
+#
+# A standalone linear run is deliberately protected by the terminus guard in
+# clip_error_tips! (it reaches its other dead end without a junction), so tip
+# clipping cannot remove these islands — hence this dedicated pass. It removes a
+# whole component ONLY when it is provably error under ALL of:
+#   * SEPARATE component (never the main/largest component),
+#   * SMALL (span <= max_component_length),
+#   * uniformly LOW coverage (MAX per-vertex coverage <= max_component_support,
+#     the ~1-2 error floor), AND
+#   * REAL-SEQUENCE GUARD: shares no canonical k-mer with any well-supported
+#     (coverage >= min_real_support) vertex. A standalone island that COULD be
+#     genuine low-coverage minor sequence — because it re-uses real k-mer content
+#     — is RETAINED. This biases to UNDER-pruning (td-h6w9): leave a debris
+#     contig rather than risk removing a real low-coverage variant.
+
+"""
+    _label_dna_string(label) -> String
+
+Best-effort DNA string for a vertex label. K-mer / BioSequence labels stringify
+to their sequence; an already-string label is returned as-is.
+"""
+function _label_dna_string(label)
+    label isa AbstractString && return label
+    return String(label)
+end
+
+"""
+    _accumulate_canonical_kmers!(kset::Set{String}, label, k::Int)
+
+Add the canonical `k`-mer string keys of a vertex `label`'s sequence to `kset`.
+Canonicalization is the lexicographic min of a k-mer and its reverse complement
+(strand-agnostic key), so a run and its reverse-complement copy hash together —
+this is what lets the real-sequence guard recognise reverse-strand overlap with a
+supported contig. For a fixed-length k-mer graph each label contributes exactly
+one key.
+"""
+function _accumulate_canonical_kmers!(kset::Set{String}, label, k::Int)
+    s = _label_dna_string(label)
+    n = length(s)
+    n < k && return kset
+    for i in 1:(n - k + 1)
+        sub = s[i:(i + k - 1)]
+        rc = String(BioSequences.reverse_complement(BioSequences.LongDNA{4}(sub)))
+        push!(kset, min(sub, rc))
+    end
+    return kset
+end
+
+"""
+    _connected_components_labels(labels, out_index, in_index, ::Type{T}) where {T}
+
+Weakly-connected components of the graph, as label vectors, via BFS over the
+UNDIRECTED closure of the prebuilt in/out adjacency indices. `O(V+E)`: every
+vertex is enqueued once and every edge is followed a constant number of times.
+"""
+function _connected_components_labels(labels::AbstractVector{T},
+        out_index::AbstractDict, in_index::AbstractDict, ::Type{T}) where {T}
+    components = Vector{Vector{T}}()
+    seen = Set{T}()
+    queue = T[]
+    for start in labels
+        start in seen && continue
+        push!(seen, start)
+        empty!(queue)
+        push!(queue, start)
+        comp = T[]
+        head = 1
+        while head <= length(queue)
+            v = queue[head]
+            head += 1
+            push!(comp, v)
+            for nbr in get(out_index, v, T[])
+                if !(nbr in seen)
+                    push!(seen, nbr)
+                    push!(queue, nbr)
+                end
+            end
+            for nbr in get(in_index, v, T[])
+                if !(nbr in seen)
+                    push!(seen, nbr)
+                    push!(queue, nbr)
+                end
+            end
+        end
+        push!(components, comp)
+    end
+    return components
+end
+
+"""
+    prune_disconnected_error_components!(graph; k, max_component_length=2000,
+        max_component_support=2, min_real_support=3) -> (; removed, components_pruned)
+
+Remove standalone DISCONNECTED components that are provably sequencing-error
+debris, in `O(V+E)`. A component is pruned ONLY when it is NOT the main (largest)
+component AND its span `<= max_component_length` AND its MAXIMUM per-vertex
+coverage `<= max_component_support` (uniformly at the ~1-2 error floor) AND it
+shares no canonical k-mer with any well-supported (`coverage >= min_real_support`)
+vertex (the real-sequence guard). Any component failing even one condition —
+including a data-supported genome that happens to be disconnected — is RETAINED.
+
+The design deliberately UNDER-prunes (td-h6w9): the coverage gate keys on the
+component MAXIMUM (not mean), so a single supported k-mer anywhere in the
+component vetoes removal, and the canonical-k-mer guard retains anything that
+re-uses real sequence content. Span is estimated as `n_vertices + k - 1` (the
+length of a linear k-mer chain), an over-estimate for branchy components, which
+only makes the size cap MORE conservative.
+
+# Returns
+- `(; removed::Int, components_pruned::Int)`: vertices removed and components
+  pruned.
+"""
+function prune_disconnected_error_components!(graph::MetaGraphsNext.MetaGraph;
+        k::Int,
+        max_component_length::Int = 2000,
+        max_component_support::Real = 2,
+        min_real_support::Real = 3)
+    labels = collect(MetaGraphsNext.labels(graph))
+    isempty(labels) && return (; removed = 0, components_pruned = 0)
+    T = eltype(labels)
+    out_index = _build_out_adjacency_index(graph, T)
+    in_index = _build_in_adjacency_index(graph, T)
+
+    components = _connected_components_labels(labels, out_index, in_index, T)
+    # A single component means nothing is disconnected: this pass only removes
+    # SEPARATE components, so structure within the one component is out of scope.
+    length(components) <= 1 && return (; removed = 0, components_pruned = 0)
+
+    # The largest component is the main assembly and is never a prune candidate.
+    main_idx = argmax(map(length, components))
+
+    # Canonical k-mers of every well-supported vertex, built once in O(V). A
+    # candidate that touches any of these is retained (real-sequence guard).
+    # Candidate vertices (max coverage <= max_component_support < min_real_support)
+    # are never themselves in this set, so it cannot self-veto a genuine error.
+    well_supported_kmers = Set{String}()
+    for v in labels
+        if _vertex_support(graph, v) >= min_real_support
+            _accumulate_canonical_kmers!(well_supported_kmers, v, k)
+        end
+    end
+
+    removed = 0
+    components_pruned = 0
+    for (ci, comp) in enumerate(components)
+        ci == main_idx && continue
+        span = length(comp) + k - 1
+        span <= max_component_length || continue
+        all(v -> _vertex_support(graph, v) <= max_component_support, comp) || continue
+
+        comp_kmers = Set{String}()
+        for v in comp
+            _accumulate_canonical_kmers!(comp_kmers, v, k)
+        end
+        any(km -> km in well_supported_kmers, comp_kmers) && continue
+
+        for v in comp
+            haskey(graph, v) && delete!(graph, v)
+        end
+        removed += length(comp)
+        components_pruned += 1
+    end
+    return (; removed = removed, components_pruned = components_pruned)
+end
+
 """
     clean_corrector_graph!(graph; k=21, clip_tips=true, collapse_bubbles=true, ...) -> Dict{String,Any}
 
 Linear-time defragmentation of the corrector's final graph, run BEFORE contig
-extraction (td-969e). Combines coverage-1 dead-end tip clipping and guarded
-low-coverage bubble collapse, then re-clips any tips exposed by a collapse. Every
-removal targets an unambiguous error; a data-supported variant is never collapsed
-(the td-h6w9 variation-preservation invariant is enforced by
-[`clip_error_tips!`](@ref) and [`collapse_error_bubbles!`](@ref)).
+extraction (td-969e). Combines coverage-1 dead-end tip clipping, guarded
+low-coverage bubble collapse, and disconnected error-component pruning (td-byva):
+first tips/bubbles are alternated to a fixpoint (re-clipping any tips exposed by a
+collapse), then whole standalone error-debris components are pruned. Every removal
+targets an unambiguous error; a data-supported variant is never collapsed (the
+td-h6w9 variation-preservation invariant is enforced by
+[`clip_error_tips!`](@ref), [`collapse_error_bubbles!`](@ref), and
+[`prune_disconnected_error_components!`](@ref)).
 
 # Keywords
 - `k::Int=21`: k-mer size; the tip-length ceiling is `tip_length_multiple * k`.
 - `clip_tips::Bool=true`: run coverage-1 dead-end tip clipping.
 - `collapse_bubbles::Bool=true`: run the guarded low-coverage bubble collapse.
+- `prune_components::Bool=true`: run disconnected error-component pruning.
 - `max_tip_support::Real=1`: max coverage for a removable tip vertex.
 - `tip_length_multiple::Int=3`: tip-length ceiling in units of `k`.
 - `max_error_support::Real=2`: max mean coverage for a collapsible bubble branch.
 - `min_real_support::Real=3`: min mean coverage the surviving sibling must have.
 - `max_bubble_length::Int=100`: max branch trace length for bubble detection.
 - `max_rounds::Int=10`: max tip-clipping rounds per invocation.
+- `max_component_length::Int=2000`: max span of a prunable disconnected component.
+- `max_component_support::Real=2`: max per-vertex coverage in a prunable component.
 
 # Returns
 - `Dict{String,Any}`: cleanup telemetry (vertices before/after, tips removed,
-  bubbles collapsed).
+  bubbles collapsed, components pruned, component vertices removed).
 """
 function clean_corrector_graph!(graph::MetaGraphsNext.MetaGraph;
         k::Int = 21,
         clip_tips::Bool = true,
         collapse_bubbles::Bool = true,
+        prune_components::Bool = true,
         max_tip_support::Real = 2,
         tip_length_multiple::Int = 3,
         max_error_support::Real = 2,
         min_real_support::Real = 3,
         max_bubble_length::Int = 100,
         max_rounds::Int = 10,
-        max_outer_rounds::Int = 5)
+        max_outer_rounds::Int = 5,
+        max_component_length::Int = 2000,
+        max_component_support::Real = 2)
     n_before = length(collect(MetaGraphsNext.labels(graph)))
     tip_max_length = max(1, tip_length_multiple * k)
     tips_removed = 0
     bubbles_collapsed = 0
+    components_pruned = 0
+    component_vertices_removed = 0
 
     # Alternate tip clipping and guarded bubble collapse to a fixpoint: clipping a
     # tip can expose a bubble whose error branch is now reachable, and collapsing a
@@ -1397,10 +1584,27 @@ function clean_corrector_graph!(graph::MetaGraphsNext.MetaGraph;
         (round_tips == 0 && round_bubbles == 0) && break
     end
 
+    # Prune standalone error-debris components AFTER the tip/bubble fixpoint.
+    # Tip clipping and bubble collapse only reshape structure WITHIN a component
+    # and never split one component into two, so the disconnected-component set is
+    # stable and a single pruning pass suffices. The main (largest) component is
+    # always retained; only small, uniformly-low-coverage islands that share no
+    # real k-mer content are removed (td-byva / td-h6w9).
+    if prune_components
+        r = prune_disconnected_error_components!(graph; k = k,
+            max_component_length = max_component_length,
+            max_component_support = max_component_support,
+            min_real_support = min_real_support)
+        components_pruned += r.components_pruned
+        component_vertices_removed += r.removed
+    end
+
     return Dict{String, Any}(
         "graph_cleanup_vertices_before" => n_before,
         "graph_cleanup_vertices_after" => length(collect(MetaGraphsNext.labels(graph))),
         "graph_cleanup_tips_removed" => tips_removed,
         "graph_cleanup_bubbles_collapsed" => bubbles_collapsed,
+        "graph_cleanup_components_pruned" => components_pruned,
+        "graph_cleanup_component_vertices_removed" => component_vertices_removed,
     )
 end

--- a/src/rhizomorph/assembly.jl
+++ b/src/rhizomorph/assembly.jl
@@ -1439,7 +1439,8 @@ function _qualmer_graph_to_assembly(graph, num_input_sequences::Int, config;
             "Graph cleanup (td-969e): $(cleanup_stats["graph_cleanup_vertices_before"]) -> " *
             "$(cleanup_stats["graph_cleanup_vertices_after"]) vertices " *
             "($(cleanup_stats["graph_cleanup_tips_removed"]) tips clipped, " *
-            "$(cleanup_stats["graph_cleanup_bubbles_collapsed"]) error bubbles collapsed)")
+            "$(cleanup_stats["graph_cleanup_bubbles_collapsed"]) error bubbles collapsed, " *
+            "$(get(cleanup_stats, "graph_cleanup_components_pruned", 0)) error components pruned)")
     end
 
     # Find contigs by extracting maximal unitigs (non-branching paths), mirroring

--- a/test/4_assembly/corrector_graph_cleanup_test.jl
+++ b/test/4_assembly/corrector_graph_cleanup_test.jl
@@ -19,6 +19,7 @@ import FASTX
 import Kmers
 import MetaGraphsNext
 import Random
+import BioSequences
 
 const _CGC = Mycelia.Rhizomorph
 const _CGC_BASES = ['A', 'C', 'G', 'T']
@@ -169,5 +170,124 @@ Test.@testset "corrector graph cleanup primitives (td-969e)" begin
         # Real balanced variant SURVIVES the composed cleanup (both alleles kept).
         Test.@test haskey(graph, kmer_a)
         Test.@test haskey(graph, kmer_b)
+    end
+
+    # Reverse complement of a plain DNA string (for the real-sequence guard test).
+    _cgc_rc(s) = string(BioSequences.reverse_complement(BioSequences.LongDNA{4}(s)))
+
+    Test.@testset "prune_disconnected_error_components!: coverage-1 island pruned, backbone kept" begin
+        rng = Random.MersenneTwister(66)
+        backbone = _cgc_backbone(rng, 60)                 # main genome, coverage 10
+        # A totally unrelated coverage-1 read: a SEPARATE connected component of
+        # error k-mers that shares no k-mer with the backbone.
+        island = _cgc_backbone(Random.MersenneTwister(4242), 30)
+        reads = FASTX.FASTA.Record[]
+        for i in 1:10
+            push!(reads, _cgc_fasta("main$i", backbone))
+        end
+        push!(reads, _cgc_fasta("island", island))
+
+        graph = _CGC.build_kmer_graph(reads, k; dataset_id = "t", mode = :singlestrand)
+        island_kmer = Kmers.DNAKmer{k}(island[10:(10 + k - 1)])
+        backbone_kmers = [Kmers.DNAKmer{k}(backbone[i:(i + k - 1)])
+                          for i in 1:(length(backbone) - k + 1)]
+        Test.@test _cgc_cov(graph, island_kmer) == 1
+        Test.@test all(kmref -> haskey(graph, kmref), backbone_kmers)
+
+        res = _CGC.prune_disconnected_error_components!(graph; k = k,
+            max_component_support = 2, min_real_support = 3)
+
+        Test.@test res.components_pruned >= 1
+        Test.@test res.removed >= 1
+        Test.@test !haskey(graph, island_kmer)                        # error island removed
+        Test.@test all(kmref -> haskey(graph, kmref), backbone_kmers) # backbone untouched
+    end
+
+    Test.@testset "prune_disconnected_error_components!: high-coverage disconnected genome RETAINED" begin
+        rng = Random.MersenneTwister(77)
+        backbone = _cgc_backbone(rng, 80)                 # larger main component
+        # A SECOND real genome, disconnected but well-supported (coverage 10). The
+        # coverage gate must retain it even though it is not the main component.
+        second = _cgc_backbone(Random.MersenneTwister(8484), 50)
+        reads = FASTX.FASTA.Record[]
+        for i in 1:10
+            push!(reads, _cgc_fasta("main$i", backbone))
+            push!(reads, _cgc_fasta("second$i", second))
+        end
+
+        graph = _CGC.build_kmer_graph(reads, k; dataset_id = "t", mode = :singlestrand)
+        second_kmer = Kmers.DNAKmer{k}(second[20:(20 + k - 1)])
+        Test.@test _cgc_cov(graph, second_kmer) == 10
+
+        res = _CGC.prune_disconnected_error_components!(graph; k = k,
+            max_component_support = 2, min_real_support = 3)
+
+        Test.@test res.components_pruned == 0
+        Test.@test haskey(graph, second_kmer)             # well-supported genome kept
+    end
+
+    Test.@testset "prune_disconnected_error_components!: real-sequence guard RETAINS overlapping island" begin
+        rng = Random.MersenneTwister(88)
+        backbone = _cgc_backbone(rng, 60)                 # main genome, coverage 10
+        # A coverage-1 read that is the REVERSE COMPLEMENT of a backbone segment.
+        # In :singlestrand mode its k-mers are distinct vertices (a separate
+        # component) but their CANONICAL forms match the backbone's, so the
+        # real-sequence guard must RETAIN it (it could be genuine reverse-strand
+        # minor sequence), even though it is small and coverage-1.
+        rc_segment = _cgc_rc(backbone[1:30])
+        reads = FASTX.FASTA.Record[]
+        for i in 1:10
+            push!(reads, _cgc_fasta("main$i", backbone))
+        end
+        push!(reads, _cgc_fasta("rc", rc_segment))
+
+        graph = _CGC.build_kmer_graph(reads, k; dataset_id = "t", mode = :singlestrand)
+        rc_kmer = Kmers.DNAKmer{k}(rc_segment[10:(10 + k - 1)])
+        Test.@test haskey(graph, rc_kmer)
+        Test.@test _cgc_cov(graph, rc_kmer) == 1          # low coverage, but real content
+
+        res = _CGC.prune_disconnected_error_components!(graph; k = k,
+            max_component_support = 2, min_real_support = 3)
+
+        # Shares canonical k-mers with the well-supported backbone -> retained.
+        Test.@test res.components_pruned == 0
+        Test.@test haskey(graph, rc_kmer)
+    end
+
+    Test.@testset "prune_disconnected_error_components!: single component -> no-op" begin
+        rng = Random.MersenneTwister(99)
+        backbone = _cgc_backbone(rng, 60)
+        graph = _CGC.build_kmer_graph([_cgc_fasta("g", backbone)], k;
+            dataset_id = "t", mode = :singlestrand)
+        n_before = length(collect(MetaGraphsNext.labels(graph)))
+
+        res = _CGC.prune_disconnected_error_components!(graph; k = k)
+
+        Test.@test res.removed == 0
+        Test.@test res.components_pruned == 0
+        Test.@test length(collect(MetaGraphsNext.labels(graph))) == n_before
+    end
+
+    Test.@testset "clean_corrector_graph!: prunes error island + reports telemetry" begin
+        rng = Random.MersenneTwister(101)
+        backbone = _cgc_backbone(rng, 80)
+        island = _cgc_backbone(Random.MersenneTwister(1357), 30)
+        reads = FASTX.FASTA.Record[]
+        for i in 1:10
+            push!(reads, _cgc_fasta("main$i", backbone))
+        end
+        push!(reads, _cgc_fasta("island", island))
+
+        graph = _CGC.build_kmer_graph(reads, k; dataset_id = "t", mode = :singlestrand)
+        island_kmer = Kmers.DNAKmer{k}(island[10:(10 + k - 1)])
+        backbone_kmers = [Kmers.DNAKmer{k}(backbone[i:(i + k - 1)])
+                          for i in 1:(length(backbone) - k + 1)]
+
+        stats = _CGC.clean_corrector_graph!(graph; k = k)
+
+        Test.@test stats["graph_cleanup_components_pruned"] >= 1
+        Test.@test stats["graph_cleanup_component_vertices_removed"] >= 1
+        Test.@test !haskey(graph, island_kmer)                        # island gone
+        Test.@test all(kmref -> haskey(graph, kmref), backbone_kmers) # backbone intact
     end
 end


### PR DESCRIPTION
## Summary

- Adds `prune_disconnected_error_components!` to the `:scalable` corrector's `clean_corrector_graph!` pass (`src/rhizomorph/algorithms/simplification.jl`).
- After RC-dedup + tip/bubble cleanup the main genome collapses to a single full-length contig, but the corrector's final graph still carries standalone **disconnected** components — small coverage-1/2 islands of sequencing-error k-mers that never joined the main path. `clip_error_tips!`/`collapse_error_bubbles!` only reshape structure *within* a component (the terminus guard protects a standalone linear run), so these islands survive to contig extraction and each becomes a spurious contig.
- The new O(V+E) pass removes a whole component **only** when it is provably error under ALL of: (1) a separate component, never the main/largest; (2) small (span `<= max_component_length`, default 2000); (3) uniformly low coverage (MAX per-vertex coverage `<= max_component_support`, default 2); AND (4) a real-sequence guard — shares no canonical k-mer with any well-supported (`coverage >= min_real_support`) vertex.
- Weakly-connected components via BFS over the undirected closure of the merged in/out adjacency indices; well-supported canonical-k-mer set built once in O(V). Gated on component **maximum** coverage so a single supported k-mer vetoes removal — deliberately under-prunes rather than risk removing a real low-coverage variant (td-h6w9).

## Verification

Toy sweep, readlen=150, 20x, err=0.01, k=21, `corrector=:iterative, strategy=:scalable`. Before = master (tips+bubbles), After = this branch (+pruner):

| genome | n_contigs | N50 | largest | frac |
| --- | --- | --- | --- | --- |
| 1kb before | 2 | 974 | 974 | 1.002 |
| 1kb after | **1** | 974 | 974 | 0.974 |
| 3kb before | 6 | 2957 | 2957 | 1.036 |
| 3kb after | **1** | 2957 | 2957 | 0.986 |

N50 and largest-contig are identical before/after (the main genome is untouched); the contig-count drop and frac normalization (from >1.0 down to ~0.98) reflect removal of spurious error-debris islands, not real sequence. Threshold used: max component coverage = 2, size cap = 2000 bp.

## Test Plan

- [x] `corrector_graph_cleanup_test` 42/42 (18 new: island pruned + backbone kept; high-coverage disconnected genome retained; real-sequence guard retains an overlapping RC island; single-component no-op; composed telemetry)
- [x] `variation_preservation_holdout_test` 24/24
- [x] `scalable_corrector_strategy_test` 40/40
- [x] `iterative_assembly_tests` 196/196

## Related

td-byva (extends td-969e corrector cleanup); honors the td-h6w9 variation-preservation invariant.

