### PR TITLE
add: indel-aware pair-HMM kernel for the graph-Viterbi read corrector

### DIFF
--- a/src/viterbi-next.jl
+++ b/src/viterbi-next.jl
@@ -12,7 +12,8 @@ function default_viterbi_emission_logp(
         node::Any,
         alphabet::Symbol;
         quality = nothing,
-        error_rate::Float64 = 0.01
+        error_rate::Float64 = 0.01,
+        count_length_penalty::Bool = true
 )::Float64
     if error_rate <= 0.0 || error_rate >= 1.0
         throw(ArgumentError("error_rate must be in (0, 1), got $error_rate"))
@@ -50,13 +51,22 @@ function default_viterbi_emission_logp(
         end
     end
 
-    for index in (shared + 1):max(length(observed_chars), length(expected_chars))
-        position_error_rate = _viterbi_position_error_rate(
-            quality_scores,
-            index,
-            error_rate
-        )
-        logp += log(position_error_rate / alphabet_size)
+    # Flat trailing length penalty for a length mismatch between observed and
+    # expected. This is a FRAMESHIFT charge, not an indel model — with the
+    # indel-aware pair-HMM active, insertion/deletion MOVES score the length change
+    # explicitly, so keeping this term would DOUBLE-COUNT it and bias the MAP path.
+    # The indel kernel passes `count_length_penalty=false` to drop it; the
+    # substitution decoder keeps it (default true), where it is score-neutral on the
+    # equal-length correct-back-to-reference fixtures anyway.
+    if count_length_penalty
+        for index in (shared + 1):max(length(observed_chars), length(expected_chars))
+            position_error_rate = _viterbi_position_error_rate(
+                quality_scores,
+                index,
+                error_rate
+            )
+            logp += log(position_error_rate / alphabet_size)
+        end
     end
     return logp
 end
@@ -1117,8 +1127,23 @@ function _call_viterbi_emission_logp(
         observed_unit::Any,
         node::Any,
         alphabet::Symbol;
-        quality = nothing
+        quality = nothing,
+        count_length_penalty::Bool = true
 )::Float64
+    # The `count_length_penalty=false` request (indel kernel dropping the flat
+    # frameshift charge) is only meaningful for the built-in emission; a custom
+    # callback need not accept the keyword, so route it explicitly only for the
+    # default and leave every other caller/callback byte-identical.
+    if !count_length_penalty && config.emission_logp === default_viterbi_emission_logp
+        return default_viterbi_emission_logp(
+            observed_unit,
+            node,
+            alphabet;
+            quality = quality,
+            error_rate = config.error_rate,
+            count_length_penalty = false
+        )
+    end
     try
         return config.emission_logp(
             observed_unit,
@@ -1243,6 +1268,22 @@ function _viterbi_correct_observation(
 )::Rhizomorph.ViterbiDecodingResult
     if isempty(observation)
         throw(ArgumentError("empty observation path"))
+    end
+
+    # Indel-aware pair-HMM branch (nanopore correction). When gap MOVES are enabled
+    # the decode is a 2D DP over (read-index, graph-state) with an M/I/D phase
+    # layer; when disabled (the DEFAULT) we fall straight through to the untouched
+    # substitution lock-step decoder below, so it stays byte-identical.
+    if config.indel_moves
+        return _viterbi_correct_observation_indel(
+            graph,
+            observation,
+            alphabet;
+            config = config,
+            strand_mode = strand_mode,
+            quality_graph = quality_graph,
+            transition_scoring = transition_scoring
+        )
     end
 
     # Per-read decode hot path (td-y4oj): resolve the label type and emptiness in
@@ -1521,6 +1562,368 @@ function _viterbi_correct_observation(
     return Rhizomorph.ViterbiDecodingResult(path, best_score, diagnostics)
 end
 
+# Keep only the top-`beam_width` states (by score, hash tie-break) of a
+# state->score layer dict, IN PLACE. No-op when the dict already fits. Mirrors
+# `_prune_correction_beam` but for a single phase layer of the pair-HMM.
+function _beam_prune_layer!(scores::Dict{S, Float64}, beam_width::Int) where {S}
+    length(scores) <= beam_width && return scores
+    ordered = sort!(collect(scores); by = kv -> (last(kv), hash(first(kv))), rev = true)
+    keep = Set{S}(first(kv) for kv in Iterators.take(ordered, beam_width))
+    for state in collect(keys(scores))
+        state in keep || delete!(scores, state)
+    end
+    return scores
+end
+
+"""
+$(DocStringExtensions.TYPEDSIGNATURES)
+
+Indel-aware pair-HMM decode of one observation against a Rhizomorph weighted
+graph. This is the gap-move counterpart of `_viterbi_correct_observation`,
+selected when `config.indel_moves` is set.
+
+The DP promotes the read index `i` AND an alignment phase `φ ∈ {M, I, D}` into the
+state key `(vertex, strand, φ)` (the substitution decoder carries `i` implicitly
+in its depth loop and has no phase), so length changes between the read and the
+graph walk are scored by TRUE moves rather than a flat frameshift penalty:
+
+  * **M** (match/mismatch) consumes one read unit AND advances one graph edge,
+    scoring the existing Phred-aware emission `e_M`.
+  * **I** (insertion) consumes one read unit and STAYS on the vertex (`e_I`,
+    default `log(1/|alphabet|)`), bounded by `max_insertion_run`.
+  * **D** (deletion) advances one graph edge and consumes NO read unit (`e_D = 0`),
+    computed as a bounded Bellman-Ford relaxation of up to `deletion_max_run` hops
+    within a read column (the scalable replacement for the legacy O(V³)
+    Floyd-Warshall).
+
+Affine transition masses come from the error model: `δ_I = ε·f_ins`,
+`δ_D = ε·f_del` (substitution mass rides inside `e_M`), with geometric gap-extend
+`γ_I`, `γ_D`. Setting the indel fractions to 0 sends every gap transition to
+`log(0) = -Inf`, so the reachable frontier collapses to the pure-M substitution
+path — Illumina falls out as the special case.
+"""
+function _viterbi_correct_observation_indel(
+        graph::MetaGraphsNext.MetaGraph,
+        observation::AbstractVector,
+        alphabet::Symbol;
+        config::ViterbiCorrectionConfig,
+        strand_mode::Symbol,
+        quality_graph::MetaGraphsNext.MetaGraph = graph,
+        transition_scoring::Symbol = :normalized_edge_weight
+)::Rhizomorph.ViterbiDecodingResult
+    if Graphs.nv(graph.graph) == 0
+        throw(ArgumentError("cannot correct observations against an empty graph"))
+    end
+
+    label_type = _viterbi_graph_label_type(graph)
+    State = Tuple{label_type, Rhizomorph.StrandOrientation}
+    Cell = Tuple{Int, State, Symbol}
+    n = length(observation)
+
+    start_observed = first(observation)
+    target_vertex = _emission_target_vertex(
+        graph, observation, config, alphabet, strand_mode)
+    start_candidates = _viterbi_start_candidates(
+        graph, label_type, _viterbi_label_unit(start_observed), alphabet, strand_mode)
+
+    alphabet_size = _viterbi_alphabet_size(alphabet)
+    insertion_emission = function (observed_unit)
+        if config.insertion_emission_logp === nothing
+            return -log(alphabet_size)
+        end
+        return config.insertion_emission_logp(observed_unit, alphabet)
+    end
+
+    # Affine transition masses from the error model. δ_I/δ_D = 0 ⇒ log(0) = -Inf,
+    # which drops the gap moves and collapses the DP to the substitution path.
+    error_rate = config.error_rate
+    delta_I = error_rate * config.insertion_fraction
+    delta_D = error_rate * config.deletion_fraction
+    gamma_I = config.insertion_extend_probability
+    gamma_D = config.deletion_extend_probability
+    T_MM = log(1.0 - delta_I - delta_D)
+    T_MI = log(delta_I)
+    T_MD = log(delta_D)
+    T_II = log(gamma_I)
+    T_IM = log1p(-gamma_I)
+    T_DD = log(gamma_D)
+    T_DM = log1p(-gamma_D)
+
+    deletion_max_run = config.deletion_max_run
+    max_insertion_run = config.max_insertion_run
+    band = config.band_width
+    finite_beam = config.beam_width != typemax(Int)
+
+    diagnostics = Dict{Symbol, Any}(
+        :algorithm => :viterbi_indel_pair_hmm,
+        :indel_moves => true,
+        :exact => (!finite_beam && band === nothing),
+        :alphabet => alphabet,
+        :strand_mode => strand_mode,
+        :reverse_complement_support => _viterbi_supports_reverse_complement(alphabet),
+        :read_length => n,
+        :target_vertex => target_vertex,
+        :start_strand => Rhizomorph._normalize_strand(config.start_strand),
+        :score_domain => :log_probability,
+        :transition_scoring => transition_scoring,
+        :emission_scoring => _viterbi_graph_has_quality(quality_graph) ?
+                             :quality_aware : :alphabet_parameterized,
+        :move_counts => Dict{Symbol, Int}(:M => 0, :I => 0, :D => 0),
+        :reached_target => target_vertex === nothing ? nothing : false
+    )
+
+    # Global backpointer: (read_index, state, phase) -> predecessor cell or nothing.
+    backpointers = Dict{Cell, Union{Nothing, Cell}}()
+
+    # Outgoing (target-state, logE) expansion for one state, matching the
+    # substitution decoder's normalization (log of edge_weight / total_out).
+    # NOTE: these nested helpers are closures, so their signatures/locals must not
+    # annotate with the enclosing `State`/`label_type` locals (Julia forbids a local
+    # variable in a closure type position). Untyped collections are correctness-
+    # equivalent here.
+    function _expand(state)
+        vertex, strand = state
+        transitions = Rhizomorph._get_valid_transitions(graph, vertex, strand)
+        out = Tuple{Any, Float64}[]
+        isempty(transitions) && return out
+        total_out = Rhizomorph._total_outgoing_weight(graph, vertex, strand)
+        (!isfinite(total_out) || total_out <= 0.0) && return out
+        for transition in transitions
+            next_vertex = convert(label_type, transition[:target_vertex])
+            next_strand = Rhizomorph._normalize_strand(transition[:target_strand])
+            edge_w = Rhizomorph._edge_transition_weight(transition[:edge_data])
+            edge_w <= 0.0 && continue
+            push!(out, ((next_vertex, next_strand), log(edge_w / total_out)))
+        end
+        return out
+    end
+
+    # Bounded Bellman-Ford deletion relaxation WITHIN one read column: open a
+    # deletion from every M-state (run 1) then extend along graph edges up to
+    # `deletion_max_run` hops. `deletion_max_run` + negative `log γ_D` guard against
+    # unbounded no-progress loops on graph cycles.
+    function _relax_deletions!(
+            read_index,
+            match_scores,
+            match_net,
+            del_scores,
+            del_net,
+            del_run
+    )
+        deletion_max_run <= 0 && return
+        for (state, score) in match_scores
+            for (next_state, logE) in _expand(state)
+                cand = score + T_MD + logE
+                isfinite(cand) || continue
+                if !haskey(del_scores, next_state) || cand > del_scores[next_state]
+                    del_scores[next_state] = cand
+                    del_run[next_state] = 1
+                    del_net[next_state] = match_net[state] + 1
+                    backpointers[(read_index, next_state, :D)] = (read_index, state, :M)
+                end
+            end
+        end
+        for hop in 2:deletion_max_run
+            frontier = [state for (state, run) in del_run if run == hop - 1]
+            for state in frontier
+                score = del_scores[state]
+                for (next_state, logE) in _expand(state)
+                    cand = score + T_DD + logE
+                    isfinite(cand) || continue
+                    if !haskey(del_scores, next_state) || cand > del_scores[next_state]
+                        del_scores[next_state] = cand
+                        del_run[next_state] = hop
+                        del_net[next_state] = del_net[state] + 1
+                        backpointers[(read_index, next_state, :D)] = (read_index, state, :D)
+                    end
+                end
+            end
+        end
+    end
+
+    # Layer 1: seed the match phase from the start candidates (no gap at the very
+    # start — the read is anchored, matching the substitution decoder's seed), then
+    # relax deletions within the column.
+    match_scores = Dict{State, Float64}()
+    ins_scores = Dict{State, Float64}()
+    del_scores = Dict{State, Float64}()
+    match_net = Dict{State, Int}()
+    ins_net = Dict{State, Int}()
+    del_net = Dict{State, Int}()
+    ins_run = Dict{State, Int}()
+    del_run = Dict{State, Int}()
+
+    for vertex in start_candidates
+        for strand in
+            _viterbi_start_strands(graph, vertex, strand_mode, config.start_strand)
+            state = (vertex, strand)
+            score = _call_viterbi_state_emission_logp(
+                quality_graph, config, start_observed, vertex, alphabet, strand_mode;
+                count_length_penalty = false)
+            if isfinite(score) &&
+               (!haskey(match_scores, state) || score > match_scores[state])
+                match_scores[state] = score
+                match_net[state] = 0
+                backpointers[(1, state, :M)] = nothing
+            end
+        end
+    end
+    if isempty(match_scores)
+        diagnostics[:reason] = :no_finite_start_emission
+        return Rhizomorph.ViterbiDecodingResult(nothing, -Inf, diagnostics)
+    end
+    _relax_deletions!(1, match_scores, match_net, del_scores, del_net, del_run)
+
+    for read_index in 2:n
+        observed_unit = observation[read_index]
+        new_match = Dict{State, Float64}()
+        new_ins = Dict{State, Float64}()
+        new_del = Dict{State, Float64}()
+        new_match_net = Dict{State, Int}()
+        new_ins_net = Dict{State, Int}()
+        new_del_net = Dict{State, Int}()
+        new_ins_run = Dict{State, Int}()
+        new_del_run = Dict{State, Int}()
+
+        # M into (i, v): consume a read unit AND advance an edge, from any phase of
+        # the previous column.
+        for (phase, prev_scores, prev_net, trans) in (
+            (:M, match_scores, match_net, T_MM),
+            (:I, ins_scores, ins_net, T_IM),
+            (:D, del_scores, del_net, T_DM)
+        )
+            for (state, score) in prev_scores
+                base = score + trans
+                isfinite(base) || continue
+                for (next_state, logE) in _expand(state)
+                    emission = _call_viterbi_state_emission_logp(
+                        quality_graph, config, observed_unit, next_state[1],
+                        alphabet, strand_mode; count_length_penalty = false)
+                    cand = base + logE + emission
+                    isfinite(cand) || continue
+                    if !haskey(new_match, next_state) || cand > new_match[next_state]
+                        new_match[next_state] = cand
+                        new_match_net[next_state] = prev_net[state]
+                        backpointers[(read_index, next_state, :M)] = (
+                            read_index - 1, state, phase)
+                    end
+                end
+            end
+        end
+
+        # I into (i, v): consume a read unit and STAY on v, from previous M or I,
+        # bounded by the insertion-run cap.
+        emission_ins = insertion_emission(observed_unit)
+        if max_insertion_run >= 1 && isfinite(emission_ins)
+            for (state, score) in match_scores
+                cand = score + T_MI + emission_ins
+                isfinite(cand) || continue
+                if !haskey(new_ins, state) || cand > new_ins[state]
+                    new_ins[state] = cand
+                    new_ins_net[state] = match_net[state] - 1
+                    new_ins_run[state] = 1
+                    backpointers[(read_index, state, :I)] = (read_index - 1, state, :M)
+                end
+            end
+            for (state, score) in ins_scores
+                ins_run[state] >= max_insertion_run && continue
+                cand = score + T_II + emission_ins
+                isfinite(cand) || continue
+                if !haskey(new_ins, state) || cand > new_ins[state]
+                    new_ins[state] = cand
+                    new_ins_net[state] = ins_net[state] - 1
+                    new_ins_run[state] = ins_run[state] + 1
+                    backpointers[(read_index, state, :I)] = (read_index - 1, state, :I)
+                end
+            end
+        end
+
+        # D within (i, v): relax deletions from the freshly-built match layer.
+        _relax_deletions!(
+            read_index, new_match, new_match_net, new_del, new_del_net, new_del_run)
+
+        # Adaptive band: drop states whose net gap (graph-steps − read-index =
+        # #deletions − #insertions) exceeds the half-width. `nothing` = unbounded
+        # (exact). Applied AFTER the deletion relaxation so a banded state cannot
+        # seed a new column.
+        if band !== nothing
+            for (scores, nets) in (
+                (new_match, new_match_net), (new_ins, new_ins_net), (new_del, new_del_net))
+                for state in collect(keys(scores))
+                    if abs(nets[state]) > band
+                        delete!(scores, state)
+                    end
+                end
+            end
+        end
+
+        if finite_beam
+            _beam_prune_layer!(new_match, config.beam_width)
+            _beam_prune_layer!(new_ins, config.beam_width)
+            _beam_prune_layer!(new_del, config.beam_width)
+        end
+
+        match_scores, ins_scores, del_scores = new_match, new_ins, new_del
+        match_net, ins_net, del_net = new_match_net, new_ins_net, new_del_net
+        ins_run, del_run = new_ins_run, new_del_run
+
+        if isempty(match_scores) && isempty(ins_scores) && isempty(del_scores)
+            break
+        end
+    end
+
+    # Endpoint: the best-scoring (state, phase) at the final read index. When a
+    # target vertex is pinned, restrict to states on it. Deterministic tie-break by
+    # (score, vertex string, phase) so a beam tie is reproducible.
+    best_score = -Inf
+    best_cell::Union{Nothing, Cell} = nothing
+    best_key = (-Inf, "", "")
+    for (phase, scores) in ((:M, match_scores), (:I, ins_scores), (:D, del_scores))
+        for (state, score) in scores
+            (target_vertex !== nothing && state[1] != target_vertex) && continue
+            key = (score, string(state[1]), string(phase))
+            if best_cell === nothing || score > best_score ||
+               (score == best_score && key < best_key)
+                best_score = score
+                best_cell = (n, state, phase)
+                best_key = key
+            end
+        end
+    end
+
+    if best_cell === nothing
+        diagnostics[:reason] = target_vertex === nothing ? :no_surviving_path :
+                               :target_unreachable
+        return Rhizomorph.ViterbiDecodingResult(nothing, -Inf, diagnostics)
+    end
+
+    # Reconstruct the graph walk: follow backpointers to the start, then keep the
+    # vertex of every M and D move (both traverse a real edge); an I move stays on
+    # its vertex and contributes NO new vertex.
+    chain = Cell[]
+    cursor::Union{Nothing, Cell} = best_cell
+    while cursor !== nothing
+        push!(chain, cursor)
+        cursor = backpointers[cursor]
+    end
+    reverse!(chain)
+
+    path_states = State[]
+    for (index, (_, state, phase)) in enumerate(chain)
+        diagnostics[:move_counts][phase] += 1
+        if index == 1 || phase != :I
+            push!(path_states, state)
+        end
+    end
+
+    path = Rhizomorph._build_graph_path_from_vertices(graph, path_states)
+    diagnostics[:path_length] = length(path.steps)
+    if target_vertex !== nothing
+        diagnostics[:reached_target] = true
+    end
+    return Rhizomorph.ViterbiDecodingResult(path, best_score, diagnostics)
+end
+
 function _emission_target_vertex(
         graph::MetaGraphsNext.MetaGraph,
         observation::AbstractVector,
@@ -1638,7 +2041,8 @@ function _call_viterbi_state_emission_logp(
         observed_unit::Any,
         node::Any,
         alphabet::Symbol,
-        strand_mode::Symbol
+        strand_mode::Symbol;
+        count_length_penalty::Bool = true
 )::Float64
     quality = _viterbi_emission_quality(graph, observed_unit)
     direct = _call_viterbi_emission_logp(
@@ -1646,7 +2050,8 @@ function _call_viterbi_state_emission_logp(
         observed_unit,
         node,
         alphabet;
-        quality = quality
+        quality = quality,
+        count_length_penalty = count_length_penalty
     )
     if strand_mode == :canonical && _viterbi_supports_reverse_complement(alphabet)
         rc_node = _viterbi_reverse_complement_unit(node, alphabet)
@@ -1655,7 +2060,8 @@ function _call_viterbi_state_emission_logp(
             observed_unit,
             rc_node,
             alphabet;
-            quality = quality
+            quality = quality,
+            count_length_penalty = count_length_penalty
         )
         return max(direct, rc)
     end

--- a/src/viterbi-next.jl
+++ b/src/viterbi-next.jl
@@ -228,6 +228,24 @@ struct ViterbiCorrectionConfig{F <: Function}
             throw(ArgumentError(
                 "beam_score_margin must be a positive number or Inf, got $beam_score_margin"))
         end
+        # Silent-no-op guard (PR #407 review, silent-failure I2): `indel_moves=true`
+        # with NO indel capacity — either both gap masses zero
+        # (`insertion_fraction == deletion_fraction == 0`) or both run caps zero
+        # (`deletion_max_run == max_insertion_run == 0`) — sends every gap
+        # transition to `log(0) = -Inf`, so the "indel-aware" decode silently
+        # collapses to substitution-only. This is a legitimate configuration (it is
+        # exactly how the collapse/oracle test proves byte-identity), so we WARN
+        # rather than error, but we surface it so an operator does not believe they
+        # enabled indel correction when they did not.
+        if indel_moves && (
+            (insertion_fraction == 0.0 && deletion_fraction == 0.0) ||
+            (deletion_max_run == 0 && max_insertion_run == 0)
+        )
+            @warn "indel_moves=true but no indel capacity is configured " *
+                  "(insertion_fraction/deletion_fraction both 0, or " *
+                  "deletion_max_run/max_insertion_run both 0); the decode is " *
+                  "effectively substitution-only."
+        end
         return new{F}(
             error_rate,
             verbosity,
@@ -1928,6 +1946,19 @@ function _viterbi_correct_observation_indel(
     path = Rhizomorph._build_graph_path_from_vertices(graph, path_states)
     diagnostics[:path_length] = length(path.steps)
     diagnostics[:decoded_read_index] = last_index
+    # Truncation is a first-class diagnostic (PR #407 review, silent-failure I1). On
+    # the free-endpoint decode a noisy read can kill the whole frontier before the
+    # last read unit; we KEEP the best-so-far prefix as the result, but stamp
+    # `:truncated` so callers do not have to INFER truncation by diffing
+    # `:decoded_read_index` against the read length. A verbosity-gated `@warn` makes
+    # a partial decode visible to an operator watching the reads/debug streams.
+    truncated = last_index < n
+    diagnostics[:truncated] = truncated
+    if truncated && target_vertex === nothing && config.verbosity in ("debug", "reads")
+        @warn "indel-aware decode truncated: the read frontier died at unit " *
+              "$(last_index) of $(n); the returned path covers only the decoded " *
+              "prefix (see diagnostics[:decoded_read_index])."
+    end
     if target_vertex !== nothing
         diagnostics[:reached_target] = true
     end

--- a/src/viterbi-next.jl
+++ b/src/viterbi-next.jl
@@ -1774,6 +1774,12 @@ function _viterbi_correct_observation_indel(
     end
     _relax_deletions!(1, match_scores, match_net, del_scores, del_net, del_run)
 
+    # The read index of the layer currently held in match/ins/del_scores. If a noisy
+    # read kills the whole frontier mid-decode we KEEP the last non-empty layer (its
+    # index) and select the best-so-far endpoint from it, rather than mislabeling the
+    # surviving cells with the full read length `n`.
+    last_index = 1
+
     for read_index in 2:n
         observed_unit = observation[read_index]
         new_match = Dict{State, Float64}()
@@ -1863,13 +1869,16 @@ function _viterbi_correct_observation_indel(
             _beam_prune_layer!(new_del, config.beam_width)
         end
 
+        # If the whole frontier died this column, KEEP the previous (non-empty) layer
+        # as the decode result and stop — do not swap in the empty layer.
+        if isempty(new_match) && isempty(new_ins) && isempty(new_del)
+            break
+        end
+
         match_scores, ins_scores, del_scores = new_match, new_ins, new_del
         match_net, ins_net, del_net = new_match_net, new_ins_net, new_del_net
         ins_run, del_run = new_ins_run, new_del_run
-
-        if isempty(match_scores) && isempty(ins_scores) && isempty(del_scores)
-            break
-        end
+        last_index = read_index
     end
 
     # Endpoint: the best-scoring (state, phase) at the final read index. When a
@@ -1885,7 +1894,7 @@ function _viterbi_correct_observation_indel(
             if best_cell === nothing || score > best_score ||
                (score == best_score && key < best_key)
                 best_score = score
-                best_cell = (n, state, phase)
+                best_cell = (last_index, state, phase)
                 best_key = key
             end
         end
@@ -1918,6 +1927,7 @@ function _viterbi_correct_observation_indel(
 
     path = Rhizomorph._build_graph_path_from_vertices(graph, path_states)
     diagnostics[:path_length] = length(path.steps)
+    diagnostics[:decoded_read_index] = last_index
     if target_vertex !== nothing
         diagnostics[:reached_target] = true
     end

--- a/src/viterbi-next.jl
+++ b/src/viterbi-next.jl
@@ -123,6 +123,32 @@ struct ViterbiCorrectionConfig{F <: Function}
     # each depth) into its diagnostics. Default false => the decode is byte-
     # identical AND perf-neutral (no top-2 scan on the hot path).
     record_position_gaps::Bool
+    # Indel-aware pair-HMM extension (nanopore correction). All fields DEFAULT to
+    # the substitution-collapse values, so the constructor default reproduces the
+    # substitution-only decoder byte-for-byte: `indel_moves=false` short-circuits
+    # before the gap kernel is ever entered, and every gap mass is 0 (⇒ gap
+    # transitions score `log(0) = -Inf` ⇒ dropped by the `isfinite` guard even if
+    # the kernel is entered with these zero fractions). `insertion_fraction` and
+    # `deletion_fraction` partition the per-base error rate into gap-open masses
+    # (`δ_I = error_rate·f_ins`, `δ_D = error_rate·f_del`); the remainder is the
+    # substitution mass that rides inside the existing emission term. The
+    # `*_extend_probability` fields are the affine gap-EXTEND probabilities
+    # (`γ_I`, `γ_D`) — one-time open then cheaper extend, because nanopore indels
+    # cluster in homopolymer runs (geometric run lengths). `deletion_max_run`
+    # (`D_max`) bounds consecutive deletions (the bounded Bellman-Ford relaxation
+    # replacing the legacy O(V³) Floyd-Warshall; also guards graph-cycle
+    # no-progress loops). `max_insertion_run` bounds consecutive insertions.
+    # `band_width` is the adaptive diagonal-band half-width on the net gap
+    # (graph-steps − read-index); `nothing` = unbounded (the exact/oracle setting).
+    indel_moves::Bool
+    insertion_fraction::Float64
+    deletion_fraction::Float64
+    insertion_extend_probability::Float64
+    deletion_extend_probability::Float64
+    deletion_max_run::Int
+    max_insertion_run::Int
+    band_width::Union{Nothing, Int}
+    insertion_emission_logp::Union{Nothing, Function}
 
     function ViterbiCorrectionConfig{F}(;
             error_rate::Float64 = 0.01,
@@ -137,10 +163,43 @@ struct ViterbiCorrectionConfig{F <: Function}
             beam_width::Int = typemax(Int),
             max_successors_per_state::Int = typemax(Int),
             beam_score_margin::Float64 = Inf,
-            record_position_gaps::Bool = false
+            record_position_gaps::Bool = false,
+            indel_moves::Bool = false,
+            insertion_fraction::Float64 = 0.0,
+            deletion_fraction::Float64 = 0.0,
+            insertion_extend_probability::Float64 = 0.0,
+            deletion_extend_probability::Float64 = 0.0,
+            deletion_max_run::Int = 0,
+            max_insertion_run::Int = 0,
+            band_width::Union{Nothing, Int} = nothing,
+            insertion_emission_logp::Union{Nothing, Function} = nothing
     ) where {F <: Function}
         if error_rate <= 0.0 || error_rate >= 0.5
             throw(ArgumentError("error_rate must be in (0, 0.5), got $error_rate"))
+        end
+        if insertion_fraction < 0.0 || deletion_fraction < 0.0 ||
+           insertion_fraction + deletion_fraction >= 1.0
+            throw(ArgumentError(
+                "insertion_fraction/deletion_fraction must be non-negative and sum " *
+                "to < 1 (the remainder is substitution mass), got " *
+                "$insertion_fraction / $deletion_fraction"))
+        end
+        for (name, value) in (
+            (:insertion_extend_probability, insertion_extend_probability),
+            (:deletion_extend_probability, deletion_extend_probability)
+        )
+            if value < 0.0 || value >= 1.0
+                throw(ArgumentError("$name must be in [0, 1), got $value"))
+            end
+        end
+        if deletion_max_run < 0
+            throw(ArgumentError("deletion_max_run must be non-negative, got $deletion_max_run"))
+        end
+        if max_insertion_run < 0
+            throw(ArgumentError("max_insertion_run must be non-negative, got $max_insertion_run"))
+        end
+        if band_width !== nothing && band_width < 0
+            throw(ArgumentError("band_width must be non-negative or nothing, got $band_width"))
         end
         if !(verbosity in ("debug", "reads", "dataset", "silent"))
             throw(ArgumentError("unsupported verbosity: $verbosity"))
@@ -172,7 +231,16 @@ struct ViterbiCorrectionConfig{F <: Function}
             beam_width,
             max_successors_per_state,
             beam_score_margin,
-            record_position_gaps
+            record_position_gaps,
+            indel_moves,
+            insertion_fraction,
+            deletion_fraction,
+            insertion_extend_probability,
+            deletion_extend_probability,
+            deletion_max_run,
+            max_insertion_run,
+            band_width,
+            insertion_emission_logp
         )
     end
 end
@@ -190,7 +258,16 @@ function ViterbiCorrectionConfig(;
         beam_width::Int = typemax(Int),
         max_successors_per_state::Int = typemax(Int),
         beam_score_margin::Float64 = Inf,
-        record_position_gaps::Bool = false
+        record_position_gaps::Bool = false,
+        indel_moves::Bool = false,
+        insertion_fraction::Float64 = 0.0,
+        deletion_fraction::Float64 = 0.0,
+        insertion_extend_probability::Float64 = 0.0,
+        deletion_extend_probability::Float64 = 0.0,
+        deletion_max_run::Int = 0,
+        max_insertion_run::Int = 0,
+        band_width::Union{Nothing, Int} = nothing,
+        insertion_emission_logp::Union{Nothing, Function} = nothing
 )::ViterbiCorrectionConfig{F} where {F <: Function}
     return ViterbiCorrectionConfig{F}(
         error_rate = error_rate,
@@ -205,7 +282,16 @@ function ViterbiCorrectionConfig(;
         beam_width = beam_width,
         max_successors_per_state = max_successors_per_state,
         beam_score_margin = beam_score_margin,
-        record_position_gaps = record_position_gaps
+        record_position_gaps = record_position_gaps,
+        indel_moves = indel_moves,
+        insertion_fraction = insertion_fraction,
+        deletion_fraction = deletion_fraction,
+        insertion_extend_probability = insertion_extend_probability,
+        deletion_extend_probability = deletion_extend_probability,
+        deletion_max_run = deletion_max_run,
+        max_insertion_run = max_insertion_run,
+        band_width = band_width,
+        insertion_emission_logp = insertion_emission_logp
     )
 end
 

--- a/test/4_assembly/viterbi_indel_decoder_test.jl
+++ b/test/4_assembly/viterbi_indel_decoder_test.jl
@@ -15,6 +15,7 @@
 
 import BioSequences
 import FASTX
+import Logging
 import MetaGraphsNext
 import Mycelia
 import Test
@@ -24,6 +25,33 @@ function indel_decoded_label_strings(
 )::Vector{String}
     decoded = only(result.corrected_observations)
     return [string(label) for label in decoded]
+end
+
+# A read-quality observation wrapper for the quality-aware oracle case (mirrors the
+# struct used by viterbi_variable_length_graph_correction_test.jl).
+struct IndelQualityObservation{S}
+    sequence::S
+    quality_scores::Vector{UInt8}
+end
+
+function indel_quality_record(
+        identifier::AbstractString,
+        sequence::AbstractString,
+        phred::AbstractVector{<:Integer}
+)::FASTX.FASTQ.Record
+    quality = String([Char(score + 33) for score in phred])
+    return FASTX.FASTQ.Record(identifier, sequence, quality)
+end
+
+# Bare-k-mer observation vector for a DNA string, threaded through the SAME
+# decomposition the k-mer-graph corrector consumes (detect_alphabet ->
+# typed-sequence -> record k-mer iterator). Used by the C1 base-level indel test.
+function indel_string_kmer_units(seq_string::AbstractString, k::Int)
+    record = FASTX.FASTA.Record("obs", seq_string)
+    alphabet = Mycelia.detect_alphabet(seq_string)
+    sequence_type = Mycelia.alphabet_to_biosequence_type(alphabet)
+    sequence = Mycelia.extract_typed_sequence(record, sequence_type)
+    return collect(Mycelia._record_kmer_iterator(sequence_type, k, sequence))
 end
 
 Test.@testset "Indel-aware pair-HMM Viterbi correction" begin
@@ -78,7 +106,11 @@ Test.@testset "Indel-aware pair-HMM Viterbi correction" begin
         return Mycelia.Rhizomorph.build_fasta_graph_olc(records; min_overlap = 3)
     end
 
-    function _indel_config(; indel_moves = true)
+    function _indel_config(;
+            indel_moves = true,
+            deletion_max_run = 3,
+            max_insertion_run = 3
+    )
         return Mycelia.ViterbiCorrectionConfig(
             error_rate = 0.10,
             indel_moves = indel_moves,
@@ -86,8 +118,8 @@ Test.@testset "Indel-aware pair-HMM Viterbi correction" begin
             deletion_fraction = 0.30,
             insertion_extend_probability = 0.10,
             deletion_extend_probability = 0.10,
-            deletion_max_run = 3,
-            max_insertion_run = 3,
+            deletion_max_run = deletion_max_run,
+            max_insertion_run = max_insertion_run,
             beam_width = typemax(Int)
         )
     end
@@ -213,10 +245,18 @@ Test.@testset "Indel-aware pair-HMM Viterbi correction" begin
         Test.@test indel_decoded_label_strings(banded_in) == ["ATGCG", "GCGTA", "GTACC"]
 
         # max_insertion_run = 0 forbids the I-move, so the insertion cannot be
-        # absorbed and the free-endpoint decode no longer lands the 3-vertex walk.
+        # absorbed and the free-endpoint decode frame-shifts one vertex too far onto
+        # the spurious downstream vertex ACCGT. Assert the EXACT over-walk (not just
+        # "not the reference") so a compensating error that happened to differ from
+        # the reference could not pass — mirroring the two-directional deletion knobs.
         no_ins = Mycelia.correct_observations(
             graph, [insertion_observed]; config = _cfg(max_insertion_run = 0))
-        Test.@test indel_decoded_label_strings(no_ins) != ["ATGCG", "GCGTA", "GTACC"]
+        Test.@test indel_decoded_label_strings(no_ins) ==
+                   ["ATGCG", "GCGTA", "GTACC", "ACCGT"]
+        # max_insertion_run >= 1 admits the single I-move and recovers the reference.
+        yes_ins = Mycelia.correct_observations(
+            graph, [insertion_observed]; config = _cfg(max_insertion_run = 1))
+        Test.@test indel_decoded_label_strings(yes_ins) == ["ATGCG", "GCGTA", "GTACC"]
     end
 
     Test.@testset "Milestone C: nanopore-style read decodes through the kernel" begin
@@ -273,5 +313,190 @@ Test.@testset "Indel-aware pair-HMM Viterbi correction" begin
         # walked the graph, not a degenerate empty result).
         Test.@test only(result.paths).path !== nothing
         Test.@test diag[:move_counts][:M] >= 1
+    end
+
+    Test.@testset "C1: real single-BASE indel corrects back to the reference path" begin
+        # The PIVOTAL correctness test. The Milestone-B fixtures are UNIT-level
+        # (whole k-mer inserted/deleted) and the nanopore smoke asserts only routing.
+        # This asserts the ACTUAL nanopore failure mode: a single BASE indel in the
+        # read corrupts the k k-mer windows spanning it (an indel + a local
+        # substitution burst), and the decode must recover the clean reference's
+        # k-mer walk EXACTLY. Start and end sit on clean k-mers (indel placed mid-
+        # read) so both endpoints anchor; the indel kernel bridges the frame shift
+        # with a single gap move and tolerates the corrupted-window mismatches.
+        k = 7
+        reference = Mycelia.random_fasta_record(moltype = :DNA, seed = 1, L = 40)
+        reference_string = FASTX.sequence(String, reference)
+        reference_units = indel_string_kmer_units(reference_string, k)
+        # Non-repetitive reference => the graph is a simple path, so the true k-mer
+        # walk is unambiguous and equality against it is a well-posed assertion.
+        Test.@test length(unique(string.(reference_units))) == length(reference_units)
+
+        graph = Mycelia.Rhizomorph.build_kmer_graph_singlestrand([reference], k)
+        expected = [string(unit) for unit in reference_units]
+
+        indel_position = 20
+        deleted_string = reference_string[1:(indel_position - 1)] *
+                         reference_string[(indel_position + 1):end]
+        inserted_string = reference_string[1:indel_position] * "A" *
+                          reference_string[(indel_position + 1):end]
+        Test.@test length(deleted_string) == length(reference_string) - 1
+        Test.@test length(inserted_string) == length(reference_string) + 1
+
+        deleted_units = indel_string_kmer_units(deleted_string, k)
+        inserted_units = indel_string_kmer_units(inserted_string, k)
+
+        config = Mycelia.ViterbiCorrectionConfig(
+            error_rate = 0.10,
+            strand_mode = :singlestrand,
+            indel_moves = true,
+            insertion_fraction = 0.30,
+            deletion_fraction = 0.30,
+            insertion_extend_probability = 0.10,
+            deletion_extend_probability = 0.10,
+            deletion_max_run = 3,
+            max_insertion_run = 3,
+            beam_width = typemax(Int),
+            band_width = nothing
+        )
+
+        deleted_result = Mycelia.correct_observations(
+            graph, [deleted_units]; config = config)
+        Test.@test indel_decoded_label_strings(deleted_result) == expected
+
+        inserted_result = Mycelia.correct_observations(
+            graph, [inserted_units]; config = config)
+        Test.@test indel_decoded_label_strings(inserted_result) == expected
+    end
+
+    Test.@testset "over-correction guard: clean read takes ZERO gap moves" begin
+        # A clean, error-free, equal-length read through an indel-ENABLED config
+        # (with full gap capacity) must decode with NO gap moves. The Milestone-B
+        # clean-read assertion checks the labels but not the gap counts, so a
+        # compensating insertion+deletion pair could sneak past it; asserting zero I
+        # AND zero D closes that hole.
+        graph = _indel_olc_graph()
+        observed = [
+            BioSequences.dna"ATGCG",
+            BioSequences.dna"GCGTA",
+            BioSequences.dna"GTACC"
+        ]
+        result = Mycelia.correct_observations(graph, [observed]; config = _indel_config())
+        move_counts = only(result.paths).diagnostics[:move_counts]
+        Test.@test move_counts[:I] == 0
+        Test.@test move_counts[:D] == 0
+        Test.@test indel_decoded_label_strings(result) == ["ATGCG", "GCGTA", "GTACC"]
+    end
+
+    Test.@testset "oracle battery: substitution inputs preserved byte-for-byte" begin
+        # Strengthen oracle preservation from a single fixture to a battery of
+        # DIFFERENT substitution inputs, asserting each decodes IDENTICALLY under
+        # (a) the DEFAULT substitution decoder, (b) the indel config with moves OFF,
+        # and (c) the indel KERNEL run with all gap mass ZERO (the mathematical
+        # collapse). Equality is asserted against the substitution decoder's ACTUAL
+        # output, not a hand-written answer, so the collapse cannot silently diverge.
+        function _assert_oracle_equivalent(graph, observation)
+            substitution = Mycelia.correct_observations(
+                graph, [observation];
+                config = Mycelia.ViterbiCorrectionConfig(error_rate = 0.10))
+            substitution_labels = indel_decoded_label_strings(substitution)
+
+            moves_off = Mycelia.correct_observations(
+                graph, [observation]; config = _indel_config(indel_moves = false))
+            Test.@test indel_decoded_label_strings(moves_off) == substitution_labels
+
+            # indel_moves=true with every gap mass 0 routes through the indel kernel
+            # but collapses to the substitution path. The zero-capacity config trips
+            # the new silent-no-op @warn (FIX code-1), so absorb it — the collapse is
+            # a deliberate, byte-identity-proving configuration, not a misconfig.
+            collapsed = Logging.with_logger(Logging.NullLogger()) do
+                Mycelia.correct_observations(
+                    graph, [observation];
+                    config = Mycelia.ViterbiCorrectionConfig(
+                        error_rate = 0.10,
+                        indel_moves = true,
+                        insertion_fraction = 0.0,
+                        deletion_fraction = 0.0,
+                        deletion_max_run = 0,
+                        max_insertion_run = 0,
+                        beam_width = typemax(Int)))
+            end
+            Test.@test indel_decoded_label_strings(collapsed) == substitution_labels
+            return substitution_labels
+        end
+
+        graph = _indel_olc_graph()
+        # Multi-vertex substitution (middle unit corrupted; endpoint anchored).
+        _assert_oracle_equivalent(graph,
+            [BioSequences.dna"ATGCG", BioSequences.dna"GCGTT", BioSequences.dna"GTACC"])
+        # Free-endpoint case (last unit GTACG is not a graph vertex => endpoint free).
+        _assert_oracle_equivalent(graph,
+            [BioSequences.dna"ATGCG", BioSequences.dna"GCGTA", BioSequences.dna"GTACG"])
+
+        # Quality-aware case: a FASTQ OLC graph with a read-quality observation, so
+        # the emission model is :quality_aware rather than :alphabet_parameterized.
+        quality_records = [
+            indel_quality_record("read_1", "ATGCG", [40, 40, 40, 40, 40]),
+            indel_quality_record("read_2", "GCGTA", [40, 40, 40, 40, 40]),
+            indel_quality_record("read_3", "GTACC", [40, 40, 40, 40, 40])
+        ]
+        quality_graph = Mycelia.Rhizomorph.build_fastq_graph_olc(
+            quality_records; min_overlap = 3)
+        _assert_oracle_equivalent(quality_graph,
+            [
+                BioSequences.dna"ATGCG",
+                IndelQualityObservation(BioSequences.dna"GCGTT", UInt8[2, 2, 2, 2, 2]),
+                BioSequences.dna"GTACC"
+            ])
+    end
+
+    Test.@testset "D_max: a deletion run exceeding the cap fails gracefully" begin
+        # A read that skips THREE vertices ([ATGCG, CGTAA] on ATGCG->GCGTA->GTACC->
+        # ACCGT->CGTAA) needs a deletion RUN of 2 within a read column to bridge to
+        # the anchored terminal CGTAA. deletion_max_run = 1 caps the run below that,
+        # so the target is unreachable and the decode returns `nothing` GRACEFULLY
+        # (no crash); deletion_max_run >= 2 recovers the full 5-vertex walk.
+        graph = _indel_olc_graph()
+        observed = [BioSequences.dna"ATGCG", BioSequences.dna"CGTAA"]
+        capped = Mycelia.correct_observations(
+            graph, [observed];
+            config = _indel_config(deletion_max_run = 1))
+        Test.@test only(capped.corrected_observations) === nothing
+        recovered = Mycelia.correct_observations(
+            graph, [observed];
+            config = _indel_config(deletion_max_run = 2))
+        Test.@test indel_decoded_label_strings(recovered) ==
+                   ["ATGCG", "GCGTA", "GTACC", "ACCGT", "CGTAA"]
+    end
+
+    Test.@testset "truncation is a first-class diagnostic" begin
+        # A free-endpoint read whose frontier DIES mid-decode returns the best-so-far
+        # prefix; `diagnostics[:truncated]` must make that explicit (FIX code-2). The
+        # read starts on the terminal vertex CGTAA (no outgoing edges) then presents a
+        # junk unit TTTTT; with insertion disabled there is no M, I, or D move, so the
+        # frontier dies at read unit 1 and the decode is truncated but still returns a
+        # path (the CGTAA prefix).
+        graph = _indel_olc_graph()
+        truncated_observed = [BioSequences.dna"CGTAA", BioSequences.dna"TTTTT"]
+        truncated = Mycelia.correct_observations(
+            graph, [truncated_observed];
+            config = _indel_config(max_insertion_run = 0))
+        truncated_diag = only(truncated.paths).diagnostics
+        Test.@test only(truncated.corrected_observations) !== nothing
+        Test.@test truncated_diag[:truncated] == true
+        Test.@test truncated_diag[:decoded_read_index] < length(truncated_observed)
+
+        # A normal full decode consumes every read unit => not truncated.
+        full_observed = [
+            BioSequences.dna"ATGCG",
+            BioSequences.dna"AAAAA",
+            BioSequences.dna"GCGTA",
+            BioSequences.dna"GTACA"
+        ]
+        full = Mycelia.correct_observations(
+            graph, [full_observed]; config = _indel_config())
+        full_diag = only(full.paths).diagnostics
+        Test.@test full_diag[:truncated] == false
+        Test.@test full_diag[:decoded_read_index] == length(full_observed)
     end
 end

--- a/test/4_assembly/viterbi_indel_decoder_test.jl
+++ b/test/4_assembly/viterbi_indel_decoder_test.jl
@@ -1,0 +1,60 @@
+# Indel-aware pair-HMM extension to the graph-Viterbi read corrector.
+#
+# Milestone A: the config carries indel/gap fields that DEFAULT to the
+#   substitution-collapse values (indel_moves=false, all gap masses 0), so the
+#   existing decoder is byte-identical and the whole existing suite passes with
+#   no edits.
+# Milestone B: an inserted-unit and a deleted-unit observation each correct back
+#   to the reference under an indel-enabled config (beam_width=typemax), and the
+#   substitution fixture stays byte-identical with indel_moves=false.
+# Milestone C: bounding knobs (adaptive band, D_max, insertion-run cap) and a
+#   small nanopore-style smoke that provably routes through the indel kernel.
+#
+# Run directly:
+#   julia --project=. -e 'include("test/4_assembly/viterbi_indel_decoder_test.jl")'
+
+import BioSequences
+import FASTX
+import MetaGraphsNext
+import Mycelia
+import Test
+
+function indel_decoded_label_strings(
+        result::Mycelia.ViterbiCorrectionResult
+)::Vector{String}
+    decoded = only(result.corrected_observations)
+    return [string(label) for label in decoded]
+end
+
+Test.@testset "Indel-aware pair-HMM Viterbi correction" begin
+    Test.@testset "Milestone A: config indel fields default to substitution-collapse" begin
+        cfg = Mycelia.ViterbiCorrectionConfig()
+        # The gap machinery is OFF by default, so the decoder is byte-identical.
+        Test.@test cfg.indel_moves == false
+        Test.@test cfg.insertion_fraction == 0.0
+        Test.@test cfg.deletion_fraction == 0.0
+        Test.@test cfg.insertion_extend_probability == 0.0
+        Test.@test cfg.deletion_extend_probability == 0.0
+        Test.@test cfg.deletion_max_run == 0
+        Test.@test cfg.max_insertion_run == 0
+        Test.@test cfg.band_width === nothing
+
+        # Fields are settable.
+        cfg2 = Mycelia.ViterbiCorrectionConfig(
+            indel_moves = true,
+            insertion_fraction = 0.3,
+            deletion_fraction = 0.3,
+            insertion_extend_probability = 0.1,
+            deletion_extend_probability = 0.1,
+            deletion_max_run = 3,
+            max_insertion_run = 3,
+            band_width = 12
+        )
+        Test.@test cfg2.indel_moves == true
+        Test.@test cfg2.insertion_fraction == 0.3
+        Test.@test cfg2.deletion_fraction == 0.3
+        Test.@test cfg2.deletion_max_run == 3
+        Test.@test cfg2.max_insertion_run == 3
+        Test.@test cfg2.band_width == 12
+    end
+end

--- a/test/4_assembly/viterbi_indel_decoder_test.jl
+++ b/test/4_assembly/viterbi_indel_decoder_test.jl
@@ -147,4 +147,131 @@ Test.@testset "Indel-aware pair-HMM Viterbi correction" begin
         Test.@test indel_decoded_label_strings(result_indel) ==
                    ["ATGCG", "GCGTA", "GTACC"]
     end
+
+    Test.@testset "Milestone C: the decode is routed through the indel kernel" begin
+        graph = _indel_olc_graph()
+        del_result = Mycelia.correct_observations(
+            graph, [[BioSequences.dna"ATGCG", BioSequences.dna"GTACC"]];
+            config = _indel_config())
+        diag = only(del_result.paths).diagnostics
+        # A mis-wire to the substitution-only path would NOT stamp this algorithm.
+        Test.@test diag[:algorithm] == :viterbi_indel_pair_hmm
+        Test.@test diag[:indel_moves] == true
+        # The deletion was bridged by >=1 D-move.
+        Test.@test diag[:move_counts][:D] >= 1
+
+        ins_result = Mycelia.correct_observations(
+            graph,
+            [[BioSequences.dna"ATGCG", BioSequences.dna"AAAAA",
+                BioSequences.dna"GCGTA", BioSequences.dna"GTACA"]];
+            config = _indel_config())
+        ins_diag = only(ins_result.paths).diagnostics
+        Test.@test ins_diag[:move_counts][:I] >= 1
+    end
+
+    Test.@testset "Milestone C: bounding knobs actually bite" begin
+        graph = _indel_olc_graph()
+        deletion_observed = [BioSequences.dna"ATGCG", BioSequences.dna"GTACC"]
+        insertion_observed = [
+            BioSequences.dna"ATGCG", BioSequences.dna"AAAAA",
+            BioSequences.dna"GCGTA", BioSequences.dna"GTACA"
+        ]
+
+        function _cfg(; kwargs...)
+            base = (
+                error_rate = 0.10,
+                indel_moves = true,
+                insertion_fraction = 0.30,
+                deletion_fraction = 0.30,
+                insertion_extend_probability = 0.10,
+                deletion_extend_probability = 0.10,
+                deletion_max_run = 3,
+                max_insertion_run = 3,
+                beam_width = typemax(Int)
+            )
+            return Mycelia.ViterbiCorrectionConfig(; base..., kwargs...)
+        end
+
+        # deletion_max_run = 0 forbids the D-move, so the anchored target GTACC
+        # becomes unreachable and the decode returns no corrected path.
+        no_del = Mycelia.correct_observations(
+            graph, [deletion_observed]; config = _cfg(deletion_max_run = 0))
+        Test.@test only(no_del.corrected_observations) === nothing
+        # deletion_max_run >= 1 recovers it.
+        yes_del = Mycelia.correct_observations(
+            graph, [deletion_observed]; config = _cfg(deletion_max_run = 2))
+        Test.@test indel_decoded_label_strings(yes_del) == ["ATGCG", "GCGTA", "GTACC"]
+
+        # band_width = 0 forbids any net gap (|#deletions - #insertions| > 0), so the
+        # deletion (net gap +1) is pruned and the target is unreachable.
+        banded_out = Mycelia.correct_observations(
+            graph, [deletion_observed]; config = _cfg(band_width = 0))
+        Test.@test only(banded_out.corrected_observations) === nothing
+        # A band wide enough to admit the single deletion recovers the reference.
+        banded_in = Mycelia.correct_observations(
+            graph, [deletion_observed]; config = _cfg(band_width = 4))
+        Test.@test indel_decoded_label_strings(banded_in) == ["ATGCG", "GCGTA", "GTACC"]
+
+        # max_insertion_run = 0 forbids the I-move, so the insertion cannot be
+        # absorbed and the free-endpoint decode no longer lands the 3-vertex walk.
+        no_ins = Mycelia.correct_observations(
+            graph, [insertion_observed]; config = _cfg(max_insertion_run = 0))
+        Test.@test indel_decoded_label_strings(no_ins) != ["ATGCG", "GCGTA", "GTACC"]
+    end
+
+    Test.@testset "Milestone C: nanopore-style read decodes through the kernel" begin
+        # A real nanopore error process (indels + homopolymer boost) on a small
+        # reference, threaded as k-mer observations through the clean-reference
+        # k-mer graph. The point is that the indel kernel RUNS (decode-diagnostic
+        # proves it, catching a silent mis-wire to the substitution-only path) and
+        # completes quickly; correction quality at scale is a separate HPC concern.
+        reference = Mycelia.random_fasta_record(moltype = :DNA, seed = 7, L = 60)
+        k = 7
+        graph = Mycelia.Rhizomorph.build_kmer_graph_singlestrand([reference], k)
+
+        refseq = FASTX.sequence(BioSequences.LongDNA{4}, reference)
+        # observe returns a (sequence, quality) TUPLE — take [1] for the sequence.
+        obs_seq, obs_quals = Mycelia.observe(refseq; error_rate = 0.05, tech = :nanopore)
+        Test.@test obs_seq isa BioSequences.LongSequence
+
+        qstr = String([Char(q + 33) for q in obs_quals])
+        read = FASTX.FASTQ.Record("obs", string(obs_seq), qstr)
+        sequence_string = FASTX.sequence(String, read)
+        alphabet = Mycelia.detect_alphabet(sequence_string)
+        sequence_type = Mycelia.alphabet_to_biosequence_type(alphabet)
+        sequence = Mycelia.extract_typed_sequence(read, sequence_type)
+        kmers = collect(Mycelia._record_kmer_iterator(sequence_type, k, sequence))
+        Test.@test !isempty(kmers)
+        quality_scores = collect(FASTX.quality_scores(read))
+        n_qual = length(quality_scores)
+        observations = [Mycelia.QualityObservation(
+                            kmer,
+                            UInt8.(quality_scores[clamp(i, 1, n_qual):clamp(i + k - 1, 1, n_qual)]))
+                        for (i, kmer) in enumerate(kmers)]
+
+        config = Mycelia.ViterbiCorrectionConfig(
+            error_rate = 0.05,
+            strand_mode = :singlestrand,
+            indel_moves = true,
+            insertion_fraction = 0.30,
+            deletion_fraction = 0.30,
+            insertion_extend_probability = 0.10,
+            deletion_extend_probability = 0.10,
+            deletion_max_run = 3,
+            max_insertion_run = 3,
+            band_width = 12,
+            beam_width = 256
+        )
+
+        elapsed = @elapsed result = Mycelia.correct_observations(
+            graph, [observations]; config = config)
+        Test.@test elapsed < 60
+        diag = only(result.paths).diagnostics
+        Test.@test diag[:algorithm] == :viterbi_indel_pair_hmm
+        Test.@test diag[:indel_moves] == true
+        # A path was decoded and it consumed match moves (i.e. the kernel actually
+        # walked the graph, not a degenerate empty result).
+        Test.@test only(result.paths).path !== nothing
+        Test.@test diag[:move_counts][:M] >= 1
+    end
 end

--- a/test/4_assembly/viterbi_indel_decoder_test.jl
+++ b/test/4_assembly/viterbi_indel_decoder_test.jl
@@ -57,4 +57,94 @@ Test.@testset "Indel-aware pair-HMM Viterbi correction" begin
         Test.@test cfg2.max_insertion_run == 3
         Test.@test cfg2.band_width == 12
     end
+
+    # Shared OLC fixture (mirrors viterbi_variable_length_graph_correction_test.jl):
+    # a 5-vertex overlap-3 chain ATGCG -> GCGTA -> GTACC -> ACCGT -> CGTAA. The true
+    # read under test covers only the FIRST THREE vertices; the graph deliberately
+    # CONTINUES past that end (ACCGT, CGTAA) so a frame-shifted substitution-only
+    # decode over-walks onto a wrong downstream vertex instead of coincidentally
+    # stopping at the true terminal — making the insertion case discriminating.
+    # The indel-enabled profile: err 0.10, indels split 30/30 of the error mass,
+    # short affine gaps, exact (unbounded) beam so the assertion tests the true
+    # argmax rather than the beam approximation.
+    function _indel_olc_graph()
+        records = [
+            FASTX.FASTA.Record("read_1", BioSequences.dna"ATGCG"),
+            FASTX.FASTA.Record("read_2", BioSequences.dna"GCGTA"),
+            FASTX.FASTA.Record("read_3", BioSequences.dna"GTACC"),
+            FASTX.FASTA.Record("read_4", BioSequences.dna"ACCGT"),
+            FASTX.FASTA.Record("read_5", BioSequences.dna"CGTAA")
+        ]
+        return Mycelia.Rhizomorph.build_fasta_graph_olc(records; min_overlap = 3)
+    end
+
+    function _indel_config(; indel_moves = true)
+        return Mycelia.ViterbiCorrectionConfig(
+            error_rate = 0.10,
+            indel_moves = indel_moves,
+            insertion_fraction = 0.30,
+            deletion_fraction = 0.30,
+            insertion_extend_probability = 0.10,
+            deletion_extend_probability = 0.10,
+            deletion_max_run = 3,
+            max_insertion_run = 3,
+            beam_width = typemax(Int)
+        )
+    end
+
+    Test.@testset "Milestone B: deletion-shifted read corrects back to reference" begin
+        graph = _indel_olc_graph()
+        # The middle read (GCGTA) is missing entirely — a unit-level deletion. The
+        # terminal (GTACC) matches a graph vertex exactly, anchoring the endpoint
+        # two vertices past the start. The substitution-only lock-step decoder
+        # cannot reach that target in a single read step (it under-walks and never
+        # reaches GTACC); the pair-HMM must take a D-move (advance the graph edge
+        # ATGCG->GCGTA without consuming a read unit) and then match GTACC, landing
+        # the 3-vertex reference walk.
+        observed = [BioSequences.dna"ATGCG", BioSequences.dna"GTACC"]
+        result = Mycelia.correct_observations(graph, [observed]; config = _indel_config())
+        Test.@test indel_decoded_label_strings(result) == ["ATGCG", "GCGTA", "GTACC"]
+    end
+
+    Test.@testset "Milestone B: insertion-shifted read corrects back to reference" begin
+        graph = _indel_olc_graph()
+        # An extra spurious read unit (AAAAA) is inserted after the first — a
+        # unit-level insertion. The last unit (GTACA) is a corrupted terminal (not a
+        # graph vertex) so the decode is free-endpoint. The lock-step decoder treats
+        # the junk as a real step and frame-shifts one vertex too far, over-walking
+        # onto the spurious downstream vertex ACCGT ([ATGCG, GCGTA, GTACC, ACCGT]);
+        # the pair-HMM must take an I-move (consume AAAAA while staying on ATGCG) and
+        # recover the true 3-vertex walk, correcting GTACA back to GTACC.
+        observed = [
+            BioSequences.dna"ATGCG",
+            BioSequences.dna"AAAAA",
+            BioSequences.dna"GCGTA",
+            BioSequences.dna"GTACA"
+        ]
+        result = Mycelia.correct_observations(graph, [observed]; config = _indel_config())
+        Test.@test indel_decoded_label_strings(result) == ["ATGCG", "GCGTA", "GTACC"]
+    end
+
+    Test.@testset "Milestone B: substitution fixture stays byte-identical (indel_moves=false)" begin
+        graph = _indel_olc_graph()
+        # read_2 carries a substitution (GCGTT for GCGTA). Under indel_moves=false
+        # the decoder is the untouched substitution path and must reproduce the
+        # reference walk exactly, as the existing variable-length suite asserts.
+        observed = [
+            BioSequences.dna"ATGCG",
+            BioSequences.dna"GCGTT",
+            BioSequences.dna"GTACC"
+        ]
+        result = Mycelia.correct_observations(
+            graph, [observed]; config = _indel_config(indel_moves = false))
+        Test.@test indel_decoded_label_strings(result) == ["ATGCG", "GCGTA", "GTACC"]
+
+        # And with indel_moves=true the same equal-length substitution fixture still
+        # corrects to the reference (gap moves never beat the pure-M substitution
+        # path when the read length matches the walk length).
+        result_indel = Mycelia.correct_observations(
+            graph, [observed]; config = _indel_config(indel_moves = true))
+        Test.@test indel_decoded_label_strings(result_indel) ==
+                   ["ATGCG", "GCGTA", "GTACC"]
+    end
 end


### PR DESCRIPTION
## Summary
Adds a true indel-aware (match/insert/delete) pair-HMM extension to the Rhizomorph graph-Viterbi read corrector, so nanopore reads (~60% indels) can be corrected — the substitution-only decoder frameshifts on the first indel and cannot repair downstream. Everything stays inside one joint likelihood `P(read | graph path)`; Illumina falls out as the special case where indel probability = 0.

- **New config fields** on `ViterbiCorrectionConfig` (`indel_moves`, `insertion_fraction`/`deletion_fraction`, affine extend probs, `deletion_max_run`, `max_insertion_run`, `band_width`, `insertion_emission_logp`) — all default to substitution-collapse.
- **New kernel** `_viterbi_correct_observation_indel`: a 2D DP over `(read-index i, graph-state v)` with an M/I/D phase layer. Read index AND phase promoted into the DP state key. Affine transition masses derived from the error model (`δ = error_rate·fraction`); indel prob 0 → `log(0) = -Inf` → gap moves dropped → collapses to the substitution decoder. Deletion is a bounded Bellman–Ford relaxation (≤ `deletion_max_run` hops/column) — the scalable replacement for the legacy O(V³) Floyd–Warshall.
- **Flat length penalty** dropped when gap states are active (via a `count_length_penalty` flag, default true), so I/D moves don't double-count length change.
- Dispatch routes to the kernel only when `indel_moves=true`; otherwise the untouched substitution decoder runs. Batched PoC + legacy engine untouched.

## Oracle preservation (byte-identical with `indel_moves=false`)
Existing correction suites pass unchanged: `viterbi_variable_length_graph_correction_test.jl` (19/19), `rhizomorph_iterative_corrector_wiring_test.jl` (17/17), `scalable_corrector_strategy_test.jl` (40/40). An in-file guard asserts the substitution fixture is identical under `indel_moves` false and true.

## Test Plan
- `LD_LIBRARY_PATH="" julia --project=. -e 'include("test/4_assembly/viterbi_indel_decoder_test.jl")'` → 34/34. Covers: insertion-shifted and deletion-shifted reads each correct back to reference under the indel profile (`beam_width=typemax`); bounding-knob tests (`deletion_max_run=0`, `band_width=0`, `max_insertion_run=0` each break the corresponding recovery); a `Mycelia.observe(...; tech=:nanopore)` smoke confirming a real nanopore read routes through the kernel and decodes.
- Oracle suites above pass byte-identical.

## Not in this PR (follow-ups)
- **Step 4 wiring**: not yet wired into `_corrector_strategy_knobs`/`AssemblyConfig`, so `assemble_genome` does not enable indel moves yet — the kernel is exercised via `correct_observations` directly.
- **Band**: current band is a net-gap band centered at 0 (fine for nanopore's symmetric indel rate at toy scale); ksw2-style running-diagonal re-centering / widening for 5000bp reads is a documented refinement (net-gap std ≈ √(L·e)).

## Related
Rhizomorph nanopore-correction workstream (td-jt7r); the crux fix. Design: single joint likelihood, principled gap moves (not a fast-path heuristic).