### PR TITLE
Empirically localize the residual alpha~1.47 in the :scalable corrector to per-read Viterbi decode (td-firp)

### DIFF
--- a/benchmarking/empirical_48k_component_profile.jl
+++ b/benchmarking/empirical_48k_component_profile.jl
@@ -139,15 +139,24 @@ const BUCKETS = [
         ["_qualmer_path_to_consensus_fastq", "path_to_sequence",
          "_reconstruct_oriented_kmer_path", "_generate_fastq_contigs_from_qualmer_graph"]),
     # --- correction-phase components ---
-    ("C5. per-read Viterbi decode",
+    # per-read decode split into sub-components so, if decode is the driver, the
+    # fix rec can target the exact internal term (weighted-graph rebuild vs the
+    # Viterbi frontier engine vs likelihood vs soft-EM competing paths).
+    ("C5a. decode: weighted-graph build",
+        ["build_correction_weighted_graph", "weighted_graph_from_rhizomorph"]),
+    ("C5b. decode: Viterbi frontier engine",
+        ["viterbi_decode_next", "beam_pruned_viterbi_decode_next",
+         "_beam_pruned_viterbi_decode_next", "_get_valid_transitions",
+         "_total_outgoing_weight", "_prune_viterbi_beam", "find_optimal_sequence_path"]),
+    ("C5c. decode: soft-EM competing paths",
+        ["accumulate_competing_paths", "_enumerate_competing_paths",
+         "register_soft_edge_weights", "clear_soft_edge_weights"]),
+    ("C5d. decode: read likelihood calc",
+        ["calculate_read_likelihood", "calculate_sequence_likelihood"]),
+    ("C5e. decode: setup/other",
         ["improve_read_likelihood", "try_viterbi_path_improvement",
-         "find_optimal_sequence_path", "calculate_read_likelihood",
-         "calculate_sequence_likelihood", "build_correction_weighted_graph",
-         "weighted_graph_from_rhizomorph", "viterbi_decode_next",
-         "beam_pruned_viterbi_decode_next", "_beam_pruned_viterbi_decode_next",
-         "_get_valid_transitions", "_prune_viterbi_beam",
-         "accumulate_competing_paths", "_enumerate_competing_paths",
-         "correct_observations", "adjust_quality_scores"]),
+         "correct_observations", "path_to_sequence", "adjust_quality_scores",
+         "should_decode_read"]),
     ("C4. stage0 cheap_correct", ["_stage0_cheap_correct", "_stage0_correct_read"]),
     ("C3. solid_kmer classification",
         ["_solid_kmer_set", "classify_kmers", "MixtureModelClassifier"]),
@@ -383,6 +392,14 @@ function main()
         hdr *= Printf.@sprintf(" %8s %10s", "alpha", "alpha_lg")
         println(sink, hdr)
         println(sink, "-"^length(hdr))
+        # Aggregate the decode sub-components (C5a..C5e) into a synthetic
+        # "C5*. per-read decode (TOTAL)" so the component-level answer (decode as a
+        # whole vs cleanup/contig/build) is directly readable next to the split.
+        decode_labels = filter(l -> startswith(l, "C5"), all_labels)
+        agg_decode = Dict{Int, Float64}()  # size-index -> summed decode seconds
+        for (i, r) in enumerate(results)
+            agg_decode[i] = sum(get(r.seconds, l, 0.0) for l in decode_labels; init = 0.0)
+        end
         # sort components by seconds at the largest size (descending)
         largest = results[end]
         order = sort(all_labels; by = l -> -get(largest.seconds, l, 0.0))
@@ -400,6 +417,22 @@ function main()
                 isnan(a) ? "-" : Printf.@sprintf("%.2f", a),
                 isnan(alg) ? "-" : Printf.@sprintf("%.2f", alg))
             println(sink, row)
+        end
+        # synthetic aggregate decode row
+        if !isempty(decode_labels)
+            dys = Float64[agg_decode[i] for i in 1:length(results)]
+            da = loglog_alpha(gfloat, dys)
+            dalg = length(results) >= 2 ?
+                pairwise_alpha(gfloat[end-1], dys[end-1], gfloat[end], dys[end]) : NaN
+            drow = Printf.@sprintf("%-42s", "C5*. per-read decode (TOTAL C5a-e)")
+            for y in dys
+                drow *= Printf.@sprintf(" %10.1f", y)
+            end
+            drow *= Printf.@sprintf(" %8s %10s",
+                isnan(da) ? "-" : Printf.@sprintf("%.2f", da),
+                isnan(dalg) ? "-" : Printf.@sprintf("%.2f", dalg))
+            println(sink, "-"^length(hdr))
+            println(sink, drow)
         end
         println(sink, "-"^length(hdr))
         totrow = Printf.@sprintf("%-42s", "TOTAL (wall)")
@@ -420,15 +453,23 @@ function main()
         println(sink, "  at the biggest size is the TRUE residual super-linear (alpha~1.47) driver.")
 
         # --- auto-verdict: dominant super-linear component at the large end ---
+        # Candidates = individual non-decode components + the AGGREGATE decode
+        # (so a decode driver is judged as one component, not diluted across C5a-e).
+        candidates = Vector{Tuple{String, Vector{Float64}}}()
+        for label in all_labels
+            startswith(label, "C5") && continue  # folded into the aggregate below
+            push!(candidates, (label, Float64[get(r.seconds, label, 0.0) for r in results]))
+        end
+        !isempty(decode_labels) &&
+            push!(candidates, ("C5*. per-read decode (TOTAL C5a-e)",
+                Float64[agg_decode[i] for i in 1:length(results)]))
         best_label = ""
         best_score = -Inf
-        for label in all_labels
-            ys = Float64[get(r.seconds, label, 0.0) for r in results]
+        for (label, ys) in candidates
             alg = length(results) >= 2 ?
                 pairwise_alpha(gfloat[end-1], ys[end-1], gfloat[end], ys[end]) : NaN
             (isnan(alg) || alg <= 1.3) && continue
-            # score = large-end seconds weighted by how super-linear it is
-            score = ys[end] * (alg - 1.0)
+            score = ys[end] * (alg - 1.0)   # large-end seconds x super-linearity
             if score > best_score
                 best_score = score
                 best_label = label
@@ -439,7 +480,9 @@ function main()
             println(sink, "AUTO-VERDICT: no single component exceeds alpha_lg 1.3 at the large end;")
             println(sink, "  the residual is diffuse across components (re-examine the table above).")
         else
-            ys = Float64[get(r.seconds, label, 0.0) for label in [best_label] for r in results]
+            ys = startswith(best_label, "C5*") ?
+                Float64[agg_decode[i] for i in 1:length(results)] :
+                Float64[get(r.seconds, best_label, 0.0) for r in results]
             println(sink, "AUTO-VERDICT: dominant super-linear component at the large end =")
             println(sink, "  >>> $(best_label) <<<")
             println(sink, "  ($(Printf.@sprintf("%.1f", ys[end]))s at $(results[end].glen)bp, " *

--- a/benchmarking/empirical_48k_component_profile.jl
+++ b/benchmarking/empirical_48k_component_profile.jl
@@ -1,0 +1,459 @@
+# empirical_48k_component_profile.jl
+#
+# EMPIRICALLY localize the residual super-linear (alpha ~1.47) term in the
+# :scalable corrector at large genome scale (bead td-firp).
+#
+# WHY THIS HARNESS EXISTS (what the two prior attempts got wrong)
+# --------------------------------------------------------------
+# #381 (benchmarking/largescale_component_profile.jl) localized the alpha~1.47
+# term to CONTIG-EXTRACTION (find_linear_path's O(L^2) neighbor-membership walk)
+# by SOURCE ANALYSIS on a LINEAR PROXY graph: its Part B timed the reassembly
+# sub-components on an ERROR-FREE read set, arguing the corrected-read graph is
+# "near-linear". The #383 fix that followed did NOT move the 48 kb wall time
+# (2109 -> 2163 s). The reason: the REAL corrected graph at 48 kb is BRANCHY
+# (~98 separate contigs, none genome-spanning), so find_linear_path walks ~98
+# SHORT paths and never enters its quadratic regime. The linear proxy was the
+# WORST case for find_linear_path but the WRONG case for the real corrector.
+#
+# LESSON (and this harness's discipline): profile the ACTUAL corrector run
+# empirically. Do NOT reconstruct the reassembly graph from an error-free proxy;
+# do NOT reason about O(.) from source on a graph the corrector never produces.
+#
+# WHAT THIS HARNESS MEASURES (fully empirical, no proxy)
+# -----------------------------------------------------
+# For each genome size, it runs the SINGLE real public entry point that performs
+# the WHOLE corrector pipeline in one call --
+#
+#     Mycelia.Rhizomorph.assemble_genome(reads;
+#         corrector = :iterative, strategy = :scalable, k = 21, verbose = false)
+#
+# -- which internally does: iterative correction (mycelia_iterative_assemble,
+# :scalable knobs) THEN reassembly of the corrected reads WITH graph_cleanup ON
+# (clean_corrector_graph!, defaults ON only on this corrector reassembly path --
+# NOT on a standalone corrector=:none reassembly, which is why the prior Part A
+# split missed the new cleanup cost). The run is executed under Julia's stdlib
+# Profile sampler, and every sample is bucketed to the component whose entry
+# function sits on its call stack. Per-component seconds = wall * sample-share,
+# aggregated across ALL k-rungs, ALL iterations, AND the final reassembly. This
+# attributes the real end-to-end wall time -- including the freshly-added
+# clean_corrector_graph! / _dedup_reverse_complements passes -- to each
+# component with NO isolated proxy anywhere.
+#
+# It then fits alpha per component (log-log regression of seconds vs genome
+# length, plus the large-end pairwise alpha) and names the component whose alpha
+# exceeds ~1.3 at the large end as the TRUE alpha~1.47 driver.
+#
+# Read-only w.r.t. src: no library function is modified or monkey-patched. Only
+# the stdlib sampler observes the unmodified corrector.
+#
+# RUN (from the worktree):
+#   LD_LIBRARY_PATH='' ~/.juliaup/bin/julia --project=. \
+#     benchmarking/empirical_48k_component_profile.jl
+#
+# Optional env:
+#   MYCELIA_E48_SIZES     comma genome sizes bp   (default 5000,10000,20000)
+#   MYCELIA_E48_COVERAGE  fold coverage           (default 20)
+#   MYCELIA_E48_READLEN   read length bp          (default 150)
+#   MYCELIA_E48_ERR       per-base error rate     (default 0.01)
+#   MYCELIA_E48_K         corrector max_k         (default 21)
+#   MYCELIA_E48_SEED      RNG seed                (default 42)
+#   MYCELIA_E48_DELAY     profile sampler delay s (default 0.002)
+#   MYCELIA_E48_OUT       results file (append)   (default benchmarking/results/empirical_48k_component_profile.txt)
+
+import Mycelia
+import FASTX
+import BioSequences
+import Random
+import Profile
+import Printf
+import Dates
+import Statistics
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+_parse_sizes(s) = Int[parse(Int, strip(x)) for x in split(s, ",") if !isempty(strip(x))]
+
+const SIZES    = _parse_sizes(get(ENV, "MYCELIA_E48_SIZES", "5000,10000,20000"))
+const COVERAGE = parse(Float64, get(ENV, "MYCELIA_E48_COVERAGE", "20"))
+const READLEN  = parse(Int, get(ENV, "MYCELIA_E48_READLEN", "150"))
+const ERR_RATE = parse(Float64, get(ENV, "MYCELIA_E48_ERR", "0.01"))
+const MAX_K    = parse(Int, get(ENV, "MYCELIA_E48_K", "21"))
+const SEED     = parse(Int, get(ENV, "MYCELIA_E48_SEED", "42"))
+const DELAY    = parse(Float64, get(ENV, "MYCELIA_E48_DELAY", "0.002"))
+const TECH     = :illumina
+const OUT_PATH = get(ENV, "MYCELIA_E48_OUT",
+    joinpath(@__DIR__, "results", "empirical_48k_component_profile.txt"))
+
+# ---------------------------------------------------------------------------
+# Read simulation -- mirrors the validated illumina cell used by the prior
+# scaling profilers (random_fasta_record + Mycelia.observe).
+# ---------------------------------------------------------------------------
+function simulate_reads(refseq::BioSequences.LongDNA{4}, readlen::Int, coverage::Real,
+        error_rate::Float64, tech::Symbol, rng::Random.AbstractRNG)
+    glen = length(refseq)
+    effective_readlen = min(readlen, glen)
+    n_reads = max(1, ceil(Int, coverage * glen / effective_readlen))
+    records = Vector{FASTX.FASTQ.Record}()
+    for i in 1:n_reads
+        start = glen == effective_readlen ? 1 : rand(rng, 1:(glen - effective_readlen + 1))
+        frag = refseq[start:(start + effective_readlen - 1)]
+        rand(rng, Bool) && (frag = BioSequences.reverse_complement(frag))
+        obs_seq, quals = Mycelia.observe(frag; error_rate = error_rate, tech = tech)
+        isempty(obs_seq) && continue
+        qstr = String([Char(q + 33) for q in quals])
+        push!(records, FASTX.FASTQ.Record("read_$(i)", string(obs_seq), qstr))
+    end
+    return records
+end
+
+function build_fixture(glen::Int)
+    rng = Random.MersenneTwister(SEED)
+    ref_rec = Mycelia.random_fasta_record(moltype = :DNA, seed = SEED, L = glen)
+    refseq = FASTX.sequence(BioSequences.LongDNA{4}, ref_rec)
+    reads = simulate_reads(refseq, READLEN, COVERAGE, ERR_RATE, TECH, rng)
+    return refseq, reads
+end
+
+# ---------------------------------------------------------------------------
+# Component buckets. Ordered leaf->root FIRST-MATCH, so put phase-specific,
+# deeper-in-the-stack entry functions FIRST. The reassembly-side cleanup/dedup/
+# extract buckets use function names that appear ONLY on the reassembly path, so
+# they never steal correction-phase samples even though both phases build graphs
+# and touch bubbles.
+#   * clean_corrector_graph! -> clip_error_tips! / collapse_error_bubbles!
+#     are the reassembly-only defrag pass (td-969e / #384) -- the PRIME new
+#     suspect; distinct from the correction gate's _hard_vertex_set/
+#     detect_bubbles_next.
+# ---------------------------------------------------------------------------
+const BUCKETS = [
+    # --- reassembly-only components (matched first; names are phase-unique) ---
+    ("R1. clean_corrector_graph! (NEW defrag)",
+        ["clean_corrector_graph!", "clip_error_tips!", "collapse_error_bubbles!"]),
+    ("R2. contig extraction (find_contigs)",
+        ["find_contigs_next", "find_linear_path", "find_eulerian_paths_next",
+         "_select_linear_neighbor", "_dominant_neighbor"]),
+    ("R3. RC-dedup (_dedup_reverse_complements)",
+        ["_dedup_reverse_complements", "_canonical_string"]),
+    ("R4. consensus/quality (path->fastq)",
+        ["_qualmer_path_to_consensus_fastq", "path_to_sequence",
+         "_reconstruct_oriented_kmer_path", "_generate_fastq_contigs_from_qualmer_graph"]),
+    # --- correction-phase components ---
+    ("C5. per-read Viterbi decode",
+        ["improve_read_likelihood", "try_viterbi_path_improvement",
+         "find_optimal_sequence_path", "calculate_read_likelihood",
+         "calculate_sequence_likelihood", "build_correction_weighted_graph",
+         "weighted_graph_from_rhizomorph", "viterbi_decode_next",
+         "beam_pruned_viterbi_decode_next", "_beam_pruned_viterbi_decode_next",
+         "_get_valid_transitions", "_prune_viterbi_beam",
+         "accumulate_competing_paths", "_enumerate_competing_paths",
+         "correct_observations", "adjust_quality_scores"]),
+    ("C4. stage0 cheap_correct", ["_stage0_cheap_correct", "_stage0_correct_read"]),
+    ("C3. solid_kmer classification",
+        ["_solid_kmer_set", "classify_kmers", "MixtureModelClassifier"]),
+    ("C2. hard_vertex_set (corr bubbles)", ["_hard_vertex_set", "detect_bubbles_next"]),
+    # --- shared build + IO (matched last so phase-specific work wins) ---
+    ("B1. build_qualmer_graph", ["build_qualmer_graph"]),
+    ("IO. write/read fastq", ["write_fastq", "_write_reads_to_fastq"]),
+]
+
+function classify_sample(frame_names::Vector{String})
+    for name in frame_names            # leaf -> root
+        for (label, keys) in BUCKETS
+            for kw in keys
+                occursin(kw, name) && return label
+            end
+        end
+    end
+    return "0. other (corrector/reassembly/GC/overhead)"
+end
+
+function split_samples(data::Vector{UInt64})
+    samples = Vector{Vector{UInt64}}()
+    cur = UInt64[]
+    for ip in data
+        if ip == 0
+            isempty(cur) || (push!(samples, copy(cur)); empty!(cur))
+        else
+            push!(cur, ip)
+        end
+    end
+    isempty(cur) || push!(samples, cur)
+    return samples
+end
+
+function bucket_profile()
+    data = Profile.fetch(include_meta = false)
+    lidict = Profile.getdict(data)
+    samples = split_samples(data)
+    counts = Dict{String, Int}()
+    for s in samples
+        names = String[]
+        for ip in s
+            for sf in get(lidict, ip, Base.StackTraces.StackFrame[])
+                push!(names, string(sf.func))
+            end
+        end
+        label = classify_sample(names)
+        counts[label] = get(counts, label, 0) + 1
+    end
+    total = sum(values(counts); init = 0)
+    return counts, total
+end
+
+# ---------------------------------------------------------------------------
+# One real end-to-end profiled run at a genome size.
+# ---------------------------------------------------------------------------
+struct SizeResult
+    glen::Int
+    nreads::Int
+    wall::Float64
+    total_samples::Int
+    ncontigs::Int
+    max_contig::Int
+    k_progression::Vector{Int}
+    n_passes::Int            # total correction iterations across all k-rungs
+    decode_fracs::Vector{Float64}
+    verts_before::Int        # graph vertices entering clean_corrector_graph!
+    verts_after::Int
+    tips_removed::Int
+    bubbles_collapsed::Int
+    seconds::Dict{String, Float64}   # component label -> attributed seconds
+end
+
+function run_size(io, glen::Int)
+    _, reads = build_fixture(glen)
+    println(io, "\n[size $(glen)bp] simulated $(length(reads)) reads " *
+                "(readlen=$(READLEN), $(COVERAGE)x, err=$(ERR_RATE))")
+    flush(io)
+
+    Profile.clear()
+    Profile.init(n = 10^8, delay = DELAY)
+    local result
+    wall = @elapsed begin
+        redirect_stdout(devnull) do
+            Profile.@profile begin
+                result = Mycelia.Rhizomorph.assemble_genome(reads;
+                    corrector = :iterative, strategy = :scalable,
+                    k = MAX_K, verbose = false)
+            end
+        end
+    end
+
+    counts, total = bucket_profile()
+    seconds = Dict{String, Float64}()
+    for (label, n) in counts
+        seconds[label] = total == 0 ? 0.0 : wall * n / total
+    end
+
+    # AssemblyResult introspection. contigs::Vector{String} (length = contig bp);
+    # assembly_stats::Dict{String,Any} (STRING keys). Best-effort but with the
+    # exact keys verified against the AssemblyResult shape.
+    ncontigs = 0
+    max_contig = 0
+    kprog = Int[]
+    n_passes = 0
+    decode_fracs = Float64[]
+    verts_before = 0
+    verts_after = 0
+    tips_removed = 0
+    bubbles_collapsed = 0
+    try
+        contigs = result.contigs            # Vector{String}
+        ncontigs = length(contigs)
+        ncontigs > 0 && (max_contig = maximum(length(c) for c in contigs))
+    catch
+    end
+    try
+        stats = result.assembly_stats
+        _iv(key) = (v = get(stats, key, nothing); v === nothing ? 0 : Int(v))
+        haskey(stats, "k_progression") && (kprog = collect(Int, stats["k_progression"]))
+        if haskey(stats, "decode_fraction_per_pass")
+            decode_fracs = collect(Float64, stats["decode_fraction_per_pass"])
+            n_passes = length(decode_fracs)
+        end
+        verts_before = _iv("graph_cleanup_vertices_before")
+        verts_after = _iv("graph_cleanup_vertices_after")
+        tips_removed = _iv("graph_cleanup_tips_removed")
+        bubbles_collapsed = _iv("graph_cleanup_bubbles_collapsed")
+    catch
+    end
+
+    println(io, Printf.@sprintf(
+        "[size %dbp] wall=%.1fs samples=%d contigs=%d max_contig=%dbp k_prog=%s passes=%d cleanup=%d->%dV(-%dtips,-%dbub)",
+        glen, wall, total, ncontigs, max_contig, isempty(kprog) ? "?" : string(kprog),
+        n_passes, verts_before, verts_after, tips_removed, bubbles_collapsed))
+    flush(io)
+
+    return SizeResult(glen, length(reads), wall, total, ncontigs, max_contig, kprog,
+        n_passes, decode_fracs, verts_before, verts_after, tips_removed, bubbles_collapsed,
+        seconds)
+end
+
+# ---------------------------------------------------------------------------
+# alpha fit: slope of log(seconds) vs log(genome_len).
+# ---------------------------------------------------------------------------
+function loglog_alpha(xs::Vector{Float64}, ys::Vector{Float64})
+    # keep only strictly-positive y (component actually observed)
+    idx = findall(y -> y > 0, ys)
+    length(idx) < 2 && return NaN
+    lx = log.(xs[idx]); ly = log.(ys[idx])
+    mx = Statistics.mean(lx); my = Statistics.mean(ly)
+    denom = sum((lx .- mx) .^ 2)
+    denom == 0 && return NaN
+    return sum((lx .- mx) .* (ly .- my)) / denom
+end
+
+pairwise_alpha(g1, t1, g2, t2) =
+    (t1 > 0 && t2 > 0) ? log(t2 / t1) / log(g2 / g1) : NaN
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+function main()
+    mkpath(dirname(OUT_PATH))
+    io = open(OUT_PATH, "a")
+    header(sink) = begin
+        println(sink, "="^92)
+        println(sink, "EMPIRICAL :scalable per-component scaling on the REAL corrector run (td-firp)")
+        println(sink, "  started : $(Dates.now())")
+        println(sink, "  entry   : assemble_genome(reads; corrector=:iterative, strategy=:scalable, k=$(MAX_K))")
+        println(sink, "  sizes   : $(SIZES) bp   readlen=$(READLEN)  cov=$(COVERAGE)x  err=$(ERR_RATE)")
+        println(sink, "  sampler : Profile delay=$(DELAY)s   (per-component sec = wall * sample-share)")
+        println(sink, "  NOTE    : full end-to-end real run (correction + reassembly WITH clean_corrector_graph!).")
+        println(sink, "            NOT a proxy graph, NOT source O(.) reasoning, NOT an isolated component.")
+        println(sink, "="^92)
+    end
+    header(stdout); header(io)
+
+    # --- Warmup: compile the WHOLE assemble_genome(corrector=:iterative) path on a
+    # tiny input so the profiled runs are ~pure runtime, not first-call compilation.
+    # Warm up at the SAME k=MAX_K and a non-trivial genome so EVERY k-rung on the
+    # ladder (3..21) plus the reassembly / clean_corrector_graph! / find_contigs /
+    # dedup paths are compiled before the first measured run -- otherwise the first
+    # real size absorbs k=21-rung + reassembly compilation into "0. other".
+    println(stdout, "\n[warmup] compiling the full corrector+reassembly path (k=$(MAX_K)) ...")
+    flush(stdout)
+    _, wreads = build_fixture(1500)
+    redirect_stdout(devnull) do
+        Mycelia.Rhizomorph.assemble_genome(wreads;
+            corrector = :iterative, strategy = :scalable,
+            k = MAX_K, verbose = false)
+    end
+    println(stdout, "[warmup] done")
+    flush(stdout)
+
+    results = SizeResult[]
+    for glen in SIZES
+        push!(results, run_size(stdout, glen))
+        # also log to file as we go so a long run is crash-durable
+        rl = results[end]
+        println(io, Printf.@sprintf(
+            "[size %dbp] wall=%.1fs samples=%d contigs=%d max_contig=%dbp k_prog=%s passes=%d cleanup=%d->%dV(-%dtips,-%dbub)",
+            rl.glen, rl.wall, rl.total_samples, rl.ncontigs, rl.max_contig,
+            isempty(rl.k_progression) ? "?" : string(rl.k_progression),
+            rl.n_passes, rl.verts_before, rl.verts_after, rl.tips_removed, rl.bubbles_collapsed))
+        flush(io)
+    end
+
+    # --- Per-component scaling table + alpha fit ---
+    all_labels = sort(collect(Set(Iterators.flatten(keys(r.seconds) for r in results))))
+    gfloat = Float64[Float64(r.glen) for r in results]
+
+    function emit_table(sink)
+        println(sink, "\n" * "="^92)
+        println(sink, "REAL-RUN GRAPH DIAGNOSTICS (evidence the corrected graph is branchy, not linear)")
+        println(sink, Printf.@sprintf("  %-8s %8s %8s %10s %8s %14s %10s %10s",
+            "size", "nreads", "contigs", "maxcontig", "passes", "k_prog", "cleanupV", "tips/bub"))
+        for r in results
+            println(sink, Printf.@sprintf("  %-8s %8d %8d %9dbp %8d %14s %5d->%-5d %5d/%-5d",
+                "$(r.glen)bp", r.nreads, r.ncontigs, r.max_contig, r.n_passes,
+                isempty(r.k_progression) ? "?" : string(r.k_progression),
+                r.verts_before, r.verts_after, r.tips_removed, r.bubbles_collapsed))
+        end
+        println(sink, "  (max_contig << genome and contigs>>1 => branchy; find_linear_path never")
+        println(sink, "   enters its quadratic regime -- confirming the #381 linear-proxy premise was wrong.)")
+
+        println(sink, "\n" * "="^92)
+        println(sink, "PER-COMPONENT SCALING TABLE (seconds attributed from the REAL run)")
+        hdr = Printf.@sprintf("%-42s", "component")
+        for r in results
+            hdr *= Printf.@sprintf(" %10s", "$(r.glen)bp")
+        end
+        hdr *= Printf.@sprintf(" %8s %10s", "alpha", "alpha_lg")
+        println(sink, hdr)
+        println(sink, "-"^length(hdr))
+        # sort components by seconds at the largest size (descending)
+        largest = results[end]
+        order = sort(all_labels; by = l -> -get(largest.seconds, l, 0.0))
+        for label in order
+            ys = Float64[get(r.seconds, label, 0.0) for r in results]
+            a = loglog_alpha(gfloat, ys)
+            # large-end pairwise alpha: last two sizes
+            alg = length(results) >= 2 ?
+                pairwise_alpha(gfloat[end-1], ys[end-1], gfloat[end], ys[end]) : NaN
+            row = Printf.@sprintf("%-42s", label)
+            for y in ys
+                row *= Printf.@sprintf(" %10.1f", y)
+            end
+            row *= Printf.@sprintf(" %8s %10s",
+                isnan(a) ? "-" : Printf.@sprintf("%.2f", a),
+                isnan(alg) ? "-" : Printf.@sprintf("%.2f", alg))
+            println(sink, row)
+        end
+        println(sink, "-"^length(hdr))
+        totrow = Printf.@sprintf("%-42s", "TOTAL (wall)")
+        walls = Float64[r.wall for r in results]
+        for w in walls
+            totrow *= Printf.@sprintf(" %10.1f", w)
+        end
+        atot = loglog_alpha(gfloat, walls)
+        atotlg = length(results) >= 2 ?
+            pairwise_alpha(gfloat[end-1], walls[end-1], gfloat[end], walls[end]) : NaN
+        totrow *= Printf.@sprintf(" %8s %10s",
+            isnan(atot) ? "-" : Printf.@sprintf("%.2f", atot),
+            isnan(atotlg) ? "-" : Printf.@sprintf("%.2f", atotlg))
+        println(sink, totrow)
+        println(sink, "\n  alpha    = log-log regression slope of seconds vs genome length (full range)")
+        println(sink, "  alpha_lg = large-end pairwise slope over the last two sizes")
+        println(sink, "  Interpretation: the component with alpha_lg > ~1.3 AND a large second-count")
+        println(sink, "  at the biggest size is the TRUE residual super-linear (alpha~1.47) driver.")
+
+        # --- auto-verdict: dominant super-linear component at the large end ---
+        best_label = ""
+        best_score = -Inf
+        for label in all_labels
+            ys = Float64[get(r.seconds, label, 0.0) for r in results]
+            alg = length(results) >= 2 ?
+                pairwise_alpha(gfloat[end-1], ys[end-1], gfloat[end], ys[end]) : NaN
+            (isnan(alg) || alg <= 1.3) && continue
+            # score = large-end seconds weighted by how super-linear it is
+            score = ys[end] * (alg - 1.0)
+            if score > best_score
+                best_score = score
+                best_label = label
+            end
+        end
+        println(sink, "\n" * "="^92)
+        if isempty(best_label)
+            println(sink, "AUTO-VERDICT: no single component exceeds alpha_lg 1.3 at the large end;")
+            println(sink, "  the residual is diffuse across components (re-examine the table above).")
+        else
+            ys = Float64[get(r.seconds, label, 0.0) for label in [best_label] for r in results]
+            println(sink, "AUTO-VERDICT: dominant super-linear component at the large end =")
+            println(sink, "  >>> $(best_label) <<<")
+            println(sink, "  ($(Printf.@sprintf("%.1f", ys[end]))s at $(results[end].glen)bp, " *
+                          "$(Printf.@sprintf("%.0f%%", 100*ys[end]/results[end].wall)) of wall).")
+            println(sink, "  This is the EMPIRICALLY MEASURED driver on the real corrector run.")
+        end
+        println(sink, "  finished: $(Dates.now())")
+        println(sink, "="^92)
+    end
+
+    emit_table(stdout)
+    emit_table(io)
+    close(io)
+    println(stdout, "\n[results appended to] $(OUT_PATH)")
+end
+
+main()

--- a/benchmarking/results/empirical_48k_component_profile.txt
+++ b/benchmarking/results/empirical_48k_component_profile.txt
@@ -1,0 +1,57 @@
+============================================================================================
+EMPIRICAL :scalable per-component scaling on the REAL corrector run (td-firp)
+  started : 2026-07-09T15:56:06.133
+  entry   : assemble_genome(reads; corrector=:iterative, strategy=:scalable, k=21)
+  sizes   : [5000, 10000, 20000] bp   readlen=150  cov=20.0x  err=0.01
+  sampler : Profile delay=0.002s   (per-component sec = wall * sample-share)
+  NOTE    : full end-to-end real run (correction + reassembly WITH clean_corrector_graph!).
+            NOT a proxy graph, NOT source O(.) reasoning, NOT an isolated component.
+============================================================================================
+[size 5000bp] wall=59.5s samples=11178 contigs=15 max_contig=2807bp k_prog=[3, 9, 21] passes=5 cleanup=10596->10134V(-180tips,-14bub)
+[size 10000bp] wall=151.0s samples=30948 contigs=36 max_contig=5355bp k_prog=[3, 9, 21] passes=5 cleanup=21542->20669V(-532tips,-17bub)
+[size 20000bp] wall=455.1s samples=93095 contigs=71 max_contig=13529bp k_prog=[3, 9, 21] passes=5 cleanup=43270->41878V(-854tips,-27bub)
+
+============================================================================================
+REAL-RUN GRAPH DIAGNOSTICS (evidence the corrected graph is branchy, not linear)
+  size       nreads  contigs  maxcontig   passes         k_prog   cleanupV   tips/bub
+  5000bp        667       15      2807bp        5     [3, 9, 21] 10596->10134   180/14   
+  10000bp      1334       36      5355bp        5     [3, 9, 21] 21542->20669   532/17   
+  20000bp      2667       71     13529bp        5     [3, 9, 21] 43270->41878   854/27   
+  (max_contig << genome and contigs>>1 => branchy; find_linear_path never
+   enters its quadratic regime -- confirming the #381 linear-proxy premise was wrong.)
+
+============================================================================================
+PER-COMPONENT SCALING TABLE (seconds attributed from the REAL run)
+component                                      5000bp    10000bp    20000bp    alpha   alpha_lg
+-----------------------------------------------------------------------------------------------
+C5e. decode: setup/other                         25.4       64.3      186.4     1.44       1.53
+C5b. decode: Viterbi frontier engine             20.2       51.4      174.5     1.56       1.76
+0. other (corrector/reassembly/GC/overhead)        7.6       21.0       50.7     1.37       1.27
+B1. build_qualmer_graph                           3.6        7.6       22.5     1.31       1.56
+C5c. decode: soft-EM competing paths              0.9        2.8       10.4     1.78       1.91
+C5d. decode: read likelihood calc                 0.9        2.2        3.0     0.87       0.44
+C3. solid_kmer classification                     0.2        0.3        2.4     1.85       2.82
+R4. consensus/quality (path->fastq)               0.0        0.1        1.7     2.88       4.01
+R1. clean_corrector_graph! (NEW defrag)           0.2        0.3        1.5     1.53       2.47
+C4. stage0 cheap_correct                          0.4        0.6        1.2     0.89       0.97
+C5a. decode: weighted-graph build                 0.1        0.2        0.5     0.97       1.03
+C2. hard_vertex_set (corr bubbles)                0.0        0.1        0.2     1.02       1.17
+R2. contig extraction (find_contigs)              0.0        0.0        0.0     0.94       1.42
+IO. write/read fastq                              0.0        0.0        0.0        -          -
+-----------------------------------------------------------------------------------------------
+C5*. per-read decode (TOTAL C5a-e)               47.5      121.0      374.8     1.49       1.63
+-----------------------------------------------------------------------------------------------
+TOTAL (wall)                                     59.5      151.0      455.1     1.47       1.59
+
+  alpha    = log-log regression slope of seconds vs genome length (full range)
+  alpha_lg = large-end pairwise slope over the last two sizes
+  Interpretation: the component with alpha_lg > ~1.3 AND a large second-count
+  at the biggest size is the TRUE residual super-linear (alpha~1.47) driver.
+
+============================================================================================
+AUTO-VERDICT: dominant super-linear component at the large end =
+  >>> C5*. per-read decode (TOTAL C5a-e) <<<
+  (374.8s at 20000bp, 82% of wall).
+  This is the EMPIRICALLY MEASURED driver on the real corrector run.
+  finished: 2026-07-09T16:07:29.649
+============================================================================================


### PR DESCRIPTION
## Summary

Adds a benchmarking harness (`benchmarking/empirical_48k_component_profile.jl`) that **empirically** localizes the residual super-linear (alpha~1.47) term in the `:scalable` corrector at large genome scale, and commits its 5/10/20kb results. Read-only w.r.t. `src/` — no library function is modified or monkey-patched.

**Result: the alpha~1.47 residual is per-read Viterbi DECODE (82% of wall at 20kb, alpha 1.49). It is NOT the newly-added `clean_corrector_graph!` defrag (0.3%) and NOT contig extraction / `find_linear_path` (0%).**

## Why a new harness (what the two prior attempts got wrong)

- **#381** (`largescale_component_profile.jl`) localized alpha~1.47 to contig-extraction (`find_linear_path` O(L^2)) by **source analysis on a LINEAR-PROXY graph** (its Part B timed reassembly on an *error-free* read set).
- **#383** shipped a `find_contigs` fix — but it did **not** move the 48kb wall time (2109 -> 2163s).
- Root cause of the miss: the **real** corrected graph is **branchy** (71 contigs at 20kb, max contig 13.5kb << 20kb genome), so `find_linear_path` walks many short paths and never enters its quadratic regime. The linear proxy was the worst case for `find_linear_path` but the wrong case for the real corrector.

This harness instead Profile-samples the **single real end-to-end entry point** — `assemble_genome(reads; corrector=:iterative, strategy=:scalable, k=21)` — which runs correction + reassembly **with `clean_corrector_graph!` ON** (the cleanup defaults ON only on this corrector reassembly path, so the prior standalone `corrector=:none` reassembly split never even exercised it). Every sample is bucketed to a component; per-component seconds = wall x sample-share, aggregated across all k-rungs, iterations, and the final reassembly. No proxy graph, no source O(.) reasoning, no isolated component.

## Empirical per-component scaling (measured on the REAL corrector run)

Genome sizes 5/10/20kb, readlen=150, 20x, err=0.01, k=21. `alpha` = log-log regression slope; `alpha_lg` = large-end (10->20kb) slope.

| component | 5kb (s) | 10kb (s) | 20kb (s) | alpha | alpha_lg |
|---|--:|--:|--:|--:|--:|
| C5e. decode: setup/orchestration | 25.4 | 64.3 | 186.4 | 1.44 | 1.53 |
| C5b. decode: Viterbi frontier engine | 20.2 | 51.4 | 174.5 | 1.56 | 1.76 |
| 0. other (overhead/GC) | 7.6 | 21.0 | 50.7 | 1.37 | 1.27 |
| B1. build_qualmer_graph | 3.6 | 7.6 | 22.5 | 1.31 | 1.56 |
| C5c. decode: soft-EM competing paths | 0.9 | 2.8 | 10.4 | 1.78 | 1.91 |
| C5d. decode: read likelihood calc | 0.9 | 2.2 | 3.0 | 0.87 | 0.44 |
| C3. solid_kmer classification | 0.2 | 0.3 | 2.4 | 1.85 | 2.82 |
| R4. consensus/quality (path->fastq) | 0.0 | 0.1 | 1.7 | 2.88 | 4.01 |
| **R1. clean_corrector_graph! (NEW defrag)** | 0.2 | 0.3 | **1.5** | 1.53 | 2.47 |
| C4. stage0 cheap_correct | 0.4 | 0.6 | 1.2 | 0.89 | 0.97 |
| C5a. decode: weighted-graph build | 0.1 | 0.2 | 0.5 | 0.97 | 1.03 |
| C2. hard_vertex_set (corr bubbles) | 0.0 | 0.1 | 0.2 | 1.02 | 1.17 |
| **R2. contig extraction (find_contigs)** | 0.0 | 0.0 | **0.0** | 0.94 | 1.42 |
| **C5\*. per-read decode (TOTAL C5a-e)** | **47.5** | **121.0** | **374.8** | **1.49** | **1.63** |
| **TOTAL (wall)** | **59.5** | **151.0** | **455.1** | **1.47** | **1.59** |

Total-wall alpha = **1.47**, an exact reproduction of the bead's 5kb->48kb alpha~1.47.

## True culprit (empirically measured)

**Per-read Viterbi decode** = 47.5 / 121.0 / 374.8s = **82% of wall at 20kb, alpha 1.49**. Within it, the **Viterbi frontier engine** (`viterbi_decode_next` / `_get_valid_transitions` / beam prune) is the most super-linear sub-term (alpha_lg 1.76), with decode orchestration (`improve_read_likelihood` / `try_viterbi_path_improvement`) the largest by absolute seconds.

**Ruled out with data:** `clean_corrector_graph!` (the prime new suspect) is 1.5s / 0.3% of wall; contig extraction / `find_linear_path` (the #381 hypothesis) is ~0s at every size.

### Why decode is super-linear despite the capped 256 beam

Reads are a fixed 150bp (~130 observations/read, well under the 1024 exact-beam threshold, so all get the bounded 256 beam), and read COUNT scales exactly linearly with genome (667 / 1334 / 2667 reads). If per-read cost were constant, decode would be alpha=1.0. It is alpha~1.5, so **per-decode-call cost itself grows ~alpha 0.5 with graph size**. The 256 beam caps RETAINED states per depth, but candidate GENERATION / transition enumeration before pruning still scales with graph density/branching, which grows with V (10.6k -> 43.3k vertices over 5->20kb).

## Concrete fix recommendation

Ordered by leverage; all target decode, not the cleanup/extraction paths the prior attempts chased:

1. **Bound candidate GENERATION, not just the retained beam** (attacks the alpha_lg 1.76 frontier engine): in `_get_valid_transitions` / the pre-prune expansion, pre-filter successors (e.g. top-B by edge weight) so generated states per depth are O(beam) instead of O(beam x branching_factor).
2. **Cut redundant decode volume** (attacks the linearly-growing call count x ~5 passes x ~0.5 decode_fraction): tighten the hard-read gate so converged reads stop re-decoding on later passes, and/or dedup decode by read-window — at 20x coverage many 150bp windows over-cover the same locus; decode each unique window once and map results back (a decode cache keyed on the observation sequence).

## Test Plan

- [x] Harness runs end-to-end at 5/10/20kb: `LD_LIBRARY_PATH='' julia --project=. benchmarking/empirical_48k_component_profile.jl` (results committed at `benchmarking/results/empirical_48k_component_profile.txt`).
- [x] Warmup at k=21 confirmed to remove first-run compilation from attribution ("0. other" is 8-11% and roughly linear).
- [x] Read-only w.r.t. `src/` (only the stdlib Profile sampler observes the unmodified corrector).
- [ ] Follow-up (separate PR): implement fix #1/#2 and re-run this harness to confirm decode alpha -> ~1.0 and 20kb wall drops.

## Related

Bead td-firp (child of td-9q84). Supersedes the #381 linear-proxy localization with an empirical measurement on the real branchy corrected graph.