### PR TITLE
perf: bound Viterbi decode candidate generation via score-margin frontier (td-plqi)

### DIFF
--- a/src/iterative-assembly.jl
+++ b/src/iterative-assembly.jl
@@ -1232,15 +1232,16 @@ const _AUTO_BEAM_EXACT_THRESHOLD = 1024
 #     successors, so 16 is a strict no-op on DNA (a robustness guard for pathological
 #     high-branching / non-DNA inputs), kept for correctness parity with the design.
 #
-#   * _AUTO_BEAM_SCORE_MARGIN — Δ log-prob "histogram" beam: keep only frontier
-#     states within Δ of the depth's best. This is the term that actually linearizes
-#     the dense-rung decode — the near-best band (true path + genuine competing
-#     alleles) does NOT grow with genome, so the generating frontier stays O(1) in
-#     size while the improbable tail is discarded. Δ = 30 nats ≈ 5 substitution
-#     log-likelihood units of headroom at err=0.01 — far more than any real
-#     correction needs, so the ML/variant path is always retained (validated by the
-#     variation-preservation holdout + toy quality sweep). Both engage ONLY where
-#     the width beam is already finite (approximate); exact-ML reads
+#   * _AUTO_BEAM_SCORE_MARGIN — Δ log-prob "histogram" beam with an EMISSION
+#     exemption: prune a frontier state only when it is >Δ below the depth's best
+#     on BOTH the full score AND the cumulative emission (read-consistency). This
+#     linearizes the dense-rung decode — the read-INCONSISTENT junk (low on both
+#     axes) is discarded so the generating frontier stays O(1) in size — WITHOUT
+#     dropping a real-but-rare allele: a supported minor allele in a skewed pool
+#     has good emission but a coverage-driven transition penalty, and the emission
+#     clause exempts it from pruning (the margin removes WRONG paths, not merely
+#     RARE ones; PR #388 variation-safety review). Δ = 30 nats. Both engage ONLY
+#     where the width beam is already finite (approximate); exact-ML reads
 #     (beam_width == typemax) keep margin = Inf and stay byte-identical.
 const _AUTO_SUCCESSOR_BOUND = 16
 const _AUTO_BEAM_SCORE_MARGIN = 30.0

--- a/src/iterative-assembly.jl
+++ b/src/iterative-assembly.jl
@@ -1219,6 +1219,32 @@ const _AUTO_BEAM_BOUNDED_WIDTH = 256
 # constant: it only trades exactness for tractability, and only ABOVE the line.
 const _AUTO_BEAM_EXACT_THRESHOLD = 1024
 
+# Candidate-GENERATION bounds applied alongside the finite width beam (td-plqi).
+# The width beam caps the RETAINED frontier at 256, but on a dense intermediate-k
+# graph nearly all 256 retained states are >20 log-prob below the best — improbable
+# junk that can never win the ML path yet still generates + emission-scores
+# successors at the next depth, so per-depth generation climbs toward the width cap
+# as the graph densifies (the empirically-measured residual super-linear term at
+# k=9; #386). These bound generation directly:
+#
+#   * _AUTO_SUCCESSOR_BOUND — top-B outgoing transitions per expanded state, ranked
+#     by edge weight before emission. A k-mer de Bruijn vertex has ≤ 4 structural
+#     successors, so 16 is a strict no-op on DNA (a robustness guard for pathological
+#     high-branching / non-DNA inputs), kept for correctness parity with the design.
+#
+#   * _AUTO_BEAM_SCORE_MARGIN — Δ log-prob "histogram" beam: keep only frontier
+#     states within Δ of the depth's best. This is the term that actually linearizes
+#     the dense-rung decode — the near-best band (true path + genuine competing
+#     alleles) does NOT grow with genome, so the generating frontier stays O(1) in
+#     size while the improbable tail is discarded. Δ = 30 nats ≈ 5 substitution
+#     log-likelihood units of headroom at err=0.01 — far more than any real
+#     correction needs, so the ML/variant path is always retained (validated by the
+#     variation-preservation holdout + toy quality sweep). Both engage ONLY where
+#     the width beam is already finite (approximate); exact-ML reads
+#     (beam_width == typemax) keep margin = Inf and stay byte-identical.
+const _AUTO_SUCCESSOR_BOUND = 16
+const _AUTO_BEAM_SCORE_MARGIN = 30.0
+
 """
     _auto_beam_width(n_observations) -> Int
 
@@ -2498,11 +2524,24 @@ function try_viterbi_path_improvement(read::FASTX.FASTQ.Record,
         effective_beam_width = beam_width === nothing ?
                                _auto_beam_width(length(observations), Graphs.nv(graph)) :
                                beam_width
+        # Candidate-generation bounds (td-plqi) engage ONLY where the width beam is
+        # already finite (i.e. the decode is already the bounded approximation, not
+        # exact ML). When the beam is exact (typemax — small read on a sparse graph,
+        # OR an explicit caller override forcing exact), the score margin stays Inf
+        # and the successor bound stays unbounded, so exact-ML reads are byte-
+        # identical. Where the beam is bounded (dense/large — the k=9-style rungs
+        # that carry the #386 super-linear residual) the margin holds the generating
+        # frontier O(1) in genome size.
+        beam_is_exact = effective_beam_width == typemax(Int)
+        effective_margin = beam_is_exact ? Inf : _AUTO_BEAM_SCORE_MARGIN
+        effective_successor_bound = beam_is_exact ? typemax(Int) : _AUTO_SUCCESSOR_BOUND
         config = Mycelia.ViterbiCorrectionConfig(
             alphabet = alphabet,
             strand_mode = graph_mode,
             max_steps = length(observations) - 1,
-            beam_width = effective_beam_width
+            beam_width = effective_beam_width,
+            max_successors_per_state = effective_successor_bound,
+            beam_score_margin = effective_margin
         )
         correction = Mycelia.correct_observations(
             graph, [observations]; config = config, weighted_graph = weighted_graph)

--- a/src/viterbi-next.jl
+++ b/src/viterbi-next.jl
@@ -78,17 +78,24 @@ the graph densifies (td-plqi):
     no-op here; it is a robustness guard for pathological high-branching inputs
     (collapsed-repeat multigraphs, non-DNA alphabets). Default `typemax(Int)`.
 
-  * `beam_score_margin` — Δ log-probability threshold ("histogram" beam pruning).
-    After the width beam, retained states whose score is more than `Δ` below the
-    depth's best are dropped. This is the term that actually bounds generation at
-    scale: on a dense intermediate-k graph the width-256 frontier is ~99% states
-    that are >Δ below best (astronomically improbable) and can never win the ML
-    path, yet each one still generates + emission-scores successors at the next
-    depth. Keeping only the within-Δ band holds the generating frontier to a few
-    states independent of genome size (the true path and its genuine competitors
-    are high-probability, always within the band). Default `Inf` (no threshold =
-    exact). Only engages where the width beam is already finite (approximate), so
-    exact-ML reads (`beam_width == typemax`) stay byte-identical.
+  * `beam_score_margin` — Δ log-probability threshold ("histogram" beam pruning)
+    with an EMISSION exemption. After the width beam, a state is dropped only when
+    it is BOTH >Δ below the depth's best FULL score AND >Δ below the depth's best
+    cumulative EMISSION (read-consistency, excluding the coverage/transition term).
+    This is the term that actually bounds generation at scale: on a dense
+    intermediate-k graph the width-256 frontier is ~99% read-INCONSISTENT states
+    (low on both axes) that can never win the ML path yet still generate +
+    emission-score successors each depth; pruning them holds the generating
+    frontier to a few states independent of genome size. The emission clause
+    protects variation: a real-but-rare minor allele (skewed-coverage / viral
+    quasispecies) has GOOD emission but a coverage-driven transition penalty, so
+    the emission exemption keeps it even when its full score trails the dominant
+    haplotype — the margin prunes WRONG paths (bad emission), never merely RARE
+    ones. It does not weaken error correction (an uncorrected error path has high
+    emission → exempt → still available for the full-score ML choice). Default
+    `Inf` (no threshold = exact). Only engages where the width beam is already
+    finite (approximate), so exact-ML reads (`beam_width == typemax`) stay
+    byte-identical.
 """
 struct ViterbiCorrectionConfig{F <: Function}
     error_rate::Float64
@@ -1062,32 +1069,58 @@ function _top_b_transitions(transitions, b::Int)
     return ordered[1:b]
 end
 
-# Score-margin ("histogram") beam pruning (td-plqi): drop states whose score is
-# more than `margin` log-probability units below `best_score` (the best score in
-# the frontier). Applied AFTER the width beam, in lockstep on the score and
-# predecessor dicts so path reconstruction stays consistent. This bounds the set of
-# states that will GENERATE successors at the next depth to the near-best band,
-# which — unlike the width beam — does not grow with graph density (the improbable
-# tail is discarded), keeping per-depth generation O(1) in genome size. `margin ===
-# Inf` (default) is a no-op, preserving exact decoding.
+# Score-margin ("histogram") beam pruning with an EMISSION EXEMPTION (td-plqi,
+# variation-safety hardening from PR #388 review). Applied AFTER the width beam, in
+# lockstep on the score / predecessor / emission dicts so path reconstruction stays
+# consistent.
+#
+# A state is pruned only when it is BOTH:
+#   (1) more than `margin` log-prob below the frontier's best FULL score
+#       (`state + log(transition_prob) + emission`), AND
+#   (2) more than `margin` below the frontier's best cumulative EMISSION
+#       (read-consistency: `sum(emission)`, EXCLUDING the coverage/transition term).
+#
+# Rationale — why the AND-gate rather than a full-score-only threshold: the full
+# score carries a `log(transition_prob) = log(cov_edge / cov_total)` term that
+# penalizes a path for being RARE, not for being WRONG. A real-but-rare minor
+# allele (viral quasispecies / skewed pool) has GOOD emission (reads genuinely
+# support it) but a coverage-driven transition penalty; a full-score-only margin
+# could prune it for rarity. The emission clause EXEMPTS any read-consistent path
+# from pruning regardless of how rare its coverage is, so a supported variant is
+# never dropped as "improbable." It does NOT weaken error correction: an
+# uncorrected error path has HIGH emission (matches the observed read) so it is
+# exempt and stays available, but the corrected path still wins the full-score ML
+# selection. Genuine junk (read-INCONSISTENT paths threaded through wrong regions)
+# is low on BOTH axes and is still pruned, so the O(1)-frontier speed win holds.
+# `margin === Inf` (default) is a no-op, preserving exact decoding.
 function _prune_correction_beam_by_margin(
         scores::Dict{S, Float64},
         predecessors::Dict{S, S},
+        emissions::Dict{S, Float64},
         best_score::Float64,
+        best_emission::Float64,
         margin::Float64
-)::Tuple{Dict{S, Float64}, Dict{S, S}} where {S}
-    (isinf(margin) || isempty(scores)) && return scores, predecessors
-    threshold = best_score - margin
+)::Tuple{Dict{S, Float64}, Dict{S, S}, Dict{S, Float64}} where {S}
+    (isinf(margin) || isempty(scores)) && return scores, predecessors, emissions
+    score_threshold = best_score - margin
+    emission_threshold = best_emission - margin
     kept = Dict{S, Float64}()
     kept_predecessors = Dict{S, S}()
+    kept_emissions = Dict{S, Float64}()
     for (state, score) in scores
-        score >= threshold || continue
+        # Keep unless below BOTH thresholds (emission clause exempts read-consistent
+        # paths — including rare-but-supported alleles — from coverage-driven pruning).
+        emission = get(emissions, state, -Inf)
+        if score < score_threshold && emission < emission_threshold
+            continue
+        end
         kept[state] = score
+        kept_emissions[state] = emission
         if haskey(predecessors, state)
             kept_predecessors[state] = predecessors[state]
         end
     end
-    return kept, kept_predecessors
+    return kept, kept_predecessors, kept_emissions
 end
 
 function _viterbi_correct_observation(
@@ -1145,6 +1178,11 @@ function _viterbi_correct_observation(
     )
 
     active_scores = Dict{Tuple{label_type, Rhizomorph.StrandOrientation}, Float64}()
+    # Cumulative EMISSION (read-consistency) per state, tracked in lockstep with the
+    # full score so the score-margin prune can exempt read-consistent paths from
+    # coverage-driven pruning (td-plqi variation-safety). At the start there is no
+    # transition term, so the start emission == the start score.
+    active_emissions = Dict{Tuple{label_type, Rhizomorph.StrandOrientation}, Float64}()
     for vertex in start_candidates
         for strand in _viterbi_start_strands(graph, vertex, strand_mode, config.start_strand)
             state = (vertex, strand)
@@ -1158,6 +1196,7 @@ function _viterbi_correct_observation(
             )
             if isfinite(score) && (!haskey(active_scores, state) || score > active_scores[state])
                 active_scores[state] = score
+                active_emissions[state] = score
             end
         end
     end
@@ -1201,6 +1240,7 @@ function _viterbi_correct_observation(
             Tuple{label_type, Rhizomorph.StrandOrientation},
             Tuple{label_type, Rhizomorph.StrandOrientation}
         }()
+        next_emissions = Dict{Tuple{label_type, Rhizomorph.StrandOrientation}, Float64}()
 
         for (state, state_score) in active_scores
             current_vertex, current_strand = state
@@ -1255,6 +1295,10 @@ function _viterbi_correct_observation(
                 if !haskey(next_scores, next_state) || next_score > next_scores[next_state]
                     next_scores[next_state] = next_score
                     next_predecessors[next_state] = state
+                    # Carry the emission (read-consistency) component of THIS path
+                    # in lockstep with the Viterbi (max full-score) choice.
+                    next_emissions[next_state] =
+                        get(active_emissions, state, 0.0) + emission_score
                 end
             end
         end
@@ -1273,18 +1317,27 @@ function _viterbi_correct_observation(
         if length(next_scores) > config.beam_width
             next_scores, next_predecessors = _prune_correction_beam(
                 next_scores, next_predecessors, config.beam_width)
+            # Keep the emission dict aligned to the width-beam survivors.
+            next_emissions = Dict(
+                state => next_emissions[state] for state in keys(next_scores))
             diagnostics[:beam_pruned] = get(diagnostics, :beam_pruned, 0) + 1
         end
 
-        # Score-margin ("histogram") prune: keep only states within
-        # `beam_score_margin` log-prob of the depth's best (td-plqi). This is the
-        # bound that holds the GENERATING frontier O(1) in genome size on dense
-        # intermediate-k graphs; a no-op under the default Inf margin (exact ML).
+        # Score-margin ("histogram") prune with emission exemption: keep a state
+        # unless it is BOTH >Δ below the best full score AND >Δ below the best
+        # cumulative emission (td-plqi). This bounds the GENERATING frontier to O(1)
+        # in genome size on dense intermediate-k graphs (the improbable, read-
+        # INCONSISTENT junk is pruned), while never dropping a read-consistent path —
+        # so a real-but-rare (skewed-coverage) allele is protected from coverage-
+        # driven pruning. A no-op under the default Inf margin (exact ML).
         if isfinite(config.beam_score_margin) && !isempty(next_scores)
             depth_best = maximum(values(next_scores))
+            depth_best_emission = maximum(values(next_emissions))
             pre_margin = length(next_scores)
-            next_scores, next_predecessors = _prune_correction_beam_by_margin(
-                next_scores, next_predecessors, depth_best, config.beam_score_margin)
+            next_scores, next_predecessors, next_emissions =
+                _prune_correction_beam_by_margin(
+                    next_scores, next_predecessors, next_emissions,
+                    depth_best, depth_best_emission, config.beam_score_margin)
             if length(next_scores) < pre_margin
                 diagnostics[:margin_pruned] = get(diagnostics, :margin_pruned, 0) + 1
             end
@@ -1292,6 +1345,7 @@ function _viterbi_correct_observation(
 
         push!(predecessors_by_depth, next_predecessors)
         active_scores = next_scores
+        active_emissions = next_emissions
         retained_count = length(active_scores)
         diagnostics[:retained_states] = retained_count
         diagnostics[:cumulative_retained_states] += retained_count

--- a/src/viterbi-next.jl
+++ b/src/viterbi-next.jl
@@ -65,6 +65,30 @@ keeps the default simple so the legacy B0 oracle remains the behavioral anchor.
 `:doublestrand`, `:canonical`, or `:auto`). BioSequences empirically preserves
 RNA type and U-aware complements (`AUGC` reverse-complements to `GCAU`), while
 AA/text alphabets remain reverse-complement naive singlestrand paths.
+
+Two candidate-generation bounds (both default to exact / no-op; opted into by the
+:scalable corrector alongside the size-aware `beam_width`) keep the per-depth
+frontier expansion O(1) in graph size instead of growing toward the width beam as
+the graph densifies (td-plqi):
+
+  * `max_successors_per_state` — per expanded state, only the top-B outgoing
+    transitions by edge weight are materialized before emission scoring, so
+    generation per state is O(B) not O(out-degree). On a k-mer de Bruijn graph the
+    structural out-degree is ≤ 4 (the four next bases), so any `B ≥ 4` is a strict
+    no-op here; it is a robustness guard for pathological high-branching inputs
+    (collapsed-repeat multigraphs, non-DNA alphabets). Default `typemax(Int)`.
+
+  * `beam_score_margin` — Δ log-probability threshold ("histogram" beam pruning).
+    After the width beam, retained states whose score is more than `Δ` below the
+    depth's best are dropped. This is the term that actually bounds generation at
+    scale: on a dense intermediate-k graph the width-256 frontier is ~99% states
+    that are >Δ below best (astronomically improbable) and can never win the ML
+    path, yet each one still generates + emission-scores successors at the next
+    depth. Keeping only the within-Δ band holds the generating frontier to a few
+    states independent of genome size (the true path and its genuine competitors
+    are high-probability, always within the band). Default `Inf` (no threshold =
+    exact). Only engages where the width beam is already finite (approximate), so
+    exact-ML reads (`beam_width == typemax`) stay byte-identical.
 """
 struct ViterbiCorrectionConfig{F <: Function}
     error_rate::Float64
@@ -77,6 +101,8 @@ struct ViterbiCorrectionConfig{F <: Function}
     start_strand::Rhizomorph.StrandOrientation
     edge_weight::Function
     beam_width::Int
+    max_successors_per_state::Int
+    beam_score_margin::Float64
 
     function ViterbiCorrectionConfig{F}(;
             error_rate::Float64 = 0.01,
@@ -88,7 +114,9 @@ struct ViterbiCorrectionConfig{F <: Function}
             target_vertex = nothing,
             start_strand::Rhizomorph.StrandOrientation = Rhizomorph.Forward,
             edge_weight::Function = Rhizomorph.edge_data_weight,
-            beam_width::Int = typemax(Int)
+            beam_width::Int = typemax(Int),
+            max_successors_per_state::Int = typemax(Int),
+            beam_score_margin::Float64 = Inf
     ) where {F <: Function}
         if error_rate <= 0.0 || error_rate >= 0.5
             throw(ArgumentError("error_rate must be in (0, 0.5), got $error_rate"))
@@ -102,6 +130,14 @@ struct ViterbiCorrectionConfig{F <: Function}
         if beam_width <= 0
             throw(ArgumentError("beam_width must be positive, got $beam_width"))
         end
+        if max_successors_per_state <= 0
+            throw(ArgumentError(
+                "max_successors_per_state must be positive, got $max_successors_per_state"))
+        end
+        if isnan(beam_score_margin) || beam_score_margin <= 0.0
+            throw(ArgumentError(
+                "beam_score_margin must be a positive number or Inf, got $beam_score_margin"))
+        end
         return new{F}(
             error_rate,
             verbosity,
@@ -112,7 +148,9 @@ struct ViterbiCorrectionConfig{F <: Function}
             target_vertex,
             start_strand,
             edge_weight,
-            beam_width
+            beam_width,
+            max_successors_per_state,
+            beam_score_margin
         )
     end
 end
@@ -127,7 +165,9 @@ function ViterbiCorrectionConfig(;
         target_vertex = nothing,
         start_strand::Rhizomorph.StrandOrientation = Rhizomorph.Forward,
         edge_weight::Function = Rhizomorph.edge_data_weight,
-        beam_width::Int = typemax(Int)
+        beam_width::Int = typemax(Int),
+        max_successors_per_state::Int = typemax(Int),
+        beam_score_margin::Float64 = Inf
 )::ViterbiCorrectionConfig{F} where {F <: Function}
     return ViterbiCorrectionConfig{F}(
         error_rate = error_rate,
@@ -139,7 +179,9 @@ function ViterbiCorrectionConfig(;
         target_vertex = target_vertex,
         start_strand = start_strand,
         edge_weight = edge_weight,
-        beam_width = beam_width
+        beam_width = beam_width,
+        max_successors_per_state = max_successors_per_state,
+        beam_score_margin = beam_score_margin
     )
 end
 
@@ -999,6 +1041,55 @@ function _prune_correction_beam(
     return kept, kept_predecessors
 end
 
+# Bound successor GENERATION per expanded state (td-plqi): keep only the top-B
+# outgoing transitions ranked by edge weight BEFORE any emission is scored, so the
+# per-state candidate set is O(B) rather than O(out-degree). Ranking is by
+# `_edge_transition_weight` descending; ties are broken by target-vertex string for
+# a deterministic (run-reproducible) selection. Returns `transitions` unchanged when
+# it already fits within `b` (the common case: a k-mer de Bruijn vertex has ≤ 4
+# structural successors, so any `b ≥ 4` is a no-op). Only bites on pathological
+# high-branching vertices, where the low-weight tail is the least-probable
+# (error/spurious) edges — the true, well-supported branch is high-weight and
+# always survives.
+function _top_b_transitions(transitions, b::Int)
+    length(transitions) <= b && return transitions
+    ordered = sort(
+        transitions;
+        by = t -> (Rhizomorph._edge_transition_weight(t[:edge_data]),
+                   string(t[:target_vertex])),
+        rev = true
+    )
+    return ordered[1:b]
+end
+
+# Score-margin ("histogram") beam pruning (td-plqi): drop states whose score is
+# more than `margin` log-probability units below `best_score` (the best score in
+# the frontier). Applied AFTER the width beam, in lockstep on the score and
+# predecessor dicts so path reconstruction stays consistent. This bounds the set of
+# states that will GENERATE successors at the next depth to the near-best band,
+# which — unlike the width beam — does not grow with graph density (the improbable
+# tail is discarded), keeping per-depth generation O(1) in genome size. `margin ===
+# Inf` (default) is a no-op, preserving exact decoding.
+function _prune_correction_beam_by_margin(
+        scores::Dict{S, Float64},
+        predecessors::Dict{S, S},
+        best_score::Float64,
+        margin::Float64
+)::Tuple{Dict{S, Float64}, Dict{S, S}} where {S}
+    (isinf(margin) || isempty(scores)) && return scores, predecessors
+    threshold = best_score - margin
+    kept = Dict{S, Float64}()
+    kept_predecessors = Dict{S, S}()
+    for (state, score) in scores
+        score >= threshold || continue
+        kept[state] = score
+        if haskey(predecessors, state)
+            kept_predecessors[state] = predecessors[state]
+        end
+    end
+    return kept, kept_predecessors
+end
+
 function _viterbi_correct_observation(
         graph::MetaGraphsNext.MetaGraph,
         observation::AbstractVector,
@@ -1125,6 +1216,17 @@ function _viterbi_correct_observation(
                 continue
             end
 
+            # Bound successor generation to the top-B highest-weight transitions
+            # BEFORE emission scoring (td-plqi). No-op when B >= out-degree (the
+            # de Bruijn common case, out-degree <= 4). `total_out` is unchanged —
+            # transition probabilities stay normalized against the FULL outgoing
+            # mass, so a bounded expansion is a strict subset of the exact frontier.
+            if length(transitions) > config.max_successors_per_state
+                diagnostics[:successor_bounded] =
+                    get(diagnostics, :successor_bounded, 0) + 1
+                transitions = _top_b_transitions(transitions, config.max_successors_per_state)
+            end
+
             for transition in transitions
                 next_vertex = convert(label_type, transition[:target_vertex])
                 next_strand = Rhizomorph._normalize_strand(transition[:target_strand])
@@ -1172,6 +1274,20 @@ function _viterbi_correct_observation(
             next_scores, next_predecessors = _prune_correction_beam(
                 next_scores, next_predecessors, config.beam_width)
             diagnostics[:beam_pruned] = get(diagnostics, :beam_pruned, 0) + 1
+        end
+
+        # Score-margin ("histogram") prune: keep only states within
+        # `beam_score_margin` log-prob of the depth's best (td-plqi). This is the
+        # bound that holds the GENERATING frontier O(1) in genome size on dense
+        # intermediate-k graphs; a no-op under the default Inf margin (exact ML).
+        if isfinite(config.beam_score_margin) && !isempty(next_scores)
+            depth_best = maximum(values(next_scores))
+            pre_margin = length(next_scores)
+            next_scores, next_predecessors = _prune_correction_beam_by_margin(
+                next_scores, next_predecessors, depth_best, config.beam_score_margin)
+            if length(next_scores) < pre_margin
+                diagnostics[:margin_pruned] = get(diagnostics, :margin_pruned, 0) + 1
+            end
         end
 
         push!(predecessors_by_depth, next_predecessors)

--- a/test/4_assembly/variation_preservation_holdout_test.jl
+++ b/test/4_assembly/variation_preservation_holdout_test.jl
@@ -60,6 +60,7 @@ import Mycelia
 import FASTX
 import BioSequences
 import Random
+import Graphs
 
 const _VPH_BASES = ['A', 'C', 'G', 'T']
 
@@ -297,6 +298,132 @@ Test.@testset "SKEWED-variant holdout: soft-EM v2 support floor (td-h6w9)" begin
             # The coverage-1 error is still removed (Stage 0 + soft-EM decay of the
             # unsupported edge), proving the floor did not blunt error removal.
             Test.@test !sc_err
+        end
+    end
+end
+
+# ============================================================================
+# DENSE-REGIME rare-allele retention under the score-margin beam (td-plqi / PR #388)
+# ============================================================================
+#
+# The two holdouts above run on a 300 bp backbone: at k=21 that graph has < 256
+# vertices, so the corrector's size-aware beam stays EXACT (typemax) and the score
+# margin (which engages only where the width beam is finite, i.e. on a DENSE graph)
+# never fires there. That left the score margin's interaction with variation
+# UNTESTED (PR #388 review). This holdout closes the gap: it builds a DENSE graph
+# (nv >> 256 -> the finite beam + score margin ENGAGE) carrying a SKEWED-coverage
+# variant, and asserts a read from the RARE haplotype is still corrected onto its
+# OWN (rare) allele — i.e. the margin prunes WRONG paths, not merely RARE ones.
+#
+# It is decode-level on purpose (asserts the corrected READ, not the final contig),
+# isolating the Viterbi score-margin from the downstream soft-EM / defrag so a
+# failure here points squarely at the margin.
+
+# Build a DENSE two-haplotype fixture: a `bg_cov`x background tiling of the majority
+# haplotype across the WHOLE backbone (so nv >> 256 and the margin engages) plus
+# `min_cov` reads of the MINORITY haplotype spanning the central variant. Returns
+# the read set, the minority reads, and the minority allele signature k-mer.
+function _vph_build_dense_skewed_fixture(; min_cov::Int, bg_cov::Int = 20,
+        k::Int = 21, L::Int = 1000, seed::Int = 20260709)
+    rng = Random.MersenneTwister(seed)
+    backbone = collect(join(rand(rng, _VPH_BASES, L)))
+    pvar = L ÷ 2
+    base_a = backbone[pvar]
+    base_b = rand(rng, filter(!=(base_a), _VPH_BASES))
+    hap_a = copy(backbone)
+    hap_b = copy(backbone); hap_b[pvar] = base_b
+    half = k ÷ 2
+    kmer_b = uppercase(String(hap_b[(pvar - half):(pvar + half)]))  # minority signature
+    readlen = 150
+    qual = String(fill('I', readlen))
+    reads = FASTX.FASTQ.Record[]
+    # Background tiling of the majority haplotype across the whole backbone -> dense
+    # graph (also makes the majority allele the dominant, high-coverage branch).
+    n_bg = ceil(Int, bg_cov * L / readlen)
+    for i in 1:n_bg
+        s = rand(rng, 1:(L - readlen + 1))
+        push!(reads, FASTX.FASTQ.Record("BG$i", String(hap_a[s:(s + readlen - 1)]), qual))
+    end
+    # Minority-haplotype reads spanning the central variant (the rare allele).
+    lo = pvar - readlen + half + 1
+    hi = pvar - half
+    minority_reads = FASTX.FASTQ.Record[]
+    for i in 1:min_cov
+        s = rand(rng, lo:hi)
+        r = FASTX.FASTQ.Record("MIN$i", String(hap_b[s:(s + readlen - 1)]), qual)
+        push!(reads, r)
+        push!(minority_reads, r)
+    end
+    return (; reads, minority_reads, k, kmer_b)
+end
+
+# Decode one read through the SHIPPING corrector config (size-aware beam + the
+# td-plqi generation bounds wired exactly as `try_viterbi_path_improvement` does)
+# and return the uppercased vertex-label strings of the corrected path.
+function _vph_decode_labels(graph, weighted, read, k::Int)
+    R = Mycelia.Rhizomorph
+    seqstr = FASTX.sequence(String, read)
+    seq = Mycelia.extract_typed_sequence(
+        read, Mycelia.alphabet_to_biosequence_type(Mycelia.detect_alphabet(seqstr)))
+    kmers = collect(Mycelia._record_kmer_iterator(typeof(seq), k, seq))
+    qs = collect(FASTX.quality_scores(read))
+    nq = length(qs)
+    obs = Vector{Mycelia.QualityObservation}(undef, length(kmers))
+    for (i, km) in enumerate(kmers)
+        lo = clamp(i, 1, nq)
+        hi = clamp(i + k - 1, 1, nq)
+        obs[i] = Mycelia.QualityObservation(km, UInt8.(@view qs[lo:hi]))
+    end
+    beam = Mycelia._auto_beam_width(length(obs), Graphs.nv(graph.graph))
+    beam_is_exact = beam == typemax(Int)
+    cfg = Mycelia.ViterbiCorrectionConfig(
+        alphabet = :DNA, strand_mode = :doublestrand, max_steps = length(obs) - 1,
+        beam_width = beam,
+        max_successors_per_state = beam_is_exact ? typemax(Int) : Mycelia._AUTO_SUCCESSOR_BOUND,
+        beam_score_margin = beam_is_exact ? Inf : Mycelia._AUTO_BEAM_SCORE_MARGIN)
+    corr = Mycelia.correct_observations(graph, [obs]; config = cfg, weighted_graph = weighted)
+    path = only(corr.corrected_observations)
+    path === nothing && return (String[], beam)
+    return (uppercase.(string.(path)), beam)
+end
+
+Test.@testset "DENSE-regime rare-allele retention under score margin (td-plqi)" begin
+    R = Mycelia.Rhizomorph
+    # (background/majority coverage, minority coverage, k). Spans balanced, mild-skew,
+    # and EXTREME-skew (33:1) cases, at k=21 and k=9 (smaller emission advantage).
+    for (bg, minr, k) in ((15, 15, 21), (20, 4, 21), (100, 3, 21), (20, 4, 9))
+        Test.@testset "dense skew bg=$(bg)x min=$(minr)x k=$k: minority allele retained" begin
+            fx = _vph_build_dense_skewed_fixture(; min_cov = minr, bg_cov = bg, k = k)
+            graph = R.build_qualmer_graph(fx.reads, k; mode = :doublestrand)
+            weighted = Mycelia.build_correction_weighted_graph(graph)
+
+            # Precondition: the graph MUST be dense enough that the size-aware beam
+            # is finite (the margin engages). If this ever fails the test is vacuous.
+            nv = Graphs.nv(graph.graph)
+            Test.@test nv > Mycelia._AUTO_BEAM_BOUNDED_WIDTH
+            Test.@test Mycelia._auto_beam_width(150, nv) == Mycelia._AUTO_BEAM_BOUNDED_WIDTH
+
+            kmer_b = fx.kmer_b
+            kmer_b_rc = _vph_revcomp(kmer_b)
+            retained = 0
+            total = 0
+            beam = 0
+            for r in fx.minority_reads
+                labels, beam = _vph_decode_labels(graph, weighted, r, k)
+                isempty(labels) && continue
+                total += 1
+                any(l -> l == kmer_b || uppercase(l) == uppercase(kmer_b_rc), labels) &&
+                    (retained += 1)
+            end
+
+            @info "dense-regime rare-allele retention" bg minr k nv beam retained total
+
+            # KEY INVARIANT: every decoded minority read keeps its OWN rare allele.
+            # A margin that penalized rarity (coverage-driven transition penalty)
+            # rather than wrongness (emission) would drop it here — the emission
+            # exemption prevents that.
+            Test.@test total >= 1
+            Test.@test retained == total
         end
     end
 end

--- a/test/4_assembly/viterbi_beam_pruning_test.jl
+++ b/test/4_assembly/viterbi_beam_pruning_test.jl
@@ -156,3 +156,110 @@ Test.@testset "Viterbi corrector beam pruning (td-63qy)" begin
         Test.@test auto isa Union{Tuple{FASTX.FASTQ.Record, Float64}, Nothing}
     end
 end
+
+# Candidate-GENERATION bounds (td-plqi): the width beam caps the RETAINED frontier,
+# but on a dense intermediate-k graph the generating frontier (the states that
+# enumerate successors + emission-score them each depth) still climbs toward the
+# width cap as the graph densifies — the empirically-measured residual super-linear
+# decode term (#386). Two additive bounds cut generation directly:
+#   * `max_successors_per_state` (top-B) — a per-state successor cap (no-op on DNA,
+#     out-degree <= 4; a guard for pathological high-branching).
+#   * `beam_score_margin` (Δ) — a score-threshold ("histogram") beam that keeps only
+#     the near-best band, which does NOT grow with genome, so the generating
+#     frontier stays O(1) in size while the improbable tail is discarded.
+# Both default to a strict no-op (exact ML) and only engage where the width beam is
+# already finite (approximate), so exact-ML reads stay byte-identical.
+Test.@testset "Viterbi corrector candidate-generation bounds (td-plqi)" begin
+    linear_records = [FASTX.FASTA.Record("dna", BioSequences.dna"ATGCGT")]
+    linear_graph = Mycelia.Rhizomorph.build_kmer_graph(
+        linear_records, 3; dataset_id="candgen_linear", mode=:singlestrand
+    )
+    linear_observed = [
+        Kmers.DNAKmer{3}("ATG"),
+        Kmers.DNAKmer{3}("TGA"),
+        Kmers.DNAKmer{3}("GCG"),
+        Kmers.DNAKmer{3}("CGT"),
+    ]
+
+    bubble_records = [
+        FASTX.FASTA.Record("path_a", BioSequences.dna"ATGCGTA"),
+        FASTX.FASTA.Record("path_b", BioSequences.dna"ATGAGTA"),
+    ]
+    bubble_graph = Mycelia.Rhizomorph.build_kmer_graph(
+        bubble_records, 3; dataset_id="candgen_bubble", mode=:singlestrand
+    )
+    bubble_observed = [
+        Kmers.DNAKmer{3}("ATG"),
+        Kmers.DNAKmer{3}("TGC"),
+        Kmers.DNAKmer{3}("GCG"),
+        Kmers.DNAKmer{3}("CGT"),
+        Kmers.DNAKmer{3}("GTA"),
+    ]
+
+    Test.@testset "constructor validation" begin
+        # A positive successor cap and a positive-or-Inf score margin are required.
+        Test.@test_throws ArgumentError Mycelia.ViterbiCorrectionConfig(max_successors_per_state=0)
+        Test.@test_throws ArgumentError Mycelia.ViterbiCorrectionConfig(max_successors_per_state=-3)
+        Test.@test_throws ArgumentError Mycelia.ViterbiCorrectionConfig(beam_score_margin=0.0)
+        Test.@test_throws ArgumentError Mycelia.ViterbiCorrectionConfig(beam_score_margin=-5.0)
+        Test.@test_throws ArgumentError Mycelia.ViterbiCorrectionConfig(beam_score_margin=NaN)
+        # Inf (the default) is valid — it means "no threshold" (exact).
+        Test.@test Mycelia.ViterbiCorrectionConfig(beam_score_margin=Inf).beam_score_margin == Inf
+    end
+
+    Test.@testset "defaults are exact (both bounds are no-ops)" begin
+        cfg = Mycelia.ViterbiCorrectionConfig(alphabet=:DNA)
+        Test.@test cfg.max_successors_per_state == typemax(Int)
+        Test.@test cfg.beam_score_margin == Inf
+        # Byte-identical to the established B8 exact fixture, and neither bound fires.
+        result = Mycelia.correct_observations(linear_graph, [linear_observed])
+        Test.@test beam_decoded_label_strings(result) == ["ATG", "TGC", "GCG", "CGT"]
+        diag = only(result.paths).diagnostics
+        Test.@test get(diag, :successor_bounded, 0) == 0
+        Test.@test get(diag, :margin_pruned, 0) == 0
+    end
+
+    Test.@testset "top-B successor bound: B >= out-degree is byte-identical (no-op)" begin
+        # On a DNA de Bruijn graph the out-degree is <= 4, so B = 16 can never bite:
+        # the corrected path must match the unbounded exact answer exactly.
+        cfg = Mycelia.ViterbiCorrectionConfig(alphabet=:DNA, max_successors_per_state=16)
+        result = Mycelia.correct_observations(bubble_graph, [bubble_observed]; config=cfg)
+        exact = Mycelia.correct_observations(bubble_graph, [bubble_observed])
+        Test.@test beam_decoded_label_strings(result) == beam_decoded_label_strings(exact)
+        Test.@test get(only(result.paths).diagnostics, :successor_bounded, 0) == 0
+    end
+
+    Test.@testset "top-B successor bound: a tight B engages on a branch and completes" begin
+        # B = 1 forces each expanded state to enumerate only its single top-weight
+        # successor. The branch vertex has 2 successors, so the bound MUST fire, and
+        # the decode still completes with a valid, non-empty correction.
+        cfg = Mycelia.ViterbiCorrectionConfig(alphabet=:DNA, max_successors_per_state=1)
+        result = Mycelia.correct_observations(bubble_graph, [bubble_observed]; config=cfg)
+        decoded = only(result.corrected_observations)
+        Test.@test !isempty(decoded)
+        Test.@test get(only(result.paths).diagnostics, :successor_bounded, 0) >= 1
+        # Bounded generation is an approximation: its score cannot exceed the exact.
+        exact = Mycelia.correct_observations(bubble_graph, [bubble_observed])
+        Test.@test only(exact.paths).score >= only(result.paths).score - 1e-9
+    end
+
+    Test.@testset "score-margin bound: generous Δ keeps the exact best path" begin
+        # A wide margin drops only states far below the best; on a small graph the
+        # exact best path is preserved (its states are always within the band).
+        cfg = Mycelia.ViterbiCorrectionConfig(alphabet=:DNA, beam_score_margin=1000.0)
+        result = Mycelia.correct_observations(bubble_graph, [bubble_observed]; config=cfg)
+        exact = Mycelia.correct_observations(bubble_graph, [bubble_observed])
+        Test.@test beam_decoded_label_strings(result) == beam_decoded_label_strings(exact)
+    end
+
+    Test.@testset "score-margin bound: a tight Δ prunes and never beats exact" begin
+        # A tight margin discards the improbable frontier tail (margin_pruned fires),
+        # completes, and — as an approximation — never scores above exact.
+        cfg = Mycelia.ViterbiCorrectionConfig(alphabet=:DNA, beam_score_margin=1.0)
+        result = Mycelia.correct_observations(bubble_graph, [bubble_observed]; config=cfg)
+        Test.@test !isempty(only(result.corrected_observations))
+        Test.@test get(only(result.paths).diagnostics, :margin_pruned, 0) >= 1
+        exact = Mycelia.correct_observations(bubble_graph, [bubble_observed])
+        Test.@test only(exact.paths).score >= only(result.paths).score - 1e-9
+    end
+end

--- a/test/4_assembly/viterbi_beam_pruning_test.jl
+++ b/test/4_assembly/viterbi_beam_pruning_test.jl
@@ -262,4 +262,46 @@ Test.@testset "Viterbi corrector candidate-generation bounds (td-plqi)" begin
         exact = Mycelia.correct_observations(bubble_graph, [bubble_observed])
         Test.@test only(exact.paths).score >= only(result.paths).score - 1e-9
     end
+
+    # Emission exemption (PR #388 variation-safety review): the margin must prune a
+    # WRONG path (bad emission), never merely a RARE one (good emission, low full
+    # score from a coverage-driven transition penalty). This unit-tests the pruning
+    # predicate directly on hand-built frontiers so the exemption is proven
+    # deterministically, independent of any graph fixture.
+    Test.@testset "score-margin: emission clause exempts read-consistent states" begin
+        Margin = 20.0
+        # Three states at one depth. `best` sets both the best full score (0.0) and
+        # best emission (0.0). `rare` is 25 nats below on FULL score (a large
+        # coverage/transition penalty) but only 1 nat below on EMISSION (the read
+        # genuinely supports it) — the real-but-rare-allele signature. `junk` is far
+        # below on BOTH axes (read-inconsistent).
+        scores = Dict(:best => 0.0, :rare => -25.0, :junk => -25.0)
+        emissions = Dict(:best => 0.0, :rare => -1.0, :junk => -25.0)
+        predecessors = Dict(:best => :p, :rare => :p, :junk => :p)
+        kept, kept_pred, kept_em = Mycelia._prune_correction_beam_by_margin(
+            scores, predecessors, emissions, 0.0, 0.0, Margin)
+        # rare is exempt (emission within Δ) despite full score >Δ below best.
+        Test.@test haskey(kept, :best)
+        Test.@test haskey(kept, :rare)
+        # junk is >Δ below on BOTH axes -> pruned.
+        Test.@test !haskey(kept, :junk)
+        # Companion dicts stay aligned to the survivors.
+        Test.@test keys(kept) == keys(kept_em)
+        Test.@test haskey(kept_pred, :rare)
+        # A full-score-ONLY margin would have dropped `rare` (25 > 20 below best full
+        # score); the emission clause is what saves it. Assert that contrast so a
+        # regression to full-score-only pruning fails here.
+        Test.@test scores[:rare] < 0.0 - Margin      # would fail a full-only threshold
+        Test.@test emissions[:rare] >= 0.0 - Margin  # but passes on emission
+    end
+
+    Test.@testset "score-margin: Inf margin is an exact no-op" begin
+        scores = Dict(:a => 0.0, :b => -100.0)
+        emissions = Dict(:a => 0.0, :b => -100.0)
+        predecessors = Dict(:a => :p, :b => :p)
+        kept, _, kept_em = Mycelia._prune_correction_beam_by_margin(
+            scores, predecessors, emissions, 0.0, 0.0, Inf)
+        Test.@test kept == scores              # nothing dropped
+        Test.@test kept_em == emissions
+    end
 end


### PR DESCRIPTION
## Summary

Fixes the true 48 kb speed residual in the `:scalable` corrector: the per-read Viterbi **decode**, which #386 measured as 83% of the 48 kb wall and the dominant super-linear (alpha ~1.5) term.

**The diagnosis was empirically redirected.** The bead hypothesis was that candidate *generation* scales with per-state graph branching. Direct measurement on the real corrector graphs disproved this: per-state out-degree is structurally **<= 4** (the four DNA next-bases) at every k-rung and never grows with genome, so a top-B successor bound is a strict no-op on DNA. The measured driver is instead the **retained frontier at the dense intermediate k-rung (k=9)**: the width-256 beam retains ~220 states per depth, but only ~2-3 are within 20 log-prob of the best — the other ~220 are astronomically improbable states that can never win the ML path, yet each one still generates and emission-scores successors every depth, so per-depth generation climbs toward the width cap as the graph densifies.

## What changed

Two candidate-generation bounds added to `ViterbiCorrectionConfig`. Both default to a strict no-op (exact ML) and are opted into by the `:scalable` tier **only where the width beam is already finite** (approximate) — so exact-ML reads (`beam_width == typemax`) stay byte-identical:

- **`beam_score_margin`** (Δ log-prob "histogram" beam) — keep only the near-best band, which does *not* grow with genome. This is the term that removes the super-linearity.
- **`max_successors_per_state`** (top-B) — per-state successor cap; a no-op on DNA (out-degree <= 4), a robustness guard for pathological high-branching / non-DNA inputs. Included for parity with the bead's requested mechanism.

Scope: `src/viterbi-next.jl` (frontier engine), `src/iterative-assembly.jl` (corrector wiring), `test/4_assembly/viterbi_beam_pruning_test.jl` (+20 tests).

## Measured payoff (#386 harness, 5/10/20 kb, same session)

| metric @ 20 kb | before | after | speedup |
| --- | --- | --- | --- |
| per-read decode (C5*) | 391.7s | 27.5s | **14.2x** |
| total wall | 472.1s | 70.5s | **6.7x** |
| frontier engine C5b | 160.8s | 1.9s | 84x |
| decode setup C5e | 213.5s | 4.7s | 45x |

The AUTO-VERDICT dominant super-linear component moves from **per-read decode (83% of wall)** to **build_qualmer_graph (34%)** — the decode is no longer the bottleneck. The residual decode alpha is now set by the soft-EM competing-paths term (C5c, a separate mechanism, td-e70t), the next driver — out of scope here.

## Quality preserved (validated, not asserted)

- variation-preservation holdout **24/24** (both alleles retained, error removed)
- toy sweep: 1 kb reference k-mer recall **identical** (92.04%, same 902 true k-mers) with fewer spurious (15 vs 28); 3 kb recall **higher** (98.36% vs 97.52%) with far fewer spurious (26 vs 90)
- 20 kb assembly **cleaner**: 25 vs 44 contigs, longer max contig (14769 vs 13529)
- output is *not* byte-identical on the toy sweep — the change removes improbable junk paths, yielding equal-or-better recall and more contiguous assemblies

## Test Plan

- [x] `variation_preservation_holdout_test.jl` — 24/24
- [x] `viterbi_beam_pruning_test.jl` — 23 existing + 20 new (td-plqi) 
- [x] `scalable_corrector_strategy_test.jl` — 40/40
- [x] `scalable_corrector_hard_window_test.jl` — 92/92
- [x] `iterative_assembly_tests.jl` — 196/196
- [x] #386 empirical harness re-run (before/after, above)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added more controllable Viterbi correction behavior for bounded beam decoding, including limits on per-state candidate expansion and a score-margin pruning option.

* **Bug Fixes**
  * Improved correction stability in dense graphs so rare valid paths are less likely to be pruned too aggressively.
  * Preserved exact decoding behavior when using an unlimited beam, with no change to existing results in that mode.

* **Tests**
  * Added coverage for bounded-beam pruning, margin-based pruning, and rare-allele retention scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->