### PR TITLE
add: reference-free correction calibration (Tier-1) + calibration metrics library

### DIFF
--- a/benchmarking/calibration_metrics.jl
+++ b/benchmarking/calibration_metrics.jl
@@ -1,0 +1,106 @@
+# Pure calibration metrics — NO Mycelia dependency.
+# ================================================
+#
+# Reliability curve, Expected Calibration Error (ECE), AUROC, and Brier score for
+# a set of confidence scores vs boolean ground-truth labels. These did not exist
+# in the repo (only a Mann-Whitney AUC buried in benchmarking/stage0_*); this is
+# the reusable calibration toolkit the Rhizomorph "reference-free correctness
+# prediction" work (td-pw7p Priority #2) is built on. Depends only on Julia Base.
+#
+# Terminology: `confidences` are predicted P(label=true) in [0,1]; `labels` are
+# the observed booleans. A well-calibrated predictor has, among all items it
+# assigned confidence ~p, a fraction ~p that are actually true.
+#
+#   reliability_bins(conf, labels; nbins)  -> per-bin (mean_conf, accuracy, count)
+#   expected_calibration_error(...)        -> ECE = sum_b (n_b/N) |acc_b - conf_b|
+#   auroc(scores, labels)                  -> P(score(true) > score(false)) (rank-based; scores need NOT be in [0,1])
+#   brier_score(conf, labels)              -> mean((conf - label)^2)
+#
+# AUROC measures DISCRIMINATION (does the signal separate true from false) and is
+# rank-based, so it accepts any real-valued score. ECE / reliability / Brier
+# measure CALIBRATION and require `confidences` already mapped to [0,1]
+# probabilities (fit a Platt/isotonic map first for a raw signal).
+
+"""
+    reliability_bins(confidences, labels; nbins=10) -> Vector{NamedTuple}
+
+Equal-width binning of `confidences` in [0,1]. Returns one entry per NON-EMPTY
+bin: `(lo, hi, mean_conf, accuracy, count)` where `accuracy` is the fraction of
+`labels` that are true among items whose confidence fell in `[lo, hi)` (the last
+bin is closed, `[lo, hi]`). A calibrated predictor has `accuracy ~ mean_conf` in
+every bin.
+"""
+function reliability_bins(confidences::AbstractVector{<:Real},
+        labels::AbstractVector{Bool}; nbins::Int = 10)
+    length(confidences) == length(labels) ||
+        throw(ArgumentError("confidences and labels must have equal length"))
+    nbins >= 1 || throw(ArgumentError("nbins must be >= 1"))
+    edges = range(0.0, 1.0; length = nbins + 1)
+    out = NamedTuple[]
+    for b in 1:nbins
+        lo = edges[b]
+        hi = edges[b + 1]
+        # last bin is closed on the right so confidence==1.0 lands somewhere
+        idx = b < nbins ? findall(c -> lo <= c < hi, confidences) :
+              findall(c -> lo <= c <= hi, confidences)
+        isempty(idx) && continue
+        cnt = length(idx)
+        mean_conf = sum(confidences[idx]) / cnt
+        accuracy = count(labels[idx]) / cnt
+        push!(out, (
+            lo = lo, hi = hi, mean_conf = mean_conf, accuracy = accuracy, count = cnt))
+    end
+    return out
+end
+
+"""
+    expected_calibration_error(confidences, labels; nbins=10) -> Float64
+
+ECE = sum over bins of (bin_count / N) * |bin_accuracy - bin_mean_confidence|.
+0 is perfectly calibrated; 1 is worst. Requires `confidences` in [0,1].
+"""
+function expected_calibration_error(confidences::AbstractVector{<:Real},
+        labels::AbstractVector{Bool}; nbins::Int = 10)
+    n = length(confidences)
+    n == 0 && return NaN
+    bins = reliability_bins(confidences, labels; nbins = nbins)
+    return sum(bin.count / n * abs(bin.accuracy - bin.mean_conf) for bin in bins; init = 0.0)
+end
+
+"""
+    auroc(scores, labels) -> Float64
+
+Area under the ROC curve via the Mann-Whitney U statistic:
+P(score(a true item) > score(a false item)), with ties counted as 0.5. Returns
+NaN if either class is empty (AUROC undefined). Rank-based, so `scores` need not
+be probabilities — any real-valued discrimination signal works. 0.5 = no
+discrimination, 1.0 = perfect, <0.5 = anti-correlated.
+"""
+function auroc(scores::AbstractVector{<:Real}, labels::AbstractVector{Bool})
+    length(scores) == length(labels) ||
+        throw(ArgumentError("scores and labels must have equal length"))
+    pos = scores[labels]
+    neg = scores[.!labels]
+    (isempty(pos) || isempty(neg)) && return NaN
+    wins = 0.0
+    for p in pos, q in neg
+
+        wins += p > q ? 1.0 : (p == q ? 0.5 : 0.0)
+    end
+    return wins / (length(pos) * length(neg))
+end
+
+"""
+    brier_score(confidences, labels) -> Float64
+
+Mean squared error of the predicted probabilities: mean((conf - label)^2), where
+label is 1.0 for true / 0.0 for false. 0 is best; combines calibration and
+refinement. Requires `confidences` in [0,1].
+"""
+function brier_score(confidences::AbstractVector{<:Real}, labels::AbstractVector{Bool})
+    n = length(confidences)
+    n == 0 && return NaN
+    length(confidences) == length(labels) ||
+        throw(ArgumentError("confidences and labels must have equal length"))
+    return sum((confidences[i] - (labels[i] ? 1.0 : 0.0))^2 for i in 1:n) / n
+end

--- a/benchmarking/calibration_metrics_test.jl
+++ b/benchmarking/calibration_metrics_test.jl
@@ -1,0 +1,56 @@
+# Pure unit test for calibration_metrics.jl — NO Mycelia dependency, runs in ms.
+#
+# Run:
+#   julia benchmarking/calibration_metrics_test.jl
+
+import Test
+
+include(joinpath(@__DIR__, "calibration_metrics.jl"))
+
+Test.@testset "calibration metrics" begin
+    # --- reliability_bins ----------------------------------------------------
+    conf = [0.1, 0.2, 0.8, 0.9]
+    labels = [false, false, true, true]
+    bins = reliability_bins(conf, labels; nbins = 2)
+    Test.@test length(bins) == 2
+    Test.@test bins[1].count == 2
+    Test.@test bins[1].mean_conf ≈ 0.15
+    Test.@test bins[1].accuracy == 0.0
+    Test.@test bins[2].count == 2
+    Test.@test bins[2].mean_conf ≈ 0.85
+    Test.@test bins[2].accuracy == 1.0
+    # empty bins are dropped (nothing in the middle range here with nbins=2)
+    Test.@test all(b -> b.count > 0, bins)
+
+    # --- expected_calibration_error ------------------------------------------
+    # bin1: |0 - 0.15|=0.15 weight 0.5; bin2: |1 - 0.85|=0.15 weight 0.5 => 0.15
+    Test.@test expected_calibration_error(conf, labels; nbins = 2) ≈ 0.15
+    # perfectly-calibrated extremes => ECE 0
+    Test.@test expected_calibration_error([0.0, 1.0], [false, true]; nbins = 2) ≈ 0.0
+    # a confidently-wrong predictor => ECE 1.0 (conf 1.0 on all-false, 0.0 on all-true)
+    Test.@test expected_calibration_error([1.0, 0.0], [false, true]; nbins = 2) ≈ 1.0
+
+    # --- auroc (rank-based discrimination) -----------------------------------
+    Test.@test auroc([0.1, 0.2, 0.8, 0.9], [false, false, true, true]) == 1.0   # perfect
+    Test.@test auroc([0.9, 0.1], [false, true]) == 0.0                          # reversed
+    Test.@test auroc([0.5, 0.5], [true, false]) == 0.5                          # tie => 0.5
+    Test.@test isnan(auroc([0.3, 0.7], [true, true]))                           # one class => undefined
+    # accepts non-probability scores (rank-based): coverage-like integers
+    Test.@test auroc([2, 5, 9, 1], [false, true, true, false]) == 1.0
+
+    # --- brier_score ----------------------------------------------------------
+    # mean((0.1)^2,(0.2)^2,(0.2)^2,(0.1)^2) = (0.01+0.04+0.04+0.01)/4 = 0.025
+    Test.@test brier_score(conf, labels) ≈ 0.025
+    Test.@test brier_score([0.0, 1.0], [false, true]) == 0.0                    # perfect
+    Test.@test brier_score([1.0, 0.0], [false, true]) == 1.0                    # worst
+
+    # --- degenerate / empty inputs -------------------------------------------
+    Test.@test isnan(expected_calibration_error(Float64[], Bool[]))
+    Test.@test isnan(brier_score(Float64[], Bool[]))
+    Test.@test isnan(auroc(Float64[], Bool[]))
+    Test.@test isempty(reliability_bins(Float64[], Bool[]))
+
+    # --- length-mismatch guards ----------------------------------------------
+    Test.@test_throws ArgumentError auroc([0.1, 0.2], [true])
+    Test.@test_throws ArgumentError reliability_bins([0.1], [true, false])
+end

--- a/benchmarking/rhizomorph_correction_accuracy_benchmark.jl
+++ b/benchmarking/rhizomorph_correction_accuracy_benchmark.jl
@@ -5,9 +5,10 @@
 # injected-error ground truth. This closes the gap left by the two existing
 # harnesses:
 #
-#   * benchmarking/viterbi_accuracy_benchmark.jl ("B8") measures RECALL ONLY and
-#     targets the bare `correct_observations` decode primitive — NOT the shipped
-#     assemble_genome(corrector=:iterative, strategy=:scalable) pipeline.
+#   * benchmarking/viterbi_accuracy_benchmark.jl ("B8") measures recall and net
+#     edit-distance reduction — but NOT per-base precision / over-correction rate
+#     — and targets the bare `correct_observations` decode primitive, NOT the
+#     shipped assemble_genome(corrector=:iterative, strategy=:scalable) pipeline.
 #   * benchmarking/rhizomorph_correction_validation_sweep.jl measures ASSEMBLY
 #     metrics (N50 / genome_fraction), not per-base correction accuracy.
 #
@@ -21,14 +22,16 @@
 # property and must be measured there, against known injected errors.
 #
 # CORRECTOR ENTRY POINT: this harness calls `Mycelia.mycelia_iterative_assemble`
-# directly with the EXACT knobs `_corrector_strategy_knobs(:scalable)` supplies
-# to the wired path (src/rhizomorph/assembly.jl:783). That function IS the
-# read-corrector half of assemble_genome(corrector=:iterative, strategy=:scalable)
-# — assemble_genome merely re-assembles its corrected reads into contigs (which
-# would discard the per-read identity this harness needs). Corrected reads are
-# read back from `result[:metadata][:final_fastq_file]` and joined to their truth
-# fragments by read ID (unkmerizable/skipped reads pass through uncorrected; the
-# ID-join surfaces any drop-outs explicitly rather than silently miscounting).
+# directly with the EXACT knobs the `:scalable` branch of
+# `_corrector_strategy_knobs` supplies to the wired path (both live in
+# src/rhizomorph/assembly.jl; symbol-anchored, not line-anchored, since that file
+# is actively edited). `mycelia_iterative_assemble` IS the read-corrector half of
+# assemble_genome(corrector=:iterative, strategy=:scalable) — assemble_genome
+# merely re-assembles its corrected reads into contigs (which would discard the
+# per-read identity this harness needs). Corrected reads are read back from
+# `result[:metadata][:final_fastq_file]` and joined to their truth fragments by
+# read ID (unkmerizable/skipped reads pass through uncorrected; the ID-join
+# surfaces any drop-outs explicitly rather than silently miscounting).
 #
 # GROUND TRUTH (substitution-only, this version): errors are injected with
 # `Mycelia.mutate_dna_substitution_fraction` (length-preserving, no indels), so
@@ -50,7 +53,17 @@
 #   precision       = true_fixes / total_edits          (total_edits = C != O)
 #   over_correction = over_corrections / correct_positions  (O==T but C!=T)
 #   correction_rate = total_edits / total_bases         (compare to error_rate)
-# where a true_fix is an injected position corrected to truth (C==T at O!=T).
+# where a true_fix is an injected position corrected to truth (C==T at O!=T). An
+# edit is one of three classes — true_fix, mis_fix (error edited to a WRONG base),
+# or over_correction (correct base made wrong) — and they partition exactly:
+# total_edits == true_fixes + mis_fixes + over_corrections. mis_fixes vs
+# over_corrections attributes precision loss to failed corrections vs collateral
+# damage. Zero-denominator metrics are NaN ("undefined here", not a measured 0).
+#
+# GUARDS: a VERDICT requires BOTH the scale floor AND a minimum aggregate SCORED
+# fraction (MYCELIA_RCA_MIN_SCORED_FRACTION) so clean-looking metrics on a tiny
+# surviving subset (mass drops/exclusions) cannot be quoted as validation; a
+# crashed cell is marked ok=false in the CSV; an empty corrector output errors.
 #
 # SCALE GUARD: reuses rhizomorph_scale_guard.jl (via the sweep include). Below
 # the floor the run is labelled SMOKE-ONLY and MUST NOT be quoted as validation.
@@ -92,8 +105,10 @@ include(joinpath(@__DIR__, "rhizomorph_correction_validation_sweep.jl"))
 """
 Simulate fixed-length substitution-only reads for one (error_rate, readlen) cell.
 Each read samples a random fragment (either strand) of `refseq`, injects
-substitutions at `error_rate` via `Mycelia.mutate_dna_substitution_fraction`
-(length-preserving), and is emitted with a uniform Phred `assigned_q`.
+`ceil(error_rate * readlen)` substitutions (so the realized rate is >= nominal;
+e.g. err=0.01 at readlen=150 -> ceil(1.5)=2 -> 0.0133 realized) via
+`Mycelia.mutate_dna_substitution_fraction` (length-preserving), and is emitted
+with a uniform Phred `assigned_q`.
 
 Returns `(records, truth_by_id, observed_by_id, injected_total, sampled_bases)`:
 `truth_by_id[id]` / `observed_by_id[id]` are the pre-/post-error read sequences
@@ -132,9 +147,10 @@ end
 # === Run the wired :scalable corrector on one read set ======================
 
 """
-Correct `records` with the WIRED :scalable knobs (exact replica of
-`_corrector_strategy_knobs(:scalable)` as consumed at
-src/rhizomorph/assembly.jl:879). Returns `(corrected_by_id, result_dict)` where
+Correct `records` with the WIRED :scalable knobs (exact replica of the
+`:scalable` branch of `_corrector_strategy_knobs` as consumed by the
+`mycelia_iterative_assemble` call in `_assemble_with_iterative_corrector`, both
+in src/rhizomorph/assembly.jl). Returns `(corrected_by_id, result_dict)` where
 `corrected_by_id[id]` is the corrected read sequence keyed by read id.
 """
 function correct_reads_scalable(records::Vector{FASTX.FASTQ.Record}, k::Int)
@@ -175,71 +191,23 @@ function correct_reads_scalable(records::Vector{FASTX.FASTQ.Record}, k::Int)
             corrected_by_id[FASTX.identifier(rec)] = String(FASTX.sequence(BioSequences.LongDNA{4}, rec))
         end
     end
+    # A structurally-valid but EMPTY corrected FASTQ (zero records) is never a
+    # legitimate result for a non-empty input — it would otherwise flow to
+    # per_base_metrics as "every read dropped" (all-NaN metrics) with no error.
+    # Fail loud so an empty-output corrector bug can't masquerade as a real run.
+    if !isempty(records) && isempty(corrected_by_id)
+        error("iterative corrector produced 0 corrected reads from $(length(records)) input reads " *
+              "(corrected FASTQ $(corrected_fastq) was empty); refusing to score an empty result")
+    end
     return corrected_by_id, result
 end
 
 # === Per-base metric computation ============================================
-
-"""
-Compute per-base correction metrics over all reads by joining `corrected_by_id`
-to `truth_by_id` / `observed_by_id` on read id. Reads absent from the corrected
-set (`reads_dropped`) and reads whose corrected length != truth length
-(`reads_excluded_len`, a Viterbi indel path) are counted and EXCLUDED from the
-positional metric rather than silently miscounted.
-
-Position classification for a scored read (truth T, observed O, corrected C, |T|=|O|=|C|):
-  injected error   : O[p] != T[p]
-  edit             : C[p] != O[p]
-  true_fix         : O[p] != T[p]  AND  C[p] == T[p]
-  over_correction  : O[p] == T[p]  AND  C[p] != T[p]   (a correct base made wrong)
-"""
-function per_base_metrics(truth_by_id::Dict{String, String},
-        observed_by_id::Dict{String, String}, corrected_by_id::Dict{String, String})
-    tp = 0                 # true fixes
-    total_edits = 0        # positions where C != O
-    injected = 0           # positions where O != T
-    over = 0               # over-corrections (O==T, C!=T)
-    correct_positions = 0  # positions where O == T
-    total_bases = 0
-    reads_scored = 0
-    reads_excluded_len = 0
-    reads_dropped = 0
-    for (rid, T) in truth_by_id
-        O = observed_by_id[rid]
-        if !haskey(corrected_by_id, rid)
-            reads_dropped += 1
-            continue
-        end
-        C = corrected_by_id[rid]
-        # collect to Char vectors: ACGT are ASCII, but this is robust to any
-        # codeunit subtlety and lets us index positionally.
-        Tc = collect(T)
-        Oc = collect(O)
-        Cc = collect(C)
-        if length(Cc) != length(Tc)
-            reads_excluded_len += 1
-            continue
-        end
-        reads_scored += 1
-        L = length(Tc)
-        total_bases += L
-        for p in 1:L
-            terr = Oc[p] != Tc[p]
-            edited = Cc[p] != Oc[p]
-            terr ? (injected += 1) : (correct_positions += 1)
-            edited && (total_edits += 1)
-            (terr && Cc[p] == Tc[p]) && (tp += 1)
-            (!terr && Cc[p] != Tc[p]) && (over += 1)
-        end
-    end
-    recall = injected == 0 ? NaN : tp / injected
-    precision = total_edits == 0 ? NaN : tp / total_edits
-    over_rate = correct_positions == 0 ? NaN : over / correct_positions
-    correction_rate = total_bases == 0 ? NaN : total_edits / total_bases
-    return (; tp, total_edits, injected, over, correct_positions, total_bases,
-        recall, precision, over_rate, correction_rate,
-        reads_scored, reads_excluded_len, reads_dropped)
-end
+# `per_base_metrics` lives in a pure, Mycelia-free companion so its
+# classification math is unit-testable in milliseconds. See that file's header
+# for the full position classification and the
+# `total_edits == true_fixes + mis_fixes + over_corrections` partition invariant.
+include(joinpath(@__DIR__, "rhizomorph_correction_accuracy_metrics.jl"))
 
 # === Main sweep =============================================================
 
@@ -254,6 +222,10 @@ function run_accuracy_benchmark()
     assigned_q = parse(Int, get(ENV, "MYCELIA_RCA_ASSIGNED_Q", "20"))
     seed = parse(Int, get(ENV, "MYCELIA_RCA_SEED", "42"))
     scale_floor = parse(Float64, get(ENV, "MYCELIA_RCA_SCALE_FLOOR", string(SCALE_FLOOR_BASES)))
+    # Minimum aggregate fraction of reads that must actually be SCORED (joined +
+    # positionally comparable) for a VERDICT — guards against clean-looking
+    # metrics computed on a tiny surviving subset. SMOKE-ONLY otherwise.
+    min_scored_fraction = parse(Float64, get(ENV, "MYCELIA_RCA_MIN_SCORED_FRACTION", "0.5"))
 
     println("=== Rhizomorph Correction ACCURACY Benchmark (wired :scalable corrector) ===")
     println("Start time     : $(Dates.now())")
@@ -276,9 +248,13 @@ function run_accuracy_benchmark()
     glen = length(refseq)
     println("Reference: $ref_label ($glen bp)")
 
+    # Harness-local guard (the wired pipeline does NOT clamp k — it uses config.k
+    # directly): only triggers in degenerate tiny-genome / short-read configs. At
+    # the default k=21, readlen>=150 it never fires, and max_k=max(k,13) matches
+    # the authoritative floor either way.
     min_readlen = minimum(min.(readlens, glen))
     if k > min_readlen
-        @warn "k=$k exceeds shortest effective read length $min_readlen; clamping"
+        @warn "k=$k exceeds shortest effective read length $min_readlen; clamping (harness-local, not in the wired pipeline)"
         k = min_readlen
     end
 
@@ -288,15 +264,21 @@ function run_accuracy_benchmark()
         reference = String[], genome_len = Int[], error_rate = Float64[],
         regime = String[], readlen = Int[], target_coverage = Float64[],
         effective_coverage = Float64[], k = Int[], assigned_q = Int[],
-        n_reads = Int[], reads_scored = Int[], reads_dropped = Int[],
-        reads_excluded_len = Int[], total_bases = Int[],
-        injected_errors = Int[], total_edits = Int[], true_fixes = Int[],
-        over_corrections = Int[], correct_positions = Int[],
-        recall = Float64[], precision = Float64[], over_correction_rate = Float64[],
-        correction_rate = Float64[], corrector_runtime_s = Float64[]
+        ok = Bool[], n_reads = Int[], reads_scored = Int[], scored_fraction = Float64[],
+        reads_dropped = Int[], reads_excluded_len = Int[], corrected_unjoined = Int[],
+        total_bases = Int[], injected_errors = Int[], total_edits = Int[],
+        true_fixes = Int[], mis_fixes = Int[], over_corrections = Int[],
+        correct_positions = Int[], recall = Float64[], precision = Float64[],
+        over_correction_rate = Float64[], correction_rate = Float64[],
+        corrector_runtime_s = Float64[]
     )
 
     min_effective_coverage = Inf
+    # Aggregate scored-fraction across cells governs the VERDICT alongside the
+    # scale floor: clean-looking recall/precision on a tiny scored subset (mass
+    # drops/exclusions) must NOT be quotable as validation.
+    total_reads_all = 0
+    total_scored_all = 0
 
     println("\n--- Sweeping (error_rate x read-regime) on the wired :scalable corrector ---")
     for err in errs
@@ -327,23 +309,36 @@ function run_accuracy_benchmark()
             runtime = round(time() - t0; digits = 3)
 
             m = per_base_metrics(truth_by_id, observed_by_id, corrected_by_id)
+            total_reads_all += length(records)
+            total_scored_all += m.reads_scored
+            # ID-format mismatch diagnostic: corrected reads exist but none
+            # joined to truth => the corrector renamed ids, NOT a genuine drop.
+            # Without this, every read reports as "dropped" and the operator
+            # misdiagnoses a join bug as a corrector that fixed nothing.
+            if ok && m.reads_scored == 0 && m.corrected_unjoined > 0
+                @warn "No corrected read joined to truth by id, yet the corrector emitted reads — " *
+                      "likely a read-ID FORMAT mismatch (renamed ids), not genuine drops" err readlen corrected_unjoined = m.corrected_unjoined
+            end
             push!(rows,
                 (
                     reference = ref_label, genome_len = glen, error_rate = err,
                     regime = regime, readlen = readlen, target_coverage = coverage,
                     effective_coverage = eff_cov, k = k, assigned_q = assigned_q,
-                    n_reads = length(records), reads_scored = m.reads_scored,
-                    reads_dropped = m.reads_dropped, reads_excluded_len = m.reads_excluded_len,
+                    ok = ok, n_reads = length(records), reads_scored = m.reads_scored,
+                    scored_fraction = m.scored_fraction, reads_dropped = m.reads_dropped,
+                    reads_excluded_len = m.reads_excluded_len,
+                    corrected_unjoined = m.corrected_unjoined,
                     total_bases = m.total_bases, injected_errors = m.injected,
-                    total_edits = m.total_edits, true_fixes = m.tp,
+                    total_edits = m.total_edits, true_fixes = m.tp, mis_fixes = m.mis_fixes,
                     over_corrections = m.over, correct_positions = m.correct_positions,
                     recall = m.recall, precision = m.precision,
                     over_correction_rate = m.over_rate, correction_rate = m.correction_rate,
                     corrector_runtime_s = runtime))
             println("    ok=$ok scored=$(m.reads_scored)/$(length(records)) " *
+                    "(frac=$(round(m.scored_fraction; digits=3))) " *
                     "dropped=$(m.reads_dropped) excl_len=$(m.reads_excluded_len)")
             println("    recall=$(round(m.recall; digits=4)) precision=$(round(m.precision; digits=4)) " *
-                    "over_corr_rate=$(round(m.over_rate; digits=6)) " *
+                    "mis_fixes=$(m.mis_fixes) over_corr_rate=$(round(m.over_rate; digits=6)) " *
                     "correction_rate=$(round(m.correction_rate; digits=4)) (vs err=$err) $(runtime)s")
         end
     end
@@ -352,43 +347,59 @@ function run_accuracy_benchmark()
     println("\n=== Per-(error_rate, regime) correction accuracy ===")
     _fmt = (v) -> rpad(string(v), 12)
     println(join(
-        _fmt.(["err", "regime", "readlen", "recall", "precision",
+        _fmt.(["err", "regime", "readlen", "recall", "precision", "mis_fix",
             "over_rate", "corr_rate", "scored"]),
         ""))
     for r in eachrow(sort(rows, [:error_rate, :readlen]))
         println(join(
             _fmt.([r.error_rate, r.regime, r.readlen,
                 round(r.recall; digits = 4), round(r.precision; digits = 4),
-                round(r.over_correction_rate; digits = 6),
+                r.mis_fixes, round(r.over_correction_rate; digits = 6),
                 round(r.correction_rate; digits = 4), r.reads_scored]),
             ""))
     end
 
-    # === Scale guard ===
+    # === Scale + scored-fraction guard ===
+    # Two independent gates must BOTH pass for a VERDICT:
+    #   (1) scale floor  — enough sequenced bases (coverage x genome length)
+    #   (2) scored floor — enough reads actually entered the positional metric,
+    #       so recall/precision don't rest on a tiny surviving subset.
     eff_cov_for_guard = isfinite(min_effective_coverage) ? min_effective_coverage : 0.0
     metric = scale_metric_bases(eff_cov_for_guard, glen)
-    verdict_allowed = scale_verdict_allowed(eff_cov_for_guard, glen; floor = scale_floor)
+    scale_ok = scale_verdict_allowed(eff_cov_for_guard, glen; floor = scale_floor)
+    agg_scored_fraction = total_reads_all == 0 ? 0.0 : total_scored_all / total_reads_all
+    scored_ok = agg_scored_fraction >= min_scored_fraction
+    verdict_allowed = scale_ok && scored_ok
     mode = verdict_allowed ? "VERDICT" : "SMOKE-ONLY"
 
     rows[!, :mode] = fill(mode, DataFrames.nrow(rows))
     rows[!, :scale_metric_bases] = fill(metric, DataFrames.nrow(rows))
     rows[!, :scale_floor_bases] = fill(scale_floor, DataFrames.nrow(rows))
+    rows[!, :agg_scored_fraction] = fill(round(agg_scored_fraction; digits = 4), DataFrames.nrow(rows))
     timestamp = Dates.format(Dates.now(), "yyyymmdd_HHMMSS")
     csv_path = joinpath(results_dir, "rhizomorph_correction_accuracy_$(timestamp).csv")
     CSV.write(csv_path, rows)
     println("\nCSV written: $csv_path")
+    println("Aggregate scored fraction: $(round(agg_scored_fraction; digits=4)) (floor $(min_scored_fraction))")
 
     if verdict_allowed
-        println("\n=== VERDICT (scale metric $(round(metric; digits=0)) bases >= floor $(scale_floor)) ===")
+        println("\n=== VERDICT (scale $(round(metric; digits=0)) bases >= $(scale_floor); scored $(round(agg_scored_fraction; digits=3)) >= $(min_scored_fraction)) ===")
         println("Interpretation per cell:")
         println("  recall high + precision high + over_correction_rate ~0 => corrector fixes errors cleanly")
-        println("  precision < recall or over_correction_rate elevated    => corrector over-corrects")
+        println("  precision < recall via mis_fixes => failed corrections; via over_corrections => collateral damage")
         println("  correction_rate should track error_rate (edits ~ true errors); >> error_rate => over-editing")
     else
-        println("\n=== SMOKE-ONLY (scale metric $(round(metric; digits=0)) bases < floor $(scale_floor)) ===")
-        println("This run is BELOW the scale floor and MUST NOT be quoted as validation.")
-        println("It confirms the harness parses + runs end-to-end. Raise coverage/genome size")
-        println("(or run the full Lambda-phage config on Lovelace) for a VERDICT.")
+        reasons = String[]
+        scale_ok ||
+            push!(reasons, "scale metric $(round(metric; digits=0)) < floor $(scale_floor)")
+        scored_ok || push!(reasons,
+            "scored fraction $(round(agg_scored_fraction; digits=3)) < floor $(min_scored_fraction)")
+        println("\n=== SMOKE-ONLY ($(join(reasons, "; "))) ===")
+        println("This run MUST NOT be quoted as validation. " *
+                (scale_ok ? "" : "Raise coverage/genome size. ") *
+                (scored_ok ? "" :
+                 "Too few reads scored (mass drops/exclusions) — investigate before trusting metrics. "))
+        println("Run the full Lambda-phage config on Lovelace for a VERDICT.")
     end
 
     println("\n=== Accuracy benchmark complete: $(Dates.now()) ===")

--- a/benchmarking/rhizomorph_correction_accuracy_benchmark.jl
+++ b/benchmarking/rhizomorph_correction_accuracy_benchmark.jl
@@ -1,0 +1,402 @@
+# Rhizomorph Correction ACCURACY Benchmark — precision / over-correction / recall
+# ==============================================================================
+#
+# Measures PER-BASE correction quality of the WIRED :scalable corrector against
+# injected-error ground truth. This closes the gap left by the two existing
+# harnesses:
+#
+#   * benchmarking/viterbi_accuracy_benchmark.jl ("B8") measures RECALL ONLY and
+#     targets the bare `correct_observations` decode primitive — NOT the shipped
+#     assemble_genome(corrector=:iterative, strategy=:scalable) pipeline.
+#   * benchmarking/rhizomorph_correction_validation_sweep.jl measures ASSEMBLY
+#     metrics (N50 / genome_fraction), not per-base correction accuracy.
+#
+# The central question (user direction 2026-07-11): does the wired corrector
+# fix injected errors WITHOUT over-correcting (changing a correct base to a
+# wrong one), and is its edit VOLUME ~ the injected error rate?
+#
+# WHY per-base and not assembly metrics: a prior program error (td-wlfq
+# retraction) quoted an assembly-level genome-fraction "improvement" that was
+# actually a read-coverage artifact. Correction quality is a per-read / per-base
+# property and must be measured there, against known injected errors.
+#
+# CORRECTOR ENTRY POINT: this harness calls `Mycelia.mycelia_iterative_assemble`
+# directly with the EXACT knobs `_corrector_strategy_knobs(:scalable)` supplies
+# to the wired path (src/rhizomorph/assembly.jl:783). That function IS the
+# read-corrector half of assemble_genome(corrector=:iterative, strategy=:scalable)
+# — assemble_genome merely re-assembles its corrected reads into contigs (which
+# would discard the per-read identity this harness needs). Corrected reads are
+# read back from `result[:metadata][:final_fastq_file]` and joined to their truth
+# fragments by read ID (unkmerizable/skipped reads pass through uncorrected; the
+# ID-join surfaces any drop-outs explicitly rather than silently miscounting).
+#
+# GROUND TRUTH (substitution-only, this version): errors are injected with
+# `Mycelia.mutate_dna_substitution_fraction` (length-preserving, no indels), so
+# truth/observed/corrected are positionally comparable and per-base metrics are
+# EXACT with no alignment. Injected positions are recovered by diffing observed
+# vs truth (E = {p : observed[p] != truth[p]}). Indel-bearing regimes
+# (nanopore/pacbio) need an alignment-based classifier and are a tracked
+# follow-on; a length-guard here excludes (and reports) any read whose corrected
+# length differs from truth so a Viterbi indel path can never corrupt the metric.
+#
+# READ QUALITY: reads are emitted with a UNIFORM Phred (MYCELIA_RCA_ASSIGNED_Q,
+# default 20). This deliberately does NOT leak truth into the per-base quality
+# string — the corrector must detect errors from GRAPH COVERAGE (a substitution
+# spawns low-coverage k-mers), which is the mechanism under test. A truth-derived
+# quality string would make the benchmark trivially easy and defensibility-void.
+#
+# METRICS (aggregated over all scored reads in a cell):
+#   recall          = true_fixes / injected_errors
+#   precision       = true_fixes / total_edits          (total_edits = C != O)
+#   over_correction = over_corrections / correct_positions  (O==T but C!=T)
+#   correction_rate = total_edits / total_bases         (compare to error_rate)
+# where a true_fix is an injected position corrected to truth (C==T at O!=T).
+#
+# SCALE GUARD: reuses rhizomorph_scale_guard.jl (via the sweep include). Below
+# the floor the run is labelled SMOKE-ONLY and MUST NOT be quoted as validation.
+#
+# Usage:
+#   # Local smoke (synthetic ~2 kb genome, no network, SMOKE-ONLY):
+#   MYCELIA_RCA_SMOKE=true LD_LIBRARY_PATH='' \
+#     julia --project=. benchmarking/rhizomorph_correction_accuracy_benchmark.jl
+#
+#   # Full run (Lambda phage, real coverage, VERDICT) on Lovelace:
+#   MYCELIA_RCA_COVERAGE=30 LD_LIBRARY_PATH='' \
+#     julia --project=. benchmarking/rhizomorph_correction_accuracy_benchmark.jl
+#
+# Environment variables (mirror the validation-sweep interface, RCA prefix):
+#   MYCELIA_RCA_SMOKE            truthy -> synthetic genome, no download (default false)
+#   MYCELIA_RCA_ACCESSION       reference accession (default NC_001416, Lambda phage)
+#   MYCELIA_RCA_SMOKE_GENOME_LEN synthetic genome length in smoke mode (default 2000)
+#   MYCELIA_RCA_ERR             comma-separated substitution rates (default 0.01,0.05,0.10)
+#   MYCELIA_RCA_READLEN         comma-separated read lengths (default 150)
+#   MYCELIA_RCA_COVERAGE        target fold coverage (default 30; smoke default 10)
+#   MYCELIA_RCA_K               assembly k-mer size (default 21)
+#   MYCELIA_RCA_ASSIGNED_Q      uniform Phred assigned to every base (default 20)
+#   MYCELIA_RCA_SEED            RNG seed (default 42)
+#   MYCELIA_RCA_SCALE_FLOOR     override the scale-guard floor in bases
+
+import Pkg
+if isinteractive()
+    Pkg.activate(joinpath(@__DIR__, ".."))
+end
+
+# Reuse acquire_reference, regime_for_readlen, the _parse_* helpers, and the
+# scale guard (rhizomorph_scale_guard.jl, which the sweep itself includes) rather
+# than duplicating them. The sweep's run_sweep() is guarded by
+# `PROGRAM_FILE == @__FILE__`, so including it here only DEFINES functions.
+include(joinpath(@__DIR__, "rhizomorph_correction_validation_sweep.jl"))
+
+# === Substitution-only read simulation with retained truth ==================
+
+"""
+Simulate fixed-length substitution-only reads for one (error_rate, readlen) cell.
+Each read samples a random fragment (either strand) of `refseq`, injects
+substitutions at `error_rate` via `Mycelia.mutate_dna_substitution_fraction`
+(length-preserving), and is emitted with a uniform Phred `assigned_q`.
+
+Returns `(records, truth_by_id, observed_by_id, injected_total, sampled_bases)`:
+`truth_by_id[id]` / `observed_by_id[id]` are the pre-/post-error read sequences
+(equal length), keyed by the FASTQ read id so corrected reads can be joined back.
+"""
+function simulate_substitution_reads(refseq::BioSequences.LongDNA{4}, readlen::Int,
+        coverage::Real, error_rate::Float64, rng::Random.AbstractRNG; assigned_q::Int = 20)
+    glen = length(refseq)
+    effective_readlen = min(readlen, glen)
+    n_reads = max(1, ceil(Int, coverage * glen / effective_readlen))
+    records = Vector{FASTX.FASTQ.Record}()
+    truth_by_id = Dict{String, String}()
+    observed_by_id = Dict{String, String}()
+    injected_total = 0
+    sampled_bases = 0
+    qstr_for = (n) -> repeat(string(Char(assigned_q + 33)), n)
+    for i in 1:n_reads
+        start = glen == effective_readlen ? 1 : rand(rng, 1:(glen - effective_readlen + 1))
+        frag = refseq[start:(start + effective_readlen - 1)]
+        rand(rng, Bool) && (frag = BioSequences.reverse_complement(frag))
+        truth = String(frag)
+        observed_seq = Mycelia.mutate_dna_substitution_fraction(frag; fraction = error_rate, rng = rng)
+        observed = String(observed_seq)
+        rid = "read_$(i)"
+        # Substitution-only + length-preserving => positional diff is the exact
+        # injected-error set for this read.
+        injected_total += count(p -> observed[p] != truth[p], eachindex(truth))
+        sampled_bases += effective_readlen
+        truth_by_id[rid] = truth
+        observed_by_id[rid] = observed
+        push!(records, FASTX.FASTQ.Record(rid, observed, qstr_for(length(observed))))
+    end
+    return records, truth_by_id, observed_by_id, injected_total, sampled_bases
+end
+
+# === Run the wired :scalable corrector on one read set ======================
+
+"""
+Correct `records` with the WIRED :scalable knobs (exact replica of
+`_corrector_strategy_knobs(:scalable)` as consumed at
+src/rhizomorph/assembly.jl:879). Returns `(corrected_by_id, result_dict)` where
+`corrected_by_id[id]` is the corrected read sequence keyed by read id.
+"""
+function correct_reads_scalable(records::Vector{FASTX.FASTQ.Record}, k::Int)
+    input_dir = mktempdir()
+    output_dir = mktempdir()
+    temp_fastq = joinpath(input_dir, "corrector_input.fastq")
+    open(FASTX.FASTQ.Writer, temp_fastq) do w
+        for r in records
+            write(w, r)
+        end
+    end
+    max_k = max(k, 13)
+    result = Mycelia.mycelia_iterative_assemble(
+        temp_fastq;
+        max_k = max_k,
+        skip_solid = true,
+        graph_mode = :doublestrand,
+        n_k_rungs = 3,
+        max_iterations_per_k = 2,
+        hard_window = true,
+        soft_em = true,
+        cheap_correct = true,
+        beam_width = nothing,
+        verbose = false,
+        enable_checkpointing = false,
+        output_dir = output_dir
+    )
+    corrected_fastq = get(result[:metadata], :final_fastq_file, nothing)
+    if corrected_fastq === nothing
+        error("iterative corrector metadata is missing :final_fastq_file; " *
+              "keys=$(collect(keys(result[:metadata])))")
+    elseif !isfile(corrected_fastq)
+        error("iterative corrector :final_fastq_file points at a nonexistent path: $corrected_fastq")
+    end
+    corrected_by_id = Dict{String, String}()
+    open(FASTX.FASTQ.Reader, corrected_fastq) do reader
+        for rec in reader
+            corrected_by_id[FASTX.identifier(rec)] = String(FASTX.sequence(BioSequences.LongDNA{4}, rec))
+        end
+    end
+    return corrected_by_id, result
+end
+
+# === Per-base metric computation ============================================
+
+"""
+Compute per-base correction metrics over all reads by joining `corrected_by_id`
+to `truth_by_id` / `observed_by_id` on read id. Reads absent from the corrected
+set (`reads_dropped`) and reads whose corrected length != truth length
+(`reads_excluded_len`, a Viterbi indel path) are counted and EXCLUDED from the
+positional metric rather than silently miscounted.
+
+Position classification for a scored read (truth T, observed O, corrected C, |T|=|O|=|C|):
+  injected error   : O[p] != T[p]
+  edit             : C[p] != O[p]
+  true_fix         : O[p] != T[p]  AND  C[p] == T[p]
+  over_correction  : O[p] == T[p]  AND  C[p] != T[p]   (a correct base made wrong)
+"""
+function per_base_metrics(truth_by_id::Dict{String, String},
+        observed_by_id::Dict{String, String}, corrected_by_id::Dict{String, String})
+    tp = 0                 # true fixes
+    total_edits = 0        # positions where C != O
+    injected = 0           # positions where O != T
+    over = 0               # over-corrections (O==T, C!=T)
+    correct_positions = 0  # positions where O == T
+    total_bases = 0
+    reads_scored = 0
+    reads_excluded_len = 0
+    reads_dropped = 0
+    for (rid, T) in truth_by_id
+        O = observed_by_id[rid]
+        if !haskey(corrected_by_id, rid)
+            reads_dropped += 1
+            continue
+        end
+        C = corrected_by_id[rid]
+        # collect to Char vectors: ACGT are ASCII, but this is robust to any
+        # codeunit subtlety and lets us index positionally.
+        Tc = collect(T)
+        Oc = collect(O)
+        Cc = collect(C)
+        if length(Cc) != length(Tc)
+            reads_excluded_len += 1
+            continue
+        end
+        reads_scored += 1
+        L = length(Tc)
+        total_bases += L
+        for p in 1:L
+            terr = Oc[p] != Tc[p]
+            edited = Cc[p] != Oc[p]
+            terr ? (injected += 1) : (correct_positions += 1)
+            edited && (total_edits += 1)
+            (terr && Cc[p] == Tc[p]) && (tp += 1)
+            (!terr && Cc[p] != Tc[p]) && (over += 1)
+        end
+    end
+    recall = injected == 0 ? NaN : tp / injected
+    precision = total_edits == 0 ? NaN : tp / total_edits
+    over_rate = correct_positions == 0 ? NaN : over / correct_positions
+    correction_rate = total_bases == 0 ? NaN : total_edits / total_bases
+    return (; tp, total_edits, injected, over, correct_positions, total_bases,
+        recall, precision, over_rate, correction_rate,
+        reads_scored, reads_excluded_len, reads_dropped)
+end
+
+# === Main sweep =============================================================
+
+function run_accuracy_benchmark()
+    smoke = _truthy(get(ENV, "MYCELIA_RCA_SMOKE", "false"))
+    accession = get(ENV, "MYCELIA_RCA_ACCESSION", "NC_001416")  # Lambda phage
+    smoke_len = parse(Int, get(ENV, "MYCELIA_RCA_SMOKE_GENOME_LEN", "2000"))
+    errs = _parse_float_list(get(ENV, "MYCELIA_RCA_ERR", ""), [0.01, 0.05, 0.10])
+    readlens = _parse_int_list(get(ENV, "MYCELIA_RCA_READLEN", ""), [150])
+    coverage = parse(Float64, get(ENV, "MYCELIA_RCA_COVERAGE", smoke ? "10" : "30"))
+    k = parse(Int, get(ENV, "MYCELIA_RCA_K", "21"))
+    assigned_q = parse(Int, get(ENV, "MYCELIA_RCA_ASSIGNED_Q", "20"))
+    seed = parse(Int, get(ENV, "MYCELIA_RCA_SEED", "42"))
+    scale_floor = parse(Float64, get(ENV, "MYCELIA_RCA_SCALE_FLOOR", string(SCALE_FLOOR_BASES)))
+
+    println("=== Rhizomorph Correction ACCURACY Benchmark (wired :scalable corrector) ===")
+    println("Start time     : $(Dates.now())")
+    println("Mode           : $(smoke ? "SMOKE (synthetic genome, no network)" : "FULL (download $accession)")")
+    println("Error rates    : $errs  (substitution-only)")
+    println("Read lengths   : $readlens")
+    println("Coverage       : $(coverage)x")
+    println("k / assigned_Q : $k / Q$assigned_q")
+    println("Corrector      : mycelia_iterative_assemble with :scalable knobs (skip_solid, hard_window, soft_em, cheap_correct, doublestrand)")
+    println("Scale floor    : $(scale_floor) bases")
+
+    workdir = mktempdir(prefix = "rca_bench_")
+    results_dir = joinpath(@__DIR__, "results")
+    mkpath(results_dir)
+
+    println("\n--- Acquiring reference ---")
+    refseq, ref_path,
+    ref_label = acquire_reference(
+        smoke = smoke, accession = accession, smoke_len = smoke_len, seed = seed, workdir = workdir)
+    glen = length(refseq)
+    println("Reference: $ref_label ($glen bp)")
+
+    min_readlen = minimum(min.(readlens, glen))
+    if k > min_readlen
+        @warn "k=$k exceeds shortest effective read length $min_readlen; clamping"
+        k = min_readlen
+    end
+
+    rng = Random.MersenneTwister(seed)
+
+    rows = DataFrames.DataFrame(
+        reference = String[], genome_len = Int[], error_rate = Float64[],
+        regime = String[], readlen = Int[], target_coverage = Float64[],
+        effective_coverage = Float64[], k = Int[], assigned_q = Int[],
+        n_reads = Int[], reads_scored = Int[], reads_dropped = Int[],
+        reads_excluded_len = Int[], total_bases = Int[],
+        injected_errors = Int[], total_edits = Int[], true_fixes = Int[],
+        over_corrections = Int[], correct_positions = Int[],
+        recall = Float64[], precision = Float64[], over_correction_rate = Float64[],
+        correction_rate = Float64[], corrector_runtime_s = Float64[]
+    )
+
+    min_effective_coverage = Inf
+
+    println("\n--- Sweeping (error_rate x read-regime) on the wired :scalable corrector ---")
+    for err in errs
+        for readlen in readlens
+            regime, _tech = regime_for_readlen(readlen)
+            println("\n[cell] err=$err  regime=$regime  readlen=$readlen")
+
+            records, truth_by_id,
+            observed_by_id,
+            injected_total,
+            sampled_bases = simulate_substitution_reads(
+                refseq, readlen, coverage, err, rng; assigned_q = assigned_q)
+            eff_cov = glen == 0 ? 0.0 : round(sampled_bases / glen; digits = 2)
+            min_effective_coverage = min(min_effective_coverage, eff_cov)
+            println("  simulated $(length(records)) reads, effective coverage $(eff_cov)x, injected $(injected_total) substitutions")
+
+            local corrected_by_id
+            t0 = time()
+            ok = true
+            try
+                corrected_by_id, _result = correct_reads_scalable(records, k)
+            catch e
+                @warn "Corrector failed for this cell — recording NaN metrics" err readlen exception = (
+                    e, catch_backtrace())
+                ok = false
+                corrected_by_id = Dict{String, String}()
+            end
+            runtime = round(time() - t0; digits = 3)
+
+            m = per_base_metrics(truth_by_id, observed_by_id, corrected_by_id)
+            push!(rows,
+                (
+                    reference = ref_label, genome_len = glen, error_rate = err,
+                    regime = regime, readlen = readlen, target_coverage = coverage,
+                    effective_coverage = eff_cov, k = k, assigned_q = assigned_q,
+                    n_reads = length(records), reads_scored = m.reads_scored,
+                    reads_dropped = m.reads_dropped, reads_excluded_len = m.reads_excluded_len,
+                    total_bases = m.total_bases, injected_errors = m.injected,
+                    total_edits = m.total_edits, true_fixes = m.tp,
+                    over_corrections = m.over, correct_positions = m.correct_positions,
+                    recall = m.recall, precision = m.precision,
+                    over_correction_rate = m.over_rate, correction_rate = m.correction_rate,
+                    corrector_runtime_s = runtime))
+            println("    ok=$ok scored=$(m.reads_scored)/$(length(records)) " *
+                    "dropped=$(m.reads_dropped) excl_len=$(m.reads_excluded_len)")
+            println("    recall=$(round(m.recall; digits=4)) precision=$(round(m.precision; digits=4)) " *
+                    "over_corr_rate=$(round(m.over_rate; digits=6)) " *
+                    "correction_rate=$(round(m.correction_rate; digits=4)) (vs err=$err) $(runtime)s")
+        end
+    end
+
+    # === Summary table ===
+    println("\n=== Per-(error_rate, regime) correction accuracy ===")
+    _fmt = (v) -> rpad(string(v), 12)
+    println(join(
+        _fmt.(["err", "regime", "readlen", "recall", "precision",
+            "over_rate", "corr_rate", "scored"]),
+        ""))
+    for r in eachrow(sort(rows, [:error_rate, :readlen]))
+        println(join(
+            _fmt.([r.error_rate, r.regime, r.readlen,
+                round(r.recall; digits = 4), round(r.precision; digits = 4),
+                round(r.over_correction_rate; digits = 6),
+                round(r.correction_rate; digits = 4), r.reads_scored]),
+            ""))
+    end
+
+    # === Scale guard ===
+    eff_cov_for_guard = isfinite(min_effective_coverage) ? min_effective_coverage : 0.0
+    metric = scale_metric_bases(eff_cov_for_guard, glen)
+    verdict_allowed = scale_verdict_allowed(eff_cov_for_guard, glen; floor = scale_floor)
+    mode = verdict_allowed ? "VERDICT" : "SMOKE-ONLY"
+
+    rows[!, :mode] = fill(mode, DataFrames.nrow(rows))
+    rows[!, :scale_metric_bases] = fill(metric, DataFrames.nrow(rows))
+    rows[!, :scale_floor_bases] = fill(scale_floor, DataFrames.nrow(rows))
+    timestamp = Dates.format(Dates.now(), "yyyymmdd_HHMMSS")
+    csv_path = joinpath(results_dir, "rhizomorph_correction_accuracy_$(timestamp).csv")
+    CSV.write(csv_path, rows)
+    println("\nCSV written: $csv_path")
+
+    if verdict_allowed
+        println("\n=== VERDICT (scale metric $(round(metric; digits=0)) bases >= floor $(scale_floor)) ===")
+        println("Interpretation per cell:")
+        println("  recall high + precision high + over_correction_rate ~0 => corrector fixes errors cleanly")
+        println("  precision < recall or over_correction_rate elevated    => corrector over-corrects")
+        println("  correction_rate should track error_rate (edits ~ true errors); >> error_rate => over-editing")
+    else
+        println("\n=== SMOKE-ONLY (scale metric $(round(metric; digits=0)) bases < floor $(scale_floor)) ===")
+        println("This run is BELOW the scale floor and MUST NOT be quoted as validation.")
+        println("It confirms the harness parses + runs end-to-end. Raise coverage/genome size")
+        println("(or run the full Lambda-phage config on Lovelace) for a VERDICT.")
+    end
+
+    println("\n=== Accuracy benchmark complete: $(Dates.now()) ===")
+    return (csv_path = csv_path, mode = mode, rows = rows)
+end
+
+# Only run when invoked as a script; `include`-ing this file (from the unit test)
+# just defines the functions.
+if abspath(PROGRAM_FILE) == @__FILE__
+    run_accuracy_benchmark()
+end

--- a/benchmarking/rhizomorph_correction_accuracy_benchmark_test.jl
+++ b/benchmarking/rhizomorph_correction_accuracy_benchmark_test.jl
@@ -1,14 +1,14 @@
-# Unit test for the Rhizomorph correction ACCURACY benchmark.
+# Unit test for the Rhizomorph correction ACCURACY benchmark's SIMULATOR.
 #
-# Validates the pure per-base metric classifier `per_base_metrics` on tiny
-# hand-constructed cases with a KNOWN correct answer, and the truth-retention +
-# length-preservation invariants of `simulate_substitution_reads`. This does not
-# run the corrector (that is the slow, network-optional smoke run); it pins the
-# metric MATH, which is what makes the benchmark's numbers trustworthy.
-#
-# Including the benchmark file loads Mycelia (needed for the substitution
-# simulator's mutate_dna_substitution_fraction); the metric assertions
-# themselves are pure.
+# Validates the truth-retention + length-preservation invariants of
+# `simulate_substitution_reads` (which needs Mycelia for
+# mutate_dna_substitution_fraction). The pure per-base metric math is tested
+# separately in rhizomorph_correction_accuracy_metrics_test.jl (Mycelia-free,
+# millisecond runtime). The corrector integration (correct_reads_scalable,
+# run_accuracy_benchmark) is exercised by the MYCELIA_RCA_SMOKE end-to-end run,
+# whose scale + scored-fraction guard is its safety net; note the FASTQ read-ID
+# round-trip (write read_$i -> corrector -> read back) is ONLY observable there,
+# never in these unit tests, so the smoke run is a required verification step.
 #
 # Run:
 #   LD_LIBRARY_PATH='' julia --project=. \
@@ -20,84 +20,7 @@ import BioSequences
 
 include(joinpath(@__DIR__, "rhizomorph_correction_accuracy_benchmark.jl"))
 
-Test.@testset "rhizomorph correction accuracy — per_base_metrics" begin
-    # --- Case A: a clean fix -------------------------------------------------
-    # 1 injected substitution (pos 2 C->G), corrected back to truth.
-    truth = Dict("r1" => "ACGT")
-    observed = Dict("r1" => "AGGT")
-    corrected = Dict("r1" => "ACGT")
-    m = per_base_metrics(truth, observed, corrected)
-    Test.@test m.injected == 1
-    Test.@test m.total_edits == 1
-    Test.@test m.tp == 1
-    Test.@test m.over == 0
-    Test.@test m.recall == 1.0
-    Test.@test m.precision == 1.0
-    Test.@test m.over_rate == 0.0
-    Test.@test m.correction_rate == 1 / 4
-    Test.@test m.reads_scored == 1
-
-    # --- Case B: an over-correction (a correct base made wrong) ---------------
-    # No injected error; corrector changes pos 4 T->A. precision must drop, and
-    # recall is NaN because there were zero errors to recall.
-    truth = Dict("r1" => "ACGT")
-    observed = Dict("r1" => "ACGT")
-    corrected = Dict("r1" => "ACGA")
-    m = per_base_metrics(truth, observed, corrected)
-    Test.@test m.injected == 0
-    Test.@test m.total_edits == 1
-    Test.@test m.tp == 0
-    Test.@test m.over == 1
-    Test.@test isnan(m.recall)          # 0 injected -> undefined recall
-    Test.@test m.precision == 0.0       # 1 edit, 0 good -> precision 0
-    Test.@test m.over_rate == 1 / 4
-
-    # --- Case C: a missed error (no edit at the error) ------------------------
-    truth = Dict("r1" => "ACGT")
-    observed = Dict("r1" => "AGGT")
-    corrected = Dict("r1" => "AGGT")
-    m = per_base_metrics(truth, observed, corrected)
-    Test.@test m.injected == 1
-    Test.@test m.total_edits == 0
-    Test.@test m.tp == 0
-    Test.@test m.recall == 0.0
-    Test.@test isnan(m.precision)       # 0 edits -> undefined precision
-    Test.@test m.over_rate == 0.0
-
-    # --- Case D: a dropped read (absent from corrected set) -------------------
-    truth = Dict("r1" => "ACGT", "r2" => "TTTT")
-    observed = Dict("r1" => "AGGT", "r2" => "TTTT")
-    corrected = Dict("r1" => "ACGT")   # r2 dropped by the corrector
-    m = per_base_metrics(truth, observed, corrected)
-    Test.@test m.reads_dropped == 1
-    Test.@test m.reads_scored == 1     # only r1 scored
-    Test.@test m.tp == 1               # r1's fix still counted
-
-    # --- Case E: a length-mismatched corrected read (Viterbi indel path) ------
-    # Excluded from the positional metric, and reported.
-    truth = Dict("r1" => "ACGT")
-    observed = Dict("r1" => "AGGT")
-    corrected = Dict("r1" => "ACGTA")  # corrector emitted a longer read
-    m = per_base_metrics(truth, observed, corrected)
-    Test.@test m.reads_excluded_len == 1
-    Test.@test m.reads_scored == 0
-    Test.@test m.total_bases == 0
-
-    # --- Aggregation across reads --------------------------------------------
-    # r1 clean fix (1 injected, 1 fixed); r2 over-correction (0 injected, 1 spurious edit).
-    truth = Dict("r1" => "ACGT", "r2" => "GGGG")
-    observed = Dict("r1" => "AGGT", "r2" => "GGGG")
-    corrected = Dict("r1" => "ACGT", "r2" => "GGCG")
-    m = per_base_metrics(truth, observed, corrected)
-    Test.@test m.injected == 1
-    Test.@test m.total_edits == 2      # 1 true fix + 1 over-correction
-    Test.@test m.tp == 1
-    Test.@test m.over == 1
-    Test.@test m.recall == 1.0         # the single injected error was fixed
-    Test.@test m.precision == 1 / 2    # half the edits were spurious
-end
-
-Test.@testset "rhizomorph correction accuracy — simulate_substitution_reads" begin
+Test.@testset "simulate_substitution_reads — truth retention + length preservation" begin
     rng = Random.MersenneTwister(7)
     refseq = BioSequences.randdnaseq(rng, 500)
     err = 0.05
@@ -120,7 +43,9 @@ Test.@testset "rhizomorph correction accuracy — simulate_substitution_reads" b
         O = observed_by_id[rid]
         Test.@test length(T) == length(O)
         Test.@test length(O) == readlen
-        diffs = count(p -> collect(O)[p] != collect(T)[p], eachindex(collect(T)))
+        Tc = collect(T)
+        Oc = collect(O)
+        diffs = count(p -> Oc[p] != Tc[p], eachindex(Tc))
         per_read_injected += diffs
         # ceil(err * readlen) substitutions injected per read (distinct positions,
         # always to a different base) => exactly that many diffs.
@@ -128,4 +53,22 @@ Test.@testset "rhizomorph correction accuracy — simulate_substitution_reads" b
     end
     Test.@test injected_total == per_read_injected
     Test.@test sampled_bases == length(records) * readlen
+end
+
+Test.@testset "simulate_substitution_reads — readlen > genome clamps to genome length" begin
+    # The effective_readlen = min(readlen, glen) clamp: a 60 bp genome with a
+    # 150 bp requested readlen must emit 60 bp reads, not error or pad.
+    rng = Random.MersenneTwister(11)
+    glen = 60
+    refseq = BioSequences.randdnaseq(rng, glen)
+    records, truth_by_id,
+    observed_by_id,
+    injected_total,
+    sampled_bases = simulate_substitution_reads(
+        refseq, 150, 5.0, 0.05, rng; assigned_q = 20)
+    Test.@test !isempty(records)
+    for rec in records
+        Test.@test length(FASTX.sequence(rec)) == glen   # clamped to genome length
+    end
+    Test.@test sampled_bases == length(records) * glen
 end

--- a/benchmarking/rhizomorph_correction_accuracy_benchmark_test.jl
+++ b/benchmarking/rhizomorph_correction_accuracy_benchmark_test.jl
@@ -1,0 +1,131 @@
+# Unit test for the Rhizomorph correction ACCURACY benchmark.
+#
+# Validates the pure per-base metric classifier `per_base_metrics` on tiny
+# hand-constructed cases with a KNOWN correct answer, and the truth-retention +
+# length-preservation invariants of `simulate_substitution_reads`. This does not
+# run the corrector (that is the slow, network-optional smoke run); it pins the
+# metric MATH, which is what makes the benchmark's numbers trustworthy.
+#
+# Including the benchmark file loads Mycelia (needed for the substitution
+# simulator's mutate_dna_substitution_fraction); the metric assertions
+# themselves are pure.
+#
+# Run:
+#   LD_LIBRARY_PATH='' julia --project=. \
+#     benchmarking/rhizomorph_correction_accuracy_benchmark_test.jl
+
+import Test
+import Random
+import BioSequences
+
+include(joinpath(@__DIR__, "rhizomorph_correction_accuracy_benchmark.jl"))
+
+Test.@testset "rhizomorph correction accuracy — per_base_metrics" begin
+    # --- Case A: a clean fix -------------------------------------------------
+    # 1 injected substitution (pos 2 C->G), corrected back to truth.
+    truth = Dict("r1" => "ACGT")
+    observed = Dict("r1" => "AGGT")
+    corrected = Dict("r1" => "ACGT")
+    m = per_base_metrics(truth, observed, corrected)
+    Test.@test m.injected == 1
+    Test.@test m.total_edits == 1
+    Test.@test m.tp == 1
+    Test.@test m.over == 0
+    Test.@test m.recall == 1.0
+    Test.@test m.precision == 1.0
+    Test.@test m.over_rate == 0.0
+    Test.@test m.correction_rate == 1 / 4
+    Test.@test m.reads_scored == 1
+
+    # --- Case B: an over-correction (a correct base made wrong) ---------------
+    # No injected error; corrector changes pos 4 T->A. precision must drop, and
+    # recall is NaN because there were zero errors to recall.
+    truth = Dict("r1" => "ACGT")
+    observed = Dict("r1" => "ACGT")
+    corrected = Dict("r1" => "ACGA")
+    m = per_base_metrics(truth, observed, corrected)
+    Test.@test m.injected == 0
+    Test.@test m.total_edits == 1
+    Test.@test m.tp == 0
+    Test.@test m.over == 1
+    Test.@test isnan(m.recall)          # 0 injected -> undefined recall
+    Test.@test m.precision == 0.0       # 1 edit, 0 good -> precision 0
+    Test.@test m.over_rate == 1 / 4
+
+    # --- Case C: a missed error (no edit at the error) ------------------------
+    truth = Dict("r1" => "ACGT")
+    observed = Dict("r1" => "AGGT")
+    corrected = Dict("r1" => "AGGT")
+    m = per_base_metrics(truth, observed, corrected)
+    Test.@test m.injected == 1
+    Test.@test m.total_edits == 0
+    Test.@test m.tp == 0
+    Test.@test m.recall == 0.0
+    Test.@test isnan(m.precision)       # 0 edits -> undefined precision
+    Test.@test m.over_rate == 0.0
+
+    # --- Case D: a dropped read (absent from corrected set) -------------------
+    truth = Dict("r1" => "ACGT", "r2" => "TTTT")
+    observed = Dict("r1" => "AGGT", "r2" => "TTTT")
+    corrected = Dict("r1" => "ACGT")   # r2 dropped by the corrector
+    m = per_base_metrics(truth, observed, corrected)
+    Test.@test m.reads_dropped == 1
+    Test.@test m.reads_scored == 1     # only r1 scored
+    Test.@test m.tp == 1               # r1's fix still counted
+
+    # --- Case E: a length-mismatched corrected read (Viterbi indel path) ------
+    # Excluded from the positional metric, and reported.
+    truth = Dict("r1" => "ACGT")
+    observed = Dict("r1" => "AGGT")
+    corrected = Dict("r1" => "ACGTA")  # corrector emitted a longer read
+    m = per_base_metrics(truth, observed, corrected)
+    Test.@test m.reads_excluded_len == 1
+    Test.@test m.reads_scored == 0
+    Test.@test m.total_bases == 0
+
+    # --- Aggregation across reads --------------------------------------------
+    # r1 clean fix (1 injected, 1 fixed); r2 over-correction (0 injected, 1 spurious edit).
+    truth = Dict("r1" => "ACGT", "r2" => "GGGG")
+    observed = Dict("r1" => "AGGT", "r2" => "GGGG")
+    corrected = Dict("r1" => "ACGT", "r2" => "GGCG")
+    m = per_base_metrics(truth, observed, corrected)
+    Test.@test m.injected == 1
+    Test.@test m.total_edits == 2      # 1 true fix + 1 over-correction
+    Test.@test m.tp == 1
+    Test.@test m.over == 1
+    Test.@test m.recall == 1.0         # the single injected error was fixed
+    Test.@test m.precision == 1 / 2    # half the edits were spurious
+end
+
+Test.@testset "rhizomorph correction accuracy — simulate_substitution_reads" begin
+    rng = Random.MersenneTwister(7)
+    refseq = BioSequences.randdnaseq(rng, 500)
+    err = 0.05
+    readlen = 100
+    records, truth_by_id,
+    observed_by_id,
+    injected_total,
+    sampled_bases = simulate_substitution_reads(
+        refseq, readlen, 5.0, err, rng; assigned_q = 20)
+
+    Test.@test !isempty(records)
+    Test.@test length(truth_by_id) == length(records)
+
+    # Every read: truth and observed same length (substitution-only), and observed
+    # differs from truth at exactly the injected positions.
+    per_read_injected = 0
+    for rec in records
+        rid = FASTX.identifier(rec)
+        T = truth_by_id[rid]
+        O = observed_by_id[rid]
+        Test.@test length(T) == length(O)
+        Test.@test length(O) == readlen
+        diffs = count(p -> collect(O)[p] != collect(T)[p], eachindex(collect(T)))
+        per_read_injected += diffs
+        # ceil(err * readlen) substitutions injected per read (distinct positions,
+        # always to a different base) => exactly that many diffs.
+        Test.@test diffs == ceil(Int, err * readlen)
+    end
+    Test.@test injected_total == per_read_injected
+    Test.@test sampled_bases == length(records) * readlen
+end

--- a/benchmarking/rhizomorph_correction_accuracy_metrics.jl
+++ b/benchmarking/rhizomorph_correction_accuracy_metrics.jl
@@ -1,0 +1,106 @@
+# Pure per-base correction-accuracy metrics — NO Mycelia dependency.
+# ==================================================================
+#
+# Factored out of rhizomorph_correction_accuracy_benchmark.jl so the metric
+# classification math can be unit-tested in milliseconds without loading Mycelia
+# (the benchmark's simulator + corrector integration is tested separately). This
+# file depends only on Julia Base.
+#
+# `per_base_metrics` joins corrected reads to per-read truth BY READ ID and
+# classifies every base of every scored read. Reads absent from the corrected
+# set (`reads_dropped`) and reads whose corrected length != truth length
+# (`reads_excluded_len`, a Viterbi indel path) are counted and EXCLUDED from the
+# positional metric rather than silently miscounted. `corrected_unjoined` counts
+# corrected reads whose id is NOT in truth — a non-zero value alongside
+# reads_scored==0 is the signature of an ID-FORMAT mismatch (the corrector
+# renamed reads) rather than genuine drops, which the caller warns on.
+#
+# Position classification for a scored read (truth T, observed O, corrected C, |T|=|O|=|C|):
+#   injected error   : O[p] != T[p]
+#   edit             : C[p] != O[p]
+#   true_fix         : O[p] != T[p]  AND  C[p] == T[p]     (error corrected to truth)
+#   mis_fix          : O[p] != T[p]  AND  C[p] != O[p]  AND  C[p] != T[p]  (error edited to a WRONG base)
+#   over_correction  : O[p] == T[p]  AND  C[p] != T[p]     (a correct base made wrong)
+#
+# These partition every edit exactly: total_edits == true_fixes + mis_fixes + over_corrections.
+# (An injected error left unchanged, C[p]==O[p], is a miss: it is neither an edit
+# nor a fix, so it depresses recall without touching precision.)
+#
+# Metrics (aggregated over all scored reads):
+#   recall          = true_fixes / injected_errors
+#   precision       = true_fixes / total_edits
+#   over_correction = over_corrections / correct_positions
+#   correction_rate = total_edits / total_bases            (compare to error_rate)
+# Zero-denominator cells return NaN (an "undefined here — denominator was zero"
+# signal, NOT a measured value); downstream readers must treat NaN as missing.
+
+"""
+    per_base_metrics(truth_by_id, observed_by_id, corrected_by_id) -> NamedTuple
+
+Compute per-base correction metrics by joining `corrected_by_id` to
+`truth_by_id` / `observed_by_id` on read id. See the file header for the exact
+position classification and the `total_edits == true_fixes + mis_fixes +
+over_corrections` partition invariant. Pure (Julia Base only).
+"""
+function per_base_metrics(truth_by_id::Dict{String, String},
+        observed_by_id::Dict{String, String}, corrected_by_id::Dict{String, String})
+    tp = 0                 # true fixes  (O!=T, C==T)
+    mis = 0                # mis-fixes   (O!=T, edited, C!=T)
+    over = 0               # over-corrections (O==T, C!=T)
+    total_edits = 0        # positions where C != O
+    injected = 0           # positions where O != T
+    correct_positions = 0  # positions where O == T
+    total_bases = 0
+    reads_scored = 0
+    reads_excluded_len = 0
+    reads_dropped = 0
+    for (rid, T) in truth_by_id
+        O = observed_by_id[rid]
+        if !haskey(corrected_by_id, rid)
+            reads_dropped += 1
+            continue
+        end
+        C = corrected_by_id[rid]
+        # collect to Char vectors: ACGT are ASCII, but this is robust to any
+        # codeunit subtlety and lets us index positionally.
+        Tc = collect(T)
+        Oc = collect(O)
+        Cc = collect(C)
+        if length(Cc) != length(Tc)
+            reads_excluded_len += 1
+            continue
+        end
+        reads_scored += 1
+        L = length(Tc)
+        total_bases += L
+        for p in 1:L
+            terr = Oc[p] != Tc[p]
+            edited = Cc[p] != Oc[p]
+            terr ? (injected += 1) : (correct_positions += 1)
+            edited && (total_edits += 1)
+            if terr
+                if Cc[p] == Tc[p]
+                    tp += 1               # error corrected to truth
+                elseif edited
+                    mis += 1              # error edited to a wrong base
+                end
+            elseif edited                 # !terr && C!=O  ==>  C!=T (since O==T)
+                over += 1                 # a correct base made wrong
+            end
+        end
+    end
+    # Corrected reads whose id is NOT in truth: with an exact 1:1 substitution
+    # simulation this is 0; a large value alongside reads_scored==0 means the
+    # corrector renamed ids (join is broken), which the caller diagnoses.
+    corrected_unjoined = count(rid -> !haskey(truth_by_id, rid), keys(corrected_by_id))
+    n_reads = length(truth_by_id)
+    scored_fraction = n_reads == 0 ? NaN : reads_scored / n_reads
+    recall = injected == 0 ? NaN : tp / injected
+    precision = total_edits == 0 ? NaN : tp / total_edits
+    over_rate = correct_positions == 0 ? NaN : over / correct_positions
+    correction_rate = total_bases == 0 ? NaN : total_edits / total_bases
+    return (; tp, mis_fixes = mis, over, total_edits, injected, correct_positions,
+        total_bases, recall, precision, over_rate, correction_rate,
+        reads_scored, reads_excluded_len, reads_dropped, corrected_unjoined,
+        n_reads, scored_fraction)
+end

--- a/benchmarking/rhizomorph_correction_accuracy_metrics_test.jl
+++ b/benchmarking/rhizomorph_correction_accuracy_metrics_test.jl
@@ -1,0 +1,156 @@
+# Pure unit test for `per_base_metrics` — NO Mycelia dependency, runs in ms.
+#
+# Includes ONLY the pure metrics file, so the classification math is pinned
+# without loading Mycelia (the simulator/corrector integration is tested in
+# rhizomorph_correction_accuracy_benchmark_test.jl, which needs Mycelia).
+#
+# Run:
+#   julia benchmarking/rhizomorph_correction_accuracy_metrics_test.jl
+
+import Test
+
+include(joinpath(@__DIR__, "rhizomorph_correction_accuracy_metrics.jl"))
+
+Test.@testset "per_base_metrics — classification math" begin
+    # --- Case A: a clean fix -------------------------------------------------
+    m = per_base_metrics(Dict("r1" => "ACGT"), Dict("r1" => "AGGT"), Dict("r1" => "ACGT"))
+    Test.@test m.injected == 1
+    Test.@test m.total_edits == 1
+    Test.@test m.tp == 1
+    Test.@test m.mis_fixes == 0
+    Test.@test m.over == 0
+    Test.@test m.recall == 1.0
+    Test.@test m.precision == 1.0
+    Test.@test m.over_rate == 0.0
+    Test.@test m.correction_rate == 1 / 4
+    Test.@test m.reads_scored == 1
+    Test.@test m.scored_fraction == 1.0
+    Test.@test m.corrected_unjoined == 0
+    # partition invariant
+    Test.@test m.total_edits == m.tp + m.mis_fixes + m.over
+
+    # --- Case B: an over-correction (correct base made wrong) ----------------
+    m = per_base_metrics(Dict("r1" => "ACGT"), Dict("r1" => "ACGT"), Dict("r1" => "ACGA"))
+    Test.@test m.injected == 0
+    Test.@test m.total_edits == 1
+    Test.@test m.tp == 0
+    Test.@test m.mis_fixes == 0
+    Test.@test m.over == 1
+    Test.@test isnan(m.recall)          # 0 injected -> undefined recall
+    Test.@test m.precision == 0.0
+    Test.@test m.over_rate == 1 / 4
+    Test.@test m.total_edits == m.tp + m.mis_fixes + m.over
+
+    # --- Case C: a missed error (no edit at the error) -----------------------
+    m = per_base_metrics(Dict("r1" => "ACGT"), Dict("r1" => "AGGT"), Dict("r1" => "AGGT"))
+    Test.@test m.injected == 1
+    Test.@test m.total_edits == 0
+    Test.@test m.tp == 0
+    Test.@test m.mis_fixes == 0
+    Test.@test m.recall == 0.0
+    Test.@test isnan(m.precision)       # 0 edits -> undefined precision
+    Test.@test m.over_rate == 0.0
+
+    # --- Case MIS: an error edited to a WRONG base (mis-fix) -----------------
+    # pos-2 error C->G, corrector changes it to T (still wrong). Distinct from
+    # both true_fix and over_correction; depresses recall AND precision.
+    m = per_base_metrics(Dict("r1" => "ACGT"), Dict("r1" => "AGGT"), Dict("r1" => "ATGT"))
+    Test.@test m.injected == 1
+    Test.@test m.total_edits == 1
+    Test.@test m.tp == 0
+    Test.@test m.mis_fixes == 1
+    Test.@test m.over == 0
+    Test.@test m.recall == 0.0
+    Test.@test m.precision == 0.0       # the one edit did not land on truth
+    Test.@test m.over_rate == 0.0
+    Test.@test m.total_edits == m.tp + m.mis_fixes + m.over
+
+    # --- Case 3CLASS: all three edit classes in one read ---------------------
+    # T=ACGTAC O=AGCTAC (p2,p3 errors) C=ATGTGC:
+    #   p2 error edited to wrong base (mis), p3 error fixed (tp), p5 correct->G (over).
+    m = per_base_metrics(Dict("r1" => "ACGTAC"), Dict("r1" => "AGCTAC"), Dict("r1" => "ATGTGC"))
+    Test.@test m.injected == 2
+    Test.@test m.tp == 1
+    Test.@test m.mis_fixes == 1
+    Test.@test m.over == 1
+    Test.@test m.total_edits == 3
+    Test.@test m.total_edits == m.tp + m.mis_fixes + m.over
+    Test.@test m.recall == 1 / 2
+    Test.@test m.precision == 1 / 3
+    Test.@test m.correct_positions == 4
+    Test.@test m.over_rate == 1 / 4
+
+    # --- Case CLEAN: zero errors, zero edits (do-no-harm) --------------------
+    m = per_base_metrics(Dict("r1" => "ACGT"), Dict("r1" => "ACGT"), Dict("r1" => "ACGT"))
+    Test.@test m.injected == 0
+    Test.@test m.total_edits == 0
+    Test.@test m.over == 0
+    Test.@test m.over_rate == 0.0
+    Test.@test m.correction_rate == 0.0
+    Test.@test isnan(m.recall)
+    Test.@test isnan(m.precision)
+    Test.@test m.reads_scored == 1
+
+    # --- Case ALLERR: every position is an error (over_rate NaN branch) -------
+    m = per_base_metrics(Dict("r1" => "AAAA"), Dict("r1" => "CCCC"), Dict("r1" => "AAAA"))
+    Test.@test m.injected == 4
+    Test.@test m.correct_positions == 0
+    Test.@test m.tp == 4
+    Test.@test m.recall == 1.0
+    Test.@test m.precision == 1.0
+    Test.@test isnan(m.over_rate)       # 0 correct positions -> undefined over-rate
+    Test.@test m.correction_rate == 1.0
+
+    # --- Case D: a dropped read (absent from corrected set) -------------------
+    m = per_base_metrics(
+        Dict("r1" => "ACGT", "r2" => "TTTT"),
+        Dict("r1" => "AGGT", "r2" => "TTTT"),
+        Dict("r1" => "ACGT"))
+    Test.@test m.reads_dropped == 1
+    Test.@test m.reads_scored == 1
+    Test.@test m.tp == 1
+    Test.@test m.scored_fraction == 1 / 2
+
+    # --- Case E: length-mismatched corrected read (Viterbi indel path) --------
+    m = per_base_metrics(Dict("r1" => "ACGT"), Dict("r1" => "AGGT"), Dict("r1" => "ACGTA"))
+    Test.@test m.reads_excluded_len == 1
+    Test.@test m.reads_scored == 0
+    Test.@test m.total_bases == 0
+    Test.@test isnan(m.correction_rate)  # 0 total_bases -> undefined
+    Test.@test m.scored_fraction == 0.0
+
+    # --- Case UNJOINED: corrected read whose id is not in truth ---------------
+    # Signature of an ID-format mismatch; counted, not silently ignored.
+    m = per_base_metrics(
+        Dict("r1" => "ACGT"),
+        Dict("r1" => "AGGT"),
+        Dict("r1" => "ACGT", "r2" => "GGGG"))
+    Test.@test m.corrected_unjoined == 1
+    Test.@test m.reads_scored == 1
+
+    # --- Case EMPTY: empty inputs are safe (all-NaN/zero) ---------------------
+    m = per_base_metrics(Dict{String, String}(), Dict{String, String}(), Dict{
+        String, String}())
+    Test.@test m.n_reads == 0
+    Test.@test m.reads_scored == 0
+    Test.@test m.total_edits == 0
+    Test.@test isnan(m.scored_fraction)
+    Test.@test isnan(m.recall)
+    Test.@test isnan(m.precision)
+    Test.@test isnan(m.over_rate)
+    Test.@test isnan(m.correction_rate)
+
+    # --- Aggregation across reads --------------------------------------------
+    # r1 clean fix (1 injected, 1 fixed); r2 over-correction (0 injected, 1 spurious).
+    m = per_base_metrics(
+        Dict("r1" => "ACGT", "r2" => "GGGG"),
+        Dict("r1" => "AGGT", "r2" => "GGGG"),
+        Dict("r1" => "ACGT", "r2" => "GGCG"))
+    Test.@test m.injected == 1
+    Test.@test m.total_edits == 2
+    Test.@test m.tp == 1
+    Test.@test m.over == 1
+    Test.@test m.recall == 1.0
+    Test.@test m.precision == 1 / 2
+    Test.@test m.total_edits == m.tp + m.mis_fixes + m.over
+end

--- a/benchmarking/rhizomorph_correction_calibration_benchmark.jl
+++ b/benchmarking/rhizomorph_correction_calibration_benchmark.jl
@@ -109,6 +109,8 @@ function run_calibration_benchmark()
     seed = parse(Int, get(ENV, "MYCELIA_RCC_SEED", "42"))
     k_cal = parse(Int, get(ENV, "MYCELIA_RCC_KCAL", "15"))
     c0 = parse(Float64, get(ENV, "MYCELIA_RCC_C0", "2.0"))
+    c0 > 0 ||
+        throw(ArgumentError("MYCELIA_RCC_C0 must be > 0 (it is the naive-map denominator constant)"))
     nbins = parse(Int, get(ENV, "MYCELIA_RCC_NBINS", "10"))
 
     println("=== Rhizomorph Correction CALIBRATION Benchmark (Tier-1: min-k-mer-coverage) ===")
@@ -188,6 +190,14 @@ function run_calibration_benchmark()
 
     # Naive monotone map to a probability for reliability/ECE/Brier (a fitted
     # Platt/isotonic map is the follow-on; this is illustrative).
+    # NOTE: the coverage table is self-counted (it includes the read being
+    # scored), so min_cov >= 1 for every scored read and the mapped probability is
+    # FLOORED at 1/(1+c0) (=0.333 at the default c0=2). Reliability bins below that
+    # floor are therefore always empty by construction — a structural property of
+    # a self-counted reference-free signal, NOT a signal failure. It does not
+    # affect the AUROC headline (rank-based on the raw min_cov). A leave-one-out
+    # count (exclude the scored read's own k-mers) would let the signal express
+    # coverage 0; deferred with the fitted-map work.
     probs = Float64[mc / (mc + c0) for mc in min_covs]
     ece = expected_calibration_error(probs, corrects; nbins = nbins)
     br = brier_score(probs, corrects)

--- a/benchmarking/rhizomorph_correction_calibration_benchmark.jl
+++ b/benchmarking/rhizomorph_correction_calibration_benchmark.jl
@@ -1,0 +1,215 @@
+# Rhizomorph Correction CALIBRATION Benchmark (Tier-1)
+# ====================================================
+#
+# "Reference-free correctness prediction": can a signal available WITHOUT a
+# reference predict whether a corrected read is actually right? This is the
+# infrastructure for td-pw7p Priority #2 (the flagship differentiator that
+# justifies the Nature-Methods ambition).
+#
+# TIER-1 (this harness): calibrate the reference-free MINIMUM K-MER COVERAGE of a
+# corrected read — computed from a k-mer count table over the corrected read set
+# ALONE (no reference, no decoder internals). A residual error spawns
+# low-coverage k-mers, so min-coverage is the canonical "solid vs weak" signal
+# Stage 0 already trusts. We measure how well it DISCRIMINATES correct from
+# incorrect reads (AUROC) and how CALIBRATED a naive monotone map of it is
+# (reliability / ECE / Brier).
+#
+# TIER-2 (follow-on, needs decoder instrumentation): the per-BASE best-vs-2nd-best
+# path log-probability GAP. Both Viterbi loops (viterbi-next.jl, path-finding.jl)
+# already visit every competing successor but keep only the argmax; capturing the
+# runner-up is a localized but hot-loop change with a perf-neutral requirement, so
+# it is deliberately deferred. This Tier-1 harness establishes the calibration
+# toolkit (calibration_metrics.jl) that Tier-2 will reuse verbatim on the gap
+# signal; only the confidence-extraction changes.
+#
+# IMPORTANT (why not the corrected read's Phred): adjust_quality_scores
+# (src/iterative-assembly.jl) is a NO-OP on same-length reads — it returns the
+# input quality unchanged — so the corrected FASTQ's Phred carries zero
+# correction-confidence and is NOT a usable signal. Min-k-mer-coverage is.
+#
+# Signal -> probability: AUROC is rank-based and uses the raw min-coverage
+# (discrimination, no mapping needed) — it is the HONEST headline. ECE / Brier /
+# reliability need a probability, so we apply a naive monotone map
+# p = min_cov / (min_cov + C0). A PROPERLY FITTED map (Platt / isotonic on a
+# held-out split) is a follow-on; the naive map is illustrative and labelled as
+# such.
+#
+# Usage:
+#   MYCELIA_RCC_SMOKE=true LD_LIBRARY_PATH='' \
+#     julia --project=. benchmarking/rhizomorph_correction_calibration_benchmark.jl
+#
+# Env (RCC prefix; error/coverage/k mirror the accuracy harness):
+#   MYCELIA_RCC_SMOKE, MYCELIA_RCC_SMOKE_GENOME_LEN, MYCELIA_RCC_ACCESSION,
+#   MYCELIA_RCC_ERR, MYCELIA_RCC_READLEN, MYCELIA_RCC_COVERAGE, MYCELIA_RCC_K,
+#   MYCELIA_RCC_ASSIGNED_Q, MYCELIA_RCC_SEED,
+#   MYCELIA_RCC_KCAL   (k for the coverage signal, default 15),
+#   MYCELIA_RCC_C0     (naive map denominator constant, default 2.0),
+#   MYCELIA_RCC_NBINS  (reliability bins, default 10)
+
+import Pkg
+if isinteractive()
+    Pkg.activate(joinpath(@__DIR__, ".."))
+end
+
+# Reuse the accuracy harness (simulate_substitution_reads, correct_reads_scalable,
+# acquire_reference) + the pure calibration metrics. Including the accuracy
+# benchmark also pulls the validation-sweep helpers + scale guard it includes.
+include(joinpath(@__DIR__, "rhizomorph_correction_accuracy_benchmark.jl"))
+include(joinpath(@__DIR__, "calibration_metrics.jl"))
+
+# === Reference-free min-k-mer-coverage signal ===============================
+
+"""Canonical (strand-merged) k-mer string: min of the k-mer and its rev-comp."""
+function _canonical_kmer(s::AbstractString)
+    comp = Dict('A' => 'T', 'C' => 'G', 'G' => 'C', 'T' => 'A', 'N' => 'N')
+    rc = String([get(comp, c, c) for c in reverse(collect(s))])
+    return s <= rc ? String(s) : rc
+end
+
+"""
+Count canonical k_cal-mers across ALL corrected reads (a reference-free coverage
+table). Returns a Dict{String,Int}.
+"""
+function corrected_kmer_coverage(corrected_by_id::Dict{String, String}, k_cal::Int)
+    counts = Dict{String, Int}()
+    for (_id, seq) in corrected_by_id
+        length(seq) < k_cal && continue
+        cs = collect(seq)
+        for i in 1:(length(cs) - k_cal + 1)
+            kmer = _canonical_kmer(String(cs[i:(i + k_cal - 1)]))
+            counts[kmer] = get(counts, kmer, 0) + 1
+        end
+    end
+    return counts
+end
+
+"""Minimum canonical-k_cal-mer coverage along `seq` (Inf-proxy -1 if too short)."""
+function min_kmer_coverage(seq::AbstractString, counts::Dict{String, Int}, k_cal::Int)
+    length(seq) < k_cal && return -1
+    cs = collect(seq)
+    m = typemax(Int)
+    for i in 1:(length(cs) - k_cal + 1)
+        kmer = _canonical_kmer(String(cs[i:(i + k_cal - 1)]))
+        m = min(m, get(counts, kmer, 0))
+    end
+    return m
+end
+
+# === Main =====================================================================
+
+function run_calibration_benchmark()
+    smoke = _truthy(get(ENV, "MYCELIA_RCC_SMOKE", "false"))
+    accession = get(ENV, "MYCELIA_RCC_ACCESSION", "NC_001416")
+    smoke_len = parse(Int, get(ENV, "MYCELIA_RCC_SMOKE_GENOME_LEN", "2000"))
+    errs = _parse_float_list(get(ENV, "MYCELIA_RCC_ERR", ""), [0.02, 0.05, 0.10])
+    readlens = _parse_int_list(get(ENV, "MYCELIA_RCC_READLEN", ""), [150])
+    coverage = parse(Float64, get(ENV, "MYCELIA_RCC_COVERAGE", smoke ? "15" : "30"))
+    k = parse(Int, get(ENV, "MYCELIA_RCC_K", "21"))
+    assigned_q = parse(Int, get(ENV, "MYCELIA_RCC_ASSIGNED_Q", "20"))
+    seed = parse(Int, get(ENV, "MYCELIA_RCC_SEED", "42"))
+    k_cal = parse(Int, get(ENV, "MYCELIA_RCC_KCAL", "15"))
+    c0 = parse(Float64, get(ENV, "MYCELIA_RCC_C0", "2.0"))
+    nbins = parse(Int, get(ENV, "MYCELIA_RCC_NBINS", "10"))
+
+    println("=== Rhizomorph Correction CALIBRATION Benchmark (Tier-1: min-k-mer-coverage) ===")
+    println("Start time : $(Dates.now())")
+    println("Mode       : $(smoke ? "SMOKE (synthetic, no network)" : "FULL (download $accession)")")
+    println("Error rates: $errs   coverage: $(coverage)x   k: $k   k_cal: $k_cal   C0: $c0")
+
+    workdir = mktempdir(prefix = "rcc_bench_")
+    refseq, _ref_path,
+    ref_label = acquire_reference(
+        smoke = smoke, accession = accession, smoke_len = smoke_len, seed = seed, workdir = workdir)
+    glen = length(refseq)
+    println("Reference  : $ref_label ($glen bp)")
+    if k > min(minimum(readlens), glen)
+        k = min(minimum(readlens), glen)
+    end
+    rng = Random.MersenneTwister(seed)
+
+    # Pool per-read (confidence, correct) across all error-rate cells so both
+    # classes (correct / incorrect reads) are represented.
+    min_covs = Int[]
+    corrects = Bool[]
+    n_dropped = 0
+    n_short = 0
+
+    for err in errs
+        for readlen in readlens
+            println("\n[cell] err=$err readlen=$readlen")
+            records, truth_by_id,
+            _obs,
+            injected_total,
+            _sb = simulate_substitution_reads(
+                refseq, readlen, coverage, err, rng; assigned_q = assigned_q)
+            println("  $(length(records)) reads, injected $injected_total substitutions")
+            local corrected_by_id
+            try
+                corrected_by_id, _r = correct_reads_scalable(records, k)
+            catch e
+                @warn "corrector failed; skipping cell" err readlen exception = (
+                    e, catch_backtrace())
+                continue
+            end
+            counts = corrected_kmer_coverage(corrected_by_id, k_cal)
+            for (rid, T) in truth_by_id
+                if !haskey(corrected_by_id, rid)
+                    n_dropped += 1
+                    continue
+                end
+                C = corrected_by_id[rid]
+                mc = min_kmer_coverage(C, counts, k_cal)
+                if mc < 0
+                    n_short += 1
+                    continue
+                end
+                push!(min_covs, mc)
+                push!(corrects, C == T)   # reference-free signal vs TRUE correctness
+            end
+        end
+    end
+
+    n = length(min_covs)
+    println("\n--- Pooled calibration set ---")
+    println("scored reads: $n   dropped: $n_dropped   too-short(<k_cal): $n_short")
+    if n == 0
+        println("No scored reads — cannot calibrate.");
+        return nothing
+    end
+    n_correct = count(corrects)
+    println("fully-correct reads: $n_correct  ($(round(100n_correct/n; digits=1))%)   incorrect: $(n - n_correct)")
+
+    # Rank-based discrimination on the RAW signal (no probability mapping needed).
+    au = auroc(min_covs, corrects)
+    println("\nAUROC (min-k-mer-coverage discriminates correct vs incorrect reads): $(round(au; digits=4))")
+    if isnan(au)
+        println("  (AUROC undefined — only one correctness class present; vary error rate/coverage)")
+    end
+
+    # Naive monotone map to a probability for reliability/ECE/Brier (a fitted
+    # Platt/isotonic map is the follow-on; this is illustrative).
+    probs = Float64[mc / (mc + c0) for mc in min_covs]
+    ece = expected_calibration_error(probs, corrects; nbins = nbins)
+    br = brier_score(probs, corrects)
+    println("\nNaive map p = min_cov/(min_cov + $c0):  ECE=$(round(ece; digits=4))  Brier=$(round(br; digits=4))")
+    println("Reliability (naive map):")
+    println("  ", rpad("bin", 12), rpad("mean_conf", 12), rpad("accuracy", 12), "count")
+    for b in reliability_bins(probs, corrects; nbins = nbins)
+        println("  ", rpad("[$(round(b.lo;digits=2)),$(round(b.hi;digits=2)))", 12),
+            rpad(string(round(b.mean_conf; digits = 4)), 12),
+            rpad(string(round(b.accuracy; digits = 4)), 12), b.count)
+    end
+
+    println("\nInterpretation:")
+    println("  AUROC >> 0.5 => min-k-mer-coverage is a usable reference-free correctness signal.")
+    println("  AUROC ~ 0.5  => this signal does not discriminate here (try Tier-2 log-prob gap).")
+    println("  ECE near 0   => the naive map is already well-calibrated; large => needs a fitted map.")
+    println("NOTE: Tier-2 (per-base best-vs-2nd-best path log-prob gap) reuses calibration_metrics.jl")
+    println("      verbatim; only the confidence-extraction changes. That is the flagship signal.")
+    println("\n=== Calibration benchmark complete: $(Dates.now()) ===")
+    return (; n, auroc = au, ece, brier = br)
+end
+
+if abspath(PROGRAM_FILE) == @__FILE__
+    run_calibration_benchmark()
+end


### PR DESCRIPTION
## Summary

`td-pw7p` Priority #2 — reference-free correctness prediction (the flagship differentiator). Establishes the reusable calibration toolkit and a Tier-1 result on an exposed signal.

- **`benchmarking/calibration_metrics.jl`** (pure, Mycelia-free): reliability curve, **Expected Calibration Error**, **AUROC** (Mann-Whitney, rank-based), **Brier score** — none existed in the repo (only a buried AUC in `benchmarking/stage0_*`). 25-assertion Mycelia-free unit test (ms runtime, hand-computed expecteds).
- **`benchmarking/rhizomorph_correction_calibration_benchmark.jl`**: calibrates the reference-free **minimum k-mer coverage** of a corrected read (from a k-mer table over the corrected read set alone — no reference, no decoder internals) against true per-read correctness, reusing the PR #395 accuracy harness.

## Result (smoke — synthetic 2 kb, 15×, k=21, k_cal=15)

- **AUROC = 0.996** — min-k-mer-coverage is a near-perfect **discriminator** of correct vs incorrect corrected reads (weakest-k-mer well-covered ⇒ almost always correct; low-coverage bin is 0.2% correct, high bins 100%).
- **ECE = 0.29** — the *naive* probability map `p = min_cov/(min_cov+C0)` is **miscalibrated** (over-confident on low-coverage reads). Discrimination is solved; a **fitted** map (Platt/isotonic) is the follow-on.

## Tier-2 (follow-on)

The flagship signal is the per-**base** best-vs-2nd-best **path log-probability gap**. Both Viterbi loops already visit every competing successor but keep only the argmax; capturing the runner-up is a localized but hot-loop change (perf-neutral requirement), so it's deferred. Tier-2 reuses `calibration_metrics.jl` verbatim — only the confidence-extraction changes.

## Notes

- Why not the corrected read's Phred: `adjust_quality_scores` is a no-op on same-length reads (returns input quality unchanged) → output Phred carries zero correction-confidence. Documented in the harness header.
- **Stacked on `cp/rhizomorph-precision-harness` (PR #395)** — base is that branch (reuses its accuracy harness). Merge #395 first.

## Test plan

- [x] `julia benchmarking/calibration_metrics_test.jl` → 25/25 (Mycelia-free)
- [x] `MYCELIA_RCC_SMOKE=true julia --project=. benchmarking/rhizomorph_correction_calibration_benchmark.jl` → runs end-to-end, AUROC 0.996 / ECE 0.29
- [ ] VERDICT-scale run + fitted probability map → follow-on

## Related

`td-pw7p` Priority #2; epic `td-9q84`.