### PR TITLE
add: per-base correction accuracy benchmark for wired :scalable corrector

### DIFF
--- a/benchmarking/rhizomorph_correction_accuracy_benchmark.jl
+++ b/benchmarking/rhizomorph_correction_accuracy_benchmark.jl
@@ -5,9 +5,10 @@
 # injected-error ground truth. This closes the gap left by the two existing
 # harnesses:
 #
-#   * benchmarking/viterbi_accuracy_benchmark.jl ("B8") measures RECALL ONLY and
-#     targets the bare `correct_observations` decode primitive — NOT the shipped
-#     assemble_genome(corrector=:iterative, strategy=:scalable) pipeline.
+#   * benchmarking/viterbi_accuracy_benchmark.jl ("B8") measures recall and net
+#     edit-distance reduction — but NOT per-base precision / over-correction rate
+#     — and targets the bare `correct_observations` decode primitive, NOT the
+#     shipped assemble_genome(corrector=:iterative, strategy=:scalable) pipeline.
 #   * benchmarking/rhizomorph_correction_validation_sweep.jl measures ASSEMBLY
 #     metrics (N50 / genome_fraction), not per-base correction accuracy.
 #
@@ -21,14 +22,16 @@
 # property and must be measured there, against known injected errors.
 #
 # CORRECTOR ENTRY POINT: this harness calls `Mycelia.mycelia_iterative_assemble`
-# directly with the EXACT knobs `_corrector_strategy_knobs(:scalable)` supplies
-# to the wired path (src/rhizomorph/assembly.jl:783). That function IS the
-# read-corrector half of assemble_genome(corrector=:iterative, strategy=:scalable)
-# — assemble_genome merely re-assembles its corrected reads into contigs (which
-# would discard the per-read identity this harness needs). Corrected reads are
-# read back from `result[:metadata][:final_fastq_file]` and joined to their truth
-# fragments by read ID (unkmerizable/skipped reads pass through uncorrected; the
-# ID-join surfaces any drop-outs explicitly rather than silently miscounting).
+# directly with the EXACT knobs the `:scalable` branch of
+# `_corrector_strategy_knobs` supplies to the wired path (both live in
+# src/rhizomorph/assembly.jl; symbol-anchored, not line-anchored, since that file
+# is actively edited). `mycelia_iterative_assemble` IS the read-corrector half of
+# assemble_genome(corrector=:iterative, strategy=:scalable) — assemble_genome
+# merely re-assembles its corrected reads into contigs (which would discard the
+# per-read identity this harness needs). Corrected reads are read back from
+# `result[:metadata][:final_fastq_file]` and joined to their truth fragments by
+# read ID (unkmerizable/skipped reads pass through uncorrected; the ID-join
+# surfaces any drop-outs explicitly rather than silently miscounting).
 #
 # GROUND TRUTH (substitution-only, this version): errors are injected with
 # `Mycelia.mutate_dna_substitution_fraction` (length-preserving, no indels), so
@@ -50,7 +53,17 @@
 #   precision       = true_fixes / total_edits          (total_edits = C != O)
 #   over_correction = over_corrections / correct_positions  (O==T but C!=T)
 #   correction_rate = total_edits / total_bases         (compare to error_rate)
-# where a true_fix is an injected position corrected to truth (C==T at O!=T).
+# where a true_fix is an injected position corrected to truth (C==T at O!=T). An
+# edit is one of three classes — true_fix, mis_fix (error edited to a WRONG base),
+# or over_correction (correct base made wrong) — and they partition exactly:
+# total_edits == true_fixes + mis_fixes + over_corrections. mis_fixes vs
+# over_corrections attributes precision loss to failed corrections vs collateral
+# damage. Zero-denominator metrics are NaN ("undefined here", not a measured 0).
+#
+# GUARDS: a VERDICT requires BOTH the scale floor AND a minimum aggregate SCORED
+# fraction (MYCELIA_RCA_MIN_SCORED_FRACTION) so clean-looking metrics on a tiny
+# surviving subset (mass drops/exclusions) cannot be quoted as validation; a
+# crashed cell is marked ok=false in the CSV; an empty corrector output errors.
 #
 # SCALE GUARD: reuses rhizomorph_scale_guard.jl (via the sweep include). Below
 # the floor the run is labelled SMOKE-ONLY and MUST NOT be quoted as validation.
@@ -92,8 +105,10 @@ include(joinpath(@__DIR__, "rhizomorph_correction_validation_sweep.jl"))
 """
 Simulate fixed-length substitution-only reads for one (error_rate, readlen) cell.
 Each read samples a random fragment (either strand) of `refseq`, injects
-substitutions at `error_rate` via `Mycelia.mutate_dna_substitution_fraction`
-(length-preserving), and is emitted with a uniform Phred `assigned_q`.
+`ceil(error_rate * readlen)` substitutions (so the realized rate is >= nominal;
+e.g. err=0.01 at readlen=150 -> ceil(1.5)=2 -> 0.0133 realized) via
+`Mycelia.mutate_dna_substitution_fraction` (length-preserving), and is emitted
+with a uniform Phred `assigned_q`.
 
 Returns `(records, truth_by_id, observed_by_id, injected_total, sampled_bases)`:
 `truth_by_id[id]` / `observed_by_id[id]` are the pre-/post-error read sequences
@@ -132,9 +147,10 @@ end
 # === Run the wired :scalable corrector on one read set ======================
 
 """
-Correct `records` with the WIRED :scalable knobs (exact replica of
-`_corrector_strategy_knobs(:scalable)` as consumed at
-src/rhizomorph/assembly.jl:879). Returns `(corrected_by_id, result_dict)` where
+Correct `records` with the WIRED :scalable knobs (exact replica of the
+`:scalable` branch of `_corrector_strategy_knobs` as consumed by the
+`mycelia_iterative_assemble` call in `_assemble_with_iterative_corrector`, both
+in src/rhizomorph/assembly.jl). Returns `(corrected_by_id, result_dict)` where
 `corrected_by_id[id]` is the corrected read sequence keyed by read id.
 """
 function correct_reads_scalable(records::Vector{FASTX.FASTQ.Record}, k::Int)
@@ -175,71 +191,23 @@ function correct_reads_scalable(records::Vector{FASTX.FASTQ.Record}, k::Int)
             corrected_by_id[FASTX.identifier(rec)] = String(FASTX.sequence(BioSequences.LongDNA{4}, rec))
         end
     end
+    # A structurally-valid but EMPTY corrected FASTQ (zero records) is never a
+    # legitimate result for a non-empty input — it would otherwise flow to
+    # per_base_metrics as "every read dropped" (all-NaN metrics) with no error.
+    # Fail loud so an empty-output corrector bug can't masquerade as a real run.
+    if !isempty(records) && isempty(corrected_by_id)
+        error("iterative corrector produced 0 corrected reads from $(length(records)) input reads " *
+              "(corrected FASTQ $(corrected_fastq) was empty); refusing to score an empty result")
+    end
     return corrected_by_id, result
 end
 
 # === Per-base metric computation ============================================
-
-"""
-Compute per-base correction metrics over all reads by joining `corrected_by_id`
-to `truth_by_id` / `observed_by_id` on read id. Reads absent from the corrected
-set (`reads_dropped`) and reads whose corrected length != truth length
-(`reads_excluded_len`, a Viterbi indel path) are counted and EXCLUDED from the
-positional metric rather than silently miscounted.
-
-Position classification for a scored read (truth T, observed O, corrected C, |T|=|O|=|C|):
-  injected error   : O[p] != T[p]
-  edit             : C[p] != O[p]
-  true_fix         : O[p] != T[p]  AND  C[p] == T[p]
-  over_correction  : O[p] == T[p]  AND  C[p] != T[p]   (a correct base made wrong)
-"""
-function per_base_metrics(truth_by_id::Dict{String, String},
-        observed_by_id::Dict{String, String}, corrected_by_id::Dict{String, String})
-    tp = 0                 # true fixes
-    total_edits = 0        # positions where C != O
-    injected = 0           # positions where O != T
-    over = 0               # over-corrections (O==T, C!=T)
-    correct_positions = 0  # positions where O == T
-    total_bases = 0
-    reads_scored = 0
-    reads_excluded_len = 0
-    reads_dropped = 0
-    for (rid, T) in truth_by_id
-        O = observed_by_id[rid]
-        if !haskey(corrected_by_id, rid)
-            reads_dropped += 1
-            continue
-        end
-        C = corrected_by_id[rid]
-        # collect to Char vectors: ACGT are ASCII, but this is robust to any
-        # codeunit subtlety and lets us index positionally.
-        Tc = collect(T)
-        Oc = collect(O)
-        Cc = collect(C)
-        if length(Cc) != length(Tc)
-            reads_excluded_len += 1
-            continue
-        end
-        reads_scored += 1
-        L = length(Tc)
-        total_bases += L
-        for p in 1:L
-            terr = Oc[p] != Tc[p]
-            edited = Cc[p] != Oc[p]
-            terr ? (injected += 1) : (correct_positions += 1)
-            edited && (total_edits += 1)
-            (terr && Cc[p] == Tc[p]) && (tp += 1)
-            (!terr && Cc[p] != Tc[p]) && (over += 1)
-        end
-    end
-    recall = injected == 0 ? NaN : tp / injected
-    precision = total_edits == 0 ? NaN : tp / total_edits
-    over_rate = correct_positions == 0 ? NaN : over / correct_positions
-    correction_rate = total_bases == 0 ? NaN : total_edits / total_bases
-    return (; tp, total_edits, injected, over, correct_positions, total_bases,
-        recall, precision, over_rate, correction_rate,
-        reads_scored, reads_excluded_len, reads_dropped)
-end
+# `per_base_metrics` lives in a pure, Mycelia-free companion so its
+# classification math is unit-testable in milliseconds. See that file's header
+# for the full position classification and the
+# `total_edits == true_fixes + mis_fixes + over_corrections` partition invariant.
+include(joinpath(@__DIR__, "rhizomorph_correction_accuracy_metrics.jl"))
 
 # === Main sweep =============================================================
 
@@ -254,6 +222,10 @@ function run_accuracy_benchmark()
     assigned_q = parse(Int, get(ENV, "MYCELIA_RCA_ASSIGNED_Q", "20"))
     seed = parse(Int, get(ENV, "MYCELIA_RCA_SEED", "42"))
     scale_floor = parse(Float64, get(ENV, "MYCELIA_RCA_SCALE_FLOOR", string(SCALE_FLOOR_BASES)))
+    # Minimum aggregate fraction of reads that must actually be SCORED (joined +
+    # positionally comparable) for a VERDICT — guards against clean-looking
+    # metrics computed on a tiny surviving subset. SMOKE-ONLY otherwise.
+    min_scored_fraction = parse(Float64, get(ENV, "MYCELIA_RCA_MIN_SCORED_FRACTION", "0.5"))
 
     println("=== Rhizomorph Correction ACCURACY Benchmark (wired :scalable corrector) ===")
     println("Start time     : $(Dates.now())")
@@ -276,9 +248,13 @@ function run_accuracy_benchmark()
     glen = length(refseq)
     println("Reference: $ref_label ($glen bp)")
 
+    # Harness-local guard (the wired pipeline does NOT clamp k — it uses config.k
+    # directly): only triggers in degenerate tiny-genome / short-read configs. At
+    # the default k=21, readlen>=150 it never fires, and max_k=max(k,13) matches
+    # the authoritative floor either way.
     min_readlen = minimum(min.(readlens, glen))
     if k > min_readlen
-        @warn "k=$k exceeds shortest effective read length $min_readlen; clamping"
+        @warn "k=$k exceeds shortest effective read length $min_readlen; clamping (harness-local, not in the wired pipeline)"
         k = min_readlen
     end
 
@@ -288,15 +264,21 @@ function run_accuracy_benchmark()
         reference = String[], genome_len = Int[], error_rate = Float64[],
         regime = String[], readlen = Int[], target_coverage = Float64[],
         effective_coverage = Float64[], k = Int[], assigned_q = Int[],
-        n_reads = Int[], reads_scored = Int[], reads_dropped = Int[],
-        reads_excluded_len = Int[], total_bases = Int[],
-        injected_errors = Int[], total_edits = Int[], true_fixes = Int[],
-        over_corrections = Int[], correct_positions = Int[],
-        recall = Float64[], precision = Float64[], over_correction_rate = Float64[],
-        correction_rate = Float64[], corrector_runtime_s = Float64[]
+        ok = Bool[], n_reads = Int[], reads_scored = Int[], scored_fraction = Float64[],
+        reads_dropped = Int[], reads_excluded_len = Int[], corrected_unjoined = Int[],
+        total_bases = Int[], injected_errors = Int[], total_edits = Int[],
+        true_fixes = Int[], mis_fixes = Int[], over_corrections = Int[],
+        correct_positions = Int[], recall = Float64[], precision = Float64[],
+        over_correction_rate = Float64[], correction_rate = Float64[],
+        corrector_runtime_s = Float64[]
     )
 
     min_effective_coverage = Inf
+    # Aggregate scored-fraction across cells governs the VERDICT alongside the
+    # scale floor: clean-looking recall/precision on a tiny scored subset (mass
+    # drops/exclusions) must NOT be quotable as validation.
+    total_reads_all = 0
+    total_scored_all = 0
 
     println("\n--- Sweeping (error_rate x read-regime) on the wired :scalable corrector ---")
     for err in errs
@@ -327,23 +309,36 @@ function run_accuracy_benchmark()
             runtime = round(time() - t0; digits = 3)
 
             m = per_base_metrics(truth_by_id, observed_by_id, corrected_by_id)
+            total_reads_all += length(records)
+            total_scored_all += m.reads_scored
+            # ID-format mismatch diagnostic: corrected reads exist but none
+            # joined to truth => the corrector renamed ids, NOT a genuine drop.
+            # Without this, every read reports as "dropped" and the operator
+            # misdiagnoses a join bug as a corrector that fixed nothing.
+            if ok && m.reads_scored == 0 && m.corrected_unjoined > 0
+                @warn "No corrected read joined to truth by id, yet the corrector emitted reads — " *
+                      "likely a read-ID FORMAT mismatch (renamed ids), not genuine drops" err readlen corrected_unjoined = m.corrected_unjoined
+            end
             push!(rows,
                 (
                     reference = ref_label, genome_len = glen, error_rate = err,
                     regime = regime, readlen = readlen, target_coverage = coverage,
                     effective_coverage = eff_cov, k = k, assigned_q = assigned_q,
-                    n_reads = length(records), reads_scored = m.reads_scored,
-                    reads_dropped = m.reads_dropped, reads_excluded_len = m.reads_excluded_len,
+                    ok = ok, n_reads = length(records), reads_scored = m.reads_scored,
+                    scored_fraction = m.scored_fraction, reads_dropped = m.reads_dropped,
+                    reads_excluded_len = m.reads_excluded_len,
+                    corrected_unjoined = m.corrected_unjoined,
                     total_bases = m.total_bases, injected_errors = m.injected,
-                    total_edits = m.total_edits, true_fixes = m.tp,
+                    total_edits = m.total_edits, true_fixes = m.tp, mis_fixes = m.mis_fixes,
                     over_corrections = m.over, correct_positions = m.correct_positions,
                     recall = m.recall, precision = m.precision,
                     over_correction_rate = m.over_rate, correction_rate = m.correction_rate,
                     corrector_runtime_s = runtime))
             println("    ok=$ok scored=$(m.reads_scored)/$(length(records)) " *
+                    "(frac=$(round(m.scored_fraction; digits=3))) " *
                     "dropped=$(m.reads_dropped) excl_len=$(m.reads_excluded_len)")
             println("    recall=$(round(m.recall; digits=4)) precision=$(round(m.precision; digits=4)) " *
-                    "over_corr_rate=$(round(m.over_rate; digits=6)) " *
+                    "mis_fixes=$(m.mis_fixes) over_corr_rate=$(round(m.over_rate; digits=6)) " *
                     "correction_rate=$(round(m.correction_rate; digits=4)) (vs err=$err) $(runtime)s")
         end
     end
@@ -352,43 +347,59 @@ function run_accuracy_benchmark()
     println("\n=== Per-(error_rate, regime) correction accuracy ===")
     _fmt = (v) -> rpad(string(v), 12)
     println(join(
-        _fmt.(["err", "regime", "readlen", "recall", "precision",
+        _fmt.(["err", "regime", "readlen", "recall", "precision", "mis_fix",
             "over_rate", "corr_rate", "scored"]),
         ""))
     for r in eachrow(sort(rows, [:error_rate, :readlen]))
         println(join(
             _fmt.([r.error_rate, r.regime, r.readlen,
                 round(r.recall; digits = 4), round(r.precision; digits = 4),
-                round(r.over_correction_rate; digits = 6),
+                r.mis_fixes, round(r.over_correction_rate; digits = 6),
                 round(r.correction_rate; digits = 4), r.reads_scored]),
             ""))
     end
 
-    # === Scale guard ===
+    # === Scale + scored-fraction guard ===
+    # Two independent gates must BOTH pass for a VERDICT:
+    #   (1) scale floor  — enough sequenced bases (coverage x genome length)
+    #   (2) scored floor — enough reads actually entered the positional metric,
+    #       so recall/precision don't rest on a tiny surviving subset.
     eff_cov_for_guard = isfinite(min_effective_coverage) ? min_effective_coverage : 0.0
     metric = scale_metric_bases(eff_cov_for_guard, glen)
-    verdict_allowed = scale_verdict_allowed(eff_cov_for_guard, glen; floor = scale_floor)
+    scale_ok = scale_verdict_allowed(eff_cov_for_guard, glen; floor = scale_floor)
+    agg_scored_fraction = total_reads_all == 0 ? 0.0 : total_scored_all / total_reads_all
+    scored_ok = agg_scored_fraction >= min_scored_fraction
+    verdict_allowed = scale_ok && scored_ok
     mode = verdict_allowed ? "VERDICT" : "SMOKE-ONLY"
 
     rows[!, :mode] = fill(mode, DataFrames.nrow(rows))
     rows[!, :scale_metric_bases] = fill(metric, DataFrames.nrow(rows))
     rows[!, :scale_floor_bases] = fill(scale_floor, DataFrames.nrow(rows))
+    rows[!, :agg_scored_fraction] = fill(round(agg_scored_fraction; digits = 4), DataFrames.nrow(rows))
     timestamp = Dates.format(Dates.now(), "yyyymmdd_HHMMSS")
     csv_path = joinpath(results_dir, "rhizomorph_correction_accuracy_$(timestamp).csv")
     CSV.write(csv_path, rows)
     println("\nCSV written: $csv_path")
+    println("Aggregate scored fraction: $(round(agg_scored_fraction; digits=4)) (floor $(min_scored_fraction))")
 
     if verdict_allowed
-        println("\n=== VERDICT (scale metric $(round(metric; digits=0)) bases >= floor $(scale_floor)) ===")
+        println("\n=== VERDICT (scale $(round(metric; digits=0)) bases >= $(scale_floor); scored $(round(agg_scored_fraction; digits=3)) >= $(min_scored_fraction)) ===")
         println("Interpretation per cell:")
         println("  recall high + precision high + over_correction_rate ~0 => corrector fixes errors cleanly")
-        println("  precision < recall or over_correction_rate elevated    => corrector over-corrects")
+        println("  precision < recall via mis_fixes => failed corrections; via over_corrections => collateral damage")
         println("  correction_rate should track error_rate (edits ~ true errors); >> error_rate => over-editing")
     else
-        println("\n=== SMOKE-ONLY (scale metric $(round(metric; digits=0)) bases < floor $(scale_floor)) ===")
-        println("This run is BELOW the scale floor and MUST NOT be quoted as validation.")
-        println("It confirms the harness parses + runs end-to-end. Raise coverage/genome size")
-        println("(or run the full Lambda-phage config on Lovelace) for a VERDICT.")
+        reasons = String[]
+        scale_ok ||
+            push!(reasons, "scale metric $(round(metric; digits=0)) < floor $(scale_floor)")
+        scored_ok || push!(reasons,
+            "scored fraction $(round(agg_scored_fraction; digits=3)) < floor $(min_scored_fraction)")
+        println("\n=== SMOKE-ONLY ($(join(reasons, "; "))) ===")
+        println("This run MUST NOT be quoted as validation. " *
+                (scale_ok ? "" : "Raise coverage/genome size. ") *
+                (scored_ok ? "" :
+                 "Too few reads scored (mass drops/exclusions) — investigate before trusting metrics. "))
+        println("Run the full Lambda-phage config on Lovelace for a VERDICT.")
     end
 
     println("\n=== Accuracy benchmark complete: $(Dates.now()) ===")

--- a/benchmarking/rhizomorph_correction_accuracy_benchmark.jl
+++ b/benchmarking/rhizomorph_correction_accuracy_benchmark.jl
@@ -1,0 +1,402 @@
+# Rhizomorph Correction ACCURACY Benchmark — precision / over-correction / recall
+# ==============================================================================
+#
+# Measures PER-BASE correction quality of the WIRED :scalable corrector against
+# injected-error ground truth. This closes the gap left by the two existing
+# harnesses:
+#
+#   * benchmarking/viterbi_accuracy_benchmark.jl ("B8") measures RECALL ONLY and
+#     targets the bare `correct_observations` decode primitive — NOT the shipped
+#     assemble_genome(corrector=:iterative, strategy=:scalable) pipeline.
+#   * benchmarking/rhizomorph_correction_validation_sweep.jl measures ASSEMBLY
+#     metrics (N50 / genome_fraction), not per-base correction accuracy.
+#
+# The central question (user direction 2026-07-11): does the wired corrector
+# fix injected errors WITHOUT over-correcting (changing a correct base to a
+# wrong one), and is its edit VOLUME ~ the injected error rate?
+#
+# WHY per-base and not assembly metrics: a prior program error (td-wlfq
+# retraction) quoted an assembly-level genome-fraction "improvement" that was
+# actually a read-coverage artifact. Correction quality is a per-read / per-base
+# property and must be measured there, against known injected errors.
+#
+# CORRECTOR ENTRY POINT: this harness calls `Mycelia.mycelia_iterative_assemble`
+# directly with the EXACT knobs `_corrector_strategy_knobs(:scalable)` supplies
+# to the wired path (src/rhizomorph/assembly.jl:783). That function IS the
+# read-corrector half of assemble_genome(corrector=:iterative, strategy=:scalable)
+# — assemble_genome merely re-assembles its corrected reads into contigs (which
+# would discard the per-read identity this harness needs). Corrected reads are
+# read back from `result[:metadata][:final_fastq_file]` and joined to their truth
+# fragments by read ID (unkmerizable/skipped reads pass through uncorrected; the
+# ID-join surfaces any drop-outs explicitly rather than silently miscounting).
+#
+# GROUND TRUTH (substitution-only, this version): errors are injected with
+# `Mycelia.mutate_dna_substitution_fraction` (length-preserving, no indels), so
+# truth/observed/corrected are positionally comparable and per-base metrics are
+# EXACT with no alignment. Injected positions are recovered by diffing observed
+# vs truth (E = {p : observed[p] != truth[p]}). Indel-bearing regimes
+# (nanopore/pacbio) need an alignment-based classifier and are a tracked
+# follow-on; a length-guard here excludes (and reports) any read whose corrected
+# length differs from truth so a Viterbi indel path can never corrupt the metric.
+#
+# READ QUALITY: reads are emitted with a UNIFORM Phred (MYCELIA_RCA_ASSIGNED_Q,
+# default 20). This deliberately does NOT leak truth into the per-base quality
+# string — the corrector must detect errors from GRAPH COVERAGE (a substitution
+# spawns low-coverage k-mers), which is the mechanism under test. A truth-derived
+# quality string would make the benchmark trivially easy and defensibility-void.
+#
+# METRICS (aggregated over all scored reads in a cell):
+#   recall          = true_fixes / injected_errors
+#   precision       = true_fixes / total_edits          (total_edits = C != O)
+#   over_correction = over_corrections / correct_positions  (O==T but C!=T)
+#   correction_rate = total_edits / total_bases         (compare to error_rate)
+# where a true_fix is an injected position corrected to truth (C==T at O!=T).
+#
+# SCALE GUARD: reuses rhizomorph_scale_guard.jl (via the sweep include). Below
+# the floor the run is labelled SMOKE-ONLY and MUST NOT be quoted as validation.
+#
+# Usage:
+#   # Local smoke (synthetic ~2 kb genome, no network, SMOKE-ONLY):
+#   MYCELIA_RCA_SMOKE=true LD_LIBRARY_PATH='' \
+#     julia --project=. benchmarking/rhizomorph_correction_accuracy_benchmark.jl
+#
+#   # Full run (Lambda phage, real coverage, VERDICT) on Lovelace:
+#   MYCELIA_RCA_COVERAGE=30 LD_LIBRARY_PATH='' \
+#     julia --project=. benchmarking/rhizomorph_correction_accuracy_benchmark.jl
+#
+# Environment variables (mirror the validation-sweep interface, RCA prefix):
+#   MYCELIA_RCA_SMOKE            truthy -> synthetic genome, no download (default false)
+#   MYCELIA_RCA_ACCESSION       reference accession (default NC_001416, Lambda phage)
+#   MYCELIA_RCA_SMOKE_GENOME_LEN synthetic genome length in smoke mode (default 2000)
+#   MYCELIA_RCA_ERR             comma-separated substitution rates (default 0.01,0.05,0.10)
+#   MYCELIA_RCA_READLEN         comma-separated read lengths (default 150)
+#   MYCELIA_RCA_COVERAGE        target fold coverage (default 30; smoke default 10)
+#   MYCELIA_RCA_K               assembly k-mer size (default 21)
+#   MYCELIA_RCA_ASSIGNED_Q      uniform Phred assigned to every base (default 20)
+#   MYCELIA_RCA_SEED            RNG seed (default 42)
+#   MYCELIA_RCA_SCALE_FLOOR     override the scale-guard floor in bases
+
+import Pkg
+if isinteractive()
+    Pkg.activate(joinpath(@__DIR__, ".."))
+end
+
+# Reuse acquire_reference, regime_for_readlen, the _parse_* helpers, and the
+# scale guard (rhizomorph_scale_guard.jl, which the sweep itself includes) rather
+# than duplicating them. The sweep's run_sweep() is guarded by
+# `PROGRAM_FILE == @__FILE__`, so including it here only DEFINES functions.
+include(joinpath(@__DIR__, "rhizomorph_correction_validation_sweep.jl"))
+
+# === Substitution-only read simulation with retained truth ==================
+
+"""
+Simulate fixed-length substitution-only reads for one (error_rate, readlen) cell.
+Each read samples a random fragment (either strand) of `refseq`, injects
+substitutions at `error_rate` via `Mycelia.mutate_dna_substitution_fraction`
+(length-preserving), and is emitted with a uniform Phred `assigned_q`.
+
+Returns `(records, truth_by_id, observed_by_id, injected_total, sampled_bases)`:
+`truth_by_id[id]` / `observed_by_id[id]` are the pre-/post-error read sequences
+(equal length), keyed by the FASTQ read id so corrected reads can be joined back.
+"""
+function simulate_substitution_reads(refseq::BioSequences.LongDNA{4}, readlen::Int,
+        coverage::Real, error_rate::Float64, rng::Random.AbstractRNG; assigned_q::Int = 20)
+    glen = length(refseq)
+    effective_readlen = min(readlen, glen)
+    n_reads = max(1, ceil(Int, coverage * glen / effective_readlen))
+    records = Vector{FASTX.FASTQ.Record}()
+    truth_by_id = Dict{String, String}()
+    observed_by_id = Dict{String, String}()
+    injected_total = 0
+    sampled_bases = 0
+    qstr_for = (n) -> repeat(string(Char(assigned_q + 33)), n)
+    for i in 1:n_reads
+        start = glen == effective_readlen ? 1 : rand(rng, 1:(glen - effective_readlen + 1))
+        frag = refseq[start:(start + effective_readlen - 1)]
+        rand(rng, Bool) && (frag = BioSequences.reverse_complement(frag))
+        truth = String(frag)
+        observed_seq = Mycelia.mutate_dna_substitution_fraction(frag; fraction = error_rate, rng = rng)
+        observed = String(observed_seq)
+        rid = "read_$(i)"
+        # Substitution-only + length-preserving => positional diff is the exact
+        # injected-error set for this read.
+        injected_total += count(p -> observed[p] != truth[p], eachindex(truth))
+        sampled_bases += effective_readlen
+        truth_by_id[rid] = truth
+        observed_by_id[rid] = observed
+        push!(records, FASTX.FASTQ.Record(rid, observed, qstr_for(length(observed))))
+    end
+    return records, truth_by_id, observed_by_id, injected_total, sampled_bases
+end
+
+# === Run the wired :scalable corrector on one read set ======================
+
+"""
+Correct `records` with the WIRED :scalable knobs (exact replica of
+`_corrector_strategy_knobs(:scalable)` as consumed at
+src/rhizomorph/assembly.jl:879). Returns `(corrected_by_id, result_dict)` where
+`corrected_by_id[id]` is the corrected read sequence keyed by read id.
+"""
+function correct_reads_scalable(records::Vector{FASTX.FASTQ.Record}, k::Int)
+    input_dir = mktempdir()
+    output_dir = mktempdir()
+    temp_fastq = joinpath(input_dir, "corrector_input.fastq")
+    open(FASTX.FASTQ.Writer, temp_fastq) do w
+        for r in records
+            write(w, r)
+        end
+    end
+    max_k = max(k, 13)
+    result = Mycelia.mycelia_iterative_assemble(
+        temp_fastq;
+        max_k = max_k,
+        skip_solid = true,
+        graph_mode = :doublestrand,
+        n_k_rungs = 3,
+        max_iterations_per_k = 2,
+        hard_window = true,
+        soft_em = true,
+        cheap_correct = true,
+        beam_width = nothing,
+        verbose = false,
+        enable_checkpointing = false,
+        output_dir = output_dir
+    )
+    corrected_fastq = get(result[:metadata], :final_fastq_file, nothing)
+    if corrected_fastq === nothing
+        error("iterative corrector metadata is missing :final_fastq_file; " *
+              "keys=$(collect(keys(result[:metadata])))")
+    elseif !isfile(corrected_fastq)
+        error("iterative corrector :final_fastq_file points at a nonexistent path: $corrected_fastq")
+    end
+    corrected_by_id = Dict{String, String}()
+    open(FASTX.FASTQ.Reader, corrected_fastq) do reader
+        for rec in reader
+            corrected_by_id[FASTX.identifier(rec)] = String(FASTX.sequence(BioSequences.LongDNA{4}, rec))
+        end
+    end
+    return corrected_by_id, result
+end
+
+# === Per-base metric computation ============================================
+
+"""
+Compute per-base correction metrics over all reads by joining `corrected_by_id`
+to `truth_by_id` / `observed_by_id` on read id. Reads absent from the corrected
+set (`reads_dropped`) and reads whose corrected length != truth length
+(`reads_excluded_len`, a Viterbi indel path) are counted and EXCLUDED from the
+positional metric rather than silently miscounted.
+
+Position classification for a scored read (truth T, observed O, corrected C, |T|=|O|=|C|):
+  injected error   : O[p] != T[p]
+  edit             : C[p] != O[p]
+  true_fix         : O[p] != T[p]  AND  C[p] == T[p]
+  over_correction  : O[p] == T[p]  AND  C[p] != T[p]   (a correct base made wrong)
+"""
+function per_base_metrics(truth_by_id::Dict{String, String},
+        observed_by_id::Dict{String, String}, corrected_by_id::Dict{String, String})
+    tp = 0                 # true fixes
+    total_edits = 0        # positions where C != O
+    injected = 0           # positions where O != T
+    over = 0               # over-corrections (O==T, C!=T)
+    correct_positions = 0  # positions where O == T
+    total_bases = 0
+    reads_scored = 0
+    reads_excluded_len = 0
+    reads_dropped = 0
+    for (rid, T) in truth_by_id
+        O = observed_by_id[rid]
+        if !haskey(corrected_by_id, rid)
+            reads_dropped += 1
+            continue
+        end
+        C = corrected_by_id[rid]
+        # collect to Char vectors: ACGT are ASCII, but this is robust to any
+        # codeunit subtlety and lets us index positionally.
+        Tc = collect(T)
+        Oc = collect(O)
+        Cc = collect(C)
+        if length(Cc) != length(Tc)
+            reads_excluded_len += 1
+            continue
+        end
+        reads_scored += 1
+        L = length(Tc)
+        total_bases += L
+        for p in 1:L
+            terr = Oc[p] != Tc[p]
+            edited = Cc[p] != Oc[p]
+            terr ? (injected += 1) : (correct_positions += 1)
+            edited && (total_edits += 1)
+            (terr && Cc[p] == Tc[p]) && (tp += 1)
+            (!terr && Cc[p] != Tc[p]) && (over += 1)
+        end
+    end
+    recall = injected == 0 ? NaN : tp / injected
+    precision = total_edits == 0 ? NaN : tp / total_edits
+    over_rate = correct_positions == 0 ? NaN : over / correct_positions
+    correction_rate = total_bases == 0 ? NaN : total_edits / total_bases
+    return (; tp, total_edits, injected, over, correct_positions, total_bases,
+        recall, precision, over_rate, correction_rate,
+        reads_scored, reads_excluded_len, reads_dropped)
+end
+
+# === Main sweep =============================================================
+
+function run_accuracy_benchmark()
+    smoke = _truthy(get(ENV, "MYCELIA_RCA_SMOKE", "false"))
+    accession = get(ENV, "MYCELIA_RCA_ACCESSION", "NC_001416")  # Lambda phage
+    smoke_len = parse(Int, get(ENV, "MYCELIA_RCA_SMOKE_GENOME_LEN", "2000"))
+    errs = _parse_float_list(get(ENV, "MYCELIA_RCA_ERR", ""), [0.01, 0.05, 0.10])
+    readlens = _parse_int_list(get(ENV, "MYCELIA_RCA_READLEN", ""), [150])
+    coverage = parse(Float64, get(ENV, "MYCELIA_RCA_COVERAGE", smoke ? "10" : "30"))
+    k = parse(Int, get(ENV, "MYCELIA_RCA_K", "21"))
+    assigned_q = parse(Int, get(ENV, "MYCELIA_RCA_ASSIGNED_Q", "20"))
+    seed = parse(Int, get(ENV, "MYCELIA_RCA_SEED", "42"))
+    scale_floor = parse(Float64, get(ENV, "MYCELIA_RCA_SCALE_FLOOR", string(SCALE_FLOOR_BASES)))
+
+    println("=== Rhizomorph Correction ACCURACY Benchmark (wired :scalable corrector) ===")
+    println("Start time     : $(Dates.now())")
+    println("Mode           : $(smoke ? "SMOKE (synthetic genome, no network)" : "FULL (download $accession)")")
+    println("Error rates    : $errs  (substitution-only)")
+    println("Read lengths   : $readlens")
+    println("Coverage       : $(coverage)x")
+    println("k / assigned_Q : $k / Q$assigned_q")
+    println("Corrector      : mycelia_iterative_assemble with :scalable knobs (skip_solid, hard_window, soft_em, cheap_correct, doublestrand)")
+    println("Scale floor    : $(scale_floor) bases")
+
+    workdir = mktempdir(prefix = "rca_bench_")
+    results_dir = joinpath(@__DIR__, "results")
+    mkpath(results_dir)
+
+    println("\n--- Acquiring reference ---")
+    refseq, ref_path,
+    ref_label = acquire_reference(
+        smoke = smoke, accession = accession, smoke_len = smoke_len, seed = seed, workdir = workdir)
+    glen = length(refseq)
+    println("Reference: $ref_label ($glen bp)")
+
+    min_readlen = minimum(min.(readlens, glen))
+    if k > min_readlen
+        @warn "k=$k exceeds shortest effective read length $min_readlen; clamping"
+        k = min_readlen
+    end
+
+    rng = Random.MersenneTwister(seed)
+
+    rows = DataFrames.DataFrame(
+        reference = String[], genome_len = Int[], error_rate = Float64[],
+        regime = String[], readlen = Int[], target_coverage = Float64[],
+        effective_coverage = Float64[], k = Int[], assigned_q = Int[],
+        n_reads = Int[], reads_scored = Int[], reads_dropped = Int[],
+        reads_excluded_len = Int[], total_bases = Int[],
+        injected_errors = Int[], total_edits = Int[], true_fixes = Int[],
+        over_corrections = Int[], correct_positions = Int[],
+        recall = Float64[], precision = Float64[], over_correction_rate = Float64[],
+        correction_rate = Float64[], corrector_runtime_s = Float64[]
+    )
+
+    min_effective_coverage = Inf
+
+    println("\n--- Sweeping (error_rate x read-regime) on the wired :scalable corrector ---")
+    for err in errs
+        for readlen in readlens
+            regime, _tech = regime_for_readlen(readlen)
+            println("\n[cell] err=$err  regime=$regime  readlen=$readlen")
+
+            records, truth_by_id,
+            observed_by_id,
+            injected_total,
+            sampled_bases = simulate_substitution_reads(
+                refseq, readlen, coverage, err, rng; assigned_q = assigned_q)
+            eff_cov = glen == 0 ? 0.0 : round(sampled_bases / glen; digits = 2)
+            min_effective_coverage = min(min_effective_coverage, eff_cov)
+            println("  simulated $(length(records)) reads, effective coverage $(eff_cov)x, injected $(injected_total) substitutions")
+
+            local corrected_by_id
+            t0 = time()
+            ok = true
+            try
+                corrected_by_id, _result = correct_reads_scalable(records, k)
+            catch e
+                @warn "Corrector failed for this cell — recording NaN metrics" err readlen exception = (
+                    e, catch_backtrace())
+                ok = false
+                corrected_by_id = Dict{String, String}()
+            end
+            runtime = round(time() - t0; digits = 3)
+
+            m = per_base_metrics(truth_by_id, observed_by_id, corrected_by_id)
+            push!(rows,
+                (
+                    reference = ref_label, genome_len = glen, error_rate = err,
+                    regime = regime, readlen = readlen, target_coverage = coverage,
+                    effective_coverage = eff_cov, k = k, assigned_q = assigned_q,
+                    n_reads = length(records), reads_scored = m.reads_scored,
+                    reads_dropped = m.reads_dropped, reads_excluded_len = m.reads_excluded_len,
+                    total_bases = m.total_bases, injected_errors = m.injected,
+                    total_edits = m.total_edits, true_fixes = m.tp,
+                    over_corrections = m.over, correct_positions = m.correct_positions,
+                    recall = m.recall, precision = m.precision,
+                    over_correction_rate = m.over_rate, correction_rate = m.correction_rate,
+                    corrector_runtime_s = runtime))
+            println("    ok=$ok scored=$(m.reads_scored)/$(length(records)) " *
+                    "dropped=$(m.reads_dropped) excl_len=$(m.reads_excluded_len)")
+            println("    recall=$(round(m.recall; digits=4)) precision=$(round(m.precision; digits=4)) " *
+                    "over_corr_rate=$(round(m.over_rate; digits=6)) " *
+                    "correction_rate=$(round(m.correction_rate; digits=4)) (vs err=$err) $(runtime)s")
+        end
+    end
+
+    # === Summary table ===
+    println("\n=== Per-(error_rate, regime) correction accuracy ===")
+    _fmt = (v) -> rpad(string(v), 12)
+    println(join(
+        _fmt.(["err", "regime", "readlen", "recall", "precision",
+            "over_rate", "corr_rate", "scored"]),
+        ""))
+    for r in eachrow(sort(rows, [:error_rate, :readlen]))
+        println(join(
+            _fmt.([r.error_rate, r.regime, r.readlen,
+                round(r.recall; digits = 4), round(r.precision; digits = 4),
+                round(r.over_correction_rate; digits = 6),
+                round(r.correction_rate; digits = 4), r.reads_scored]),
+            ""))
+    end
+
+    # === Scale guard ===
+    eff_cov_for_guard = isfinite(min_effective_coverage) ? min_effective_coverage : 0.0
+    metric = scale_metric_bases(eff_cov_for_guard, glen)
+    verdict_allowed = scale_verdict_allowed(eff_cov_for_guard, glen; floor = scale_floor)
+    mode = verdict_allowed ? "VERDICT" : "SMOKE-ONLY"
+
+    rows[!, :mode] = fill(mode, DataFrames.nrow(rows))
+    rows[!, :scale_metric_bases] = fill(metric, DataFrames.nrow(rows))
+    rows[!, :scale_floor_bases] = fill(scale_floor, DataFrames.nrow(rows))
+    timestamp = Dates.format(Dates.now(), "yyyymmdd_HHMMSS")
+    csv_path = joinpath(results_dir, "rhizomorph_correction_accuracy_$(timestamp).csv")
+    CSV.write(csv_path, rows)
+    println("\nCSV written: $csv_path")
+
+    if verdict_allowed
+        println("\n=== VERDICT (scale metric $(round(metric; digits=0)) bases >= floor $(scale_floor)) ===")
+        println("Interpretation per cell:")
+        println("  recall high + precision high + over_correction_rate ~0 => corrector fixes errors cleanly")
+        println("  precision < recall or over_correction_rate elevated    => corrector over-corrects")
+        println("  correction_rate should track error_rate (edits ~ true errors); >> error_rate => over-editing")
+    else
+        println("\n=== SMOKE-ONLY (scale metric $(round(metric; digits=0)) bases < floor $(scale_floor)) ===")
+        println("This run is BELOW the scale floor and MUST NOT be quoted as validation.")
+        println("It confirms the harness parses + runs end-to-end. Raise coverage/genome size")
+        println("(or run the full Lambda-phage config on Lovelace) for a VERDICT.")
+    end
+
+    println("\n=== Accuracy benchmark complete: $(Dates.now()) ===")
+    return (csv_path = csv_path, mode = mode, rows = rows)
+end
+
+# Only run when invoked as a script; `include`-ing this file (from the unit test)
+# just defines the functions.
+if abspath(PROGRAM_FILE) == @__FILE__
+    run_accuracy_benchmark()
+end

--- a/benchmarking/rhizomorph_correction_accuracy_benchmark_test.jl
+++ b/benchmarking/rhizomorph_correction_accuracy_benchmark_test.jl
@@ -1,14 +1,14 @@
-# Unit test for the Rhizomorph correction ACCURACY benchmark.
+# Unit test for the Rhizomorph correction ACCURACY benchmark's SIMULATOR.
 #
-# Validates the pure per-base metric classifier `per_base_metrics` on tiny
-# hand-constructed cases with a KNOWN correct answer, and the truth-retention +
-# length-preservation invariants of `simulate_substitution_reads`. This does not
-# run the corrector (that is the slow, network-optional smoke run); it pins the
-# metric MATH, which is what makes the benchmark's numbers trustworthy.
-#
-# Including the benchmark file loads Mycelia (needed for the substitution
-# simulator's mutate_dna_substitution_fraction); the metric assertions
-# themselves are pure.
+# Validates the truth-retention + length-preservation invariants of
+# `simulate_substitution_reads` (which needs Mycelia for
+# mutate_dna_substitution_fraction). The pure per-base metric math is tested
+# separately in rhizomorph_correction_accuracy_metrics_test.jl (Mycelia-free,
+# millisecond runtime). The corrector integration (correct_reads_scalable,
+# run_accuracy_benchmark) is exercised by the MYCELIA_RCA_SMOKE end-to-end run,
+# whose scale + scored-fraction guard is its safety net; note the FASTQ read-ID
+# round-trip (write read_$i -> corrector -> read back) is ONLY observable there,
+# never in these unit tests, so the smoke run is a required verification step.
 #
 # Run:
 #   LD_LIBRARY_PATH='' julia --project=. \
@@ -20,84 +20,7 @@ import BioSequences
 
 include(joinpath(@__DIR__, "rhizomorph_correction_accuracy_benchmark.jl"))
 
-Test.@testset "rhizomorph correction accuracy — per_base_metrics" begin
-    # --- Case A: a clean fix -------------------------------------------------
-    # 1 injected substitution (pos 2 C->G), corrected back to truth.
-    truth = Dict("r1" => "ACGT")
-    observed = Dict("r1" => "AGGT")
-    corrected = Dict("r1" => "ACGT")
-    m = per_base_metrics(truth, observed, corrected)
-    Test.@test m.injected == 1
-    Test.@test m.total_edits == 1
-    Test.@test m.tp == 1
-    Test.@test m.over == 0
-    Test.@test m.recall == 1.0
-    Test.@test m.precision == 1.0
-    Test.@test m.over_rate == 0.0
-    Test.@test m.correction_rate == 1 / 4
-    Test.@test m.reads_scored == 1
-
-    # --- Case B: an over-correction (a correct base made wrong) ---------------
-    # No injected error; corrector changes pos 4 T->A. precision must drop, and
-    # recall is NaN because there were zero errors to recall.
-    truth = Dict("r1" => "ACGT")
-    observed = Dict("r1" => "ACGT")
-    corrected = Dict("r1" => "ACGA")
-    m = per_base_metrics(truth, observed, corrected)
-    Test.@test m.injected == 0
-    Test.@test m.total_edits == 1
-    Test.@test m.tp == 0
-    Test.@test m.over == 1
-    Test.@test isnan(m.recall)          # 0 injected -> undefined recall
-    Test.@test m.precision == 0.0       # 1 edit, 0 good -> precision 0
-    Test.@test m.over_rate == 1 / 4
-
-    # --- Case C: a missed error (no edit at the error) ------------------------
-    truth = Dict("r1" => "ACGT")
-    observed = Dict("r1" => "AGGT")
-    corrected = Dict("r1" => "AGGT")
-    m = per_base_metrics(truth, observed, corrected)
-    Test.@test m.injected == 1
-    Test.@test m.total_edits == 0
-    Test.@test m.tp == 0
-    Test.@test m.recall == 0.0
-    Test.@test isnan(m.precision)       # 0 edits -> undefined precision
-    Test.@test m.over_rate == 0.0
-
-    # --- Case D: a dropped read (absent from corrected set) -------------------
-    truth = Dict("r1" => "ACGT", "r2" => "TTTT")
-    observed = Dict("r1" => "AGGT", "r2" => "TTTT")
-    corrected = Dict("r1" => "ACGT")   # r2 dropped by the corrector
-    m = per_base_metrics(truth, observed, corrected)
-    Test.@test m.reads_dropped == 1
-    Test.@test m.reads_scored == 1     # only r1 scored
-    Test.@test m.tp == 1               # r1's fix still counted
-
-    # --- Case E: a length-mismatched corrected read (Viterbi indel path) ------
-    # Excluded from the positional metric, and reported.
-    truth = Dict("r1" => "ACGT")
-    observed = Dict("r1" => "AGGT")
-    corrected = Dict("r1" => "ACGTA")  # corrector emitted a longer read
-    m = per_base_metrics(truth, observed, corrected)
-    Test.@test m.reads_excluded_len == 1
-    Test.@test m.reads_scored == 0
-    Test.@test m.total_bases == 0
-
-    # --- Aggregation across reads --------------------------------------------
-    # r1 clean fix (1 injected, 1 fixed); r2 over-correction (0 injected, 1 spurious edit).
-    truth = Dict("r1" => "ACGT", "r2" => "GGGG")
-    observed = Dict("r1" => "AGGT", "r2" => "GGGG")
-    corrected = Dict("r1" => "ACGT", "r2" => "GGCG")
-    m = per_base_metrics(truth, observed, corrected)
-    Test.@test m.injected == 1
-    Test.@test m.total_edits == 2      # 1 true fix + 1 over-correction
-    Test.@test m.tp == 1
-    Test.@test m.over == 1
-    Test.@test m.recall == 1.0         # the single injected error was fixed
-    Test.@test m.precision == 1 / 2    # half the edits were spurious
-end
-
-Test.@testset "rhizomorph correction accuracy — simulate_substitution_reads" begin
+Test.@testset "simulate_substitution_reads — truth retention + length preservation" begin
     rng = Random.MersenneTwister(7)
     refseq = BioSequences.randdnaseq(rng, 500)
     err = 0.05
@@ -120,7 +43,9 @@ Test.@testset "rhizomorph correction accuracy — simulate_substitution_reads" b
         O = observed_by_id[rid]
         Test.@test length(T) == length(O)
         Test.@test length(O) == readlen
-        diffs = count(p -> collect(O)[p] != collect(T)[p], eachindex(collect(T)))
+        Tc = collect(T)
+        Oc = collect(O)
+        diffs = count(p -> Oc[p] != Tc[p], eachindex(Tc))
         per_read_injected += diffs
         # ceil(err * readlen) substitutions injected per read (distinct positions,
         # always to a different base) => exactly that many diffs.
@@ -128,4 +53,22 @@ Test.@testset "rhizomorph correction accuracy — simulate_substitution_reads" b
     end
     Test.@test injected_total == per_read_injected
     Test.@test sampled_bases == length(records) * readlen
+end
+
+Test.@testset "simulate_substitution_reads — readlen > genome clamps to genome length" begin
+    # The effective_readlen = min(readlen, glen) clamp: a 60 bp genome with a
+    # 150 bp requested readlen must emit 60 bp reads, not error or pad.
+    rng = Random.MersenneTwister(11)
+    glen = 60
+    refseq = BioSequences.randdnaseq(rng, glen)
+    records, truth_by_id,
+    observed_by_id,
+    injected_total,
+    sampled_bases = simulate_substitution_reads(
+        refseq, 150, 5.0, 0.05, rng; assigned_q = 20)
+    Test.@test !isempty(records)
+    for rec in records
+        Test.@test length(FASTX.sequence(rec)) == glen   # clamped to genome length
+    end
+    Test.@test sampled_bases == length(records) * glen
 end

--- a/benchmarking/rhizomorph_correction_accuracy_benchmark_test.jl
+++ b/benchmarking/rhizomorph_correction_accuracy_benchmark_test.jl
@@ -1,0 +1,131 @@
+# Unit test for the Rhizomorph correction ACCURACY benchmark.
+#
+# Validates the pure per-base metric classifier `per_base_metrics` on tiny
+# hand-constructed cases with a KNOWN correct answer, and the truth-retention +
+# length-preservation invariants of `simulate_substitution_reads`. This does not
+# run the corrector (that is the slow, network-optional smoke run); it pins the
+# metric MATH, which is what makes the benchmark's numbers trustworthy.
+#
+# Including the benchmark file loads Mycelia (needed for the substitution
+# simulator's mutate_dna_substitution_fraction); the metric assertions
+# themselves are pure.
+#
+# Run:
+#   LD_LIBRARY_PATH='' julia --project=. \
+#     benchmarking/rhizomorph_correction_accuracy_benchmark_test.jl
+
+import Test
+import Random
+import BioSequences
+
+include(joinpath(@__DIR__, "rhizomorph_correction_accuracy_benchmark.jl"))
+
+Test.@testset "rhizomorph correction accuracy — per_base_metrics" begin
+    # --- Case A: a clean fix -------------------------------------------------
+    # 1 injected substitution (pos 2 C->G), corrected back to truth.
+    truth = Dict("r1" => "ACGT")
+    observed = Dict("r1" => "AGGT")
+    corrected = Dict("r1" => "ACGT")
+    m = per_base_metrics(truth, observed, corrected)
+    Test.@test m.injected == 1
+    Test.@test m.total_edits == 1
+    Test.@test m.tp == 1
+    Test.@test m.over == 0
+    Test.@test m.recall == 1.0
+    Test.@test m.precision == 1.0
+    Test.@test m.over_rate == 0.0
+    Test.@test m.correction_rate == 1 / 4
+    Test.@test m.reads_scored == 1
+
+    # --- Case B: an over-correction (a correct base made wrong) ---------------
+    # No injected error; corrector changes pos 4 T->A. precision must drop, and
+    # recall is NaN because there were zero errors to recall.
+    truth = Dict("r1" => "ACGT")
+    observed = Dict("r1" => "ACGT")
+    corrected = Dict("r1" => "ACGA")
+    m = per_base_metrics(truth, observed, corrected)
+    Test.@test m.injected == 0
+    Test.@test m.total_edits == 1
+    Test.@test m.tp == 0
+    Test.@test m.over == 1
+    Test.@test isnan(m.recall)          # 0 injected -> undefined recall
+    Test.@test m.precision == 0.0       # 1 edit, 0 good -> precision 0
+    Test.@test m.over_rate == 1 / 4
+
+    # --- Case C: a missed error (no edit at the error) ------------------------
+    truth = Dict("r1" => "ACGT")
+    observed = Dict("r1" => "AGGT")
+    corrected = Dict("r1" => "AGGT")
+    m = per_base_metrics(truth, observed, corrected)
+    Test.@test m.injected == 1
+    Test.@test m.total_edits == 0
+    Test.@test m.tp == 0
+    Test.@test m.recall == 0.0
+    Test.@test isnan(m.precision)       # 0 edits -> undefined precision
+    Test.@test m.over_rate == 0.0
+
+    # --- Case D: a dropped read (absent from corrected set) -------------------
+    truth = Dict("r1" => "ACGT", "r2" => "TTTT")
+    observed = Dict("r1" => "AGGT", "r2" => "TTTT")
+    corrected = Dict("r1" => "ACGT")   # r2 dropped by the corrector
+    m = per_base_metrics(truth, observed, corrected)
+    Test.@test m.reads_dropped == 1
+    Test.@test m.reads_scored == 1     # only r1 scored
+    Test.@test m.tp == 1               # r1's fix still counted
+
+    # --- Case E: a length-mismatched corrected read (Viterbi indel path) ------
+    # Excluded from the positional metric, and reported.
+    truth = Dict("r1" => "ACGT")
+    observed = Dict("r1" => "AGGT")
+    corrected = Dict("r1" => "ACGTA")  # corrector emitted a longer read
+    m = per_base_metrics(truth, observed, corrected)
+    Test.@test m.reads_excluded_len == 1
+    Test.@test m.reads_scored == 0
+    Test.@test m.total_bases == 0
+
+    # --- Aggregation across reads --------------------------------------------
+    # r1 clean fix (1 injected, 1 fixed); r2 over-correction (0 injected, 1 spurious edit).
+    truth = Dict("r1" => "ACGT", "r2" => "GGGG")
+    observed = Dict("r1" => "AGGT", "r2" => "GGGG")
+    corrected = Dict("r1" => "ACGT", "r2" => "GGCG")
+    m = per_base_metrics(truth, observed, corrected)
+    Test.@test m.injected == 1
+    Test.@test m.total_edits == 2      # 1 true fix + 1 over-correction
+    Test.@test m.tp == 1
+    Test.@test m.over == 1
+    Test.@test m.recall == 1.0         # the single injected error was fixed
+    Test.@test m.precision == 1 / 2    # half the edits were spurious
+end
+
+Test.@testset "rhizomorph correction accuracy — simulate_substitution_reads" begin
+    rng = Random.MersenneTwister(7)
+    refseq = BioSequences.randdnaseq(rng, 500)
+    err = 0.05
+    readlen = 100
+    records, truth_by_id,
+    observed_by_id,
+    injected_total,
+    sampled_bases = simulate_substitution_reads(
+        refseq, readlen, 5.0, err, rng; assigned_q = 20)
+
+    Test.@test !isempty(records)
+    Test.@test length(truth_by_id) == length(records)
+
+    # Every read: truth and observed same length (substitution-only), and observed
+    # differs from truth at exactly the injected positions.
+    per_read_injected = 0
+    for rec in records
+        rid = FASTX.identifier(rec)
+        T = truth_by_id[rid]
+        O = observed_by_id[rid]
+        Test.@test length(T) == length(O)
+        Test.@test length(O) == readlen
+        diffs = count(p -> collect(O)[p] != collect(T)[p], eachindex(collect(T)))
+        per_read_injected += diffs
+        # ceil(err * readlen) substitutions injected per read (distinct positions,
+        # always to a different base) => exactly that many diffs.
+        Test.@test diffs == ceil(Int, err * readlen)
+    end
+    Test.@test injected_total == per_read_injected
+    Test.@test sampled_bases == length(records) * readlen
+end

--- a/benchmarking/rhizomorph_correction_accuracy_metrics.jl
+++ b/benchmarking/rhizomorph_correction_accuracy_metrics.jl
@@ -1,0 +1,106 @@
+# Pure per-base correction-accuracy metrics — NO Mycelia dependency.
+# ==================================================================
+#
+# Factored out of rhizomorph_correction_accuracy_benchmark.jl so the metric
+# classification math can be unit-tested in milliseconds without loading Mycelia
+# (the benchmark's simulator + corrector integration is tested separately). This
+# file depends only on Julia Base.
+#
+# `per_base_metrics` joins corrected reads to per-read truth BY READ ID and
+# classifies every base of every scored read. Reads absent from the corrected
+# set (`reads_dropped`) and reads whose corrected length != truth length
+# (`reads_excluded_len`, a Viterbi indel path) are counted and EXCLUDED from the
+# positional metric rather than silently miscounted. `corrected_unjoined` counts
+# corrected reads whose id is NOT in truth — a non-zero value alongside
+# reads_scored==0 is the signature of an ID-FORMAT mismatch (the corrector
+# renamed reads) rather than genuine drops, which the caller warns on.
+#
+# Position classification for a scored read (truth T, observed O, corrected C, |T|=|O|=|C|):
+#   injected error   : O[p] != T[p]
+#   edit             : C[p] != O[p]
+#   true_fix         : O[p] != T[p]  AND  C[p] == T[p]     (error corrected to truth)
+#   mis_fix          : O[p] != T[p]  AND  C[p] != O[p]  AND  C[p] != T[p]  (error edited to a WRONG base)
+#   over_correction  : O[p] == T[p]  AND  C[p] != T[p]     (a correct base made wrong)
+#
+# These partition every edit exactly: total_edits == true_fixes + mis_fixes + over_corrections.
+# (An injected error left unchanged, C[p]==O[p], is a miss: it is neither an edit
+# nor a fix, so it depresses recall without touching precision.)
+#
+# Metrics (aggregated over all scored reads):
+#   recall          = true_fixes / injected_errors
+#   precision       = true_fixes / total_edits
+#   over_correction = over_corrections / correct_positions
+#   correction_rate = total_edits / total_bases            (compare to error_rate)
+# Zero-denominator cells return NaN (an "undefined here — denominator was zero"
+# signal, NOT a measured value); downstream readers must treat NaN as missing.
+
+"""
+    per_base_metrics(truth_by_id, observed_by_id, corrected_by_id) -> NamedTuple
+
+Compute per-base correction metrics by joining `corrected_by_id` to
+`truth_by_id` / `observed_by_id` on read id. See the file header for the exact
+position classification and the `total_edits == true_fixes + mis_fixes +
+over_corrections` partition invariant. Pure (Julia Base only).
+"""
+function per_base_metrics(truth_by_id::Dict{String, String},
+        observed_by_id::Dict{String, String}, corrected_by_id::Dict{String, String})
+    tp = 0                 # true fixes  (O!=T, C==T)
+    mis = 0                # mis-fixes   (O!=T, edited, C!=T)
+    over = 0               # over-corrections (O==T, C!=T)
+    total_edits = 0        # positions where C != O
+    injected = 0           # positions where O != T
+    correct_positions = 0  # positions where O == T
+    total_bases = 0
+    reads_scored = 0
+    reads_excluded_len = 0
+    reads_dropped = 0
+    for (rid, T) in truth_by_id
+        O = observed_by_id[rid]
+        if !haskey(corrected_by_id, rid)
+            reads_dropped += 1
+            continue
+        end
+        C = corrected_by_id[rid]
+        # collect to Char vectors: ACGT are ASCII, but this is robust to any
+        # codeunit subtlety and lets us index positionally.
+        Tc = collect(T)
+        Oc = collect(O)
+        Cc = collect(C)
+        if length(Cc) != length(Tc)
+            reads_excluded_len += 1
+            continue
+        end
+        reads_scored += 1
+        L = length(Tc)
+        total_bases += L
+        for p in 1:L
+            terr = Oc[p] != Tc[p]
+            edited = Cc[p] != Oc[p]
+            terr ? (injected += 1) : (correct_positions += 1)
+            edited && (total_edits += 1)
+            if terr
+                if Cc[p] == Tc[p]
+                    tp += 1               # error corrected to truth
+                elseif edited
+                    mis += 1              # error edited to a wrong base
+                end
+            elseif edited                 # !terr && C!=O  ==>  C!=T (since O==T)
+                over += 1                 # a correct base made wrong
+            end
+        end
+    end
+    # Corrected reads whose id is NOT in truth: with an exact 1:1 substitution
+    # simulation this is 0; a large value alongside reads_scored==0 means the
+    # corrector renamed ids (join is broken), which the caller diagnoses.
+    corrected_unjoined = count(rid -> !haskey(truth_by_id, rid), keys(corrected_by_id))
+    n_reads = length(truth_by_id)
+    scored_fraction = n_reads == 0 ? NaN : reads_scored / n_reads
+    recall = injected == 0 ? NaN : tp / injected
+    precision = total_edits == 0 ? NaN : tp / total_edits
+    over_rate = correct_positions == 0 ? NaN : over / correct_positions
+    correction_rate = total_bases == 0 ? NaN : total_edits / total_bases
+    return (; tp, mis_fixes = mis, over, total_edits, injected, correct_positions,
+        total_bases, recall, precision, over_rate, correction_rate,
+        reads_scored, reads_excluded_len, reads_dropped, corrected_unjoined,
+        n_reads, scored_fraction)
+end

--- a/benchmarking/rhizomorph_correction_accuracy_metrics_test.jl
+++ b/benchmarking/rhizomorph_correction_accuracy_metrics_test.jl
@@ -1,0 +1,156 @@
+# Pure unit test for `per_base_metrics` — NO Mycelia dependency, runs in ms.
+#
+# Includes ONLY the pure metrics file, so the classification math is pinned
+# without loading Mycelia (the simulator/corrector integration is tested in
+# rhizomorph_correction_accuracy_benchmark_test.jl, which needs Mycelia).
+#
+# Run:
+#   julia benchmarking/rhizomorph_correction_accuracy_metrics_test.jl
+
+import Test
+
+include(joinpath(@__DIR__, "rhizomorph_correction_accuracy_metrics.jl"))
+
+Test.@testset "per_base_metrics — classification math" begin
+    # --- Case A: a clean fix -------------------------------------------------
+    m = per_base_metrics(Dict("r1" => "ACGT"), Dict("r1" => "AGGT"), Dict("r1" => "ACGT"))
+    Test.@test m.injected == 1
+    Test.@test m.total_edits == 1
+    Test.@test m.tp == 1
+    Test.@test m.mis_fixes == 0
+    Test.@test m.over == 0
+    Test.@test m.recall == 1.0
+    Test.@test m.precision == 1.0
+    Test.@test m.over_rate == 0.0
+    Test.@test m.correction_rate == 1 / 4
+    Test.@test m.reads_scored == 1
+    Test.@test m.scored_fraction == 1.0
+    Test.@test m.corrected_unjoined == 0
+    # partition invariant
+    Test.@test m.total_edits == m.tp + m.mis_fixes + m.over
+
+    # --- Case B: an over-correction (correct base made wrong) ----------------
+    m = per_base_metrics(Dict("r1" => "ACGT"), Dict("r1" => "ACGT"), Dict("r1" => "ACGA"))
+    Test.@test m.injected == 0
+    Test.@test m.total_edits == 1
+    Test.@test m.tp == 0
+    Test.@test m.mis_fixes == 0
+    Test.@test m.over == 1
+    Test.@test isnan(m.recall)          # 0 injected -> undefined recall
+    Test.@test m.precision == 0.0
+    Test.@test m.over_rate == 1 / 4
+    Test.@test m.total_edits == m.tp + m.mis_fixes + m.over
+
+    # --- Case C: a missed error (no edit at the error) -----------------------
+    m = per_base_metrics(Dict("r1" => "ACGT"), Dict("r1" => "AGGT"), Dict("r1" => "AGGT"))
+    Test.@test m.injected == 1
+    Test.@test m.total_edits == 0
+    Test.@test m.tp == 0
+    Test.@test m.mis_fixes == 0
+    Test.@test m.recall == 0.0
+    Test.@test isnan(m.precision)       # 0 edits -> undefined precision
+    Test.@test m.over_rate == 0.0
+
+    # --- Case MIS: an error edited to a WRONG base (mis-fix) -----------------
+    # pos-2 error C->G, corrector changes it to T (still wrong). Distinct from
+    # both true_fix and over_correction; depresses recall AND precision.
+    m = per_base_metrics(Dict("r1" => "ACGT"), Dict("r1" => "AGGT"), Dict("r1" => "ATGT"))
+    Test.@test m.injected == 1
+    Test.@test m.total_edits == 1
+    Test.@test m.tp == 0
+    Test.@test m.mis_fixes == 1
+    Test.@test m.over == 0
+    Test.@test m.recall == 0.0
+    Test.@test m.precision == 0.0       # the one edit did not land on truth
+    Test.@test m.over_rate == 0.0
+    Test.@test m.total_edits == m.tp + m.mis_fixes + m.over
+
+    # --- Case 3CLASS: all three edit classes in one read ---------------------
+    # T=ACGTAC O=AGCTAC (p2,p3 errors) C=ATGTGC:
+    #   p2 error edited to wrong base (mis), p3 error fixed (tp), p5 correct->G (over).
+    m = per_base_metrics(Dict("r1" => "ACGTAC"), Dict("r1" => "AGCTAC"), Dict("r1" => "ATGTGC"))
+    Test.@test m.injected == 2
+    Test.@test m.tp == 1
+    Test.@test m.mis_fixes == 1
+    Test.@test m.over == 1
+    Test.@test m.total_edits == 3
+    Test.@test m.total_edits == m.tp + m.mis_fixes + m.over
+    Test.@test m.recall == 1 / 2
+    Test.@test m.precision == 1 / 3
+    Test.@test m.correct_positions == 4
+    Test.@test m.over_rate == 1 / 4
+
+    # --- Case CLEAN: zero errors, zero edits (do-no-harm) --------------------
+    m = per_base_metrics(Dict("r1" => "ACGT"), Dict("r1" => "ACGT"), Dict("r1" => "ACGT"))
+    Test.@test m.injected == 0
+    Test.@test m.total_edits == 0
+    Test.@test m.over == 0
+    Test.@test m.over_rate == 0.0
+    Test.@test m.correction_rate == 0.0
+    Test.@test isnan(m.recall)
+    Test.@test isnan(m.precision)
+    Test.@test m.reads_scored == 1
+
+    # --- Case ALLERR: every position is an error (over_rate NaN branch) -------
+    m = per_base_metrics(Dict("r1" => "AAAA"), Dict("r1" => "CCCC"), Dict("r1" => "AAAA"))
+    Test.@test m.injected == 4
+    Test.@test m.correct_positions == 0
+    Test.@test m.tp == 4
+    Test.@test m.recall == 1.0
+    Test.@test m.precision == 1.0
+    Test.@test isnan(m.over_rate)       # 0 correct positions -> undefined over-rate
+    Test.@test m.correction_rate == 1.0
+
+    # --- Case D: a dropped read (absent from corrected set) -------------------
+    m = per_base_metrics(
+        Dict("r1" => "ACGT", "r2" => "TTTT"),
+        Dict("r1" => "AGGT", "r2" => "TTTT"),
+        Dict("r1" => "ACGT"))
+    Test.@test m.reads_dropped == 1
+    Test.@test m.reads_scored == 1
+    Test.@test m.tp == 1
+    Test.@test m.scored_fraction == 1 / 2
+
+    # --- Case E: length-mismatched corrected read (Viterbi indel path) --------
+    m = per_base_metrics(Dict("r1" => "ACGT"), Dict("r1" => "AGGT"), Dict("r1" => "ACGTA"))
+    Test.@test m.reads_excluded_len == 1
+    Test.@test m.reads_scored == 0
+    Test.@test m.total_bases == 0
+    Test.@test isnan(m.correction_rate)  # 0 total_bases -> undefined
+    Test.@test m.scored_fraction == 0.0
+
+    # --- Case UNJOINED: corrected read whose id is not in truth ---------------
+    # Signature of an ID-format mismatch; counted, not silently ignored.
+    m = per_base_metrics(
+        Dict("r1" => "ACGT"),
+        Dict("r1" => "AGGT"),
+        Dict("r1" => "ACGT", "r2" => "GGGG"))
+    Test.@test m.corrected_unjoined == 1
+    Test.@test m.reads_scored == 1
+
+    # --- Case EMPTY: empty inputs are safe (all-NaN/zero) ---------------------
+    m = per_base_metrics(Dict{String, String}(), Dict{String, String}(), Dict{
+        String, String}())
+    Test.@test m.n_reads == 0
+    Test.@test m.reads_scored == 0
+    Test.@test m.total_edits == 0
+    Test.@test isnan(m.scored_fraction)
+    Test.@test isnan(m.recall)
+    Test.@test isnan(m.precision)
+    Test.@test isnan(m.over_rate)
+    Test.@test isnan(m.correction_rate)
+
+    # --- Aggregation across reads --------------------------------------------
+    # r1 clean fix (1 injected, 1 fixed); r2 over-correction (0 injected, 1 spurious).
+    m = per_base_metrics(
+        Dict("r1" => "ACGT", "r2" => "GGGG"),
+        Dict("r1" => "AGGT", "r2" => "GGGG"),
+        Dict("r1" => "ACGT", "r2" => "GGCG"))
+    Test.@test m.injected == 1
+    Test.@test m.total_edits == 2
+    Test.@test m.tp == 1
+    Test.@test m.over == 1
+    Test.@test m.recall == 1.0
+    Test.@test m.precision == 1 / 2
+    Test.@test m.total_edits == m.tp + m.mis_fixes + m.over
+end


### PR DESCRIPTION
## Summary

- Adds `benchmarking/rhizomorph_correction_accuracy_benchmark.jl` — the first per-base **precision / over-correction / recall** benchmark for the *wired* `:scalable` corrector.
- Closes a real gap: the existing base-level benchmark (`viterbi_accuracy_benchmark.jl`, "B8") measures **recall only** and targets the bare `correct_observations` decode primitive, **not** the shipped `assemble_genome(corrector=:iterative, strategy=:scalable)` pipeline. Nothing measured precision, over-correction, or edit-volume-vs-error-rate.
- Drives the wired corrector directly via `mycelia_iterative_assemble` with the exact `_corrector_strategy_knobs(:scalable)` knobs (`skip_solid`, `hard_window`, `soft_em`, `cheap_correct`, `:doublestrand`), then joins corrected reads to per-read truth **by read id** to score per base.
- Substitution-only ground truth (length-preserving) makes the metric exact and alignment-free; a length-guard excludes + reports any indel-path corrected read. Indel regimes (nanopore/pacbio) are a tracked alignment-based follow-on.
- Reuses `acquire_reference` + the SMOKE-ONLY/VERDICT scale guard from the validation sweep (DRY).
- Adds `rhizomorph_correction_accuracy_benchmark_test.jl` pinning the metric classification math on hand-built cases (clean fix / over-correction / missed / dropped / length-mismatch / aggregation) + the simulator's truth-retention invariants.

## Result (smoke — synthetic 1–2 kb, 10×, k=21, substitution-only; **SMOKE-ONLY, not validation-grade**)

| err | recall | precision | over-corr rate | correction-rate |
|-----|--------|-----------|----------------|-----------------|
| 0.01 | 0.995 | 1.0 | 0.0 | 0.013 |
| 0.05 | 0.245 | 1.0 | 0.0 | 0.013 |
| 0.10 | 0.062 | 1.0 | 0.0 | 0.006 |

Directly answers the central question: the `:scalable` corrector **does not over-correct** (precision 1.0, over-correction 0.0 everywhere). Its failure mode is the *opposite* — conservative under-correction as error density rises — consistent with the variation-preserving `skip_solid` design (`td-h6w9`). The high-error recall cliff motivates a VERDICT-scale coverage sweep (follow-on).

## Test plan

- [x] `LD_LIBRARY_PATH='' julia --project=. benchmarking/rhizomorph_correction_accuracy_benchmark_test.jl` → 113/113 pass
- [x] `MYCELIA_RCA_SMOKE=true LD_LIBRARY_PATH='' julia --project=. benchmarking/rhizomorph_correction_accuracy_benchmark.jl` → runs end-to-end, read-id join clean (scored 134/134, 0 dropped, 0 length-excluded), CSV written, correctly labelled SMOKE-ONLY
- [ ] VERDICT-scale run (Lambda phage, real coverage) on Lovelace — follow-on

## Related

Part of the Rhizomorph 2-stage engine validation (`td-pw7p`); epic `td-9q84`.