### PR TITLE
add: calibrated decode gate — Stage 2 (3-model calibration) + Stage 3 (gate + frontier) (td-4osf)

### DIFF
--- a/benchmarking/calibration_metrics.jl
+++ b/benchmarking/calibration_metrics.jl
@@ -122,31 +122,46 @@ function fit_isotonic_map(scores::AbstractVector{<:Real},
     order = sortperm(scores)
     sorted_scores = Float64.(scores[order])
     sorted_labels = labels[order]
-    block_starts = Int[]
-    block_ends = Int[]
+    # Pool TIED scores into one point BEFORE PAVA. A calibration map is a function
+    # of the score, so all observations with an identical score must share one
+    # probability; without this, equal scores whose labels happen to be
+    # non-decreasing land in separate blocks with duplicate thresholds, and
+    # `searchsortedfirst` then maps a repeated score to the first block's
+    # probability instead of the shared empirical one (repeated Viterbi gaps
+    # tie routinely, so this is not a corner case).
+    point_scores = Float64[]
+    point_sums = Float64[]
+    point_counts = Int[]
+    for i in eachindex(sorted_scores)
+        if !isempty(point_scores) && sorted_scores[i] == point_scores[end]
+            point_sums[end] += sorted_labels[i] ? 1.0 : 0.0
+            point_counts[end] += 1
+        else
+            push!(point_scores, sorted_scores[i])
+            push!(point_sums, sorted_labels[i] ? 1.0 : 0.0)
+            push!(point_counts, 1)
+        end
+    end
+    # PAVA over the unique-score points → non-decreasing, unique-threshold blocks.
+    block_scores = Float64[]
     block_sums = Float64[]
     block_counts = Int[]
-    for i in eachindex(sorted_scores)
-        push!(block_starts, i)
-        push!(block_ends, i)
-        push!(block_sums, sorted_labels[i] ? 1.0 : 0.0)
-        push!(block_counts, 1)
+    for j in eachindex(point_scores)
+        push!(block_scores, point_scores[j])
+        push!(block_sums, point_sums[j])
+        push!(block_counts, point_counts[j])
         while length(block_sums) >= 2 &&
             block_sums[end - 1] / block_counts[end - 1] >
             block_sums[end] / block_counts[end]
-            block_ends[end - 1] = block_ends[end]
+            block_scores[end - 1] = block_scores[end]   # block threshold = its max score
             block_sums[end - 1] += block_sums[end]
             block_counts[end - 1] += block_counts[end]
-            pop!(block_starts)
-            pop!(block_ends)
+            pop!(block_scores)
             pop!(block_sums)
             pop!(block_counts)
         end
     end
-    return (
-        thresholds = [sorted_scores[i] for i in block_ends],
-        probabilities = block_sums ./ block_counts
-    )
+    return (thresholds = block_scores, probabilities = block_sums ./ block_counts)
 end
 
 """Map raw `scores` through a fitted isotonic probability map."""

--- a/benchmarking/calibration_metrics.jl
+++ b/benchmarking/calibration_metrics.jl
@@ -104,3 +104,58 @@ function brier_score(confidences::AbstractVector{<:Real}, labels::AbstractVector
         throw(ArgumentError("confidences and labels must have equal length"))
     return sum((confidences[i] - (labels[i] ? 1.0 : 0.0))^2 for i in 1:n) / n
 end
+
+"""
+    fit_isotonic_map(scores, labels) -> NamedTuple
+
+Fit a non-decreasing, piecewise-constant probability map with the pooled
+adjacent violators algorithm. The returned `thresholds` are sorted score upper
+bounds and `probabilities` are the corresponding empirical probabilities.
+"""
+function fit_isotonic_map(scores::AbstractVector{<:Real},
+        labels::AbstractVector{Bool})::NamedTuple
+    length(scores) == length(labels) ||
+        throw(ArgumentError("scores and labels must have equal length"))
+    isempty(scores) && throw(ArgumentError("scores and labels must be non-empty"))
+    all(isfinite, scores) || throw(ArgumentError("scores must be finite"))
+
+    order = sortperm(scores)
+    sorted_scores = Float64.(scores[order])
+    sorted_labels = labels[order]
+    block_starts = Int[]
+    block_ends = Int[]
+    block_sums = Float64[]
+    block_counts = Int[]
+    for i in eachindex(sorted_scores)
+        push!(block_starts, i)
+        push!(block_ends, i)
+        push!(block_sums, sorted_labels[i] ? 1.0 : 0.0)
+        push!(block_counts, 1)
+        while length(block_sums) >= 2 &&
+              block_sums[end - 1] / block_counts[end - 1] >
+              block_sums[end] / block_counts[end]
+            block_ends[end - 1] = block_ends[end]
+            block_sums[end - 1] += block_sums[end]
+            block_counts[end - 1] += block_counts[end]
+            pop!(block_starts)
+            pop!(block_ends)
+            pop!(block_sums)
+            pop!(block_counts)
+        end
+    end
+    return (
+        thresholds = [sorted_scores[i] for i in block_ends],
+        probabilities = block_sums ./ block_counts,
+    )
+end
+
+"""Map raw `scores` through a fitted isotonic probability map."""
+function predict_isotonic(model::NamedTuple,
+        scores::AbstractVector{<:Real})::Vector{Float64}
+    isempty(model.thresholds) && throw(ArgumentError("isotonic model is empty"))
+    return [model.probabilities[clamp(
+                searchsortedfirst(model.thresholds, Float64(score)),
+                1,
+                length(model.thresholds),
+            )] for score in scores]
+end

--- a/benchmarking/calibration_metrics.jl
+++ b/benchmarking/calibration_metrics.jl
@@ -132,8 +132,8 @@ function fit_isotonic_map(scores::AbstractVector{<:Real},
         push!(block_sums, sorted_labels[i] ? 1.0 : 0.0)
         push!(block_counts, 1)
         while length(block_sums) >= 2 &&
-              block_sums[end - 1] / block_counts[end - 1] >
-              block_sums[end] / block_counts[end]
+            block_sums[end - 1] / block_counts[end - 1] >
+            block_sums[end] / block_counts[end]
             block_ends[end - 1] = block_ends[end]
             block_sums[end - 1] += block_sums[end]
             block_counts[end - 1] += block_counts[end]
@@ -145,7 +145,7 @@ function fit_isotonic_map(scores::AbstractVector{<:Real},
     end
     return (
         thresholds = [sorted_scores[i] for i in block_ends],
-        probabilities = block_sums ./ block_counts,
+        probabilities = block_sums ./ block_counts
     )
 end
 
@@ -156,6 +156,113 @@ function predict_isotonic(model::NamedTuple,
     return [model.probabilities[clamp(
                 searchsortedfirst(model.thresholds, Float64(score)),
                 1,
-                length(model.thresholds),
+                length(model.thresholds)
             )] for score in scores]
+end
+
+"""
+    fit_logistic_map(scores, labels; iters=500, lr=0.1) -> NamedTuple
+
+Fit a Platt-style single-feature logistic probability map
+`P(true | score) = 1 / (1 + exp(-(a + b*score)))` by gradient descent on the
+standardized score, folded back to raw-score space. Returns `(a, b)` — the
+raw-space intercept and slope. Mirrors the standardize→fit→unfold structure of
+the repo's `fit_logistic_fusion`, but with a single feature and no Mycelia
+dependency. Two parameters, strictly monotone, so it inverts cleanly to a single
+raw gap cutoff (see `logistic_gap_for_probability`).
+"""
+function fit_logistic_map(scores::AbstractVector{<:Real},
+        labels::AbstractVector{Bool}; iters::Int = 500, lr::Float64 = 0.1)::NamedTuple
+    length(scores) == length(labels) ||
+        throw(ArgumentError("scores and labels must have equal length"))
+    isempty(scores) && throw(ArgumentError("scores and labels must be non-empty"))
+    all(isfinite, scores) || throw(ArgumentError("scores must be finite"))
+    x = Float64.(scores)
+    y = [l ? 1.0 : 0.0 for l in labels]
+    n = length(x)
+    μ = sum(x) / n
+    σ = sqrt(max(sum((xi - μ)^2 for xi in x) / n, eps()))
+    z = (x .- μ) ./ σ
+    α = 0.0
+    β = 0.0
+    for _ in 1:iters
+        gα = 0.0
+        gβ = 0.0
+        for i in 1:n
+            p = 1.0 / (1.0 + exp(-(α + β * z[i])))
+            err = p - y[i]
+            gα += err
+            gβ += err * z[i]
+        end
+        α -= lr * gα / n
+        β -= lr * gβ / n
+    end
+    # Fold the standardized (α, β) back to raw-score space:
+    # α + β*(x-μ)/σ = (α - β*μ/σ) + (β/σ)*x.
+    return (a = α - β * μ / σ, b = β / σ)
+end
+
+"""Map raw `scores` through a fitted logistic probability map."""
+function predict_logistic(model::NamedTuple,
+        scores::AbstractVector{<:Real})::Vector{Float64}
+    return [1.0 / (1.0 + exp(-(model.a + model.b * Float64(score)))) for score in scores]
+end
+
+"""
+    logistic_gap_for_probability(model, p) -> Float64
+
+Invert the logistic map: the raw score at which `predict_logistic` equals `p`,
+usable as a calibrated gap cutoff. `logit(p) = a + b*score` ⇒
+`score = (logit(p) - a) / b`. Requires a non-degenerate slope.
+"""
+function logistic_gap_for_probability(model::NamedTuple, p::Real)::Float64
+    0.0 < p < 1.0 || throw(ArgumentError("p must be in the open interval (0, 1)"))
+    model.b == 0.0 &&
+        throw(ArgumentError("degenerate logistic map (zero slope) cannot be inverted"))
+    return (log(p / (1 - p)) - model.a) / model.b
+end
+
+"""
+    fit_binned_map(scores, labels; nbins=10) -> NamedTuple
+
+Fit a coarse probability map by partitioning the score range into `nbins`
+equal-width bins and taking each bin's empirical fraction of true labels. Returns
+`edges` (nbins+1 boundaries) and `probabilities` (one per bin; an empty bin
+inherits the global mean so the map is always defined). The coarsest of the three
+calibration models — zero model assumptions, but edge-unstable on sparse bins.
+"""
+function fit_binned_map(scores::AbstractVector{<:Real},
+        labels::AbstractVector{Bool}; nbins::Int = 10)::NamedTuple
+    length(scores) == length(labels) ||
+        throw(ArgumentError("scores and labels must have equal length"))
+    isempty(scores) && throw(ArgumentError("scores and labels must be non-empty"))
+    all(isfinite, scores) || throw(ArgumentError("scores must be finite"))
+    nbins >= 1 || throw(ArgumentError("nbins must be >= 1"))
+    x = Float64.(scores)
+    lo, hi = extrema(x)
+    global_mean = sum(l ? 1.0 : 0.0 for l in labels) / length(labels)
+    # Degenerate range (all scores equal): a single bin at the global mean.
+    hi <= lo && return (edges = [lo, hi], probabilities = [global_mean])
+    width = (hi - lo) / nbins
+    sums = zeros(Float64, nbins)
+    counts = zeros(Int, nbins)
+    for i in eachindex(x)
+        b = clamp(Int(floor((x[i] - lo) / width)) + 1, 1, nbins)
+        sums[b] += labels[i] ? 1.0 : 0.0
+        counts[b] += 1
+    end
+    probs = [counts[b] == 0 ? global_mean : sums[b] / counts[b] for b in 1:nbins]
+    return (edges = [lo + b * width for b in 0:nbins], probabilities = probs)
+end
+
+"""Map raw `scores` through a fitted equal-width binned probability map."""
+function predict_binned(model::NamedTuple,
+        scores::AbstractVector{<:Real})::Vector{Float64}
+    nbins = length(model.probabilities)
+    lo = model.edges[1]
+    hi = model.edges[end]
+    width = (hi - lo) / nbins
+    return [model.probabilities[width <= 0 ? 1 :
+                                clamp(Int(floor((Float64(score) - lo) / width)) + 1, 1, nbins)]
+            for score in scores]
 end

--- a/benchmarking/calibration_metrics_test.jl
+++ b/benchmarking/calibration_metrics_test.jl
@@ -44,6 +44,16 @@ Test.@testset "calibration metrics" begin
     Test.@test brier_score([0.0, 1.0], [false, true]) == 0.0                    # perfect
     Test.@test brier_score([1.0, 0.0], [false, true]) == 1.0                    # worst
 
+    # --- isotonic probability map -------------------------------------------
+    raw = [0.1, 0.2, 0.3, 0.4, 0.5, 0.6]
+    truth = [false, false, true, false, true, true]
+    model = fit_isotonic_map(raw, truth)
+    calibrated = predict_isotonic(model, raw)
+    Test.@test issorted(calibrated)
+    Test.@test all(p -> 0.0 <= p <= 1.0, calibrated)
+    Test.@test calibrated[3] == calibrated[4]
+    Test.@test auroc(raw, truth) > 0.5
+
     # --- degenerate / empty inputs -------------------------------------------
     Test.@test isnan(expected_calibration_error(Float64[], Bool[]))
     Test.@test isnan(brier_score(Float64[], Bool[]))
@@ -53,4 +63,5 @@ Test.@testset "calibration metrics" begin
     # --- length-mismatch guards ----------------------------------------------
     Test.@test_throws ArgumentError auroc([0.1, 0.2], [true])
     Test.@test_throws ArgumentError reliability_bins([0.1], [true, false])
+    Test.@test_throws ArgumentError fit_isotonic_map([0.1, Inf], [false, true])
 end

--- a/benchmarking/rhizomorph_correction_pr_curve.jl
+++ b/benchmarking/rhizomorph_correction_pr_curve.jl
@@ -225,30 +225,44 @@ function run_pr_curve()
 end
 
 """
-    assess_frontier_dominance(rows; err=0.10, recall_eps=0.02, over_eps=0.01) -> NamedTuple
+    assess_frontier_dominance(rows; err=0.10, recall_eps=0.02) -> NamedTuple
 
 Programmatic frontier-dominance check (previously eyeballed from the CSV). At
 error rate `err`, decide whether any `calibrated-gap-*` operating point DOMINATES
-the `noskip+nogate` baseline: recall retained (>= baseline recall − `recall_eps`),
-over-correction pushed near zero (<= `over_eps`), and precision not below the
-baseline. Returns `(dominates, baseline, best, candidates)`. NaN metrics
-(zero-denominator rows) are treated as non-dominating.
+the `noskip+nogate` baseline. Dominance requires a STRICT up-and-right move, not a
+tie: recall retained (>= baseline recall − `recall_eps`), over-correction
+**strictly** below baseline, and precision not below baseline. The strict
+over-correction criterion is load-bearing — `calibrated-gap-0.0` is by definition
+the ungated baseline (threshold 0 reverts nothing), so it TIES every metric; a
+non-strict predicate would report it as "dominating" itself. Returns
+`(dominates, baseline, best, candidates)`. A non-finite baseline or non-finite
+candidate metrics (zero-denominator rows) are treated as non-dominating.
 """
 function assess_frontier_dominance(rows::DataFrames.DataFrame;
-        err::Float64 = 0.10, recall_eps::Float64 = 0.02, over_eps::Float64 = 0.01)
+        err::Float64 = 0.10, recall_eps::Float64 = 0.02)
     at = rows[[isapprox(r, err; atol = 1e-9) for r in rows.error_rate], :]
     base_idx = findfirst(==("noskip+nogate"), at.point)
     base_idx === nothing && return (dominates = false,
         reason = "no noskip+nogate baseline at err=$(err)",
         baseline = nothing, best = nothing, candidates = NamedTuple[])
     base = at[base_idx, :]
+    if !(isfinite(base.recall) && isfinite(base.precision) &&
+         isfinite(base.over_correction_rate))
+        return (dominates = false,
+            reason = "degenerate (non-finite) noskip+nogate baseline at err=$(err)",
+            baseline = (recall = base.recall, precision = base.precision,
+                over_rate = base.over_correction_rate),
+            best = nothing, candidates = NamedTuple[])
+    end
     winners = NamedTuple[]
     for row in DataFrames.eachrow(at)
         startswith(row.point, "calibrated-gap-") || continue
         (isfinite(row.recall) && isfinite(row.precision) &&
          isfinite(row.over_correction_rate)) || continue
+        # STRICT improvement: retain recall, strictly reduce over-correction, keep
+        # precision. The strict `<` on over-correction excludes the gap-0.0 tie.
         if row.recall >= base.recall - recall_eps &&
-           row.over_correction_rate <= over_eps &&
+           row.over_correction_rate < base.over_correction_rate &&
            row.precision >= base.precision
             push!(winners,
                 (point = row.point, recall = row.recall,

--- a/benchmarking/rhizomorph_correction_pr_curve.jl
+++ b/benchmarking/rhizomorph_correction_pr_curve.jl
@@ -52,13 +52,27 @@ include(joinpath(@__DIR__, "rhizomorph_correction_accuracy_benchmark.jl"))
 # auto-bounded Viterbi beam (256) applies to every point, so these stay tractable.
 const PR_OPERATING_POINTS = [
     (name = "scalable", skip_solid = true, cheap_correct = true, hard_window = true,
-        soft_em = true, n_k_rungs = 3, max_iterations_per_k = 2, beam_width = nothing),
+        soft_em = true, n_k_rungs = 3, max_iterations_per_k = 2, beam_width = nothing,
+        calibrated_gap_threshold = nothing),
     (name = "noskip", skip_solid = false, cheap_correct = true, hard_window = true,
-        soft_em = true, n_k_rungs = 3, max_iterations_per_k = 2, beam_width = nothing),
+        soft_em = true, n_k_rungs = 3, max_iterations_per_k = 2, beam_width = nothing,
+        calibrated_gap_threshold = nothing),
     (name = "noskip+nogate", skip_solid = false,
         cheap_correct = true, hard_window = false,
-        soft_em = true, n_k_rungs = 3, max_iterations_per_k = 2, beam_width = nothing)
+        soft_em = true, n_k_rungs = 3, max_iterations_per_k = 2, beam_width = nothing,
+        calibrated_gap_threshold = nothing)
 ]
+
+function calibrated_gap_points()
+    thresholds = _parse_float_list(
+        get(ENV, "MYCELIA_RPC_GAP_THRESHOLDS", "0.0,0.5,1.0,2.0,4.0"), Float64[])
+    return [(
+        name = "calibrated-gap-$(threshold)", skip_solid = false,
+        cheap_correct = true, hard_window = false, soft_em = true,
+        n_k_rungs = 3, max_iterations_per_k = 2, beam_width = nothing,
+        calibrated_gap_threshold = threshold,
+    ) for threshold in thresholds]
+end
 
 """
 Correct `records` with an explicit knob preset `pt` (a PR_OPERATING_POINTS entry),
@@ -85,6 +99,7 @@ function correct_reads_at_point(records::Vector{FASTX.FASTQ.Record}, k::Int, pt)
         soft_em = pt.soft_em,
         cheap_correct = pt.cheap_correct,
         beam_width = pt.beam_width,
+        calibrated_gap_threshold = pt.calibrated_gap_threshold,
         verbose = false,
         enable_checkpointing = false,
         output_dir = output_dir
@@ -112,8 +127,9 @@ function run_pr_curve()
     assigned_q = parse(Int, get(ENV, "MYCELIA_RPC_ASSIGNED_Q", "20"))
     seed = parse(Int, get(ENV, "MYCELIA_RPC_SEED", "42"))
     want = strip(get(ENV, "MYCELIA_RPC_POINTS", ""))
-    points = isempty(want) ? PR_OPERATING_POINTS :
-             filter(p -> p.name in split(want, ","), PR_OPERATING_POINTS)
+    all_points = vcat(PR_OPERATING_POINTS, calibrated_gap_points())
+    points = isempty(want) ? all_points :
+             filter(p -> p.name in split(want, ","), all_points)
 
     println("=== Rhizomorph Correction Precision-Recall Frontier ===")
     println("Start: $(Dates.now())   error rates: $errs   coverage: $(coverage)x   k: $k")

--- a/benchmarking/rhizomorph_correction_pr_curve.jl
+++ b/benchmarking/rhizomorph_correction_pr_curve.jl
@@ -67,11 +67,11 @@ function calibrated_gap_points()
     thresholds = _parse_float_list(
         get(ENV, "MYCELIA_RPC_GAP_THRESHOLDS", "0.0,0.5,1.0,2.0,4.0"), Float64[])
     return [(
-        name = "calibrated-gap-$(threshold)", skip_solid = false,
-        cheap_correct = true, hard_window = false, soft_em = true,
-        n_k_rungs = 3, max_iterations_per_k = 2, beam_width = nothing,
-        calibrated_gap_threshold = threshold,
-    ) for threshold in thresholds]
+                name = "calibrated-gap-$(threshold)", skip_solid = false,
+                cheap_correct = true, hard_window = false, soft_em = true,
+                n_k_rungs = 3, max_iterations_per_k = 2, beam_width = nothing,
+                calibrated_gap_threshold = threshold
+            ) for threshold in thresholds]
 end
 
 """
@@ -195,11 +195,72 @@ function run_pr_curve()
     csv = joinpath(results_dir, "rhizomorph_correction_pr_curve_$(ts).csv")
     CSV.write(csv, rows)
     println("\nCSV: $csv")
+
+    # Programmatic dominance verdict at the high-error rate (if the sweep covered
+    # it AND included calibrated points), replacing the eyeball read of the CSV.
+    if 0.10 in errs && any(startswith(p.name, "calibrated-gap-") for p in points)
+        dom = assess_frontier_dominance(rows; err = 0.10)
+        if dom.baseline === nothing
+            println("\n[dominance] $(dom.reason)")
+        elseif dom.dominates
+            println("\n[dominance] err=0.10 CALIBRATED GATE DOMINATES noskip+nogate: " *
+                    "$(dom.best.point) recall=$(round(dom.best.recall; digits = 4)) " *
+                    "precision=$(round(dom.best.precision; digits = 4)) " *
+                    "over_rate=$(round(dom.best.over_rate; digits = 6)) " *
+                    "(baseline recall=$(round(dom.baseline.recall; digits = 4)) " *
+                    "precision=$(round(dom.baseline.precision; digits = 4)) " *
+                    "over_rate=$(round(dom.baseline.over_rate; digits = 6)))")
+        else
+            println("\n[dominance] err=0.10 NO calibrated point dominates noskip+nogate " *
+                    "(baseline recall=$(round(dom.baseline.recall; digits = 4)) " *
+                    "precision=$(round(dom.baseline.precision; digits = 4)) " *
+                    "over_rate=$(round(dom.baseline.over_rate; digits = 6))) — widen thresholds.")
+        end
+    end
     println("\nRead the frontier per error rate: a point with HIGHER recall at ~equal precision")
     println("+ ~zero over_correction is a strict improvement (the corrector was over-conservative).")
     println("A point that trades precision/over-correction for recall exposes the real tradeoff.")
     println("=== done: $(Dates.now()) ===")
     return (; csv, rows)
+end
+
+"""
+    assess_frontier_dominance(rows; err=0.10, recall_eps=0.02, over_eps=0.01) -> NamedTuple
+
+Programmatic frontier-dominance check (previously eyeballed from the CSV). At
+error rate `err`, decide whether any `calibrated-gap-*` operating point DOMINATES
+the `noskip+nogate` baseline: recall retained (>= baseline recall − `recall_eps`),
+over-correction pushed near zero (<= `over_eps`), and precision not below the
+baseline. Returns `(dominates, baseline, best, candidates)`. NaN metrics
+(zero-denominator rows) are treated as non-dominating.
+"""
+function assess_frontier_dominance(rows::DataFrames.DataFrame;
+        err::Float64 = 0.10, recall_eps::Float64 = 0.02, over_eps::Float64 = 0.01)
+    at = rows[[isapprox(r, err; atol = 1e-9) for r in rows.error_rate], :]
+    base_idx = findfirst(==("noskip+nogate"), at.point)
+    base_idx === nothing && return (dominates = false,
+        reason = "no noskip+nogate baseline at err=$(err)",
+        baseline = nothing, best = nothing, candidates = NamedTuple[])
+    base = at[base_idx, :]
+    winners = NamedTuple[]
+    for row in DataFrames.eachrow(at)
+        startswith(row.point, "calibrated-gap-") || continue
+        (isfinite(row.recall) && isfinite(row.precision) &&
+         isfinite(row.over_correction_rate)) || continue
+        if row.recall >= base.recall - recall_eps &&
+           row.over_correction_rate <= over_eps &&
+           row.precision >= base.precision
+            push!(winners,
+                (point = row.point, recall = row.recall,
+                    precision = row.precision, over_rate = row.over_correction_rate))
+        end
+    end
+    best = isempty(winners) ? nothing :
+           sort(winners; by = w -> (w.over_rate, -w.recall))[1]
+    return (dominates = !isempty(winners),
+        baseline = (recall = base.recall, precision = base.precision,
+            over_rate = base.over_correction_rate),
+        best = best, candidates = winners)
 end
 
 if abspath(PROGRAM_FILE) == @__FILE__

--- a/benchmarking/viterbi_gap_calibration.jl
+++ b/benchmarking/viterbi_gap_calibration.jl
@@ -107,8 +107,12 @@ function _inject_substitutions(seq::AbstractString, rate::Float64, rng)::String
     chars = collect(seq)
     alts = Dict('A' => "CGT", 'C' => "AGT", 'G' => "ACT", 'T' => "ACG")
     for i in eachindex(chars)
+        # Only substitute ACGT bases, and always to a DIFFERENT base (the per-base
+        # `alts` string excludes the original), so a "substitution" is never a no-op
+        # that would mislabel an unchanged position as edited.
+        haskey(alts, chars[i]) || continue
         if rand(rng) < rate
-            opts = get(alts, chars[i], "ACGT")
+            opts = alts[chars[i]]
             chars[i] = opts[rand(rng, 1:lastindex(opts))]
         end
     end
@@ -177,14 +181,30 @@ function run_gap_calibration(;
         cfg = Mycelia.ViterbiCorrectionConfig(record_position_gaps = true, error_rate = er)
         scores = Float64[]
         labels = Bool[]
+        n_failed = 0
+        first_error = nothing
         for (rec, clean) in zip(reads, truths)
             gt = try
                 collect_gap_truth(cov, FASTX.sequence(String, rec), clean; config = cfg)
-            catch
+            catch e
+                n_failed += 1
+                first_error === nothing && (first_error = e)   # keep the first for signal
                 continue   # skip a failed/contract-violating decode
             end
             append!(scores, gt.scores)
             append!(labels, gt.labels)
+        end
+        # Distinguish systematic/partial DECODE FAILURE (a real bug or a biased
+        # survivor subset) from mere class imbalance — a bare `catch;continue` would
+        # otherwise misattribute an all-fail run to "insufficient class balance".
+        if n_failed > 0
+            @warn "gap calibration: $(n_failed)/$(length(reads)) reads failed to " *
+                  "decode at err=$(er) (calibration fit on the surviving subset — " *
+                  "possible bias)." first_error
+        end
+        if n_failed == length(reads)
+            println("err=$(er): ALL $(length(reads)) reads failed to decode — no signal, skipped")
+            continue
         end
         if isempty(scores) || all(labels) || !any(labels)
             println("err=$(er): insufficient class balance (n=$(length(scores))) — skipped")

--- a/benchmarking/viterbi_gap_calibration.jl
+++ b/benchmarking/viterbi_gap_calibration.jl
@@ -187,9 +187,15 @@ function run_gap_calibration(;
             gt = try
                 collect_gap_truth(cov, FASTX.sequence(String, rec), clean; config = cfg)
             catch e
-                n_failed += 1
-                first_error === nothing && (first_error = e)   # keep the first for signal
-                continue   # skip a failed/contract-violating decode
+                # Skip ONLY the expected "no path" decode failure; a contract
+                # violation, BoundsError, or any other defect is a real bug that must
+                # surface, not be silently averaged out of the calibration sample.
+                if e isa ArgumentError && occursin("decode produced no path", e.msg)
+                    n_failed += 1
+                    first_error === nothing && (first_error = e)
+                    continue
+                end
+                rethrow()
             end
             append!(scores, gt.scores)
             append!(labels, gt.labels)

--- a/benchmarking/viterbi_gap_calibration.jl
+++ b/benchmarking/viterbi_gap_calibration.jl
@@ -1,0 +1,58 @@
+# Tier-2 per-base Viterbi-gap calibration (td-4osf).
+
+import Mycelia
+
+include(joinpath(@__DIR__, "calibration_metrics.jl"))
+include(joinpath(@__DIR__, "benchmark_kmer_graph_fixture.jl"))
+
+"""
+    collect_gap_truth(fixture, observed_sequence, truth_sequence; config)
+
+Decode one fixed-length observation and align `position_gaps[i]` with
+`path.steps[i + 1]`. A k-mer transition contributes the newly emitted base at
+read position `i + k`; its label is true iff that corrected base matches truth.
+Collapsed-frontier `Inf` sentinels are excluded before calibration.
+"""
+function collect_gap_truth(fixture::NamedTuple,
+        observed_sequence::AbstractString,
+        truth_sequence::AbstractString;
+        config::Mycelia.ViterbiCorrectionConfig =
+            Mycelia.ViterbiCorrectionConfig(record_position_gaps = true))::NamedTuple
+    length(observed_sequence) == length(truth_sequence) ||
+        throw(ArgumentError("observed and truth sequences must have equal length"))
+    observation = fixture.to_observation(observed_sequence)
+    result = Mycelia.correct_observations(fixture.graph, [observation]; config = config)
+    path = something(result.paths[1].path, throw(ArgumentError("decode produced no path")))
+    gaps = result.paths[1].diagnostics[:position_gaps]
+    length(gaps) == length(path.steps) - 1 ||
+        throw(ArgumentError("position-gap/path alignment contract violated"))
+    k = length(String(path.steps[1].vertex_label))
+    scores = Float64[]
+    labels = Bool[]
+    positions = Int[]
+    for i in eachindex(gaps)
+        isfinite(gaps[i]) || continue
+        corrected_kmer = String(path.steps[i + 1].vertex_label)
+        position = i + k
+        position <= lastindex(truth_sequence) || continue
+        push!(scores, gaps[i])
+        push!(labels, corrected_kmer[end] == truth_sequence[position])
+        push!(positions, position)
+    end
+    return (; scores, labels, positions, result)
+end
+
+"""Fit and evaluate an isotonic probability map on finite gap/truth pairs."""
+function calibrate_gap_probability(scores::AbstractVector{<:Real},
+        labels::AbstractVector{Bool}; nbins::Int = 10)::NamedTuple
+    model = fit_isotonic_map(scores, labels)
+    probabilities = predict_isotonic(model, scores)
+    return (
+        model = model,
+        probabilities = probabilities,
+        auroc = auroc(scores, labels),
+        ece = expected_calibration_error(probabilities, labels; nbins = nbins),
+        brier = brier_score(probabilities, labels),
+        reliability = reliability_bins(probabilities, labels; nbins = nbins),
+    )
+end

--- a/benchmarking/viterbi_gap_calibration.jl
+++ b/benchmarking/viterbi_gap_calibration.jl
@@ -1,6 +1,17 @@
 # Tier-2 per-base Viterbi-gap calibration (td-4osf).
+#
+# Stage 2 (Route a, self-contained): drive `correct_observations` directly with
+# `record_position_gaps=true` on a controlled singlestrand graph, align each
+# finite per-position Viterbi gap to the corrected base, label it against truth,
+# and fit + compare THREE calibration models head-to-head (isotonic, logistic,
+# binned). AUROC (discrimination) is a property of the raw gap ranking — reported
+# ONCE, identical across models; ECE/Brier (calibration) isolate where the models
+# differ. Not a CI test (drives many whole-graph decodes); the CI-fast assertions
+# live in test/4_assembly/viterbi_gap_calibration_test.jl.
 
 import Mycelia
+import Random
+import FASTX
 
 include(joinpath(@__DIR__, "calibration_metrics.jl"))
 include(joinpath(@__DIR__, "benchmark_kmer_graph_fixture.jl"))
@@ -17,12 +28,16 @@ function collect_gap_truth(fixture::NamedTuple,
         observed_sequence::AbstractString,
         truth_sequence::AbstractString;
         config::Mycelia.ViterbiCorrectionConfig =
-            Mycelia.ViterbiCorrectionConfig(record_position_gaps = true))::NamedTuple
+        Mycelia.ViterbiCorrectionConfig(record_position_gaps = true))::NamedTuple
     length(observed_sequence) == length(truth_sequence) ||
         throw(ArgumentError("observed and truth sequences must have equal length"))
     observation = fixture.to_observation(observed_sequence)
     result = Mycelia.correct_observations(fixture.graph, [observation]; config = config)
-    path = something(result.paths[1].path, throw(ArgumentError("decode produced no path")))
+    # NB: `something(x, throw(e))` would raise EAGERLY (throw is an argument,
+    # evaluated before `something` runs) — use a lazy nothing-check so we only
+    # raise when the decode genuinely failed.
+    path = result.paths[1].path
+    path === nothing && throw(ArgumentError("decode produced no path"))
     gaps = result.paths[1].diagnostics[:position_gaps]
     length(gaps) == length(path.steps) - 1 ||
         throw(ArgumentError("position-gap/path alignment contract violated"))
@@ -42,17 +57,162 @@ function collect_gap_truth(fixture::NamedTuple,
     return (; scores, labels, positions, result)
 end
 
-"""Fit and evaluate an isotonic probability map on finite gap/truth pairs."""
-function calibrate_gap_probability(scores::AbstractVector{<:Real},
-        labels::AbstractVector{Bool}; nbins::Int = 10)::NamedTuple
-    model = fit_isotonic_map(scores, labels)
-    probabilities = predict_isotonic(model, scores)
+# The three calibration models compared head-to-head. Each is a (fit, predict)
+# pair over the same (gap, label) sample; the runtime gate consumes only a raw
+# gap threshold, so these differ only in how they turn the gap RANKING into
+# calibrated probabilities (the ECE/Brier axis).
+const CALIBRATION_MODELS = (
+    (name = "isotonic", fit = fit_isotonic_map, predict = predict_isotonic),
+    (name = "logistic", fit = fit_logistic_map, predict = predict_logistic),
+    (name = "binned", fit = fit_binned_map, predict = predict_binned)
+)
+
+"""Fit+evaluate one (fit, predict) calibration model on finite gap/truth pairs."""
+function calibrate_gap_probability(fit::Function, predict::Function,
+        scores::AbstractVector{<:Real}, labels::AbstractVector{Bool};
+        nbins::Int = 10)::NamedTuple
+    model = fit(scores, labels)
+    probabilities = predict(model, scores)
     return (
         model = model,
         probabilities = probabilities,
-        auroc = auroc(scores, labels),
         ece = expected_calibration_error(probabilities, labels; nbins = nbins),
         brier = brier_score(probabilities, labels),
-        reliability = reliability_bins(probabilities, labels; nbins = nbins),
+        reliability = reliability_bins(probabilities, labels; nbins = nbins)
     )
+end
+
+"""
+    compare_gap_calibrations(scores, labels; nbins=10) -> NamedTuple
+
+Fit all three calibration models on the same finite (gap, label) sample. Returns
+`(auroc, rows)` where `auroc` is the shared raw-gap discrimination (identical
+across models) and each row is `(model, ece, brier, cal)`. ECE/Brier isolate
+CALIBRATION quality — the only axis on which the models differ.
+"""
+function compare_gap_calibrations(scores::AbstractVector{<:Real},
+        labels::AbstractVector{Bool}; nbins::Int = 10)::NamedTuple
+    rows = [(model = m.name,
+                cal = calibrate_gap_probability(
+                    m.fit, m.predict, scores, labels; nbins = nbins))
+            for m in CALIBRATION_MODELS]
+    return (auroc = auroc(scores, labels),
+        rows = [(model = r.model, ece = r.cal.ece, brier = r.cal.brier, cal = r.cal)
+                for r in rows])
+end
+
+# Substitute each base with prob `rate` to a DIFFERENT base (length-preserving),
+# so the observed read aligns 1:1 with its truth for per-position labeling.
+function _inject_substitutions(seq::AbstractString, rate::Float64, rng)::String
+    chars = collect(seq)
+    alts = Dict('A' => "CGT", 'C' => "AGT", 'G' => "ACT", 'T' => "ACG")
+    for i in eachindex(chars)
+        if rand(rng) < rate
+            opts = get(alts, chars[i], "ACGT")
+            chars[i] = opts[rand(rng, 1:lastindex(opts))]
+        end
+    end
+    return String(chars)
+end
+
+"""
+    build_coverage_fixture(reads, k; moltype=:DNA) -> NamedTuple
+
+Build a `collect_gap_truth`-compatible fixture (`.graph`, `.to_observation`) from
+a READ SET rather than a single truth sequence. The read-coverage k-mer graph
+carries the error- and repeat-induced BRANCHES the decoder must navigate — the
+only place the per-position Viterbi margin is FINITE. A truth-only fixture graph
+is linear (unique k-mers, no competitor), so every gap is `Inf` and there is no
+calibration signal; the coverage graph is what the production gate actually
+decodes against.
+"""
+function build_coverage_fixture(reads::Vector{<:FASTX.FASTQ.Record}, k::Int;
+        moltype::Symbol = :DNA)::NamedTuple
+    graph = Mycelia.Rhizomorph.build_kmer_graph(reads, k;
+        dataset_id = "gapcal", mode = :singlestrand)
+    to_observation = seq -> _bench_convert_kmers(_bench_sequence_kmers(seq, k), k, moltype)
+    return (graph = graph, to_observation = to_observation)
+end
+
+"""
+    run_gap_calibration(; kwargs...) -> Vector
+
+At each error rate (through err=0.10): simulate a substitution read set from a
+controlled genome, build the read-COVERAGE k-mer graph (where the Viterbi margin
+is finite — see `build_coverage_fixture`), decode each read collecting finite
+per-position gaps with truth labels, then fit + compare all three calibration
+models. Prints a head-to-head table and writes
+`results/rhizomorph_gap_calibration.csv`. Deterministic under `seed`.
+"""
+function run_gap_calibration(;
+        k::Int = 11,
+        genome_length::Int = 1200,
+        readlen::Int = 120,
+        coverage::Int = 30,
+        error_rates::Vector{Float64} = [0.05, 0.08, 0.10],
+        seed::Int = 42,
+        nbins::Int = 10,
+        results_dir::String = joinpath(@__DIR__, "results"))::Vector
+    rng = Random.MersenneTwister(seed)
+    truth_genome = String(rand(rng, ['A', 'C', 'G', 'T'], genome_length))
+    n_reads = max(1, ceil(Int, coverage * genome_length / readlen))
+    mkpath(results_dir)
+    out_rows = NamedTuple[]
+    println("=== Rhizomorph Tier-2 gap calibration (3-model head-to-head) ===")
+    println("genome=$(genome_length)  k=$(k)  readlen=$(readlen)  coverage=$(coverage)x  " *
+            "n_reads=$(n_reads)  seed=$(seed)")
+    for er in error_rates
+        # Errored read set + each read's own clean truth (substitution-only, so the
+        # observed read aligns 1:1 with its truth for per-position labeling).
+        reads = FASTX.FASTQ.Record[]
+        truths = String[]
+        for i in 1:n_reads
+            st = rand(rng, 1:(genome_length - readlen + 1))
+            clean = truth_genome[st:(st + readlen - 1)]
+            observed = _inject_substitutions(clean, er, rng)
+            push!(reads, FASTX.FASTQ.Record("r$(i)", observed, String(fill('I', readlen))))
+            push!(truths, clean)
+        end
+        cov = build_coverage_fixture(reads, k)
+        cfg = Mycelia.ViterbiCorrectionConfig(record_position_gaps = true, error_rate = er)
+        scores = Float64[]
+        labels = Bool[]
+        for (rec, clean) in zip(reads, truths)
+            gt = try
+                collect_gap_truth(cov, FASTX.sequence(String, rec), clean; config = cfg)
+            catch
+                continue   # skip a failed/contract-violating decode
+            end
+            append!(scores, gt.scores)
+            append!(labels, gt.labels)
+        end
+        if isempty(scores) || all(labels) || !any(labels)
+            println("err=$(er): insufficient class balance (n=$(length(scores))) — skipped")
+            continue
+        end
+        cmp = compare_gap_calibrations(scores, labels; nbins = nbins)
+        println("err=$(er): AUROC=$(round(cmp.auroc; digits = 3))  n=$(length(scores))  " *
+                "positive_frac=$(round(count(labels) / length(labels); digits = 3))")
+        for r in cmp.rows
+            println("   $(rpad(r.model, 9))  ECE=$(round(r.ece; digits = 4))  " *
+                    "Brier=$(round(r.brier; digits = 4))")
+            push!(out_rows,
+                (error_rate = er, model = r.model, n = length(scores),
+                    auroc = cmp.auroc, ece = r.ece, brier = r.brier))
+        end
+    end
+    csv_path = joinpath(results_dir, "rhizomorph_gap_calibration.csv")
+    open(csv_path, "w") do io
+        println(io, "error_rate,model,n,auroc,ece,brier")
+        for r in out_rows
+            println(io, join((r.error_rate, r.model, r.n, r.auroc, r.ece, r.brier), ","))
+        end
+    end
+    println("Wrote $(csv_path)")
+    return out_rows
+end
+
+# Run when invoked directly (julia benchmarking/viterbi_gap_calibration.jl).
+if abspath(PROGRAM_FILE) == @__FILE__
+    run_gap_calibration()
 end

--- a/src/iterative-assembly.jl
+++ b/src/iterative-assembly.jl
@@ -416,6 +416,7 @@ function mycelia_iterative_assemble(input_fastq::String;
         soft_em::Bool = false,
         cheap_correct::Bool = false,
         beam_width::Union{Int, Nothing} = nothing,
+        calibrated_gap_threshold::Union{Float64, Nothing} = nothing,
         min_decode_k::Union{Int, Nothing} = nothing,
         decode_gate_density::Union{Float64, Nothing} = nothing,
         indel_params::Union{Nothing, IndelDecodeParams} = nothing)
@@ -772,6 +773,7 @@ function mycelia_iterative_assemble(input_fastq::String;
                     skip_solid = skip_solid,
                     cheap_correct = cheap_correct,
                     beam_width = beam_width,
+                    calibrated_gap_threshold = calibrated_gap_threshold,
                     soft_weights = current_soft_weights,
                     hard_vertices = hard_vertices,
                     windowed_decode = windowed_decode,
@@ -1711,6 +1713,7 @@ function improve_read_set_likelihood(reads::Vector{<:FASTX.FASTQ.Record}, graph,
         skip_solid::Bool = false,
         cheap_correct::Bool = false,
         beam_width::Union{Int, Nothing} = nothing,
+        calibrated_gap_threshold::Union{Float64, Nothing} = nothing,
         soft_weights::Union{Nothing, Mycelia.Rhizomorph.SoftEdgeWeightAccumulator} = nothing,
         hard_vertices::Union{Nothing, AbstractSet} = nothing,
         windowed_decode::Bool = false,
@@ -1887,7 +1890,8 @@ function improve_read_set_likelihood(reads::Vector{<:FASTX.FASTQ.Record}, graph,
                                    improve_read_likelihood(
                         read, graph, k; graph_mode = graph_mode,
                         beam_width = beam_width, weighted_graph = pass_weighted_graph,
-                        diagnostics = diag, indel_params = indel_params)
+                        diagnostics = diag, indel_params = indel_params,
+                        calibrated_gap_threshold = calibrated_gap_threshold)
                     batch_results[i] = (improved_read, was_improved)
                 end
             end
@@ -1921,7 +1925,8 @@ function improve_read_set_likelihood(reads::Vector{<:FASTX.FASTQ.Record}, graph,
                     read, graph, k; graph_mode = graph_mode,
                     beam_width = beam_width, soft_weights = soft_weights,
                     weighted_graph = pass_weighted_graph,
-                    diagnostics = diag, indel_params = indel_params)
+                    diagnostics = diag, indel_params = indel_params,
+                    calibrated_gap_threshold = calibrated_gap_threshold)
                 updated_reads[batch_start + i - 1] = improved_read
 
                 if was_improved
@@ -1998,7 +2003,8 @@ function improve_read_likelihood(read::FASTX.FASTQ.Record, graph, k::Int;
         soft_weights::Union{Nothing, Mycelia.Rhizomorph.SoftEdgeWeightAccumulator} = nothing,
         weighted_graph = nothing,
         diagnostics::Union{Nothing, CorrectorDiagnostics} = nothing,
-        indel_params::Union{Nothing, IndelDecodeParams} = nothing)::Tuple{
+        indel_params::Union{Nothing, IndelDecodeParams} = nothing,
+        calibrated_gap_threshold::Union{Float64, Nothing} = nothing)::Tuple{
         FASTX.FASTQ.Record, Bool}
     # Extract sequence and quality
     original_seq = FASTX.sequence(String, read)
@@ -2026,7 +2032,8 @@ function improve_read_likelihood(read::FASTX.FASTQ.Record, graph, k::Int;
         read, graph, k; graph_mode = graph_mode,
         beam_width = beam_width, soft_weights = soft_weights,
         weighted_graph = weighted_graph,
-        diagnostics = diagnostics, indel_params = indel_params)
+        diagnostics = diagnostics, indel_params = indel_params,
+        calibrated_gap_threshold = calibrated_gap_threshold)
 
     # Only update if significant improvement
     if likelihood_improvement > 0.01  # Threshold for meaningful improvement
@@ -2062,7 +2069,8 @@ function find_optimal_sequence_path(read::FASTX.FASTQ.Record, graph, k::Int;
         soft_weights::Union{Nothing, Mycelia.Rhizomorph.SoftEdgeWeightAccumulator} = nothing,
         weighted_graph = nothing,
         diagnostics::Union{Nothing, CorrectorDiagnostics} = nothing,
-        indel_params::Union{Nothing, IndelDecodeParams} = nothing)::Tuple{
+        indel_params::Union{Nothing, IndelDecodeParams} = nothing,
+        calibrated_gap_threshold::Union{Float64, Nothing} = nothing)::Tuple{
         FASTX.FASTQ.Record, Float64}
     # Trustworthy Viterbi (graph-as-HMM correction core, td-ak6w). Trust the
     # maximum-likelihood path or report no improvement. The prior heuristic
@@ -2094,7 +2102,8 @@ function find_optimal_sequence_path(read::FASTX.FASTQ.Record, graph, k::Int;
         read, graph, k; graph_mode = graph_mode,
         beam_width = beam_width, soft_weights = soft_weights,
         weighted_graph = weighted_graph,
-        diagnostics = diagnostics, indel_params = indel_params)
+        diagnostics = diagnostics, indel_params = indel_params,
+        calibrated_gap_threshold = calibrated_gap_threshold)
     if viterbi_result === nothing
         # Viterbi could not decode (empty observation set, structural error, or an
         # un-k-merizable read): report no improvement rather than falling back to a
@@ -2869,7 +2878,8 @@ function try_viterbi_path_improvement(read::FASTX.FASTQ.Record,
         soft_weights::Union{Nothing, Mycelia.Rhizomorph.SoftEdgeWeightAccumulator} = nothing,
         weighted_graph = nothing,
         diagnostics::Union{Nothing, CorrectorDiagnostics} = nothing,
-        indel_params::Union{Nothing, IndelDecodeParams} = nothing)::Union{
+        indel_params::Union{Nothing, IndelDecodeParams} = nothing,
+        calibrated_gap_threshold::Union{Float64, Nothing} = nothing)::Union{
         Tuple{FASTX.FASTQ.Record, Float64}, Nothing}
     try
         sequence_string = FASTX.sequence(String, read)
@@ -2949,7 +2959,8 @@ function try_viterbi_path_improvement(read::FASTX.FASTQ.Record,
                 max_steps = length(observations) - 1,
                 beam_width = effective_beam_width,
                 max_successors_per_state = effective_successor_bound,
-                beam_score_margin = effective_margin
+                beam_score_margin = effective_margin,
+                record_position_gaps = calibrated_gap_threshold !== nothing
             )
         else
             Mycelia.ViterbiCorrectionConfig(
@@ -2967,7 +2978,8 @@ function try_viterbi_path_improvement(read::FASTX.FASTQ.Record,
                 deletion_extend_probability = indel_params.deletion_extend_probability,
                 deletion_max_run = indel_params.deletion_max_run,
                 max_insertion_run = indel_params.max_insertion_run,
-                band_width = indel_params.band_width
+                band_width = indel_params.band_width,
+                record_position_gaps = calibrated_gap_threshold !== nothing
             )
         end
         correction = Mycelia.correct_observations(
@@ -3007,6 +3019,24 @@ function try_viterbi_path_improvement(read::FASTX.FASTQ.Record,
         corrected_sequence_string = corrected_sequence isa AbstractString ?
                                     corrected_sequence :
                                     string(corrected_sequence)
+        if calibrated_gap_threshold !== nothing
+            path_result = only(correction.paths)
+            path = something(path_result.path,
+                throw(ArgumentError("calibrated gap gate requires a decoded path")))
+            gaps = path_result.diagnostics[:position_gaps]
+            length(gaps) == length(path.steps) - 1 ||
+                throw(ArgumentError("position-gap/path alignment contract violated"))
+            original_chars = collect(sequence_string)
+            corrected_chars = collect(corrected_sequence_string)
+            @inbounds for i in eachindex(gaps)
+                position = i + k
+                position > length(corrected_chars) && break
+                if gaps[i] < calibrated_gap_threshold
+                    corrected_chars[position] = original_chars[position]
+                end
+            end
+            corrected_sequence_string = String(corrected_chars)
+        end
         improved_likelihood = Mycelia.calculate_sequence_likelihood(
             corrected_sequence_string, quality_scores, graph, k; graph_mode = graph_mode)
         improved_quality = Mycelia.adjust_quality_scores(

--- a/src/iterative-assembly.jl
+++ b/src/iterative-assembly.jl
@@ -1397,12 +1397,16 @@ function improve_read_likelihood_windowed(read::FASTX.FASTQ.Record, graph, k::In
         weighted_graph = nothing,
         diagnostics = nothing,  # ::Union{Nothing, CorrectorDiagnostics}; struct defined below
         pad::Union{Int, Nothing} = nothing,
+        calibrated_gap_threshold::Union{Float64, Nothing} = nothing,
         max_window::Int = 500)::Tuple{FASTX.FASTQ.Record, Bool}
-    record, improved, _decoded, _divergent = improve_read_likelihood_windowed_detail(
+    record, improved,
+    _decoded,
+    _divergent = improve_read_likelihood_windowed_detail(
         read, graph, k, hard_vertices;
         graph_mode = graph_mode, beam_width = beam_width, soft_weights = soft_weights,
         weighted_graph = weighted_graph, diagnostics = diagnostics,
-        pad = pad, max_window = max_window)
+        pad = pad, calibrated_gap_threshold = calibrated_gap_threshold,
+        max_window = max_window)
     return record, improved
 end
 
@@ -1426,6 +1430,7 @@ function improve_read_likelihood_windowed_detail(read::FASTX.FASTQ.Record, graph
         weighted_graph = nothing,
         diagnostics = nothing,  # ::Union{Nothing, CorrectorDiagnostics}; struct defined below
         pad::Union{Int, Nothing} = nothing,
+        calibrated_gap_threshold::Union{Float64, Nothing} = nothing,
         max_window::Int = 500)::Tuple{FASTX.FASTQ.Record, Bool, Int, Int}
     # Anchor each window with a full solid k-mer flank by default (`pad === nothing`
     # ⇒ `k`): a pad of `k` bases guarantees the window's first/last k-mer clears the
@@ -1433,7 +1438,8 @@ function improve_read_likelihood_windowed_detail(read::FASTX.FASTQ.Record, graph
     # the hard vertices sit in the window INTERIOR where the ML decode can re-route
     # them (a 1-base pad can pin the decode to an error k-mer at the boundary).
     effective_pad = pad === nothing ? k : pad
-    windows = _hard_window_ranges(read, k, hard_vertices; pad = effective_pad, max_window = max_window)
+    windows = _hard_window_ranges(
+        read, k, hard_vertices; pad = effective_pad, max_window = max_window)
     isempty(windows) && return read, false, 0, 0
 
     seq_chars = collect(FASTX.sequence(String, read))
@@ -1460,7 +1466,8 @@ function improve_read_likelihood_windowed_detail(read::FASTX.FASTQ.Record, graph
         improved = improve_read_likelihood(
             sub_read, graph, k; graph_mode = graph_mode,
             beam_width = beam_width, soft_weights = soft_weights,
-            weighted_graph = weighted_graph, diagnostics = diagnostics)
+            weighted_graph = weighted_graph, diagnostics = diagnostics,
+            calibrated_gap_threshold = calibrated_gap_threshold)
         improved || continue
         dseq = FASTX.sequence(String, decoded_sub)
         dqual = FASTX.quality(decoded_sub)
@@ -1886,7 +1893,8 @@ function improve_read_set_likelihood(reads::Vector{<:FASTX.FASTQ.Record}, graph,
                                    improve_read_likelihood_windowed(
                         read, graph, k, hard_vertices; graph_mode = graph_mode,
                         beam_width = beam_width, weighted_graph = pass_weighted_graph,
-                        diagnostics = diag) :
+                        diagnostics = diag,
+                        calibrated_gap_threshold = calibrated_gap_threshold) :
                                    improve_read_likelihood(
                         read, graph, k; graph_mode = graph_mode,
                         beam_width = beam_width, weighted_graph = pass_weighted_graph,
@@ -1920,7 +1928,8 @@ function improve_read_set_likelihood(reads::Vector{<:FASTX.FASTQ.Record}, graph,
                     read, graph, k, hard_vertices; graph_mode = graph_mode,
                     beam_width = beam_width, soft_weights = soft_weights,
                     weighted_graph = pass_weighted_graph,
-                    diagnostics = diag) :
+                    diagnostics = diag,
+                    calibrated_gap_threshold = calibrated_gap_threshold) :
                                improve_read_likelihood(
                     read, graph, k; graph_mode = graph_mode,
                     beam_width = beam_width, soft_weights = soft_weights,
@@ -3021,21 +3030,34 @@ function try_viterbi_path_improvement(read::FASTX.FASTQ.Record,
                                     string(corrected_sequence)
         if calibrated_gap_threshold !== nothing
             path_result = only(correction.paths)
-            path = something(path_result.path,
-                throw(ArgumentError("calibrated gap gate requires a decoded path")))
-            gaps = path_result.diagnostics[:position_gaps]
-            length(gaps) == length(path.steps) - 1 ||
-                throw(ArgumentError("position-gap/path alignment contract violated"))
+            decoded_path = path_result.path
+            gaps = get(path_result.diagnostics, :position_gaps, nothing)
             original_chars = collect(sequence_string)
             corrected_chars = collect(corrected_sequence_string)
-            @inbounds for i in eachindex(gaps)
-                position = i + k
-                position > length(corrected_chars) && break
-                if gaps[i] < calibrated_gap_threshold
-                    corrected_chars[position] = original_chars[position]
+            # Positional per-base gate (strand-safe): gaps[i] is the Viterbi margin
+            # INTO path.steps[i+1], i.e. read position i+k. Where the margin is below
+            # threshold the decode is ambiguous, so revert that base to the observed
+            # one — this is what pulls over-correction back down. `Inf` gaps (collapsed
+            # frontier ⇒ maximally confident) clear any finite threshold and are kept.
+            # Apply the gate ONLY when the decode gave us a path, its recorded gaps
+            # under the documented alignment contract (len == steps-1), and a
+            # length-preserving decode (a positional revert is undefined once an indel
+            # shifts the base<->position map). Any precondition unmet ⇒ fail OPEN to
+            # the ungated decode, never drop the read's correction. The err=0.10
+            # substitution frontier is always length-preserving, so the guards are a
+            # safety net, not a hot path.
+            if decoded_path !== nothing && gaps !== nothing &&
+               length(gaps) == length(decoded_path.steps) - 1 &&
+               length(corrected_chars) == length(original_chars)
+                @inbounds for i in eachindex(gaps)
+                    position = i + k
+                    position > length(corrected_chars) && break
+                    if gaps[i] < calibrated_gap_threshold
+                        corrected_chars[position] = original_chars[position]
+                    end
                 end
+                corrected_sequence_string = String(corrected_chars)
             end
-            corrected_sequence_string = String(corrected_chars)
         end
         improved_likelihood = Mycelia.calculate_sequence_likelihood(
             corrected_sequence_string, quality_scores, graph, k; graph_mode = graph_mode)

--- a/src/iterative-assembly.jl
+++ b/src/iterative-assembly.jl
@@ -1538,9 +1538,15 @@ parallel (`@threads`) read loop increments them race-free.
 mutable struct CorrectorDiagnostics
     structural_errors::Threads.Atomic{Int}
     unkmerizable_reads::Threads.Atomic{Int}
+    # Calibrated gate requested (threshold set, substitution mode) but a decode
+    # contract invariant was violated so gating silently fell open to the ungated
+    # decode. On a healthy substitution decode this is always 0; a nonzero value
+    # means the opt-in gate disabled itself — a regression signal, not data loss.
+    gate_skipped::Threads.Atomic{Int}
 end
 function CorrectorDiagnostics()
-    CorrectorDiagnostics(Threads.Atomic{Int}(0), Threads.Atomic{Int}(0))
+    CorrectorDiagnostics(Threads.Atomic{Int}(0), Threads.Atomic{Int}(0),
+        Threads.Atomic{Int}(0))
 end
 
 # Previously-proven-tractable finite beam (td-63qy: beam 256 completed on the
@@ -1734,6 +1740,7 @@ function improve_read_set_likelihood(reads::Vector{<:FASTX.FASTQ.Record}, graph,
     # when `diag` is a shared accumulator threaded across many passes.
     struct_before = diag.structural_errors[]
     unk_before = diag.unkmerizable_reads[]
+    gate_skipped_before = diag.gate_skipped[]
     total_reads = length(reads)
     updated_reads = Vector{FASTX.FASTQ.Record}(undef, total_reads)
     improvements_made = 0
@@ -1993,6 +2000,17 @@ function improve_read_set_likelihood(reads::Vector{<:FASTX.FASTQ.Record}, graph,
             "passed through uncorrected (not conflated with 'no likelihood gain')." total_reads structural_errors=struct_swallowed unkmerizable_reads=unk_swallowed fraction=round(
                 frac, digits = 3)
         end
+    end
+
+    # A requested calibrated gate that silently fell open on a substitution decode
+    # is a contract regression (the gate did nothing despite being opted in) — see
+    # CorrectorDiagnostics.gate_skipped. Surface it rather than let the frontier look
+    # like "the gate doesn't help."
+    gate_skipped_this_pass = diag.gate_skipped[] - gate_skipped_before
+    if gate_skipped_this_pass > 0
+        @warn "iterative corrector: calibrated gate fell open (ungated) on " *
+              "$(gate_skipped_this_pass) read(s) despite a substitution decode — the " *
+              "gap/path alignment contract was violated; the gate silently did nothing." total_reads gate_skipped = gate_skipped_this_pass
     end
 
     return updated_reads, improvements_made, skip_fraction, cheap_corrections,
@@ -3028,24 +3046,24 @@ function try_viterbi_path_improvement(read::FASTX.FASTQ.Record,
         corrected_sequence_string = corrected_sequence isa AbstractString ?
                                     corrected_sequence :
                                     string(corrected_sequence)
-        if calibrated_gap_threshold !== nothing
+        # Calibrated gate is a SUBSTITUTION-ONLY tool: the positional revert
+        # `corrected_chars[i+k] = original_chars[i+k]` requires a stable base<->column
+        # map, which only a length-preserving substitution decode provides. Under
+        # `indel_moves` a BALANCED indel decode (one insertion + one deletion) is
+        # net-length-neutral — it would pass a length check yet shift the interior
+        # map — so we exclude indel mode entirely rather than trust `length` as a
+        # proxy for alignment (review: convergent finding, 3 reviewers).
+        if calibrated_gap_threshold !== nothing && indel_params === nothing
             path_result = only(correction.paths)
             decoded_path = path_result.path
             gaps = get(path_result.diagnostics, :position_gaps, nothing)
             original_chars = collect(sequence_string)
             corrected_chars = collect(corrected_sequence_string)
-            # Positional per-base gate (strand-safe): gaps[i] is the Viterbi margin
-            # INTO path.steps[i+1], i.e. read position i+k. Where the margin is below
-            # threshold the decode is ambiguous, so revert that base to the observed
-            # one — this is what pulls over-correction back down. `Inf` gaps (collapsed
-            # frontier ⇒ maximally confident) clear any finite threshold and are kept.
-            # Apply the gate ONLY when the decode gave us a path, its recorded gaps
-            # under the documented alignment contract (len == steps-1), and a
-            # length-preserving decode (a positional revert is undefined once an indel
-            # shifts the base<->position map). Any precondition unmet ⇒ fail OPEN to
-            # the ungated decode, never drop the read's correction. The err=0.10
-            # substitution frontier is always length-preserving, so the guards are a
-            # safety net, not a hot path.
+            # gaps[i] is the Viterbi margin INTO path.steps[i+1], i.e. read position
+            # i+k. Where the margin is below threshold the decode is ambiguous, so
+            # revert that base to the observed one — this is what pulls over-correction
+            # back down. `Inf` gaps (collapsed frontier ⇒ maximally confident) clear
+            # any finite threshold and are kept.
             if decoded_path !== nothing && gaps !== nothing &&
                length(gaps) == length(decoded_path.steps) - 1 &&
                length(corrected_chars) == length(original_chars)
@@ -3057,6 +3075,13 @@ function try_viterbi_path_improvement(read::FASTX.FASTQ.Record,
                     end
                 end
                 corrected_sequence_string = String(corrected_chars)
+            elseif diagnostics !== nothing
+                # In substitution mode the decode contract (path present, gaps
+                # recorded, len == steps-1, length preserved) is ALWAYS satisfiable;
+                # a miss means the gate silently fell open to the ungated decode —
+                # count it so an opt-in gate that disabled itself is visible, not
+                # invisible (fail-open is the right data-safety choice; silence is not).
+                Threads.atomic_add!(diagnostics.gate_skipped, 1)
             end
         end
         improved_likelihood = Mycelia.calculate_sequence_likelihood(

--- a/test/4_assembly/calibrated_gap_gate_identity_test.jl
+++ b/test/4_assembly/calibrated_gap_gate_identity_test.jl
@@ -1,0 +1,70 @@
+# Calibrated decode gate (td-4osf Stage 3): byte-identity when OFF, and correct
+# gating direction when ON.
+#
+# The gate reverts a decoded base to the OBSERVED base wherever the per-position
+# Viterbi gap is below `calibrated_gap_threshold`. Two guarantees:
+#   1. OFF (threshold === nothing) and the permissive limit (threshold = -Inf,
+#      which engages gap recording + the gate but reverts nothing) produce
+#      BYTE-IDENTICAL output — the telemetry + no-op gate never perturb the decode.
+#   2. A large threshold reverts every finite-gap correction back toward the
+#      observed read, so the gated result can only move AWAY from the corrector's
+#      output and TOWARD the raw read (the gate suppresses, never fabricates).
+#
+# Run:
+#   julia --project=. test/4_assembly/calibrated_gap_gate_identity_test.jl
+
+import Test
+import Mycelia
+import FASTX
+import Random
+
+rec(id, seq) = FASTX.FASTQ.Record(id, seq, String(fill('I', length(seq))))
+seqs(reads) = [FASTX.sequence(String, r) for r in reads]
+mismatches(a, b) = count(x -> x[1] != x[2], zip(collect(a), collect(b)))
+
+Test.@testset "calibrated gap gate: OFF byte-identity + ON reverts to observed" begin
+    k = 7
+    clean_seq = "ATGCGTACGTACGTTAGCCGATACAGGTCA"
+    reads = [rec("clean$i", clean_seq) for i in 1:10]
+    err_seq = collect(clean_seq)
+    err_seq[15] = err_seq[15] == 'A' ? 'C' : 'A'          # single substitution
+    err_seq = String(err_seq)
+    push!(reads, rec("err1", err_seq))
+    graph = Mycelia.Rhizomorph.build_qualmer_graph(reads, k;
+        dataset_id = "gate", mode = :canonical, memory_profile = :full)
+
+    run_at(thresh) = begin
+        Random.seed!(11)   # deterministic: pin any global-RNG draws
+        out,
+        _ = Mycelia.improve_read_set_likelihood(reads, graph, k;
+            graph_mode = :canonical, calibrated_gap_threshold = thresh)
+        out
+    end
+
+    off = run_at(nothing)
+    permissive = run_at(-Inf)
+    strict = run_at(100.0)
+
+    # (1) BYTE-IDENTITY (the core guarantee): gate OFF === gate engaged-but-permissive.
+    # Proves the gap-recording telemetry + the no-op gate never perturb the decode.
+    Test.@test seqs(off) == seqs(permissive)
+    Test.@test length(off) == length(reads)
+
+    # (2) MONOTONE REVERT-TOWARD-OBSERVED: gating can only move a corrected base back
+    # to the observed base, so under any threshold each read is at least as close to
+    # its OWN observed input as the ungated correction is (the gate suppresses, never
+    # fabricates). Guaranteed regardless of whether a correction actually fired.
+    # (Behavioral proof that the gate changes real corrections lives in the
+    # full-pipeline frontier smoke, where err=0.10 reliably triggers corrections.)
+    obs = seqs(reads)
+    for i in eachindex(reads)
+        Test.@test mismatches(seqs(strict)[i], obs[i]) <= mismatches(seqs(off)[i], obs[i])
+    end
+
+    # Solid clean reads are untouched under every setting (no spurious edits).
+    for out in (off, permissive, strict)
+        for i in 1:10
+            Test.@test seqs(out)[i] == clean_seq
+        end
+    end
+end

--- a/test/4_assembly/calibrated_gate_indel_failopen_test.jl
+++ b/test/4_assembly/calibrated_gate_indel_failopen_test.jl
@@ -1,0 +1,80 @@
+# Calibrated gate under INDEL mode (td-4osf Stage 3, review convergent fix):
+# the positional revert requires a stable base<->column map, which only a
+# length-preserving SUBSTITUTION decode provides. A balanced indel decode (one
+# insertion + one deletion) is net-length-neutral, so a length check alone would
+# not exclude it — the gate is gated on `indel_params === nothing` instead.
+#
+# This test proves the exclusion behaviorally: with `indel_params` set, the
+# `calibrated_gap_threshold` has NO effect on the corrected output (a large
+# threshold that WOULD revert every finite-gap base in substitution mode is a
+# no-op here). Contrast: the substitution-mode gate engagement is proven by
+# rhizomorph_calibrated_gate_frontier_test.jl.
+#
+# Run:
+#   julia --project=. test/4_assembly/calibrated_gate_indel_failopen_test.jl
+
+import Test
+import Mycelia
+import FASTX
+import Random
+
+function _write_fastq(reads, dir)
+    path = joinpath(dir, "in.fastq")
+    open(FASTX.FASTQ.Writer, path) do w
+        for r in reads
+            write(w, r)
+        end
+    end
+    return path
+end
+
+function _assemble_corrected(fastq, k; threshold, indel_params, outdir)
+    Random.seed!(42)
+    result = Mycelia.mycelia_iterative_assemble(fastq;
+        max_k = max(k, 13), skip_solid = false, graph_mode = :doublestrand,
+        n_k_rungs = 1, max_iterations_per_k = 1, hard_window = false,
+        soft_em = false, cheap_correct = true, beam_width = nothing,
+        calibrated_gap_threshold = threshold, indel_params = indel_params,
+        verbose = false, enable_checkpointing = false, output_dir = outdir)
+    corrected_fastq = get(result[:metadata], :final_fastq_file, nothing)
+    (corrected_fastq === nothing || !isfile(corrected_fastq)) &&
+        error("corrector produced no :final_fastq_file")
+    out = Dict{String, String}()
+    open(FASTX.FASTQ.Reader, corrected_fastq) do reader
+        for rec in reader
+            out[FASTX.identifier(rec)] = FASTX.sequence(String, rec)
+        end
+    end
+    return out
+end
+
+Test.@testset "calibrated gate is excluded under indel mode (fail-open)" begin
+    k = 11
+    rng = Random.MersenneTwister(9)
+    genome = String(rand(rng, ['A', 'C', 'G', 'T'], 500))
+    alts = Dict('A' => "CGT", 'C' => "AGT", 'G' => "ACT", 'T' => "ACG")
+    reads = FASTX.FASTQ.Record[]
+    for i in 1:60
+        st = rand(rng, 1:(500 - 120 + 1))
+        clean = genome[st:(st + 119)]
+        obs = String([rand(rng) < 0.06 ? alts[c][rand(rng, 1:3)] : c
+                      for c in collect(clean)])
+        push!(reads, FASTX.FASTQ.Record("r$i", obs, String(fill('I', 120))))
+    end
+
+    # An indel-capable decode profile (values mirror a modest nanopore-ish setting).
+    indel = Mycelia.IndelDecodeParams(0.06, 0.4, 0.4, 0.1, 0.1, 3, 3, nothing)
+
+    corrected = mktempdir() do d
+        base = _assemble_corrected(_write_fastq(reads, d), k;
+            threshold = nothing, indel_params = indel, outdir = mktempdir())
+        # A huge threshold would revert EVERY finite-gap correction if the gate ran.
+        gated = _assemble_corrected(_write_fastq(reads, d), k;
+            threshold = 1.0e6, indel_params = indel, outdir = mktempdir())
+        (base = base, gated = gated)
+    end
+
+    # Under indel mode the gate is excluded, so the threshold changes nothing.
+    Test.@test !isempty(corrected.base)
+    Test.@test corrected.base == corrected.gated
+end

--- a/test/4_assembly/frontier_dominance_test.jl
+++ b/test/4_assembly/frontier_dominance_test.jl
@@ -1,0 +1,73 @@
+# Unit test for assess_frontier_dominance (td-4osf Stage 3): the programmatic
+# verdict that replaces eyeballing the PR-curve CSV. Exercised here on synthetic
+# DataFrames — the real sweep is not run under Pkg.test(). Guards the load-bearing
+# STRICT-improvement rule: `calibrated-gap-0.0` ties the baseline (threshold 0
+# reverts nothing) and must NOT be reported as dominating.
+#
+# Run:
+#   julia --project=. test/4_assembly/frontier_dominance_test.jl
+
+import Test
+import DataFrames
+
+include(joinpath(@__DIR__, "..", "..", "benchmarking", "rhizomorph_correction_pr_curve.jl"))
+
+# Minimal row set the verdict reads: error_rate, point, recall, precision,
+# over_correction_rate. Baseline is always "noskip+nogate".
+function _frontier(rows)
+    DataFrames.DataFrame(
+        error_rate = [r[1] for r in rows],
+        point = [r[2] for r in rows],
+        recall = [r[3] for r in rows],
+        precision = [r[4] for r in rows],
+        over_correction_rate = [r[5] for r in rows])
+end
+
+Test.@testset "assess_frontier_dominance" begin
+    # --- A genuine dominating point: recall retained, over strictly down, precision up
+    df = _frontier([
+        (0.10, "noskip+nogate", 0.90, 0.70, 0.030),
+        (0.10, "calibrated-gap-0.0", 0.90, 0.70, 0.030),   # ties baseline (must NOT win)
+        (0.10, "calibrated-gap-1.0", 0.89, 0.80, 0.010)   # strict improvement
+    ])
+    v = assess_frontier_dominance(df; err = 0.10)
+    Test.@test v.dominates
+    Test.@test v.best.point == "calibrated-gap-1.0"
+    Test.@test all(c -> c.point != "calibrated-gap-0.0", v.candidates)   # tie excluded
+
+    # --- gap-0.0 alone (ties baseline) does NOT dominate (strict over-correction)
+    df_tie = _frontier([
+        (0.10, "noskip+nogate", 0.90, 0.70, 0.030),
+        (0.10, "calibrated-gap-0.0", 0.90, 0.70, 0.030)
+    ])
+    Test.@test !assess_frontier_dominance(df_tie; err = 0.10).dominates
+
+    # --- recall collapse ⇒ not dominating even though over drops
+    df_crash = _frontier([
+        (0.10, "noskip+nogate", 0.90, 0.70, 0.030),
+        (0.10, "calibrated-gap-4.0", 0.40, 0.85, 0.005)
+    ])
+    Test.@test !assess_frontier_dominance(df_crash; err = 0.10).dominates
+
+    # --- NaN candidate metrics are excluded (never a false positive)
+    df_nan = _frontier([
+        (0.10, "noskip+nogate", 0.90, 0.70, 0.030),
+        (0.10, "calibrated-gap-1.0", NaN, NaN, NaN)
+    ])
+    Test.@test !assess_frontier_dominance(df_nan; err = 0.10).dominates
+
+    # --- NaN BASELINE ⇒ non-dominating with an explicit reason (not a false pass)
+    df_nanbase = _frontier([
+        (0.10, "noskip+nogate", NaN, NaN, NaN),
+        (0.10, "calibrated-gap-1.0", 0.89, 0.80, 0.010)
+    ])
+    vnb = assess_frontier_dominance(df_nanbase; err = 0.10)
+    Test.@test !vnb.dominates
+    Test.@test occursin("non-finite", vnb.reason)
+
+    # --- missing baseline ⇒ non-dominating with a reason
+    df_nobase = _frontier([(0.10, "calibrated-gap-1.0", 0.89, 0.80, 0.010)])
+    vmb = assess_frontier_dominance(df_nobase; err = 0.10)
+    Test.@test !vmb.dominates
+    Test.@test occursin("no noskip+nogate baseline", vmb.reason)
+end

--- a/test/4_assembly/gap_calibration_fitters_test.jl
+++ b/test/4_assembly/gap_calibration_fitters_test.jl
@@ -1,0 +1,57 @@
+# Gap-calibration fitters (td-4osf Stage 2): the three probability maps compared
+# head-to-head — isotonic (PAVA), logistic (Platt), and equal-width binning.
+#
+# These are pure (Base-only) helpers in benchmarking/calibration_metrics.jl; this
+# CI test pins their contract (monotone recovery on separable data, probability
+# range, logistic inverse round-trip, degenerate/short-input guards) inside the
+# Pkg.test() sweep, since benchmarking/ is not otherwise run in CI.
+#
+# Run:
+#   julia --project=. test/4_assembly/gap_calibration_fitters_test.jl
+
+import Test
+
+include(joinpath(@__DIR__, "..", "..", "benchmarking", "calibration_metrics.jl"))
+
+Test.@testset "gap calibration fitters (isotonic / logistic / binned)" begin
+    # Separable synthetic signal: a large gap ⇒ the corrected base is right.
+    gaps = collect(range(0.0, 5.0; length = 240))
+    labels = [g > 2.5 for g in gaps]
+
+    # Discrimination is a property of the raw ranking — identical across models.
+    Test.@test auroc(gaps, labels) == 1.0
+
+    for (fit, predict) in ((fit_isotonic_map, predict_isotonic),
+        (fit_logistic_map, predict_logistic),
+        (fit_binned_map, predict_binned))
+        model = fit(gaps, labels)
+        p = predict(model, gaps)
+        Test.@test length(p) == length(gaps)
+        Test.@test all(x -> 0.0 <= x <= 1.0, p)          # valid probabilities
+        Test.@test issorted(p)                           # monotone non-decreasing in gap
+        Test.@test p[1] < 0.5 < p[end]                   # separates the two classes
+        # Every model should be reasonably calibrated on cleanly separable data.
+        Test.@test brier_score(p, labels) < 0.2
+    end
+
+    # --- Logistic inverse round-trips predict_logistic ----------------------
+    lm = fit_logistic_map(gaps, labels)
+    for target in (0.25, 0.5, 0.75, 0.9)
+        g = logistic_gap_for_probability(lm, target)
+        Test.@test isapprox(only(predict_logistic(lm, [g])), target; atol = 1e-6)
+    end
+    # The decision boundary (P=0.5) lands near the true 2.5 threshold.
+    Test.@test isapprox(logistic_gap_for_probability(lm, 0.5), 2.5; atol = 0.3)
+
+    # --- Guards -------------------------------------------------------------
+    Test.@test_throws ArgumentError fit_isotonic_map([0.1, Inf], [false, true])
+    Test.@test_throws ArgumentError fit_logistic_map(Float64[], Bool[])
+    Test.@test_throws ArgumentError fit_binned_map([0.1, 0.2], [true])   # length mismatch
+    Test.@test_throws ArgumentError logistic_gap_for_probability(lm, 1.0)  # p not in (0,1)
+
+    # --- Degenerate range: all-equal scores ⇒ single-bin global mean --------
+    flat = fill(1.0, 10)
+    flat_labels = [true, false, true, false, true, false, true, false, true, false]
+    bm = fit_binned_map(flat, flat_labels)
+    Test.@test all(isapprox(0.5), predict_binned(bm, flat))
+end

--- a/test/4_assembly/gap_calibration_fitters_test.jl
+++ b/test/4_assembly/gap_calibration_fitters_test.jl
@@ -43,11 +43,33 @@ Test.@testset "gap calibration fitters (isotonic / logistic / binned)" begin
     # The decision boundary (P=0.5) lands near the true 2.5 threshold.
     Test.@test isapprox(logistic_gap_for_probability(lm, 0.5), 2.5; atol = 0.3)
 
-    # --- Guards -------------------------------------------------------------
-    Test.@test_throws ArgumentError fit_isotonic_map([0.1, Inf], [false, true])
-    Test.@test_throws ArgumentError fit_logistic_map(Float64[], Bool[])
-    Test.@test_throws ArgumentError fit_binned_map([0.1, 0.2], [true])   # length mismatch
-    Test.@test_throws ArgumentError logistic_gap_for_probability(lm, 1.0)  # p not in (0,1)
+    # --- Tied scores share one isotonic probability (PAVA tie-pooling) -------
+    # Repeated Viterbi gaps tie; all observations at an identical score must map
+    # to their shared empirical probability, not to a duplicate-threshold artifact.
+    tie_model = fit_isotonic_map([1.0, 1.0, 1.0, 1.0], [false, true, false, true])
+    Test.@test all(isapprox(0.5), predict_isotonic(tie_model, [1.0]))
+    # Mixed tied + separable: the two 2.0-scored obs (one T one F) pool to 0.5,
+    # strictly above the all-false 1.0 group and below the all-true 3.0 group.
+    mix = fit_isotonic_map([1.0, 1.0, 2.0, 2.0, 3.0, 3.0],
+        [false, false, false, true, true, true])
+    Test.@test predict_isotonic(mix, [1.0])[1] < predict_isotonic(mix, [2.0])[1] <
+               predict_isotonic(mix, [3.0])[1]
+    Test.@test isapprox(predict_isotonic(mix, [2.0])[1], 0.5)
+
+    # --- Guards (assert both the type AND an identifying message fragment) ----
+    throws_msg(f, frag) = begin
+        threw = false
+        try
+            f()
+        catch e
+            threw = e isa ArgumentError && occursin(frag, e.msg)
+        end
+        threw
+    end
+    Test.@test throws_msg(() -> fit_isotonic_map([0.1, Inf], [false, true]), "finite")
+    Test.@test throws_msg(() -> fit_logistic_map(Float64[], Bool[]), "non-empty")
+    Test.@test throws_msg(() -> fit_binned_map([0.1, 0.2], [true]), "equal length")
+    Test.@test throws_msg(() -> logistic_gap_for_probability(lm, 1.0), "open interval")
 
     # --- Degenerate range: all-equal scores ⇒ single-bin global mean --------
     flat = fill(1.0, 10)

--- a/test/4_assembly/rhizomorph_calibrated_gate_frontier_test.jl
+++ b/test/4_assembly/rhizomorph_calibrated_gate_frontier_test.jl
@@ -1,0 +1,78 @@
+# Calibrated gate frontier smoke (td-4osf Stage 3): at err=0.10, gating the
+# ungated (noskip+nogate) corrector by a positive gap threshold moves along the
+# precision-recall frontier in the intended direction — over-correction does not
+# rise and recall is retained.
+#
+# This is the CI-fast counterpart to the full sweep + assess_frontier_dominance in
+# benchmarking/rhizomorph_correction_pr_curve.jl (which runs at real scale and is
+# not swept by Pkg.test()). To keep the monotone guarantee exact and the runtime
+# small, it uses a SINGLE decode pass (n_k_rungs=1, max_iterations_per_k=1): the
+# gate is then pure post-decode processing, so it can only REVERT corrections —
+# never add an over-correction, never gain a true fix — relative to the ungated
+# run on the identical reads + RNG seed.
+#
+# Run:
+#   julia --project=. test/4_assembly/rhizomorph_calibrated_gate_frontier_test.jl
+
+import Test
+import Mycelia
+import Random
+import BioSequences
+
+include(joinpath(@__DIR__, "..", "..", "benchmarking", "rhizomorph_correction_pr_curve.jl"))
+
+Test.@testset "calibrated gate frontier smoke (err=0.10, single pass)" begin
+    k = 11
+    rng = Random.MersenneTwister(7)
+    genome = BioSequences.randdnaseq(rng, 600)
+    records, truth_by_id, observed_by_id,
+    injected, _ = simulate_substitution_reads(genome, 150, 10, 0.10, rng)
+    Test.@test injected > 0                          # there ARE errors to correct
+
+    base_point = (name = "noskip+nogate", skip_solid = false, cheap_correct = true,
+        hard_window = false, soft_em = false, n_k_rungs = 1, max_iterations_per_k = 1,
+        beam_width = nothing, calibrated_gap_threshold = nothing)
+    gated_point = (name = "calibrated-gap-2.0", skip_solid = false, cheap_correct = true,
+        hard_window = false, soft_em = false, n_k_rungs = 1, max_iterations_per_k = 1,
+        beam_width = nothing, calibrated_gap_threshold = 2.0)
+
+    # Permissive limit: gate engaged (records gaps) but reverts nothing.
+    permissive_point = merge(base_point,
+        (name = "permissive", calibrated_gap_threshold = -Inf))
+
+    run_point(pt) = begin
+        Random.seed!(42)   # identical stochastic conditions per point (fair comparison)
+        correct_reads_at_point(records, k, pt)
+    end
+
+    base_corr = run_point(base_point)          # gate OFF (threshold === nothing)
+    perm_corr = run_point(permissive_point)    # gate ON, reverts nothing
+    gated_corr = run_point(gated_point)        # gate ON, positive threshold
+
+    # (1) PIPELINE BYTE-IDENTITY: recording gaps + a no-op gate never perturb the
+    # decode, so gate-OFF and the permissive limit produce identical corrected reads.
+    Test.@test base_corr == perm_corr
+
+    base = per_base_metrics(truth_by_id, observed_by_id, base_corr)
+    gated = per_base_metrics(truth_by_id, observed_by_id, gated_corr)
+
+    Test.@test base.reads_scored > 0
+    for m in (base, gated)
+        Test.@test isfinite(m.recall) && 0.0 <= m.recall <= 1.0
+        Test.@test m.over_rate >= 0.0
+    end
+
+    # (2) MONOTONE ENVELOPE (exact under a single post-decode pass): gating reverts
+    # corrected bases toward observed, so it can only LOWER over-correction and the
+    # true-fix count — never raise them.
+    Test.@test gated.over_rate <= base.over_rate + 1e-9
+    Test.@test gated.recall <= base.recall + 1e-9
+
+    # (3) GATE ENGAGED, in the frontier-improving direction: at err=0.10 the gate
+    # reverts real corrections (fewer total edits) and drives over-correction down.
+    # (Whether a threshold RETAINS recall — full up-and-right dominance — is a
+    # real-scale, calibration-tuned question measured by assess_frontier_dominance
+    # in the benchmark sweep, not asserted on this single-pass toy.)
+    Test.@test gated.correction_rate < base.correction_rate
+    Test.@test gated.over_rate <= base.over_rate
+end

--- a/test/4_assembly/viterbi_gap_calibration_test.jl
+++ b/test/4_assembly/viterbi_gap_calibration_test.jl
@@ -1,0 +1,74 @@
+# Stage 2 gap calibration signal check (td-4osf): the per-position Viterbi gap
+# must DISCRIMINATE a correct decoded base from a wrong one (AUROC > 0.5), and the
+# gap<->path alignment contract must hold on real decodes.
+#
+# The finite-gap signal only exists on a BRANCHING graph — a read-coverage k-mer
+# graph carries the error/repeat-induced competition the decoder navigates,
+# whereas a truth-only (linear) graph has a single surviving state per depth and
+# every gap is Inf. So this drives the coverage-graph harness in
+# benchmarking/viterbi_gap_calibration.jl (not swept by Pkg.test()) at small scale.
+#
+# Run:
+#   julia --project=. test/4_assembly/viterbi_gap_calibration_test.jl
+
+import Test
+import Mycelia
+import FASTX
+
+include(joinpath(@__DIR__, "..", "..", "benchmarking", "viterbi_gap_calibration.jl"))
+
+Test.@testset "Tier-2 gap calibration signal (AUROC > 0.5)" begin
+    # Small, deterministic coverage-graph run at err=0.08/0.10; aggregate finite
+    # gaps + truth labels and fit all three calibration models.
+    rows = mktempdir() do dir
+        run_gap_calibration(; k = 11, genome_length = 500, readlen = 120, coverage = 25,
+            error_rates = [0.08, 0.10], seed = 1, results_dir = dir)
+    end
+
+    Test.@test !isempty(rows)                       # class balance sufficient to fit
+
+    # AUROC is shared across models per error rate (property of the raw gap ranking).
+    for er in unique(r.error_rate for r in rows)
+        er_rows = filter(r -> r.error_rate == er, rows)
+        aurocs = unique(r.auroc for r in er_rows)
+        Test.@test length(aurocs) == 1
+        au = only(aurocs)
+        Test.@test !isnan(au)
+        Test.@test au > 0.55                        # the gap is a usable signal (>> chance)
+        # All three models present with finite calibration metrics.
+        Test.@test Set(r.model for r in er_rows) == Set(["isotonic", "logistic", "binned"])
+        for r in er_rows
+            Test.@test isfinite(r.ece) && 0.0 <= r.ece <= 1.0
+            Test.@test isfinite(r.brier) && 0.0 <= r.brier <= 1.0
+        end
+    end
+
+    # --- Alignment contract + finite gaps on a real coverage-graph decode -------
+    rng = Random.MersenneTwister(3)
+    genome = String(rand(rng, ['A', 'C', 'G', 'T'], 500))
+    k = 11
+    reads = FASTX.FASTQ.Record[]
+    truths = String[]
+    for i in 1:40
+        st = rand(rng, 1:(500 - 120 + 1))
+        clean = genome[st:(st + 119)]
+        obs = _inject_substitutions(clean, 0.08, rng)
+        push!(reads, FASTX.FASTQ.Record("r$i", obs, String(fill('I', 120))))
+        push!(truths, clean)
+    end
+    cov = build_coverage_fixture(reads, k)
+    cfg = Mycelia.ViterbiCorrectionConfig(record_position_gaps = true, error_rate = 0.08)
+    any_finite = false
+    for (rec, clean) in zip(reads, truths)
+        gt = try
+            collect_gap_truth(cov, FASTX.sequence(String, rec), clean; config = cfg)
+        catch
+            continue
+        end
+        Test.@test length(gt.scores) == length(gt.labels)
+        Test.@test all(isfinite, gt.scores)         # Inf sentinels already filtered
+        Test.@test all(p -> p >= 1, gt.positions)
+        any_finite |= !isempty(gt.scores)
+    end
+    Test.@test any_finite                            # the coverage graph yields finite gaps
+end

--- a/test/4_assembly/viterbi_gap_calibration_test.jl
+++ b/test/4_assembly/viterbi_gap_calibration_test.jl
@@ -26,6 +26,9 @@ Test.@testset "Tier-2 gap calibration signal (AUROC > 0.5)" begin
     end
 
     Test.@test !isempty(rows)                       # class balance sufficient to fit
+    # BOTH requested error rates must yield results — otherwise a silently-skipped
+    # rate (insufficient class balance / regression) would pass unnoticed.
+    Test.@test Set(r.error_rate for r in rows) == Set([0.08, 0.10])
 
     # AUROC is shared across models per error rate (property of the raw gap ranking).
     for er in unique(r.error_rate for r in rows)


### PR DESCRIPTION
## Summary

Completes the td-4osf calibrated decode gate (Stages 2 + 3), building on the Stage-1
gap telemetry (#400) and the reusable graph fixture (#405).

- **Stage 2 — calibrate the real per-position Viterbi gap.** New coverage-graph harness
  (`benchmarking/viterbi_gap_calibration.jl`) decodes substitution reads against a
  read-**coverage** k-mer graph — the branching graph where the margin is finite — and
  fits + compares **three** calibration models head-to-head: isotonic (PAVA), logistic
  (Platt), and equal-width binning (`benchmarking/calibration_metrics.jl`). Reports the
  shared raw-gap AUROC once plus per-model ECE/Brier/reliability.
- **Stage 3 — calibrated gate.** A single knob `calibrated_gap_threshold`
  (`nothing` ⇒ OFF ⇒ byte-identical) threads through the corrector to a strand-safe
  **positional** splice in `try_viterbi_path_improvement` that reverts a decoded base to
  the observed base wherever the gap is below threshold. Swept as a `calibrated-gap-*`
  operating-point family in the PR-curve, with a new **programmatic** dominance check
  (`assess_frontier_dominance`) replacing the eyeballed CSV read.

### Fixes found while completing the WIP

- **Silent no-op gate (critical).** The gate used `something(path, throw(...))`, whose
  `throw` is evaluated **eagerly** as an argument, so the gate always threw — and the
  enclosing `try/catch` swallowed it, leaving every gated read **uncorrected**. Same
  eager-throw bug in `collect_gap_truth`. Both replaced with lazy `nothing`-checks; the
  gate now **fails open** to the ungated decode rather than dropping the read.
- **Windowed path not gated.** `calibrated_gap_threshold` is now threaded through
  `improve_read_likelihood_windowed[_detail]` (previously only whole-read reads were gated).
- **Length-preservation guard** before the positional splice (indel safety).

### Empirical findings (reported, not papered over)

- The raw gap is a **usable but modest** signal on the coverage graph: AUROC ≈ 0.62–0.65
  at err=0.08–0.10. Isotonic gives the sharpest calibration (lowest Brier); binning is
  ECE-trivial by construction.
- A **raw** gap threshold **trades recall for precision** rather than dominating
  `noskip+nogate` on the accessible single-pass toy (the gate is verified engaged:
  over-correction ↓, precision ↑, fewer edits). Full up-and-right **dominance** is a
  real-scale, calibration-tuned measurement left to the benchmark sweep / a follow-up —
  it is **not** claimed here.
- The gate ships **OFF by default**; no fitted threshold is baked into `src`.

## Test Plan

- [ ] `test/4_assembly/gap_calibration_fitters_test.jl` — 3 fitters: monotone recovery,
      probability range, logistic inverse round-trip, guards.
- [ ] `test/4_assembly/viterbi_gap_calibration_test.jl` — AUROC > 0.5 on a coverage graph;
      alignment contract; finite gaps exist.
- [ ] `test/4_assembly/calibrated_gap_gate_identity_test.jl` — gate OFF === permissive
      limit (byte-identity); monotone revert-toward-observed.
- [ ] `test/4_assembly/rhizomorph_calibrated_gate_frontier_test.jl` — **pipeline**
      byte-identity (`nothing` === `-Inf`); gate engaged; monotone envelope at err=0.10.
- [ ] Byte-identity baseline green (gate OFF is a no-op): `comprehensive_correctness_tests`,
      `scalable_corrector_hard_window_test`, `windowed_decode_test`, `viterbi_position_gaps_test`.
- [ ] Benchmark: `julia benchmarking/viterbi_gap_calibration.jl` (3-model table) and
      `benchmarking/rhizomorph_correction_pr_curve.jl` (frontier CSV + dominance verdict).

## Related

- Bead td-4osf; epic td-pw7p. Builds on #400 (gap telemetry) and #405 (graph fixture).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added isotonic, logistic (Platt-style), and equal-width binned probability calibration with fitting, prediction, and score/probability helpers.
  * Added calibrated confidence-gap gating for read correction, including diagnostic reporting and safe “fail-open” handling; INDEL-mode behavior remains unchanged.
  * Added new calibration benchmarking for Viterbi gap calibration and expanded precision–recall sweeps with calibrated operating-point dominance analysis.

* **Tests**
  * Added unit and end-to-end coverage for calibration fitters, Viterbi gap calibration, gate identity/monotonicity properties, and frontier-dominance edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->