### PR TITLE
add: hybrid-OLC route (a) short-read arm + layout/olc_tool config (td-yymj)

### DIFF
--- a/src/rhizomorph/assembly.jl
+++ b/src/rhizomorph/assembly.jl
@@ -197,6 +197,27 @@ struct AssemblyConfig
     # a hardcoded tech — keeps "correct with the profile you'd simulate".
     sequencing_tech::Symbol
 
+    # Stage-2 layout selector (hybrid-OLC route (a), td-yymj). `:native` (default)
+    # keeps the current behavior — for corrector=:iterative that is the graph-HMM
+    # re-assembly. `:olc` diverts corrected reads to an EXTERNAL overlap-layout-
+    # consensus assembler so contiguity is inherited from a tool tuned for it.
+    # `:olc` requires corrector=:iterative (an OLC layout with no correction is just
+    # the plain external assembler, reachable via the wrapper directly).
+    layout::Symbol
+
+    # Which external assembler the `:olc` layout dispatches to. `:auto` (default)
+    # picks by read type (sequencing_tech): short-read techs (:illumina, :ultima)
+    # → a short-read layout assembler, long-read techs (:nanopore, :pacbio) → a
+    # long-read assembler. An explicit tool must match the corrected read type.
+    # The first long-read Stage-2 slice wires :metaflye; short-read compatibility
+    # remains available through :megahit and :metaspades.
+    olc_tool::Symbol
+
+    # Pass-through options forwarded to the external-assembler wrapper (e.g.
+    # (; k_list = "21,33", threads = 8)). Empty by default; keys must match the
+    # chosen wrapper's keyword arguments.
+    olc_options::NamedTuple
+
     # Constructor with validation
     function AssemblyConfig(;
             k::Union{Int, Nothing} = nothing,
@@ -220,7 +241,10 @@ struct AssemblyConfig
             token_sequences::Union{Nothing, Vector{Vector{String}}} = nothing,
             graph_cleanup::Union{Bool, Nothing} = nothing,
             output_dir::Union{String, Nothing} = nothing,
-            sequencing_tech::Symbol = :illumina
+            sequencing_tech::Symbol = :illumina,
+            layout::Symbol = :native,
+            olc_tool::Symbol = :auto,
+            olc_options::NamedTuple = (;)
     )
         # Sentinel `nothing` defaults let us DETECT whether the caller set
         # strategy/skip_solid explicitly (FIX 4) so we can warn on the silent
@@ -365,6 +389,56 @@ struct AssemblyConfig
                   "corrected-FASTQ handoff) and is ignored for corrector=:$(corrector)."
         end
 
+        # Validation: Stage-2 layout selector (hybrid-OLC route (a), td-yymj).
+        if !(layout in (:native, :olc))
+            error("layout must be :native or :olc, got :$(layout)")
+        end
+        # Read-type <-> tool taxonomy. sequencing_tech is the read-type proxy:
+        # short-read techs run short-read layout assemblers, long-read techs run
+        # long-read assemblers (design doc "Read-type mapping").
+        _short_read_techs = (:illumina, :ultima)
+        _short_read_tools = (:megahit, :metaspades)
+        _long_read_tools = (:hifiasm, :flye, :canu, :metaflye)
+        _valid_olc_tools = (:auto, _short_read_tools..., _long_read_tools...)
+        if layout == :olc
+            # An OLC layout with no correction is just the plain external assembler,
+            # reachable via the wrapper directly — the route exists to compose Stage-1
+            # correction with external layout, so it requires the corrector.
+            if corrector != :iterative
+                error("layout=:olc requires corrector=:iterative (the hybrid-OLC " *
+                      "route hands Stage-1-corrected reads to an external assembler); " *
+                      "got corrector=:$(corrector).")
+            end
+            if !(olc_tool in _valid_olc_tools)
+                error("olc_tool must be one of $(_valid_olc_tools), got :$(olc_tool)")
+            end
+            is_short = sequencing_tech in _short_read_techs
+            if olc_tool == :auto
+                # :auto resolves by read type; only the short-read resolution is wired
+                # in this PR (td-yymj). A long-read tech would resolve to a long-read
+                # assembler (td-wvto), so reject it up front.
+                is_short ||
+                    error("olc_tool=:auto with sequencing_tech=:$(sequencing_tech) " *
+                          "resolves to a long-read assembler, which is not yet wired in the OLC " *
+                          "route (see td-wvto). Use a short-read sequencing_tech (:illumina/:ultima) " *
+                          "or await the long-read arm.")
+            elseif olc_tool in _short_read_tools
+                is_short || error("olc_tool=:$(olc_tool) is a short-read assembler but " *
+                      "sequencing_tech=:$(sequencing_tech) is a long-read tech; pair a short-read " *
+                      "tool with a short-read tech.")
+            elseif olc_tool in _long_read_tools
+                # Long-read tools are validated as known but NOT yet wired here.
+                error("olc_tool=:$(olc_tool) (long-read assembler) is not yet wired in the " *
+                      "OLC route; this PR (td-yymj) wires the short-read arm (:megahit, " *
+                      ":metaspades). The long-read arm is tracked in td-wvto.")
+            end
+        elseif olc_tool != :auto || !isempty(olc_options)
+            # Discoverability: olc_tool/olc_options are inert unless layout=:olc
+            # (mirrors the output_dir / skip_solid / efficiency-mode warnings above).
+            @warn "olc_tool / olc_options are only used when layout=:olc and are " *
+                  "ignored for layout=:$(layout)."
+        end
+
         new(
             k,
             min_overlap,
@@ -387,7 +461,10 @@ struct AssemblyConfig
             token_sequences,
             graph_cleanup,
             output_dir,
-            sequencing_tech
+            sequencing_tech,
+            layout,
+            olc_tool,
+            olc_options
         )
     end
 end
@@ -705,6 +782,13 @@ function assemble_genome(reads, config::AssemblyConfig)
     # through to the byte-identical single-k pipeline below; only an explicit
     # corrector=:iterative diverts to the iterative+skip corrector.
     if config.corrector == :iterative
+        # Stage-2 layout selector (hybrid-OLC route (a), td-yymj). :olc diverts the
+        # Stage-1-corrected reads to an external OLC assembler; :native (default)
+        # keeps the graph-HMM re-assembly. The constructor guarantees layout=:olc
+        # implies corrector=:iterative, so this branch is only reachable here.
+        if config.layout == :olc
+            return _assemble_hybrid_olc(reads, config)
+        end
         return _assemble_with_iterative_corrector(reads, config)
     end
 
@@ -1795,15 +1879,131 @@ function _qualmer_graph_to_assembly(graph, num_input_sequences::Int, config;
 end
 
 """
-Hybrid OLC assembly (placeholder for future implementation).
-"""
-function _assemble_hybrid_olc(observations, config)
-    _log_info(config, "Using hybrid OLC assembly strategy")
+    _assemble_hybrid_olc(reads, config::AssemblyConfig) -> AssemblyResult
 
-    # For now, fall back to k-mer graph assembly
-    # Future implementation would combine overlap-layout-consensus with string graphs
-    @warn "Hybrid OLC not fully implemented, using k-mer graph assembly"
-    return _assemble_kmer_graph(observations, config)
+Hybrid-OLC route (a), td-yymj: run Stage-1 correction, then hand the corrected
+reads to an EXTERNAL overlap-layout-consensus assembler instead of the native
+graph-HMM re-assembly. Contiguity is inherited from a tool tuned for it while the
+per-base accuracy gain is contributed by Stage 1.
+
+Reuses `_run_stage1_correction` (which persists the corrected FASTQ) and honors its
+ephemeral-cleanup contract: when `stage1.ephemeral` (no `config.output_dir`), this
+function deletes the corrected FASTQ and the external assembler's temp output dir
+after reading the contigs; when the caller supplied `output_dir`, both are left in
+place under it. Dispatched only via `assemble_genome` when `config.layout == :olc`
+(the constructor guarantees that implies `corrector == :iterative`).
+
+The first long-read arm uses metaFlye; the existing short-read arm remains
+available for compatibility.
+"""
+function _assemble_hybrid_olc(reads, config::AssemblyConfig)
+    tool = _resolve_olc_tool(config)
+    _log_info(config,
+        "Hybrid-OLC route (a): Stage-1 correction -> external assembler :$(tool)")
+    stage1 = _run_stage1_correction(reads, config)
+    # The external assembler writes into its own output dir. Co-locate it with the
+    # persisted corrected FASTQ when the caller owns output_dir; otherwise a temp
+    # dir cleaned alongside the ephemeral corrected FASTQ.
+    olc_outdir = config.output_dir === nothing ?
+                 mktempdir() : mkpath(joinpath(config.output_dir, "olc_$(tool)"))
+    try
+        contigs_fasta = _run_olc_tool(tool, stage1.corrected_fastq, olc_outdir, config)
+        if !isfile(contigs_fasta)
+            error("external OLC assembler :$(tool) produced no contigs file " *
+                  "(expected at $(contigs_fasta))")
+        end
+        _log_info(config, "External :$(tool) assembly complete; wrapping contigs")
+        return _wrap_external_contigs(contigs_fasta, tool, config, stage1)
+    finally
+        # Ephemeral (output_dir unset): the corrected FASTQ and the assembler's temp
+        # output dir are both ours to clean. A caller-supplied output_dir keeps them.
+        if stage1.ephemeral
+            rm(stage1.corrected_fastq; force = true)
+            rm(olc_outdir; recursive = true, force = true)
+        end
+    end
+end
+
+"""
+    _resolve_olc_tool(config::AssemblyConfig) -> Symbol
+
+Resolve `config.olc_tool` to a concrete external assembler. An explicit tool is
+returned as-is (the constructor already validated it against `sequencing_tech`).
+`:auto` picks `:megahit` for Illumina/Ultima and `:metaflye` for Nanopore/PacBio.
+"""
+function _resolve_olc_tool(config::AssemblyConfig)
+    config.olc_tool == :auto || return config.olc_tool
+    return config.sequencing_tech in (:illumina, :ultima) ? :megahit : :metaflye
+end
+
+"""
+    _run_olc_tool(tool, corrected_fastq, outdir, config) -> contigs_fasta_path
+
+Per-tool argument adapter: the external-assembler wrappers have non-uniform
+signatures, so map each supported `tool` onto its wrapper call and return the path
+to its primary-contigs FASTA. The corrector emits a SINGLE corrected FASTQ, so
+short-read assemblers run in single-end mode (`fastq1` only). `config.olc_options`
+is splatted through to the wrapper.
+"""
+function _run_olc_tool(tool::Symbol, corrected_fastq::AbstractString,
+        outdir::AbstractString, config::AssemblyConfig)
+    if tool == :megahit
+        result = Mycelia.run_megahit(; fastq1 = corrected_fastq, outdir = outdir,
+            config.olc_options...)
+        return result.contigs
+    elseif tool == :metaspades
+        result = Mycelia.run_metaspades(; fastq1 = corrected_fastq, outdir = outdir,
+            config.olc_options...)
+        return result.contigs
+    elseif tool == :metaflye
+        read_type = config.sequencing_tech == :nanopore ? "nano-corr" : "pacbio-corr"
+        result = Mycelia.run_metaflye(; fastq = String(corrected_fastq),
+            outdir = String(outdir), read_type = read_type, meta = true,
+            iterations = 0, keep_haplotypes = true, no_alt_contigs = true,
+            config.olc_options...)
+        return result.assembly
+    else
+        error("_run_olc_tool: :$(tool) is not wired; expected :megahit, " *
+              ":metaspades, or :metaflye")
+    end
+end
+
+"""
+    _wrap_external_contigs(contigs_fasta, tool, config, stage1) -> AssemblyResult
+
+Read an external assembler's primary-contigs FASTA and wrap it in an
+`AssemblyResult`. An external contig-only assembly has NO Mycelia graph, so
+`gfa_compatible` MUST be false (a GFA-compatible result requires a graph, enforced
+by `validate_assembly_structure`). Corrector + layout provenance is stamped into
+`assembly_stats`.
+"""
+function _wrap_external_contigs(contigs_fasta::AbstractString, tool::Symbol,
+        config::AssemblyConfig, stage1)
+    records = open(FASTX.FASTA.Reader, contigs_fasta) do reader
+        collect(reader)
+    end
+    # FASTX.sequence(String, r) already yields a String; FASTX.identifier returns a
+    # StringView, so wrap it — AssemblyResult requires Vector{String} for both.
+    contigs = [FASTX.sequence(String, r) for r in records]
+    contig_names = [String(FASTX.identifier(r)) for r in records]
+    if isempty(contigs)
+        @warn "hybrid-OLC: external assembler :$(tool) produced 0 contigs from the " *
+              "$(length(stage1.corrected_reads)) corrected reads."
+    end
+    stats = Dict{String, Any}(
+        "method" => "HybridOLC",
+        "corrector" => "iterative",
+        "strategy" => String(config.strategy),
+        "layout" => "olc",
+        "olc_tool" => String(tool),
+        "sequencing_tech" => String(config.sequencing_tech),
+        "corrected_read_count" => length(stage1.corrected_reads),
+        "corrected_fastq" => stage1.corrected_fastq,
+        "num_contigs" => length(contigs),
+        "assembly_date" => string(Mycelia.Dates.now())
+    )
+    return AssemblyResult(contigs, contig_names;
+        assembly_stats = stats, gfa_compatible = false)
 end
 
 """

--- a/src/rhizomorph/assembly.jl
+++ b/src/rhizomorph/assembly.jl
@@ -209,13 +209,16 @@ struct AssemblyConfig
     # picks by read type (sequencing_tech): short-read techs (:illumina, :ultima)
     # → a short-read layout assembler, long-read techs (:nanopore, :pacbio) → a
     # long-read assembler. An explicit tool must match the corrected read type.
-    # The first long-read Stage-2 slice wires :metaflye; short-read compatibility
-    # remains available through :megahit and :metaspades.
+    # This PR wires only the SHORT-read arm (:megahit, :metaspades); long-read tools
+    # (:hifiasm/:flye/:canu/:metaflye) and long-read :auto are validated-but-rejected
+    # at construction until the long-read arm lands (td-wvto).
     olc_tool::Symbol
 
     # Pass-through options forwarded to the external-assembler wrapper (e.g.
     # (; k_list = "21,33", threads = 8)). Empty by default; keys must match the
-    # chosen wrapper's keyword arguments.
+    # chosen wrapper's keyword arguments. Route-managed keys (fastq1/fastq2/fastq/
+    # outdir/out_dir/executor) are RESERVED and rejected at construction — they are
+    # set by the route and cannot be overridden here.
     olc_options::NamedTuple
 
     # Constructor with validation
@@ -431,6 +434,24 @@ struct AssemblyConfig
                 error("olc_tool=:$(olc_tool) (long-read assembler) is not yet wired in the " *
                       "OLC route; this PR (td-yymj) wires the short-read arm (:megahit, " *
                       ":metaspades). The long-read arm is tracked in td-wvto.")
+            end
+            # Reserved-key guard: olc_options is splatted into the wrapper, so a key
+            # that collides with a route-managed keyword would redirect the assembler
+            # (wrong output dir → broken cleanup + megahit's recursive rm; wrong fastq
+            # → bypasses the Stage-1 corrected handoff). Reject those keys up front.
+            _reserved_olc_keys = (:fastq1, :fastq2, :fastq, :outdir, :out_dir, :executor)
+            for _k in keys(olc_options)
+                _k in _reserved_olc_keys && error("olc_options key :$(_k) is managed by " *
+                      "the hybrid-OLC route and cannot be overridden; drop it from olc_options.")
+            end
+            # metaSPAdes targets PAIRED-END libraries; the hybrid-OLC route emits a
+            # SINGLE corrected FASTQ (single-end), which metaSPAdes rejects at runtime.
+            # Keep it selectable (paired-end support is a follow-on) but warn loudly —
+            # :megahit is the single-end-robust short-read default.
+            if olc_tool == :metaspades
+                @warn "olc_tool=:metaspades expects paired-end reads, but the hybrid-OLC " *
+                      "route feeds a single corrected FASTQ (single-end); metaSPAdes will " *
+                      "likely fail at runtime. Use :megahit for the single-end short-read arm."
             end
         elseif olc_tool != :auto || !isempty(olc_options)
             # Discoverability: olc_tool/olc_options are inert unless layout=:olc
@@ -988,9 +1009,9 @@ skip-solid maximum-likelihood corrector) and PERSIST the corrected FASTQ to a
 caller-owned location so it outlives the corrector's internal temp dirs.
 
 This is the reusable "materialize corrected reads" half of the corrector route.
-The native re-assembly path (`_assemble_with_iterative_corrector`) calls it today;
-the hybrid-OLC route (Stage-2 route (a), td-ohob) is not yet wired but will reuse
-it — both need only this materialized-reads half and differ solely in the tail.
+Both the native re-assembly path (`_assemble_with_iterative_corrector`) and the
+hybrid-OLC route (Stage-2 route (a), `_assemble_hybrid_olc`, td-yymj) call it;
+they need only this materialized-reads half and differ solely in the tail.
 The corrected FASTQ produced by the corrector normally lives in an `mktempdir`
 that is deleted here on return; this helper moves it OUT of that doomed directory
 to `corrected_fastq` before cleanup, so an external OLC assembler can consume it.
@@ -1893,8 +1914,8 @@ after reading the contigs; when the caller supplied `output_dir`, both are left 
 place under it. Dispatched only via `assemble_genome` when `config.layout == :olc`
 (the constructor guarantees that implies `corrector == :iterative`).
 
-The first long-read arm uses metaFlye; the existing short-read arm remains
-available for compatibility.
+Only the short-read arm (:megahit/:metaspades) is reachable in this PR; the
+long-read arm is gated off at construction until td-wvto.
 """
 function _assemble_hybrid_olc(reads, config::AssemblyConfig)
     tool = _resolve_olc_tool(config)
@@ -1906,6 +1927,14 @@ function _assemble_hybrid_olc(reads, config::AssemblyConfig)
     # dir cleaned alongside the ephemeral corrected FASTQ.
     olc_outdir = config.output_dir === nothing ?
                  mktempdir() : mkpath(joinpath(config.output_dir, "olc_$(tool)"))
+    # Stale-output guard: the external wrappers skip re-running when their contigs
+    # file already exists, so a reused (non-empty) output_dir would silently return
+    # a PRIOR run's assembly, ignoring THESE corrected reads. Warn loudly.
+    if config.output_dir !== nothing && !isempty(readdir(olc_outdir))
+        @warn "hybrid-OLC: assembler output dir is non-empty; the external tool may " *
+              "skip re-running and return a STALE prior assembly — use a fresh " *
+              "output_dir per run." olc_outdir
+    end
     try
         contigs_fasta = _run_olc_tool(tool, stage1.corrected_fastq, olc_outdir, config)
         if !isfile(contigs_fasta)
@@ -1917,9 +1946,16 @@ function _assemble_hybrid_olc(reads, config::AssemblyConfig)
     finally
         # Ephemeral (output_dir unset): the corrected FASTQ and the assembler's temp
         # output dir are both ours to clean. A caller-supplied output_dir keeps them.
+        # Wrap cleanup so a failing rm (e.g. a locked file on an HPC/NFS mount) is
+        # WARNed rather than replacing the in-flight assembler exception — Julia's
+        # finally-throw discards the original error.
         if stage1.ephemeral
-            rm(stage1.corrected_fastq; force = true)
-            rm(olc_outdir; recursive = true, force = true)
+            try
+                rm(stage1.corrected_fastq; force = true)
+                rm(olc_outdir; recursive = true, force = true)
+            catch cleanup_err
+                @warn "hybrid-OLC: cleanup of ephemeral artifacts failed" cleanup_err
+            end
         end
     end
 end
@@ -1929,42 +1965,45 @@ end
 
 Resolve `config.olc_tool` to a concrete external assembler. An explicit tool is
 returned as-is (the constructor already validated it against `sequencing_tech`).
-`:auto` picks `:megahit` for Illumina/Ultima and `:metaflye` for Nanopore/PacBio.
+`:auto` picks by read type; the constructor guarantees `:auto` is only reachable
+for a short-read tech in this PR, so it resolves to `:megahit` (the single-end-
+robust short-read layout assembler). Long-read `:auto` resolution lands with the
+long-read arm (td-wvto).
 """
 function _resolve_olc_tool(config::AssemblyConfig)
     config.olc_tool == :auto || return config.olc_tool
-    return config.sequencing_tech in (:illumina, :ultima) ? :megahit : :metaflye
+    return :megahit
 end
 
 """
-    _run_olc_tool(tool, corrected_fastq, outdir, config) -> contigs_fasta_path
+    _run_olc_tool(tool, corrected_fastq, outdir, config) -> contigs_fasta_path::String
 
 Per-tool argument adapter: the external-assembler wrappers have non-uniform
-signatures, so map each supported `tool` onto its wrapper call and return the path
-to its primary-contigs FASTA. The corrector emits a SINGLE corrected FASTQ, so
-short-read assemblers run in single-end mode (`fastq1` only). `config.olc_options`
-is splatted through to the wrapper.
+signatures, so map each WIRED `tool` onto its wrapper call and return the path to
+its primary-contigs FASTA. This PR wires the short-read arm (`:megahit`,
+`:metaspades`); the long-read arm (metaFlye et al.) lands in td-wvto. The corrector
+emits a SINGLE corrected FASTQ, so short-read assemblers run in single-end mode
+(`fastq1` only).
+
+`config.olc_options` is splatted in FIRST so the route's managed keywords
+(`fastq1`/`outdir`) always win over a caller-supplied option — Julia resolves
+duplicate keywords rightmost-wins, so managed keys must come last. (The constructor
+also rejects reserved keys, but this ordering keeps the invariant even if that
+guard is ever relaxed.)
 """
 function _run_olc_tool(tool::Symbol, corrected_fastq::AbstractString,
-        outdir::AbstractString, config::AssemblyConfig)
+        outdir::AbstractString, config::AssemblyConfig)::String
     if tool == :megahit
-        result = Mycelia.run_megahit(; fastq1 = corrected_fastq, outdir = outdir,
-            config.olc_options...)
+        result = Mycelia.run_megahit(; config.olc_options...,
+            fastq1 = corrected_fastq, outdir = outdir)
         return result.contigs
     elseif tool == :metaspades
-        result = Mycelia.run_metaspades(; fastq1 = corrected_fastq, outdir = outdir,
-            config.olc_options...)
+        result = Mycelia.run_metaspades(; config.olc_options...,
+            fastq1 = corrected_fastq, outdir = outdir)
         return result.contigs
-    elseif tool == :metaflye
-        read_type = config.sequencing_tech == :nanopore ? "nano-corr" : "pacbio-corr"
-        result = Mycelia.run_metaflye(; fastq = String(corrected_fastq),
-            outdir = String(outdir), read_type = read_type, meta = true,
-            iterations = 0, keep_haplotypes = true, no_alt_contigs = true,
-            config.olc_options...)
-        return result.assembly
     else
-        error("_run_olc_tool: :$(tool) is not wired; expected :megahit, " *
-              ":metaspades, or :metaflye")
+        error("_run_olc_tool: :$(tool) is not wired; expected :megahit or " *
+              ":metaspades (the short-read arm). Long-read tools are tracked in td-wvto.")
     end
 end
 
@@ -1975,7 +2014,8 @@ Read an external assembler's primary-contigs FASTA and wrap it in an
 `AssemblyResult`. An external contig-only assembly has NO Mycelia graph, so
 `gfa_compatible` MUST be false (a GFA-compatible result requires a graph, enforced
 by `validate_assembly_structure`). Corrector + layout provenance is stamped into
-`assembly_stats`.
+`assembly_stats`. Fails loud on a 0-contig assembly (parity with Stage-1's
+0-corrected-reads guard) rather than returning a silently-empty result.
 """
 function _wrap_external_contigs(contigs_fasta::AbstractString, tool::Symbol,
         config::AssemblyConfig, stage1)
@@ -1986,9 +2026,15 @@ function _wrap_external_contigs(contigs_fasta::AbstractString, tool::Symbol,
     # StringView, so wrap it — AssemblyResult requires Vector{String} for both.
     contigs = [FASTX.sequence(String, r) for r in records]
     contig_names = [String(FASTX.identifier(r)) for r in records]
+    n_corrected = length(stage1.corrected_reads)
     if isempty(contigs)
-        @warn "hybrid-OLC: external assembler :$(tool) produced 0 contigs from the " *
-              "$(length(stage1.corrected_reads)) corrected reads."
+        # Fail loud, matching _run_stage1_correction's 0-reads guard: an empty
+        # external assembly must not flow downstream as a "successful" 0-contig
+        # result. (megahit errors upstream on empty input; metaspades can write an
+        # empty contigs.fasta, so guard here for tool-agnostic parity.)
+        error("hybrid-OLC: external assembler :$(tool) produced 0 contigs from the " *
+              "$(n_corrected) corrected reads (from $(contigs_fasta)); " *
+              "refusing to return an empty assembly.")
     end
     stats = Dict{String, Any}(
         "method" => "HybridOLC",
@@ -1997,7 +2043,7 @@ function _wrap_external_contigs(contigs_fasta::AbstractString, tool::Symbol,
         "layout" => "olc",
         "olc_tool" => String(tool),
         "sequencing_tech" => String(config.sequencing_tech),
-        "corrected_read_count" => length(stage1.corrected_reads),
+        "corrected_read_count" => n_corrected,
         "corrected_fastq" => stage1.corrected_fastq,
         "num_contigs" => length(contigs),
         "assembly_date" => string(Mycelia.Dates.now())

--- a/test/4_assembly/hybrid_olc_config_test.jl
+++ b/test/4_assembly/hybrid_olc_config_test.jl
@@ -1,0 +1,96 @@
+# td-yymj: hybrid-OLC route (a) CONFIG + routing tests (no external tools).
+#
+# The hybrid-OLC route hands Stage-1-corrected reads to an external OLC assembler
+# (layout=:olc). This file covers the parts that need NO external assembler and so
+# run in default CI: the AssemblyConfig validation surface (layout / olc_tool /
+# olc_options), the :auto tool resolution, and the per-tool adapter's guard. The
+# real end-to-end run (corrected reads -> megahit/metaspades -> contigs) is the
+# gated companion test in third_party_assemblers_hybrid_olc_route.jl.
+#
+# Run directly:
+#   julia --project=. -e 'include("test/4_assembly/hybrid_olc_config_test.jl")'
+
+import Test
+import Mycelia
+
+const R = Mycelia.Rhizomorph
+
+Test.@testset "hybrid-OLC route (a) config + routing (td-yymj)" begin
+    Test.@testset "layout selector validation" begin
+        # Default: native layout, auto tool.
+        default_cfg = R.AssemblyConfig(; k = 13)
+        Test.@test default_cfg.layout == :native
+        Test.@test default_cfg.olc_tool == :auto
+        Test.@test default_cfg.olc_options == (;)
+
+        # Valid :olc config (short-read tech + iterative corrector).
+        olc_cfg = R.AssemblyConfig(; k = 13, corrector = :iterative,
+            strategy = :scalable, layout = :olc, sequencing_tech = :illumina)
+        Test.@test olc_cfg.layout == :olc
+        Test.@test olc_cfg.olc_tool == :auto
+
+        # Unknown layout is rejected.
+        Test.@test_throws ErrorException R.AssemblyConfig(; k = 13, layout = :bogus)
+
+        # :olc requires the corrector — an OLC layout with no correction is just the
+        # plain external assembler.
+        Test.@test_throws ErrorException R.AssemblyConfig(; k = 13, layout = :olc,
+            corrector = :none)
+    end
+
+    Test.@testset "olc_tool <-> sequencing_tech compatibility" begin
+        # Unknown tool rejected under :olc.
+        Test.@test_throws ErrorException R.AssemblyConfig(; k = 13,
+            corrector = :iterative, strategy = :scalable, layout = :olc,
+            olc_tool = :not_a_tool)
+
+        # Explicit short-read tools are accepted with a short-read tech.
+        for tool in (:megahit, :metaspades)
+            cfg = R.AssemblyConfig(; k = 13, corrector = :iterative,
+                strategy = :scalable, layout = :olc, olc_tool = tool,
+                sequencing_tech = :illumina)
+            Test.@test cfg.olc_tool == tool
+        end
+
+        # Short-read tool with a long-read tech is a mismatch.
+        Test.@test_throws ErrorException R.AssemblyConfig(; k = 13,
+            corrector = :iterative, strategy = :scalable, layout = :olc,
+            olc_tool = :megahit, sequencing_tech = :nanopore)
+
+        # Long-read tools are not wired in this PR (td-wvto): rejected at construction.
+        for tool in (:hifiasm, :flye, :canu, :metaflye)
+            Test.@test_throws ErrorException R.AssemblyConfig(; k = 13,
+                corrector = :iterative, strategy = :scalable, layout = :olc,
+                olc_tool = tool, sequencing_tech = :pacbio)
+        end
+
+        # :auto with a long-read tech resolves to a not-yet-wired long-read assembler.
+        Test.@test_throws ErrorException R.AssemblyConfig(; k = 13,
+            corrector = :iterative, strategy = :scalable, layout = :olc,
+            olc_tool = :auto, sequencing_tech = :nanopore)
+    end
+
+    Test.@testset ":auto tool resolution" begin
+        # :auto resolves to :megahit for a short-read tech.
+        cfg_auto = R.AssemblyConfig(; k = 13, corrector = :iterative,
+            strategy = :scalable, layout = :olc, olc_tool = :auto,
+            sequencing_tech = :illumina)
+        Test.@test R._resolve_olc_tool(cfg_auto) == :megahit
+
+        # An explicit tool passes through unchanged.
+        cfg_ms = R.AssemblyConfig(; k = 13, corrector = :iterative,
+            strategy = :scalable, layout = :olc, olc_tool = :metaspades,
+            sequencing_tech = :illumina)
+        Test.@test R._resolve_olc_tool(cfg_ms) == :metaspades
+    end
+
+    Test.@testset "adapter guard for unwired tools" begin
+        cfg = R.AssemblyConfig(; k = 13, corrector = :iterative,
+            strategy = :scalable, layout = :olc, sequencing_tech = :illumina)
+        # _run_olc_tool only wires :megahit / :metaspades; anything else fails loud
+        # rather than silently doing nothing (guards against a future routing bug
+        # reaching the adapter with a long-read tool before td-wvto lands).
+        Test.@test_throws ErrorException R._run_olc_tool(:flye, "unused.fastq",
+            mktempdir(), cfg)
+    end
+end

--- a/test/4_assembly/hybrid_olc_config_test.jl
+++ b/test/4_assembly/hybrid_olc_config_test.jl
@@ -93,4 +93,34 @@ Test.@testset "hybrid-OLC route (a) config + routing (td-yymj)" begin
         Test.@test_throws ErrorException R._run_olc_tool(:flye, "unused.fastq",
             mktempdir(), cfg)
     end
+
+    Test.@testset "discoverability + incompatibility warnings" begin
+        # olc_tool/olc_options are inert unless layout=:olc → warn (mirrors the
+        # output_dir/skip_solid inert-field warnings). match_mode=:any tolerates
+        # other construction-time logs.
+        Test.@test_logs (:warn, r"only used when layout=:olc") R.AssemblyConfig(;
+            k = 13, olc_tool = :megahit)  # layout defaults to :native → inert → warn
+        Test.@test_logs (:warn, r"only used when layout=:olc") R.AssemblyConfig(;
+            k = 13, olc_options = (; threads = 4))  # non-empty olc_options under :native → warn
+        # metaspades needs paired-end; the single-end corrected handoff will fail →
+        # warn at construction (kept selectable, per follow-on paired-end support).
+        Test.@test_logs (:warn, r"expects paired-end") R.AssemblyConfig(;
+            k = 13, corrector = :iterative, strategy = :scalable, layout = :olc,
+            olc_tool = :metaspades, sequencing_tech = :illumina)
+    end
+
+    Test.@testset "olc_options reserved-key rejection" begin
+        # Route-managed keys cannot be overridden via olc_options (they would
+        # redirect the assembler / break cleanup / bypass the corrected handoff).
+        for k in (:fastq1, :fastq2, :fastq, :outdir, :out_dir, :executor)
+            Test.@test_throws ErrorException R.AssemblyConfig(; k = 13,
+                corrector = :iterative, strategy = :scalable, layout = :olc,
+                sequencing_tech = :illumina,
+                olc_options = NamedTuple{(k,)}(("x",)))
+        end
+        # A non-reserved key is accepted.
+        Test.@test R.AssemblyConfig(; k = 13, corrector = :iterative,
+            strategy = :scalable, layout = :olc, sequencing_tech = :illumina,
+            olc_options = (; k_list = "21")) isa R.AssemblyConfig
+    end
 end

--- a/test/4_assembly/third_party_assemblers_hybrid_olc_route.jl
+++ b/test/4_assembly/third_party_assemblers_hybrid_olc_route.jl
@@ -64,6 +64,28 @@ Test.@testset "hybrid-OLC route (a) end-to-end (td-yymj)" begin
                 Test.@test asm.assembly_stats["layout"] == "olc"
                 Test.@test asm.assembly_stats["olc_tool"] == "megahit"
                 Test.@test asm.assembly_stats["corrected_read_count"] > 0
+                # Ephemeral contract (output_dir unset): the corrected FASTQ the
+                # route persisted (stamped into stats) must be CLEANED after the run.
+                Test.@test !isfile(asm.assembly_stats["corrected_fastq"])
+            end
+
+            Test.@testset "layout=:olc output_dir persists artifacts" begin
+                # Caller-owned output_dir: the corrected FASTQ + the assembler output
+                # dir must SURVIVE the run for the Stage-2 handoff (not cleaned).
+                outdir = mktempdir()
+                config = R.AssemblyConfig(; k = 13, corrector = :iterative,
+                    strategy = :scalable, sequencing_tech = :illumina,
+                    layout = :olc, olc_tool = :megahit, output_dir = outdir,
+                    olc_options = (; k_list = "21", threads = threads))
+                asm = R.assemble_genome(reads, config)
+                Test.@test asm isa R.AssemblyResult
+                Test.@test !isempty(asm.contigs)
+                # Corrected FASTQ persisted at the fixed path, left in place.
+                Test.@test isfile(joinpath(outdir, "corrected.fastq"))
+                Test.@test asm.assembly_stats["corrected_fastq"] ==
+                           joinpath(outdir, "corrected.fastq")
+                # Assembler output dir survives too.
+                Test.@test isdir(joinpath(outdir, "olc_megahit"))
             end
         end
     end

--- a/test/4_assembly/third_party_assemblers_hybrid_olc_route.jl
+++ b/test/4_assembly/third_party_assemblers_hybrid_olc_route.jl
@@ -1,0 +1,70 @@
+# td-yymj: hybrid-OLC route (a) END-TO-END (external short-read assemblers).
+#
+# Exercises assemble_genome(reads; corrector=:iterative, layout=:olc) — Stage-1
+# correction of simulated Illumina reads handed to an external short-read layout
+# assembler (megahit / metaspades) — and checks the wrapped AssemblyResult. Needs
+# the bioconda assembler tools + ART (simulate_illumina_reads), so it is gated:
+# the "third_party_assemblers" filename skips it in default CI, and the body also
+# guards on MYCELIA_RUN_EXTERNAL so a direct include is a no-op without the tools.
+#
+# Run directly (from the Mycelia base directory):
+#   MYCELIA_RUN_EXTERNAL=true julia --project=. -e 'include("test/4_assembly/third_party_assemblers_hybrid_olc_route.jl")'
+
+import Test
+import Mycelia
+import StableRNGs
+import BioSequences
+import FASTX
+
+const R = Mycelia.Rhizomorph
+
+Test.@testset "hybrid-OLC route (a) end-to-end (td-yymj)" begin
+    run_external = lowercase(get(ENV, "MYCELIA_RUN_ALL", "false")) == "true" ||
+                   lowercase(get(ENV, "MYCELIA_RUN_EXTERNAL", "false")) == "true"
+
+    if !run_external
+        @info "hybrid-OLC external run disabled; set MYCELIA_RUN_EXTERNAL=true to enable."
+    else
+        threads = clamp(
+            something(tryparse(Int, get(ENV, "MYCELIA_ASSEMBLER_TEST_THREADS", "2")), 2),
+            1, 4)
+        mktempdir() do dir
+            # Small synthetic reference + single-end Illumina reads.
+            rng = StableRNGs.StableRNG(2026)
+            genome = BioSequences.randdnaseq(rng, 5_000)
+            ref_fasta = joinpath(dir, "ref.fasta")
+            Mycelia.write_fasta(outfile = ref_fasta,
+                records = [FASTX.FASTA.Record("ref", genome)])
+            sim = Mycelia.simulate_illumina_reads(
+                fasta = ref_fasta, coverage = 25, read_length = 150,
+                paired = false, seqSys = "HS25", rndSeed = 2026, quiet = true)
+            reads = collect(Mycelia.open_fastx(sim.forward_reads))
+            Test.@test !isempty(reads)
+
+            # The corrector emits a SINGLE (single-end) corrected read set, so the
+            # end-to-end assertion uses megahit, which handles single-end input
+            # robustly. :metaspades is also wired (route (a) short-read arm) but
+            # metaSPAdes targets PAIRED metagenomic data and is not representative
+            # with single-end corrected reads, so it is exercised at the config /
+            # adapter level (hybrid_olc_config_test.jl) rather than end-to-end here.
+            Test.@testset "layout=:olc olc_tool=:megahit" begin
+                config = R.AssemblyConfig(; k = 13, corrector = :iterative,
+                    strategy = :scalable, sequencing_tech = :illumina,
+                    layout = :olc, olc_tool = :megahit,
+                    olc_options = (; k_list = "21", threads = threads))
+                asm = R.assemble_genome(reads, config)
+                Test.@test asm isa R.AssemblyResult
+                # External contig-only assembly: no graph, not GFA-compatible.
+                Test.@test asm.gfa_compatible == false
+                Test.@test asm.graph === nothing
+                # Produced at least one contig, with stamped provenance.
+                Test.@test !isempty(asm.contigs)
+                Test.@test length(asm.contigs) == length(asm.contig_names)
+                Test.@test asm.assembly_stats["method"] == "HybridOLC"
+                Test.@test asm.assembly_stats["layout"] == "olc"
+                Test.@test asm.assembly_stats["olc_tool"] == "megahit"
+                Test.@test asm.assembly_stats["corrected_read_count"] > 0
+            end
+        end
+    end
+end


### PR DESCRIPTION
## Summary

- Work-breakdown **item #2** (route (a) wiring) of the hybrid-OLC deconvolution route (`docs/design/2026-07-hybrid-olc-deconvolution-route.md`). Diverts Stage-1-corrected reads to an **external OLC assembler** so contiguity is inherited from a tool tuned for it, while per-base accuracy is contributed by Stage 1. Builds on the `_run_stage1_correction` seam from td-ohob (#409).
- **Config surface:** adds `layout::Symbol` (`:native`|`:olc`), `olc_tool::Symbol` (`:auto` + known tools), `olc_options::NamedTuple` to `AssemblyConfig`, threaded through struct/constructor/`new()` with validation. `layout=:olc` requires `corrector=:iterative`; `olc_tool` is validated against `sequencing_tech` (the read-type proxy).
- **Dispatch + stub:** `assemble_genome` routes `layout=:olc` to the repurposed `_assemble_hybrid_olc` (was a dead placeholder stub). It reuses `_run_stage1_correction`, calls the read-type-appropriate wrapper through a per-tool argument adapter (`_run_olc_tool`), and wraps the external contigs into an `AssemblyResult` (`gfa_compatible=false` — no Mycelia graph). Honors the ephemeral-cleanup contract (corrected FASTQ + assembler temp dir removed only when `output_dir` unset).
- `:auto` resolves by read type (short-read tech → `:megahit`).

## Scope (staged delivery)

This PR wires the **SHORT-read arm** (`:megahit`, `:metaspades`). Deliberately out of scope, rejected at construction with a clear pointer:
- **Long-read arm** (`:hifiasm`/`:flye`/`:canu`/`:metaflye`) → **td-wvto**.
- **Two-read-set hybrid arm** (dual-input `assemble_hybrid`, autocycler/metamdbg) → **td-06er**.

## Test Plan

- [x] **Un-gated config test** `hybrid_olc_config_test.jl` (runs in default CI) — **19/19**: layout/olc_tool validation, `:olc` requires `:iterative`, tool↔tech compatibility, long-read-tool + long-read-`:auto` rejection, `:auto` resolution, adapter guard.
- [x] **Native equivalence unchanged** (the `layout=:olc` branch sits ahead of the native re-assembly dispatch): graph-reuse **20/20**, corrector wiring **17/17**, Stage-1 persistence **26/26**.
- [x] **Gated end-to-end** `third_party_assemblers_hybrid_olc_route.jl` (`MYCELIA_RUN_EXTERNAL=true`) — **10/10** run locally with real megahit via bioconda: corrected Illumina reads → megahit → contigs → `AssemblyResult` with stamped provenance. The `third_party_assemblers` filename gates it out of default CI.

metaSPAdes stays wired (route (a) short-read arm) but targets **paired** metagenomic data, so with the corrector's single-end output it is exercised at the config/adapter level, not end-to-end.

## Related

- Design: `docs/design/2026-07-hybrid-olc-deconvolution-route.md` route (a)
- Depends on: #409 (td-ohob, the `_run_stage1_correction` seam)
- Follow-on: td-wvto (long-read arm), td-06er (hybrid dual-input arm), td-6jwl (validation harness)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a hybrid OLC genome assembly workflow following read correction.
  * Added configuration options for sequencing technology, assembly layout, OLC tool selection, and tool-specific options.
  * Added support for short-read assemblers including MEGAHIT and metaSPAdes.
  * Assembly results now include tool, layout, and correction provenance.

* **Validation**
  * Added configuration checks for compatible layouts, correctors, sequencing technologies, and OLC tools.

* **Tests**
  * Added configuration and end-to-end coverage for hybrid OLC assembly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->