### PR TITLE
fix: corrector polish — UTF-8 Viterbi emission + disable-able pruner size cap

### DIFF
--- a/src/rhizomorph/algorithms/simplification.jl
+++ b/src/rhizomorph/algorithms/simplification.jl
@@ -1451,13 +1451,33 @@ re-uses real sequence content. Span is estimated as `n_vertices + k - 1` (the
 length of a linear k-mer chain), an over-estimate for branchy components, which
 only makes the size cap MORE conservative.
 
+The two SAFETY proofs are the coverage floor (`<= max_component_support`) and the
+real-sequence guard (no shared canonical k-mer with a `>= min_real_support`
+vertex). The size cap is a separate, OPTIONAL conservatism knob whose only job is
+to spare a large but shallow island that might be a genuinely under-sequenced
+real replicon; pass `max_component_length = nothing` to disable it and prune
+large provably-error islands too (td-byva). Disabling the size cap never weakens
+the two safety proofs — a well-supported or real-content-sharing component is
+retained regardless of span.
+
+# Empirical scope note (td-byva, 10-48 kb toy genomes at 20x illumina)
+This pass removes only SEPARATE components; on the corrector's final k=21 graph at
+these scales the corrected read graph is typically a SINGLE connected component
+(0-2 disconnected islands), and the residual debris-contig count is dominated by
+WITHIN-main-component branch fragmentation (find_contigs breaks a unitig at every
+branch vertex), which is out of this pass's scope. When disconnected islands do
+occur they are usually at real-sequence coverage (correctly retained by the
+coverage floor). Extending this pass therefore cannot, by construction, reduce
+within-component fragmentation; the `max_component_length = nothing` opt-in only
+widens reach over genuine large disconnected error islands.
+
 # Returns
 - `(; removed::Int, components_pruned::Int)`: vertices removed and components
   pruned.
 """
 function prune_disconnected_error_components!(graph::MetaGraphsNext.MetaGraph;
         k::Int,
-        max_component_length::Int = 2000,
+        max_component_length::Union{Int, Nothing} = 2000,
         max_component_support::Real = 2,
         min_real_support::Real = 3)
     labels = collect(MetaGraphsNext.labels(graph))
@@ -1489,8 +1509,20 @@ function prune_disconnected_error_components!(graph::MetaGraphsNext.MetaGraph;
     components_pruned = 0
     for (ci, comp) in enumerate(components)
         ci == main_idx && continue
-        span = length(comp) + k - 1
-        span <= max_component_length || continue
+        # Size gate: an OPTIONAL conservatism knob (not one of the two safety
+        # proofs). Its sole job is to spare a LARGE low-coverage island that might
+        # be a genuinely under-sequenced real replicon (a real plasmid/segment can
+        # be big yet shallow). `max_component_length === nothing` disables it, for
+        # callers that know their input carries no low-coverage real replicon
+        # (e.g. single high-coverage isolate) and want large error islands pruned.
+        # The coverage floor and the real-sequence guard below remain binding
+        # either way, so disabling the span gate never removes real sequence that
+        # is well-supported OR shares canonical k-mer content with supported
+        # sequence — it only widens the reach over provably-error debris.
+        if max_component_length !== nothing
+            span = length(comp) + k - 1
+            span <= max_component_length || continue
+        end
         all(v -> _vertex_support(graph, v) <= max_component_support, comp) || continue
 
         comp_kmers = Set{String}()
@@ -1532,7 +1564,11 @@ td-h6w9 variation-preservation invariant is enforced by
 - `min_real_support::Real=3`: min mean coverage the surviving sibling must have.
 - `max_bubble_length::Int=100`: max branch trace length for bubble detection.
 - `max_rounds::Int=10`: max tip-clipping rounds per invocation.
-- `max_component_length::Int=2000`: max span of a prunable disconnected component.
+- `max_component_length::Union{Int,Nothing}=2000`: max span of a prunable
+  disconnected component, or `nothing` to disable the span gate and prune large
+  provably-error islands too (the coverage floor + real-sequence guard stay
+  binding). Default retains large shallow islands as possible under-sequenced
+  real replicons.
 - `max_component_support::Real=2`: max per-vertex coverage in a prunable component.
 
 # Returns
@@ -1551,7 +1587,7 @@ function clean_corrector_graph!(graph::MetaGraphsNext.MetaGraph;
         max_bubble_length::Int = 100,
         max_rounds::Int = 10,
         max_outer_rounds::Int = 5,
-        max_component_length::Int = 2000,
+        max_component_length::Union{Int, Nothing} = 2000,
         max_component_support::Real = 2)
     n_before = length(collect(MetaGraphsNext.labels(graph)))
     tip_max_length = max(1, tip_length_multiple * k)

--- a/src/viterbi-next.jl
+++ b/src/viterbi-next.jl
@@ -26,7 +26,15 @@ function default_viterbi_emission_logp(
 
     quality_scores = _normalize_viterbi_quality_scores(quality)
     alphabet_size = _viterbi_alphabet_size(resolved_alphabet)
-    shared = min(length(observed), length(expected))
+    # Compare by CHARACTER, not byte. `length`/`getindex` on a String count
+    # characters vs. address bytes respectively, so `observed[index]` throws a
+    # `StringIndexError` on any multibyte UTF-8 unit (e.g. the SentencePiece
+    # U+2581 word-boundary marker, accented letters, emoji). Materializing to
+    # `Vector{Char}` makes positional indexing character-aware for arbitrary
+    # Unicode tokens while keeping the O(n) scan.
+    observed_chars = collect(observed)
+    expected_chars = collect(expected)
+    shared = min(length(observed_chars), length(expected_chars))
 
     logp = 0.0
     for index in 1:shared
@@ -35,14 +43,14 @@ function default_viterbi_emission_logp(
             index,
             error_rate
         )
-        if observed[index] == expected[index]
+        if observed_chars[index] == expected_chars[index]
             logp += log1p(-position_error_rate)
         else
             logp += log(position_error_rate / (alphabet_size - 1))
         end
     end
 
-    for index in (shared + 1):max(length(observed), length(expected))
+    for index in (shared + 1):max(length(observed_chars), length(expected_chars))
         position_error_rate = _viterbi_position_error_rate(
             quality_scores,
             index,
@@ -1625,10 +1633,15 @@ function _decoded_path_labels(
 end
 
 function _hamming_like_distance(left::AbstractString, right::AbstractString)::Int
-    shared = min(length(left), length(right))
-    distance = abs(length(left) - length(right))
+    # Character-aware indexing (see `default_viterbi_emission_logp`): byte offsets
+    # into a multibyte UTF-8 string throw `StringIndexError`, so iterate the
+    # decoded `Char`s to keep the distance well-defined for arbitrary Unicode.
+    left_chars = collect(left)
+    right_chars = collect(right)
+    shared = min(length(left_chars), length(right_chars))
+    distance = abs(length(left_chars) - length(right_chars))
     for index in 1:shared
-        distance += left[index] == right[index] ? 0 : 1
+        distance += left_chars[index] == right_chars[index] ? 0 : 1
     end
     return distance
 end

--- a/test/4_assembly/corrector_graph_cleanup_test.jl
+++ b/test/4_assembly/corrector_graph_cleanup_test.jl
@@ -290,4 +290,109 @@ Test.@testset "corrector graph cleanup primitives (td-969e)" begin
         Test.@test !haskey(graph, island_kmer)                        # island gone
         Test.@test all(kmref -> haskey(graph, kmref), backbone_kmers) # backbone intact
     end
+
+    # ------------------------------------------------------------------
+    # Size-cap opt-out (td-byva): a LARGE (span > default 2000) uniformly
+    # coverage-1 disconnected island sharing no real k-mer content is genuine
+    # error debris, but the default size cap RETAINS it (it might be an under-
+    # sequenced real replicon). `max_component_length = nothing` disables that
+    # conservatism knob so the island is pruned — while the coverage floor and
+    # real-sequence guard stay binding (proved by the two follow-on cases).
+    # ------------------------------------------------------------------
+    # A larger k for the large-island cases so a ~2050 bp random sequence has
+    # (w.h.p.) all-unique k-mers -> uniform coverage 1, no internal repeat that
+    # would spuriously raise a vertex above the coverage floor. span at k=kk is
+    # (n_vertices + kk - 1) ~= 2050 > the default 2000 cap.
+    kk = 21
+    Test.@testset "prune: large coverage-1 island retained by default cap, pruned when disabled" begin
+        rng = Random.MersenneTwister(202)
+        # Main genome must be LARGER than the island so argmax(component length)
+        # keeps the island a prune CANDIDATE (not the retained main component).
+        backbone = _cgc_backbone(rng, 3000)               # main genome, coverage 10
+        # ~2050 bp error island => span > 2000, coverage 1, shares NO k-mer with
+        # the backbone.
+        big_island = _cgc_backbone(Random.MersenneTwister(30303), 2050)
+        base_reads = FASTX.FASTA.Record[]
+        for i in 1:10
+            push!(base_reads, _cgc_fasta("main$i", backbone))
+        end
+        push!(base_reads, _cgc_fasta("big_island", big_island))
+        island_kmer = Kmers.DNAKmer{kk}(big_island[100:(100 + kk - 1)])
+        backbone_kmers = [Kmers.DNAKmer{kk}(backbone[i:(i + kk - 1)])
+                          for i in 1:(length(backbone) - kk + 1)]
+
+        # DEFAULT cap: the large island is above the span cap -> RETAINED.
+        graph_default = _CGC.build_kmer_graph(base_reads, kk;
+            dataset_id = "t", mode = :singlestrand)
+        Test.@test _cgc_cov(graph_default, island_kmer) == 1
+        res_default = _CGC.prune_disconnected_error_components!(graph_default; k = kk,
+            max_component_support = 2, min_real_support = 3)
+        Test.@test res_default.components_pruned == 0
+        Test.@test haskey(graph_default, island_kmer)                 # retained by size cap
+
+        # DISABLED cap: coverage floor + guard both pass for this error island,
+        # so with the span gate off it is pruned; the backbone is untouched.
+        graph_nocap = _CGC.build_kmer_graph(base_reads, kk;
+            dataset_id = "t", mode = :singlestrand)
+        res_nocap = _CGC.prune_disconnected_error_components!(graph_nocap; k = kk,
+            max_component_length = nothing,
+            max_component_support = 2, min_real_support = 3)
+        Test.@test res_nocap.components_pruned >= 1
+        Test.@test res_nocap.removed >= 1
+        Test.@test !haskey(graph_nocap, island_kmer)                  # error island removed
+        Test.@test all(kmref -> haskey(graph_nocap, kmref), backbone_kmers)
+    end
+
+    Test.@testset "prune: cap disabled STILL retains large high-coverage disconnected genome" begin
+        rng = Random.MersenneTwister(303)
+        # Main genome larger than the second so the second stays a prune CANDIDATE
+        # and its retention is genuinely due to the coverage floor.
+        backbone = _cgc_backbone(rng, 3000)               # main component
+        # A large SECOND real genome (~2050 bp), disconnected but well-supported
+        # (coverage 10). The coverage floor must retain it even with the span gate
+        # off -> disabling the cap does NOT weaken the coverage-floor safety proof.
+        second = _cgc_backbone(Random.MersenneTwister(40404), 2050)
+        reads = FASTX.FASTA.Record[]
+        for i in 1:10
+            push!(reads, _cgc_fasta("main$i", backbone))
+            push!(reads, _cgc_fasta("second$i", second))
+        end
+        graph = _CGC.build_kmer_graph(reads, kk; dataset_id = "t", mode = :singlestrand)
+        second_kmer = Kmers.DNAKmer{kk}(second[100:(100 + kk - 1)])
+        Test.@test _cgc_cov(graph, second_kmer) == 10
+
+        res = _CGC.prune_disconnected_error_components!(graph; k = kk,
+            max_component_length = nothing,
+            max_component_support = 2, min_real_support = 3)
+
+        Test.@test res.components_pruned == 0
+        Test.@test haskey(graph, second_kmer)             # well-supported genome kept
+    end
+
+    Test.@testset "prune: cap disabled STILL retains large real-content-sharing island (guard)" begin
+        rng = Random.MersenneTwister(404)
+        backbone = _cgc_backbone(rng, 2100)               # large main genome, coverage 10
+        # A large coverage-1 read that is the REVERSE COMPLEMENT of a backbone
+        # segment: distinct singlestrand vertices (separate component) whose
+        # CANONICAL k-mers match the backbone. The real-sequence guard must retain
+        # it even with the span gate off -> disabling the cap does NOT weaken the
+        # real-sequence guard.
+        rc_segment = _cgc_rc(backbone[1:2050])
+        reads = FASTX.FASTA.Record[]
+        for i in 1:10
+            push!(reads, _cgc_fasta("main$i", backbone))
+        end
+        push!(reads, _cgc_fasta("rc", rc_segment))
+        graph = _CGC.build_kmer_graph(reads, kk; dataset_id = "t", mode = :singlestrand)
+        rc_kmer = Kmers.DNAKmer{kk}(rc_segment[100:(100 + kk - 1)])
+        Test.@test haskey(graph, rc_kmer)
+        Test.@test _cgc_cov(graph, rc_kmer) == 1          # low coverage, but real content
+
+        res = _CGC.prune_disconnected_error_components!(graph; k = kk,
+            max_component_length = nothing,
+            max_component_support = 2, min_real_support = 3)
+
+        Test.@test res.components_pruned == 0             # guard binding despite no size cap
+        Test.@test haskey(graph, rc_kmer)
+    end
 end

--- a/test/4_assembly/viterbi_sentencepiece_correction_test.jl
+++ b/test/4_assembly/viterbi_sentencepiece_correction_test.jl
@@ -24,21 +24,21 @@
 # `correct_observations` unchanged — NO core (viterbi-next.jl) or
 # string-graphs.jl edge-data fix was needed.
 #
-# Finding 2 (follow-on, do NOT fix here — viterbi-next.jl is owned elsewhere):
-# the TEXT emission model in viterbi-next.jl indexes token strings by BYTE, so a
-# token containing a multibyte UTF-8 character throws `StringIndexError`. Real
-# SentencePiece emits the U+2581 ("▁", 3 bytes) word-boundary marker on
-# word-initial pieces, so a raw token graph built from unstripped pieces trips
-# this. The gated leg below strips U+2581 before graph construction as a
-# workaround; a proper fix (character-aware indexing in the emission model)
-# belongs in the correction-core track.
+# Finding 2 (RESOLVED, td-oj72): the TEXT emission model in viterbi-next.jl used
+# to index token strings by BYTE, so a token containing a multibyte UTF-8
+# character threw `StringIndexError`. Real SentencePiece emits the U+2581 ("▁",
+# 3 bytes) word-boundary marker on word-initial pieces, tripping this on raw
+# token graphs. The emission model (and `_hamming_like_distance`) now index by
+# CHARACTER, so unstripped multibyte pieces correct end-to-end — see the
+# "multibyte UTF-8 tokens correct" always-on testset below. The gated leg still
+# strips U+2581 for a clean word-model vocabulary, not because it must.
 
 import Mycelia
 import Test
 
-# SentencePiece prints this 3-byte marker before word-initial pieces; stripped
-# for the correction path because the TEXT emission model is byte-indexed (see
-# Finding 2 in the header).
+# SentencePiece prints this 3-byte marker before word-initial pieces. The
+# correction path now handles it natively (see Finding 2 in the header); the
+# gated leg still strips it only for a cleaner word-model vocabulary.
 const _SP_WORD_BOUNDARY = "▁"
 
 function _sp_decoded_labels(result::Mycelia.ViterbiCorrectionResult)::Vector{String}
@@ -77,6 +77,47 @@ Test.@testset "SentencePiece token-graph Viterbi correction" begin
         # The corrupted token is restored to "brown".
         Test.@test _sp_decoded_labels(result) ==
                    ["the", "quick", "brown", "fox", "jumps"]
+    end
+
+    Test.@testset "multibyte UTF-8 tokens correct (U+2581 boundary marker)" begin
+        # Regression for the byte-indexed TEXT emission model (former Finding 2):
+        # tokens carrying the raw SentencePiece U+2581 ("▁", 3 bytes) word-
+        # boundary marker previously threw `StringIndexError` because the emission
+        # model indexed token strings by byte. The corrector now indexes by
+        # character, so unstripped multibyte pieces correct end-to-end.
+        token_sequences = [
+            ["▁the", "▁quick", "▁brown", "▁fox", "▁jumps"],
+            ["▁the", "▁lazy", "▁brown", "▁dog", "▁sleeps"],
+        ]
+        graph = Mycelia.Rhizomorph.build_token_graph(
+            token_sequences; dataset_id = "sp_unicode_tokens"
+        )
+
+        # Corrupt exactly ONE interior token with a same-length (same character
+        # count) substitution that is off-graph: "▁brown" -> "▁brawn". The marker
+        # itself stays intact, exercising the multibyte code path in emission
+        # scoring for every position.
+        observed = ["▁the", "▁quick", "▁brawn", "▁fox", "▁jumps"]
+        result = Mycelia.correct_observations(graph, [observed])
+
+        Test.@test result.diagnostics[:alphabet] == :TEXT
+        Test.@test _sp_decoded_labels(result) ==
+                   ["▁the", "▁quick", "▁brown", "▁fox", "▁jumps"]
+
+        # A second alphabet: accented Latin + emoji, to confirm the fix is not
+        # specific to U+2581. Same-length off-graph corruption of an interior
+        # token restores to the supported graph token.
+        emoji_sequences = [
+            ["café", "☕", "☀️", "π"],
+            ["café", "☕", "🌙", "π"],
+        ]
+        emoji_graph = Mycelia.Rhizomorph.build_token_graph(
+            emoji_sequences; dataset_id = "sp_emoji_tokens"
+        )
+        emoji_observed = ["café", "☕", "☀️", "ρ"]
+        emoji_result = Mycelia.correct_observations(emoji_graph, [emoji_observed])
+        Test.@test emoji_result.diagnostics[:alphabet] == :TEXT
+        Test.@test _sp_decoded_labels(emoji_result) == ["café", "☕", "☀️", "π"]
     end
 
     Test.@testset "TEXT token graph rejects reverse-complement strand modes" begin
@@ -127,8 +168,9 @@ Test.@testset "SentencePiece token-graph Viterbi correction" begin
                     output_format = :pieces
                 )
                 Test.@test encoded isa Vector{Vector{String}}
-                # Strip the U+2581 word-boundary marker: the TEXT emission model
-                # is byte-indexed and throws on multibyte pieces (Finding 2).
+                # Strip the U+2581 word-boundary marker for a clean word-model
+                # vocabulary. The corrector handles multibyte pieces natively
+                # now (Finding 2 resolved); stripping is a vocabulary choice.
                 token_sequences = [
                     [replace(piece, _SP_WORD_BOUNDARY => "") for piece in pieces]
                     for pieces in encoded


### PR DESCRIPTION
Two small, guard-preserving corrector fixes. Do not merge without review.

## FIX 1 — UTF-8-safe Viterbi TEXT emission (td-oj72)
`default_viterbi_emission_logp` and `_hamming_like_distance` in `src/viterbi-next.jl` indexed token strings by **byte** while iterating over **character** counts, throwing `StringIndexError` on any multibyte UTF-8 unit — the SentencePiece U+2581 word-boundary marker, accented letters, emoji. Both now materialize to `Vector{Char}` for character-aware positional indexing.

- New always-on regression testset in `viterbi_sentencepiece_correction_test.jl`: U+2581-prefixed tokens and an accented/emoji token set correct end-to-end.
- Stale "byte-indexed, throws" notes updated to reflect the resolved core fix.

## FIX 2 — disable-able disconnected-component size cap (td-byva)
`prune_disconnected_error_components!` / `clean_corrector_graph!` now accept `max_component_length = nothing` to disable the span gate, widening reach over large provably-error disconnected islands. The two **safety proofs** — the coverage floor and the real-sequence canonical-k-mer guard — remain binding, so disabling the cap never removes well-supported or real-content-sharing sequence. The **default stays 2000** (fully conservative), sparing large-but-shallow islands as possible under-sequenced replicons.

### Empirical investigation (10 / 20 / 48 kb toy genomes, 20x illumina)
Before/after debris-contig profiling of the real `:iterative`/`:scalable` corrector:

| genome | contigs | max contig | disconnected components |
| ------ | ------- | ---------- | ----------------------- |
| 10 kb  | 15      | 5361 bp    | 3 (2 non-main, both coverage-12 → correctly retained) |
| 20 kb  | 28      | 13513 bp   | **1 (single component)** |
| 48 kb  | 44      | 39904 bp   | **1 (single component)** |

Finding: at 20/48 kb the corrected k=21 graph is a **single connected component**, so the disconnected-component pruner is a no-op there. The ~43 debris contigs at 48 kb are dominated by **within-main-component branch fragmentation** (tiny 28–112 bp unitig fragments broken at residual branch vertices), which this pass cannot address by construction. The few disconnected islands that do occur (10 kb) are at real-sequence coverage and correctly retained. All three pruner gates are load-bearing for the genomics use case (viral quasispecies / rare disconnected strains), so the coverage floor and guard were left untouched; the safe, guard-preserving lever is the opt-in size-cap disable.

## Tests
- `corrector_graph_cleanup_test.jl`: 56/56 (10 new assertions — large coverage-1 island retained by default cap / pruned when disabled; cap-disabled still retains high-coverage genome and RC real-content island).
- `simplification_test.jl`: 226/226.
- Holdouts unchanged (default path untouched): variation-preservation 12/12, SKEWED-variant 12/12, DENSE-regime rare-allele 16/16.
- FIX 1: `viterbi_sentencepiece_correction` 12/12 (+1 skip), `viterbi_alphabet_correction` 13/13, `viterbi_cross_product_correction` 171/171.

## Scope
Touches only `src/viterbi-next.jl`, `src/rhizomorph/algorithms/simplification.jl`, and their tests. Does not touch `iterative-assembly.jl` or `evidence-functions.jl`.