### PR TITLE
add: interleaved-fastq QC + merged-taxid harmonization helpers

### DIFF
--- a/src/fastx.jl
+++ b/src/fastx.jl
@@ -1974,8 +1974,8 @@ function qc_filter_short_reads_fastp_interleaved(;
                        ".fastp_report.json",
         enable_dedup::Bool = false
 )
-    Mycelia.add_bioconda_env("fastp")
     if !(isfile(out_forward) && isfile(out_reverse) && isfile(json) && isfile(html))
+        Mycelia.add_bioconda_env("fastp")
         dedup_args = enable_dedup ? ["--dedup"] : String[]
         cmd = `$(Mycelia.CONDA_RUNNER) run --live-stream -n fastp fastp
                 --in1 $(interleaved_reads)
@@ -1987,6 +1987,8 @@ function qc_filter_short_reads_fastp_interleaved(;
                 --report_title $(report_title)
                 $(dedup_args)`
         run(cmd)
+    else
+        @info "reusing existing fastp interleaved-split outputs" out_forward out_reverse
     end
     return (
         out_forward = String(out_forward),

--- a/src/fastx.jl
+++ b/src/fastx.jl
@@ -1943,6 +1943,62 @@ end
 """
 $(DocStringExtensions.TYPEDSIGNATURES)
 
+Deinterleave an interleaved paired-end FASTQ and QC-filter it with fastp in a
+single pass, writing separate forward/reverse outputs.
+
+`fastp --interleaved_in` treats `--in1` as an interleaved FASTQ (R1/R2 records
+alternating in one file) and splits it into `--out1`/`--out2` while applying the
+usual adapter/quality trimming. Use this for inputs distributed as a single
+interleaved `.fq.gz` (e.g. CAMI benchmark reads), where the separate-file
+`qc_filter_short_reads_fastp` does not apply. The outputs are drop-in inputs for
+`megahit_cmd` / `minimap_map_paired_end_with_index` (`forward=`/`reverse=`).
+
+# Arguments
+- `interleaved_reads::String`: interleaved paired-end FASTQ (may be gzipped).
+- `out_forward::String` / `out_reverse::String`: split, QC-filtered outputs
+  (default derived from the input name via `FASTQ_REGEX`).
+- `report_title`, `html`, `json`: fastp report settings.
+- `enable_dedup::Bool = false`: pass `--dedup` to fastp.
+
+# Returns
+NamedTuple `(; out_forward, out_reverse, json, html)`.
+"""
+function qc_filter_short_reads_fastp_interleaved(;
+        interleaved_reads::String,
+        out_forward::String = replace(interleaved_reads, Mycelia.FASTQ_REGEX => ".fastp.1.fq.gz"),
+        out_reverse::String = replace(interleaved_reads, Mycelia.FASTQ_REGEX => ".fastp.2.fq.gz"),
+        report_title::String = "$(interleaved_reads) fastp report",
+        html::String = Mycelia.find_matching_prefix(out_forward, out_reverse) *
+                       ".fastp_report.html",
+        json::String = Mycelia.find_matching_prefix(out_forward, out_reverse) *
+                       ".fastp_report.json",
+        enable_dedup::Bool = false
+)
+    Mycelia.add_bioconda_env("fastp")
+    if !(isfile(out_forward) && isfile(out_reverse) && isfile(json) && isfile(html))
+        dedup_args = enable_dedup ? ["--dedup"] : String[]
+        cmd = `$(Mycelia.CONDA_RUNNER) run --live-stream -n fastp fastp
+                --in1 $(interleaved_reads)
+                --interleaved_in
+                --out1 $(out_forward)
+                --out2 $(out_reverse)
+                --json $(json)
+                --html $(html)
+                --report_title $(report_title)
+                $(dedup_args)`
+        run(cmd)
+    end
+    return (
+        out_forward = String(out_forward),
+        out_reverse = String(out_reverse),
+        json = String(json),
+        html = String(html)
+    )
+end
+
+"""
+$(DocStringExtensions.TYPEDSIGNATURES)
+
 Perform QC filtering on long-read FASTQ files using fastplong.
 
 # Arguments

--- a/src/taxonomy-and-trees.jl
+++ b/src/taxonomy-and-trees.jl
@@ -1673,6 +1673,54 @@ end
 """
 $(DocStringExtensions.TYPEDSIGNATURES)
 
+Load an NCBI `merged.dmp` into a `Dict{Int,Int}` mapping each retired (merged)
+taxid to the current taxid it was merged into.
+
+`merged.dmp` lines are `old_tax_id\t|\tnew_tax_id\t|`. Unparseable lines are
+skipped. Pair with [`harmonize_taxids`](@ref) to reconcile taxids produced
+against different NCBI taxonomy snapshots.
+"""
+function load_merged_taxid_map(merged_dmp::AbstractString)::Dict{Int, Int}
+    isfile(merged_dmp) || error("merged.dmp not found: $(merged_dmp)")
+    mapping = Dict{Int, Int}()
+    for line in eachline(merged_dmp)
+        parts = split(line, '|')
+        length(parts) >= 2 || continue
+        old_id = tryparse(Int, strip(parts[1]))
+        new_id = tryparse(Int, strip(parts[2]))
+        (old_id === nothing || new_id === nothing) && continue
+        mapping[old_id] = new_id
+    end
+    return mapping
+end
+
+"""
+$(DocStringExtensions.TYPEDSIGNATURES)
+
+Remap taxids through a merged-taxid map (retired -> current), leaving taxids that
+are absent from the map unchanged.
+
+Use this to reconcile taxids drawn from an OLDER NCBI taxonomy snapshot (e.g. the
+CAMI gold-standard profiles, keyed to the taxonomy in effect at challenge time)
+with the CURRENT namespace emitted by classifiers, so that exact-taxid comparisons
+(as in the CAMI precision/recall scorer, which does no lineage climbing) are valid
+rather than spuriously mismatched by taxid merges. Apply the *current* `merged.dmp`
+to the older taxids. The string-path method loads the map via
+[`load_merged_taxid_map`](@ref).
+"""
+function harmonize_taxids(taxids::AbstractVector{<:Integer},
+        merged_map::AbstractDict{<:Integer, <:Integer})::Vector{Int}
+    return [get(merged_map, Int(t), Int(t)) for t in taxids]
+end
+
+function harmonize_taxids(taxids::AbstractVector{<:Integer},
+        merged_dmp::AbstractString)::Vector{Int}
+    return harmonize_taxids(taxids, load_merged_taxid_map(merged_dmp))
+end
+
+"""
+$(DocStringExtensions.TYPEDSIGNATURES)
+
 Convert a vector of species/taxon names to their corresponding NCBI taxonomy IDs.
 
 # Arguments

--- a/src/taxonomy-and-trees.jl
+++ b/src/taxonomy-and-trees.jl
@@ -1679,18 +1679,43 @@ taxid to the current taxid it was merged into.
 `merged.dmp` lines are `old_tax_id\t|\tnew_tax_id\t|`. Unparseable lines are
 skipped. Pair with [`harmonize_taxids`](@ref) to reconcile taxids produced
 against different NCBI taxonomy snapshots.
+
+Errors (rather than returning a silently empty map) if zero mappings parse — the
+mechanism by which a wrong-but-present input (a gzipped `merged.dmp.gz`, a
+truncated file, or the wrong dmp such as `nodes.dmp`) would otherwise turn
+[`harmonize_taxids`](@ref) into a silent identity function and spuriously deflate
+downstream exact-taxid metrics with no signal. Warns if more lines were skipped
+than parsed.
 """
 function load_merged_taxid_map(merged_dmp::AbstractString)::Dict{Int, Int}
     isfile(merged_dmp) || error("merged.dmp not found: $(merged_dmp)")
     mapping = Dict{Int, Int}()
+    skipped = 0
     for line in eachline(merged_dmp)
+        isempty(strip(line)) && continue
         parts = split(line, '|')
-        length(parts) >= 2 || continue
+        if length(parts) < 2
+            skipped += 1
+            continue
+        end
         old_id = tryparse(Int, strip(parts[1]))
         new_id = tryparse(Int, strip(parts[2]))
-        (old_id === nothing || new_id === nothing) && continue
+        if old_id === nothing || new_id === nothing
+            skipped += 1
+            continue
+        end
         mapping[old_id] = new_id
     end
+    # A real NCBI merged.dmp has tens of thousands of rows; zero parsed mappings
+    # means the input is not a plaintext merged.dmp (gzipped / truncated / wrong
+    # file). Fail loud instead of degrading harmonize_taxids to identity.
+    isempty(mapping) && error("load_merged_taxid_map parsed 0 mappings from " *
+          "$(merged_dmp) ($(skipped) lines skipped) — expected a plaintext NCBI " *
+          "merged.dmp (`old \\t | \\t new \\t |`). A gzipped or wrong-file input " *
+          "parses to an empty map.")
+    skipped > length(mapping) &&
+        @warn "load_merged_taxid_map: skipped ($(skipped)) exceeds parsed " *
+              "($(length(mapping)))" merged_dmp
     return mapping
 end
 

--- a/test/2_preprocessing_qc/fastp_interleaved.jl
+++ b/test/2_preprocessing_qc/fastp_interleaved.jl
@@ -1,0 +1,54 @@
+# External-tier (fastp/bioconda) smoke test for the ONLY novel path in the
+# interleaved wrapper: fastp --interleaved_in splitting one file into R1/R2.
+# Registered in EXTERNAL_DEPENDENCY_FILES (test/runtests.jl) so core CI skips it;
+# runs under MYCELIA_RUN_EXTERNAL=true and is exercised end-to-end by the CAMI
+# triangulation driver on NERSC.
+import Test
+import Mycelia
+
+Test.@testset "qc_filter_short_reads_fastp_interleaved (fastp split)" begin
+    mktempdir() do dir
+        # Build a small INTERLEAVED FASTQ: records alternate R1, R2, R1, R2, ...
+        # Clean 60bp reads at high quality so fastp keeps all of them.
+        interleaved = joinpath(dir, "reads.fq")
+        npairs = 5
+        seq = "ACGT"^15                      # 60 bp
+        qual = repeat("I", 60)               # Q40
+        open(interleaved, "w") do io
+            for i in 1:npairs
+                println(io, "@read$(i)/1");
+                println(io, seq)
+                println(io, "+");
+                println(io, qual)
+                println(io, "@read$(i)/2");
+                println(io, seq)
+                println(io, "+");
+                println(io, qual)
+            end
+        end
+
+        res = Mycelia.qc_filter_short_reads_fastp_interleaved(
+            interleaved_reads = interleaved)
+
+        # All four declared outputs exist.
+        Test.@test isfile(res.out_forward)
+        Test.@test isfile(res.out_reverse)
+        Test.@test isfile(res.json)
+        Test.@test isfile(res.html)
+
+        # The single interleaved file was split into two mate files of equal,
+        # nonzero record count (the R1/R2 halves) — the behavior that would break
+        # if --out1/--out2 were transposed or --interleaved_in dropped.
+        nf = length(collect(Mycelia.open_fastx(res.out_forward)))
+        nr = length(collect(Mycelia.open_fastx(res.out_reverse)))
+        Test.@test nf == nr
+        Test.@test nf >= 1
+        Test.@test nf <= npairs
+
+        # Idempotent cache-hit path returns the same output paths without error.
+        res2 = Mycelia.qc_filter_short_reads_fastp_interleaved(
+            interleaved_reads = interleaved)
+        Test.@test res2.out_forward == res.out_forward
+        Test.@test res2.out_reverse == res.out_reverse
+    end
+end

--- a/test/6_annotation/taxid_harmonization.jl
+++ b/test/6_annotation/taxid_harmonization.jl
@@ -8,16 +8,20 @@ Test.@testset "taxid harmonization (merged.dmp)" begin
         write(dmp,
             "12\t|\t74109\t|\n" *
             "30\t|\t40\t|\n" *
-            "\t|\t\n" *          # blank/garbage line must be skipped
-            "not_an_int\t|\t5\t|\n")
+            "\t|\t\n" *              # empty fields: caught by tryparse-nothing skip
+            "not_an_int\t|\t5\t|\n" *  # non-integer old id: tryparse-nothing skip
+            "garbage_no_pipe\n")       # no '|': caught by the length<2 skip
         m = Mycelia.load_merged_taxid_map(dmp)
         Test.@test m[12] == 74109
         Test.@test m[30] == 40
-        Test.@test length(m) == 2                        # unparseable lines skipped
+        Test.@test length(m) == 2                        # all 3 junk lines skipped
 
         # Retired taxids remap; taxids absent from the map pass through unchanged.
         Test.@test Mycelia.harmonize_taxids([12, 999, 30], m) == [74109, 999, 40]
         Test.@test Mycelia.harmonize_taxids(Int[], m) == Int[]
+        # Non-Int64 element type: the Integer signature + Int(t) conversion contract.
+        Test.@test Mycelia.harmonize_taxids(Int32[12, 999], m) == [74109, 999]
+        Test.@test eltype(Mycelia.harmonize_taxids(Int32[12], m)) == Int
 
         # String-path overload loads the map itself.
         Test.@test Mycelia.harmonize_taxids([12, 999], dmp) == [74109, 999]
@@ -25,5 +29,11 @@ Test.@testset "taxid harmonization (merged.dmp)" begin
         # Missing file errors rather than silently returning identity.
         Test.@test_throws ErrorException Mycelia.load_merged_taxid_map(
             joinpath(dir, "nope.dmp"))
+
+        # I1: a present-but-wrong input (no parseable mappings) must ERROR, not
+        # return a silently empty map that degrades harmonize to identity.
+        empty_dmp = joinpath(dir, "empty.dmp")
+        write(empty_dmp, "garbage_no_pipe\nalso garbage\n")
+        Test.@test_throws ErrorException Mycelia.load_merged_taxid_map(empty_dmp)
     end
 end

--- a/test/6_annotation/taxid_harmonization.jl
+++ b/test/6_annotation/taxid_harmonization.jl
@@ -1,0 +1,29 @@
+import Test
+import Mycelia
+
+Test.@testset "taxid harmonization (merged.dmp)" begin
+    mktempdir() do dir
+        # Real NCBI merged.dmp format: old_tax_id \t | \t new_tax_id \t |
+        dmp = joinpath(dir, "merged.dmp")
+        write(dmp,
+            "12\t|\t74109\t|\n" *
+            "30\t|\t40\t|\n" *
+            "\t|\t\n" *          # blank/garbage line must be skipped
+            "not_an_int\t|\t5\t|\n")
+        m = Mycelia.load_merged_taxid_map(dmp)
+        Test.@test m[12] == 74109
+        Test.@test m[30] == 40
+        Test.@test length(m) == 2                        # unparseable lines skipped
+
+        # Retired taxids remap; taxids absent from the map pass through unchanged.
+        Test.@test Mycelia.harmonize_taxids([12, 999, 30], m) == [74109, 999, 40]
+        Test.@test Mycelia.harmonize_taxids(Int[], m) == Int[]
+
+        # String-path overload loads the map itself.
+        Test.@test Mycelia.harmonize_taxids([12, 999], dmp) == [74109, 999]
+
+        # Missing file errors rather than silently returning identity.
+        Test.@test_throws ErrorException Mycelia.load_merged_taxid_map(
+            joinpath(dir, "nope.dmp"))
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -66,6 +66,7 @@ const EXTERNAL_DEPENDENCY_FILES = Set([
     "un_parallel_corpus.jl",
     # Dir 2: Preprocessing (SRA tools)
     "preprocessing.jl",
+    "fastp_interleaved.jl",  # fastp bioconda tool (interleaved-split smoke test)
     # Dir 4: Assembly (external assemblers, Bandage, MEGAHIT)
     "bandage_integration.jl",
     "megahit_phix_workflow.jl",


### PR DESCRIPTION
## Summary
- **`qc_filter_short_reads_fastp_interleaved`** (`src/fastx.jl`): deinterleave + QC an interleaved paired-end FASTQ in a single fastp pass (`--interleaved_in --out1/--out2`). For inputs distributed as one interleaved `.fq.gz` (e.g. CAMI benchmark reads), where the separate-R1/R2 `qc_filter_short_reads_fastp` doesn't apply. Outputs are drop-in for `megahit_cmd` / `minimap_map_paired_end_with_index`.
- **`load_merged_taxid_map` + `harmonize_taxids`** (`src/taxonomy-and-trees.jl`): remap taxids through NCBI `merged.dmp` (retired → current), leaving unmapped taxids unchanged. Reconciles taxids from an older taxonomy snapshot (CAMI gold profiles, keyed to challenge-time taxonomy) with the current namespace classifiers emit, so exact-taxid comparison (the CAMI P/R scorer does no lineage climbing) is valid rather than spuriously mismatched by merges.

Motivation: both were genuinely missing from Mycelia and were about to be hand-rolled one-off in a CAMI validation driver; captured here as discoverable, documented library functions instead.

## Test Plan
- [x] `test/6_annotation/taxid_harmonization.jl` (core tier, runs by default): merged.dmp parse, remap, passthrough of unmapped taxids, empty input, string-path overload, missing-file error → **7/7 pass**.
- [x] Local: `Pkg.instantiate()` + `import Mycelia` precompiles cleanly with the edits; all three functions resolve at module scope.
- [ ] Follow-up: gated external integration test for `qc_filter_short_reads_fastp_interleaved` (needs fastp; currently exercised end-to-end by the CAMI triangulation driver on NERSC).

## Related
CAMI ground-truth precision/recall validation (triangulation driver consumes both helpers).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added interleaved paired-end FASTQ quality filtering with separate forward/reverse outputs and HTML/JSON reports.
  * Added optional duplicate removal and reuse of existing results.
  * Added tools to update retired taxonomy identifiers using NCBI merged taxonomy data.
  * Unrecognized identifiers remain unchanged, while invalid or unusable mapping files are reported clearly.

* **Tests**
  * Added coverage for FASTQ processing, report generation, caching, and taxonomy identifier harmonization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->