### PR TITLE
perf: bound soft-EM competing-path generation to remove C5c super-linearity (td-e70t)

### DIFF
--- a/benchmarking/softem_competing_paths_micro.jl
+++ b/benchmarking/softem_competing_paths_micro.jl
@@ -1,0 +1,97 @@
+# Focused micro-benchmark isolating the soft-EM competing-paths E-step (C5c,
+# td-e70t) and its scaling with graph size. Builds a canonical qualmer graph at
+# the dense k=9 rung from simulated reads at increasing genome sizes, then times
+# `accumulate_competing_paths!` over all reads (the exact per-read E-step the
+# :scalable corrector runs). Reports per-size seconds + a log-log alpha so the
+# super-linear residual is visible in isolation (no full corrector run needed).
+#
+# Run: LD_LIBRARY_PATH='' ~/.juliaup/bin/julia --project=. benchmarking/softem_competing_paths_micro.jl
+
+import Mycelia
+import FASTX
+import BioSequences
+import Random
+
+const READLEN  = 150
+const COVERAGE = 20.0
+const ERR_RATE = 0.01
+const K        = parse(Int, get(ENV, "SEM_K", "9"))
+const SEED     = 42
+const SIZES    = [parse(Int, s) for s in split(get(ENV, "SEM_SIZES", "5000,10000,20000"), ",")]
+const REPEATS  = parse(Int, get(ENV, "SEM_REPEATS", "3"))
+
+function simulate_reads(refseq, readlen, coverage, error_rate, rng)
+    glen = length(refseq)
+    effective_readlen = min(readlen, glen)
+    n_reads = max(1, ceil(Int, coverage * glen / effective_readlen))
+    records = FASTX.FASTQ.Record[]
+    for i in 1:n_reads
+        start = glen == effective_readlen ? 1 : rand(rng, 1:(glen - effective_readlen + 1))
+        frag = refseq[start:(start + effective_readlen - 1)]
+        rand(rng, Bool) && (frag = BioSequences.reverse_complement(frag))
+        obs_seq, quals = Mycelia.observe(frag; error_rate = error_rate, tech = :illumina)
+        isempty(obs_seq) && continue
+        qstr = String([Char(q + 33) for q in quals])
+        push!(records, FASTX.FASTQ.Record("read_$(i)", string(obs_seq), qstr))
+    end
+    return records
+end
+
+function build_fixture(glen)
+    rng = Random.MersenneTwister(SEED)
+    ref_rec = Mycelia.random_fasta_record(moltype = :DNA, seed = SEED, L = glen)
+    refseq = FASTX.sequence(BioSequences.LongDNA{4}, ref_rec)
+    reads = simulate_reads(refseq, READLEN, COVERAGE, ERR_RATE, rng)
+    return reads
+end
+
+# Time the E-step over all reads: mirrors the pipeline's per-read
+# `accumulate_competing_paths!` call, using a fresh accumulator each repeat.
+# `band`/`bound` typemax => unbounded (pre-fix behavior); finite => bounded fix.
+function time_estep(reads, graph, k, band, bound)
+    best = Inf
+    for _ in 1:REPEATS
+        acc = Mycelia.Rhizomorph.SoftEdgeWeightAccumulator()
+        t = @elapsed for r in reads
+            Mycelia.accumulate_competing_paths!(
+                acc, r, graph, k; graph_mode = :canonical,
+                walk_band = band, successor_bound = bound)
+        end
+        best = min(best, t)
+    end
+    return best
+end
+
+function report_alpha(label, secs)
+    xs = log.(Float64.(SIZES)); ys = log.(secs)
+    xbar = sum(xs)/length(xs); ybar = sum(ys)/length(ys)
+    alpha = sum((xs .- xbar) .* (ys .- ybar)) / sum((xs .- xbar).^2)
+    alpha_lg = (ys[end] - ys[end-1]) / (xs[end] - xs[end-1])
+    println("$(label): alpha(loglog)=$(round(alpha, digits=3))  alpha_large=$(round(alpha_lg, digits=3))")
+end
+
+function main()
+    band = Mycelia._soft_em_walk_band(K)
+    bound = Mycelia._SOFT_EM_ALT_SUCCESSOR_BOUND
+    println("soft-EM competing-paths micro-benchmark (C5c isolation, k=$(K), band=$(band), succ_bound=$(bound))")
+    println("size_bp\tnreads\tnvert\tbefore_s\tafter_s\tspeedup")
+    before = Float64[]; after = Float64[]
+    for glen in SIZES
+        reads = build_fixture(glen)
+        graph = Mycelia.Rhizomorph.build_qualmer_graph(reads, K; mode = :canonical)
+        nv = length(collect(Mycelia.MetaGraphsNext.labels(graph)))
+        # warmup (compile both paths)
+        Mycelia.accumulate_competing_paths!(
+            Mycelia.Rhizomorph.SoftEdgeWeightAccumulator(), reads[1], graph, K;
+            graph_mode = :canonical, walk_band = band, successor_bound = bound)
+        tb = time_estep(reads, graph, K, typemax(Int), typemax(Int))
+        ta = time_estep(reads, graph, K, band, bound)
+        push!(before, tb); push!(after, ta)
+        println("$(glen)\t$(length(reads))\t$(nv)\t$(round(tb, digits=4))\t$(round(ta, digits=4))\t$(round(tb/ta, digits=2))x")
+    end
+    length(SIZES) >= 2 || return
+    report_alpha("BEFORE (unbounded)", before)
+    report_alpha("AFTER  (bounded)  ", after)
+end
+
+main()

--- a/src/iterative-assembly.jl
+++ b/src/iterative-assembly.jl
@@ -2564,8 +2564,16 @@ function try_viterbi_path_improvement(read::FASTX.FASTQ.Record,
         # alternative exists (a balanced variant, whose branches are retained
         # through their own reads).
         if soft_weights !== nothing
+            # Bound the competing-path GENERATION with the same discipline as the
+            # decode bounds above (td-e70t speed residual C5c): engage the walk band
+            # + successor cap ONLY where the width beam is already finite (the
+            # dense/large reads that carry the residual), so exact-ML reads keep the
+            # unbounded (byte-identical) generation. The rejoin test precedes the
+            # band cutoff, so no real variant's read-consistent competing path drops.
             accumulate_competing_paths!(
-                soft_weights, read, graph, k; graph_mode = graph_mode)
+                soft_weights, read, graph, k; graph_mode = graph_mode,
+                walk_band = beam_is_exact ? typemax(Int) : _soft_em_walk_band(k),
+                successor_bound = beam_is_exact ? typemax(Int) : _SOFT_EM_ALT_SUCCESSOR_BOUND)
         end
 
         corrected_sequence = Mycelia.Rhizomorph.path_to_sequence(corrected_path, graph)
@@ -2966,13 +2974,127 @@ function _path_transition_logscore(labels, graph)
     return total
 end
 
+# ----------------------------------------------------------------------------
+# Competing-path generation bounds (td-e70t speed residual C5c)
+# ----------------------------------------------------------------------------
+#
+# After the decode score-margin fix (#388) linearized per-read Viterbi decode,
+# the empirical profile's fastest-growing residual is the soft-EM competing-paths
+# E-step (C5c, alpha ~1.9 in isolation). The driver is the greedy re-route walk in
+# `_consensus_alternative`: it walks highest-weight edges until it rejoins the
+# read, bounded only by the read length `n`. In a large genome a k-mer de Bruijn
+# graph has many SPURIOUS k-mer repeats (chance collisions whose incident edges
+# are themselves well covered), so a greedy re-route increasingly wanders into
+# graph bulk and runs the full `n` steps WITHOUT rejoining — the per-read cost
+# climbs with graph density even though `n` is fixed, giving the super-linear
+# term. These bounds cap the generation with the SAME discipline as the decode
+# fix (top-B successors + a near-best band + a read-consistency exemption):
+#
+#   * `_soft_em_walk_band(k)` — a genome-INDEPENDENT cap on the re-route walk. A
+#     read-consistent single-variant bubble at rung k diverges for ~k k-mers
+#     before rejoining, so `_SOFT_EM_WALK_BAND_FACTOR * k` gives generous headroom
+#     for multi-base variants while never growing with genome. The rejoin test is
+#     applied BEFORE the band cutoff, so a real allele that returns to the read
+#     within the band is ALWAYS captured; the band prunes only NON-rejoining
+#     excursions, which yield no valid spliced alternative anyway. This is the
+#     term that removes the super-linearity — the analog of the decode
+#     `beam_score_margin`. A support-based test cannot substitute here: spurious-
+#     repeat edges in a large genome are themselves high-coverage, so only the
+#     rejoin-within-band criterion (read-consistency) separates a real competing
+#     allele from graph-bulk wandering. This is the emission-exemption analog:
+#     the bound removes WRONG (non-read-consistent) paths, never a real variant's
+#     read-consistent competing path.
+#
+#   * `_SOFT_EM_ALT_SUCCESSOR_BOUND` — caps the incident branches examined per step
+#     in EACH direction (out, in). A canonical DNA de Bruijn vertex has <= 4 out and
+#     <= 4 in neighbors, so both the default `typemax` and the :scalable value 8 are
+#     no-ops on DNA; it is a robustness guard bounding per-step work on pathological
+#     high-branching (non-DNA / reduced-alphabet) inputs, matching the intent of the
+#     decode `max_successors_per_state`.
+#
+# Both default to unbounded (`typemax(Int)`), reproducing the pre-td-e70t behavior
+# byte-for-byte — the default for direct/unit-test callers and the exact decode
+# tier. The `:scalable` corrector opts in ONLY where the width beam is already
+# finite (`!beam_is_exact` — the dense/large reads that carry the residual), so
+# exact-ML reads stay byte-identical, exactly like the #388 decode bounds.
+const _SOFT_EM_WALK_BAND_FACTOR = 4
+_soft_em_walk_band(k::Integer) = _SOFT_EM_WALK_BAND_FACTOR * Int(k)
+const _SOFT_EM_ALT_SUCCESSOR_BOUND = 8
+
+# Strictly-heavier sibling of the observed branch `a -> b` (excluding `b` and the
+# incoming `avoid` vertex), or `nothing` when no strictly-better sibling exists (a
+# linear region or a balanced variant — retained, not competed away). Iterates the
+# out- then in-neighbors DIRECTLY (no intermediate label vector): finding the
+# argmax is idempotent to a bidirectional neighbor appearing in both lists (same
+# label, same `_edge_weight_between` value), so no dedup pass is needed — this
+# removes the per-position allocation that dominated the C5c profile. `bound` caps
+# the neighbors examined in each direction (a per-step work guard; on a canonical
+# DNA vertex there are <= 4 each, so the default `typemax` and the :scalable 8 are
+# both no-ops), matching the decode `max_successors_per_state`.
+function _best_alternative_sibling(graph, a, b, avoid, w_ab::Float64, bound::Int)
+    best_x, best_w = nothing, w_ab
+    c = 0
+    for x in MetaGraphsNext.outneighbor_labels(graph, a)
+        c += 1
+        c > bound && break
+        (x == b || (avoid !== nothing && x == avoid)) && continue
+        w = _edge_weight_between(graph, a, x)
+        w === nothing && continue
+        w > best_w && ((best_w, best_x) = (w, x))
+    end
+    c = 0
+    for x in MetaGraphsNext.inneighbor_labels(graph, a)
+        c += 1
+        c > bound && break
+        (x == b || (avoid !== nothing && x == avoid)) && continue
+        w = _edge_weight_between(graph, a, x)
+        w === nothing && continue
+        w > best_w && ((best_w, best_x) = (w, x))
+    end
+    return best_x
+end
+
+# Highest-weight next vertex from `cur` (excluding the incoming `prev` and any
+# vertex already in `seen`), or `nothing` when the walk dead-ends. Same direct
+# out-then-in iteration (argmax idempotent to duplicates) and `bound` guard as
+# `_best_alternative_sibling`.
+function _best_next_step(graph, cur, prev, seen, bound::Int)
+    nxt, nxt_w = nothing, 0.0
+    c = 0
+    for y in MetaGraphsNext.outneighbor_labels(graph, cur)
+        c += 1
+        c > bound && break
+        (y == prev || y in seen) && continue
+        w = _edge_weight_between(graph, cur, y)
+        w === nothing && continue
+        w > nxt_w && ((nxt_w, nxt) = (w, y))
+    end
+    c = 0
+    for y in MetaGraphsNext.inneighbor_labels(graph, cur)
+        c += 1
+        c > bound && break
+        (y == prev || y in seen) && continue
+        w = _edge_weight_between(graph, cur, y)
+        w === nothing && continue
+        w > nxt_w && ((nxt_w, nxt) = (w, y))
+    end
+    return nxt
+end
+
 # Generate ONE competing alternative to `observed` by re-routing its first
 # clearly-weak branch through the highest-weight sibling and walking greedily
 # until rejoining `observed`. Returns the spliced label path, or `nothing` when
 # no weak branch exists (a linear region, or a balanced variant whose sibling is
-# not strictly better — which is retained, not competed away). Bounded by the
-# observed length so it always terminates.
-function _consensus_alternative(observed, graph)
+# not strictly better — which is retained, not competed away).
+#
+# `walk_band` caps a NON-rejoining re-route to a genome-independent number of steps
+# (see `_soft_em_walk_band`); `successor_bound` caps the incident branches examined
+# per step (see `_SOFT_EM_ALT_SUCCESSOR_BOUND`). Both default to `typemax(Int)`
+# (unbounded — the pre-td-e70t behavior). Always bounded by the observed length so
+# it terminates regardless.
+function _consensus_alternative(observed, graph;
+        walk_band::Int = typemax(Int),
+        successor_bound::Int = typemax(Int))
     n = length(observed)
     n < 3 && return nothing
     firstpos = Dict{Any, Int}()
@@ -2983,41 +3105,34 @@ function _consensus_alternative(observed, graph)
         a, b = observed[i], observed[i + 1]
         w_ab = _edge_weight_between(graph, a, b)
         w_ab === nothing && continue
-        best_x, best_w = nothing, w_ab
-        for x in _incident_labels(graph, a)
-            x == b && continue
-            (i > 1 && x == observed[i - 1]) && continue
-            wx = _edge_weight_between(graph, a, x)
-            wx === nothing && continue
-            if wx > best_w
-                best_w, best_x = wx, x
-            end
-        end
+        best_x = _best_alternative_sibling(
+            graph, a, b, i > 1 ? observed[i - 1] : nothing, w_ab, successor_bound)
         best_x === nothing && continue   # no strictly-better sibling ⇒ not weak
         # Greedy highest-weight walk from the sibling until we rejoin `observed`
-        # at or after position i+1.
+        # at or after position i+1. `seen` is a Set so the membership test is O(1)
+        # rather than O(length(mid)) (removes a hidden per-step super-linear term).
         mid = Any[best_x]
+        seen = Set{Any}(mid)
         prev, cur = a, best_x
         rejoin = get(firstpos, best_x, 0) >= i + 1 ? firstpos[best_x] : 0
         steps = 0
         while rejoin == 0 && steps < n
             steps += 1
-            nxt, nxt_w = nothing, 0.0
-            for y in _incident_labels(graph, cur)
-                y == prev && continue
-                y in mid && continue
-                wy = _edge_weight_between(graph, cur, y)
-                wy === nothing && continue
-                if wy > nxt_w
-                    nxt_w, nxt = wy, y
-                end
-            end
+            nxt = _best_next_step(graph, cur, prev, seen, successor_bound)
             nxt === nothing && break
+            # Rejoin is tested BEFORE the band cutoff: a read-consistent competing
+            # allele that returns to the observed path (at/after i+1) is always
+            # captured, so the band never drops a real variant's competing path.
             if get(firstpos, nxt, 0) >= i + 1
                 rejoin = firstpos[nxt]
                 break
             end
+            # Band cutoff (genome-independent): beyond `walk_band` non-rejoining
+            # steps the walk is threading spurious k-mer repeats / graph bulk, not a
+            # competing allele — abandon it (yields no valid rejoined splice anyway).
+            steps >= walk_band && break
             push!(mid, nxt)
+            push!(seen, nxt)
             prev, cur = cur, nxt
         end
         if rejoin >= i + 1
@@ -3028,7 +3143,8 @@ function _consensus_alternative(observed, graph)
 end
 
 """
-    accumulate_competing_paths!(accumulator, read, graph, k; graph_mode) -> accumulator
+    accumulate_competing_paths!(accumulator, read, graph, k; graph_mode,
+        walk_band, successor_bound) -> accumulator
 
 Soft-EM v2 competing-paths E-step for ONE read (td-e70t). Builds the read's
 COMPETING candidate paths — the observed read path and (when the observed path
@@ -3048,19 +3164,31 @@ supported edges are held at raw and only unsupported (error) edges decay. A
 balanced variant produces no strictly-better sibling, so no alternative is
 generated and the observed path keeps responsibility 1.0. Never throws (guarded),
 so the decode is always safe.
+
+`walk_band` / `successor_bound` bound the alternative GENERATION (td-e70t speed
+residual C5c): `walk_band` caps a non-rejoining re-route to a genome-independent
+number of steps and `successor_bound` caps the incident branches examined per step
+(see `_soft_em_walk_band` / `_SOFT_EM_ALT_SUCCESSOR_BOUND`). Both default to
+`typemax(Int)` (unbounded — byte-identical to the pre-bound behavior); the
+`:scalable` corrector passes finite bounds only where the width beam is already
+finite, so exact-ML reads are unchanged and no real variant's read-consistent
+competing path is dropped (the rejoin test precedes the band cutoff).
 """
 function accumulate_competing_paths!(
         accumulator::Mycelia.Rhizomorph.SoftEdgeWeightAccumulator,
         read::FASTX.FASTQ.Record,
         graph,
         k::Int;
-        graph_mode::Symbol = :canonical
+        graph_mode::Symbol = :canonical,
+        walk_band::Int = typemax(Int),
+        successor_bound::Int = typemax(Int)
 )
     observed = _read_resolved_labels(read, graph, k; graph_mode = graph_mode)
     isempty(observed) && return accumulator
 
     alternative = try
-        _consensus_alternative(observed, graph)
+        _consensus_alternative(
+            observed, graph; walk_band = walk_band, successor_bound = successor_bound)
     catch
         nothing
     end


### PR DESCRIPTION
## Summary

- After #388 linearized per-read Viterbi decode, the empirical profile's fastest-growing decode residual was the soft-EM competing-paths E-step (**C5c**, alpha ~1.8). The driver is the greedy re-route walk in `_consensus_alternative`, which walks highest-weight edges until it rejoins the read: in a large genome the k-mer graph has many spurious k-mer repeats (chance collisions, themselves well-covered), so the walk increasingly wanders into graph bulk and runs the full read length **without rejoining** — per-read cost climbs with graph density even though read length is fixed.
- Bounds the alternative **generation** with the same discipline as the #388 decode fix:
  - A genome-independent **walk band** (`4*k`) caps a non-rejoining re-route. The rejoin test precedes the band cutoff, so a read-consistent competing allele that returns to the read within the band is always captured; only non-rejoining graph-bulk excursions (which yield no valid spliced alternative) are dropped. This is the **emission-exemption analog** — bound WRONG wandering, never a real variant's read-consistent competing path. A support test cannot substitute here (spurious-repeat edges are themselves high-coverage; only rejoin-within-band separates a real competing allele from graph-bulk wandering).
  - A per-step, per-direction **successor cap** (no-op on DNA, guard for pathological branching), matching the decode `max_successors_per_state`.
  - The argmax sibling / next-step scan now iterates neighbors **directly** (argmax is idempotent to a bidirectional neighbor appearing in both lists), removing the per-position incident-label allocation that dominated the profile.
- Both bounds default to **unbounded** (byte-identical to prior behavior); the `:scalable` corrector engages them only where the width beam is already finite (`!beam_is_exact`), so exact-ML reads are unchanged.

## Results

Isolated E-step micro-benchmark (`benchmarking/softem_competing_paths_micro.jl`, k=9, 5/10/20 kb):

| | 5 kb | 10 kb | 20 kb | alpha (loglog) | alpha (large) |
|---|---|---|---|---|---|
| original | 0.49s | 1.81s | 7.45s | 1.96 | 2.04 |
| bounded | 0.23s | 0.54s | 1.40s | 1.32 | 1.38 |

Real corrector run (same #386/#388 component-profile harness, apples-to-apples post-#388), **C5c**:

| | 5 kb | 10 kb | 20 kb | alpha (large) |
|---|---|---|---|---|
| base-master | 1.2s | 3.5s | 12.0s | **1.78** |
| this PR | 0.3s | 1.4s | 2.0s | **0.53** |

C5c at 20 kb: **12.0s → 2.0s (6x)**, super-linear → sub-linear. Total wall 55.3s → 48.1s. Assembly output **byte-identical** (contigs 10/15/28, max_contig 13513 bp, identical cleanup) — the bound changes speed only, not the assembly.

## Test Plan

- [x] variation-preservation holdout **24/24** (balanced 12 + skewed 12; the balanced fixture runs at 508 vertices > 256 so the band is engaged) + dense-regime rare-allele retention 16/16
- [x] `scalable_corrector_soft_em` 16/16
- [x] `soft_em_edge_weight_scaffold` 27/27 (+1 pre-existing `@test_broken`)
- [x] `iterative_assembly` 196/196, helpers 12/12
- [x] `scalable_corrector_strategy` 40/40, `hard_window` 92/92
- [x] `viterbi_beam_pruning` 23/23 + candidate-generation bounds 29/29, `corrector_graph_cleanup` 42/42

## Related

- Follows #388 (decode score-margin frontier); owns `src/iterative-assembly.jl` `accumulate_competing_paths!` / `_consensus_alternative`. Does not touch `viterbi-next.jl` or `simplification.jl`.