### PR TITLE
add: thread indel_params through the windowed :scalable decode (td-jt7r)

### DIFF
--- a/src/iterative-assembly.jl
+++ b/src/iterative-assembly.jl
@@ -1294,19 +1294,16 @@ end
 # STATUS: ACTIVE under `windowed_decode=true` (the :scalable tier). Instead of
 # decoding a hard read end-to-end, `improve_read_likelihood_windowed` extracts the
 # k-mer sub-window(s) (<=500 bp) around each hard region (`_hard_window_ranges`)
-# and decodes ONLY those windows with start_vertex/target_vertex boundary
-# constraints — `Mycelia.correct_observations` derives the start from the first
-# window observation's vertex and the target from the last (via
-# `_decode_observation_bounds`), and `max_steps = n_window_obs - 1` bounds the
-# graph_states to the window — then splices each corrected window back into the
-# read. Windowing bounds decode cost to the hard neighborhood (O(max_window))
-# rather than the whole read (O(read_length)), which is the #375 super-linear
-# per-read term for long reads. Whole-read decode (`improve_read_likelihood`)
-# remains the fallback when `windowed_decode=false`.
+# and decodes ONLY those windows before splicing each correction back into the
+# read. Quality-wrapped observations leave the target endpoint free so the last
+# k-mer remains correctable. Windowing bounds the read-length axis to the hard
+# neighborhood; graph density remains an independent frontier-cost driver
+# (td-2rxh). Whole-read decode (`improve_read_likelihood`) remains the fallback
+# when `windowed_decode=false`.
 #
 # `_hard_window_ranges` (the read-coordinate ranges to decode) is the primitive;
-# `improve_read_likelihood_windowed` (below) does the boundary-constrained decode
-# + splice. Both are unit-tested.
+# `improve_read_likelihood_windowed` (below) does the bounded-window decode +
+# splice. Both are unit-tested.
 # ------------------------------------------------------------------------------
 
 """
@@ -1377,11 +1374,11 @@ A read with no hard window (empty ranges) returns unchanged (`false`) — this o
 occurs for reads the caller's gate already classified as skip, so the whole-read
 fallback (`windowed_decode=false`) is the caller's, not this function's.
 
-Each window is anchored with a solid k-mer flank (`pad === nothing` ⇒ `k` bases)
-so its boundary start/target vertices are solid and the hard vertices sit in the
-window interior. This function windows unconditionally; the caller decides WHEN to
-window (`_windowed_decode_read_is_long` gates it to long reads, where whole-read
-decode is expensive/bounded — short reads keep the cheap, exact whole-read decode).
+Each window includes a solid k-mer flank (`pad === nothing` ⇒ `k` bases), keeping
+hard vertices in the window interior and providing solid boundary context. The
+quality-aware decoder may use the first k-mer as its start but deliberately leaves
+the target endpoint free so the last k-mer remains correctable. This function
+windows unconditionally; the caller decides WHEN to window.
 
 Returns `(record, improved)` where `improved` is `true` iff `>= 1` window was
 corrected and spliced. The lower-level `improve_read_likelihood_windowed_detail`
@@ -1446,9 +1443,9 @@ function improve_read_likelihood_windowed_detail(read::FASTX.FASTQ.Record, graph
         FASTX.FASTQ.Record, Bool, Int, Int}
     # Anchor each window with a full solid k-mer flank by default (`pad === nothing`
     # ⇒ `k`): a pad of `k` bases guarantees the window's first/last k-mer clears the
-    # hard k-mer's span, so the boundary start/target vertices are SOLID anchors and
-    # the hard vertices sit in the window INTERIOR where the ML decode can re-route
-    # them (a 1-base pad can pin the decode to an error k-mer at the boundary).
+    # hard k-mer's span, providing solid boundary context while hard vertices remain
+    # in the interior. Quality-aware decoding leaves the target endpoint free so the
+    # last k-mer remains correctable.
     effective_pad = pad === nothing ? k : pad
     windows = _hard_window_ranges(
         read, k, hard_vertices; pad = effective_pad, max_window = max_window)
@@ -1499,11 +1496,14 @@ function improve_read_likelihood_windowed_detail(read::FASTX.FASTQ.Record, graph
                     Threads.atomic_add!(diagnostics.window_divergences, 1)
             end
         else
-            # Indel decode changes length by design. Rebuild quality coordinates from
-            # a deterministic minimum-edit alignment so an internal insertion or
-            # deletion cannot shift every downstream base-quality pair in the window.
-            # This also defends against a malformed quality returned by a lower layer.
-            dqual = _align_corrected_quality(sub_seq, sub_qual, dseq)
+            # The pair-HMM traceback already rebuilt quality coordinates in
+            # `try_viterbi_path_improvement`. Reject a malformed lower-layer record
+            # rather than padding/truncating it and silently shifting qualities.
+            if length(dqual) != length(dseq)
+                diagnostics === nothing ||
+                    Threads.atomic_add!(diagnostics.structural_errors, 1)
+                continue
+            end
             push!(accepted, (w, dseq, dqual))
         end
     end
@@ -1571,17 +1571,13 @@ end
 """
     _windowed_decode_read_is_long(read, k) -> Bool
 
-Gate for WHEN to use windowed decode (td-nn6l Stage 3c). Returns `true` only for a
-read long enough that whole-read decode is EXPENSIVE — i.e. its observation count
-exceeds `_AUTO_BEAM_EXACT_THRESHOLD`, the same line above which the whole-read
-Viterbi is bounded (beam-pruned, hence inexact) to stay tractable. For such long
-reads, windowing to `<=max_window` sub-windows is BOTH cheaper (the #375 long-read
-term) AND more accurate (each window is exactly decodable again). At/below the
-threshold whole-read decode is exact and cheap, so windowing — which decodes only a
-small hard sub-span and thus discards the read's broader context — would only LOSE
-quality (a short read's hard window is tiny). Those reads keep whole-read decode as
-the fallback. This is why the :scalable quality gate (100 bp reads) never regresses:
-those reads are below the threshold and are decoded whole.
+Gate for WHEN to use windowed decode (td-nn6l Stage 3c). Returns `true` only when
+the read's observation count exceeds `_AUTO_BEAM_EXACT_THRESHOLD`, bounding the
+read-length axis by decoding `<=max_window` sub-windows. Exactness still depends on
+graph density and any explicit beam override: a short window on a graph with more
+than `_AUTO_BEAM_EXACT_GRAPH_VERTICES` vertices remains beam-bounded. Reads below
+the length threshold keep whole-read context unless another caller policy (such as
+staged indel decoding, td-2rxh) explicitly forces windowing.
 """
 function _windowed_decode_read_is_long(read::FASTX.FASTQ.Record, k::Int)::Bool
     n_obs = length(FASTX.sequence(read)) - k + 1
@@ -1821,6 +1817,7 @@ function improve_read_set_likelihood(reads::Vector{<:FASTX.FASTQ.Record}, graph,
     struct_before = diag.structural_errors[]
     unk_before = diag.unkmerizable_reads[]
     gate_skipped_before = diag.gate_skipped[]
+    window_divergences_before = diag.window_divergences[]
     total_reads = length(reads)
     updated_reads = Vector{FASTX.FASTQ.Record}(undef, total_reads)
     improvements_made = 0
@@ -2093,6 +2090,13 @@ function improve_read_set_likelihood(reads::Vector{<:FASTX.FASTQ.Record}, graph,
         @warn "iterative corrector: calibrated gate fell open (ungated) on " *
               "$(gate_skipped_this_pass) read(s) despite a substitution decode — the " *
               "gap/path alignment contract was violated; the gate silently did nothing." total_reads gate_skipped = gate_skipped_this_pass
+    end
+
+    window_divergences_this_pass =
+        diag.window_divergences[] - window_divergences_before
+    if window_divergences_this_pass > 0
+        @warn "iterative corrector: rejected substitution window(s) whose decoded " *
+              "length violated the length-preserving splice contract." total_reads window_divergences = window_divergences_this_pass
     end
 
     return updated_reads, improvements_made, skip_fraction, cheap_corrections,
@@ -2640,88 +2644,54 @@ function adjust_quality_scores(
 end
 
 """
-    _align_corrected_quality(original_sequence, original_quality, corrected_sequence)
+    _quality_from_indel_trace(original_quality, move_trace, read_index_trace, k,
+        corrected_length)
 
-Map the original per-base FASTQ qualities onto a length-changing corrected
-sequence with a deterministic minimum-edit alignment. Diagonal match/substitution
-steps inherit the corresponding observed quality, deletion steps drop the deleted
-base's quality, and insertion steps receive the lower-quality adjacent observation
-(`'!'` when no observation exists). Match diagonals win ties, followed by other
-diagonals, insertions, and deletions, making repeated-sequence ambiguity
-deterministic. The helper is a no-op for an unchanged sequence.
+Map observed FASTQ qualities onto a pair-HMM corrected sequence from the exact
+decoder traceback. The first matched k-mer inherits qualities `1:k`; subsequent
+`M` moves inherit the newly consumed observed base, `I` moves drop the consumed
+extra base, and `D` moves emit a corrected base with the lower of its adjacent
+observed qualities. Returns `nothing` when the trace is malformed or does not
+produce `corrected_length`, so callers can fail closed rather than attach shifted
+qualities. Runtime and memory are linear in the traceback length.
 """
-function _align_corrected_quality(
-        original_sequence::AbstractString,
+function _quality_from_indel_trace(
         original_quality::AbstractString,
-        corrected_sequence::AbstractString
-)::String
-    original_chars = collect(original_sequence)
+        move_trace::AbstractVector{Symbol},
+        read_index_trace::AbstractVector{Int},
+        k::Int,
+        corrected_length::Int
+)::Union{String, Nothing}
     quality_chars = collect(original_quality)
-    corrected_chars = collect(corrected_sequence)
-    length(original_chars) == length(quality_chars) ||
-        throw(ArgumentError("original sequence and quality lengths must match"))
-    original_chars == corrected_chars && return String(quality_chars)
-
-    n_original = length(original_chars)
-    n_corrected = length(corrected_chars)
-    costs = Matrix{Int}(undef, n_original + 1, n_corrected + 1)
-    @inbounds for i in 0:n_original
-        costs[i + 1, 1] = i
-    end
-    @inbounds for j in 0:n_corrected
-        costs[1, j + 1] = j
-    end
-    @inbounds for i in 1:n_original
-        for j in 1:n_corrected
-            substitution = costs[i, j] + (original_chars[i] == corrected_chars[j] ? 0 : 1)
-            deletion = costs[i, j + 1] + 1
-            insertion = costs[i + 1, j] + 1
-            costs[i + 1, j + 1] = min(substitution, deletion, insertion)
-        end
+    n_quality = length(quality_chars)
+    if k <= 0 || n_quality < k || isempty(move_trace) ||
+       length(move_trace) != length(read_index_trace) || first(move_trace) != :M
+        return nothing
     end
 
-    aligned_reversed = Char[]
-    i = n_original
-    j = n_corrected
-    while i > 0 || j > 0
-        current = costs[i + 1, j + 1]
-        diagonal = i > 0 && j > 0 &&
-                   current == costs[i, j] +
-                              (original_chars[i] == corrected_chars[j] ? 0 : 1)
-        matching_diagonal = diagonal && original_chars[i] == corrected_chars[j]
-        insertion = j > 0 && current == costs[i + 1, j] + 1
-        deletion = i > 0 && current == costs[i, j + 1] + 1
-
-        if matching_diagonal || (diagonal && !insertion && !deletion)
-            push!(aligned_reversed, quality_chars[i])
-            i -= 1
-            j -= 1
-        elseif insertion
-            left_quality = i > 0 ? quality_chars[i] : nothing
-            right_quality = i < n_original ? quality_chars[i + 1] : nothing
-            inserted_quality = if left_quality === nothing && right_quality === nothing
-                '!'
-            elseif left_quality === nothing
-                right_quality
-            elseif right_quality === nothing
-                left_quality
-            else
-                min(left_quality, right_quality)
-            end
-            push!(aligned_reversed, inserted_quality)
-            j -= 1
-        elseif deletion
-            i -= 1
+    corrected_quality = copy(quality_chars[1:k])
+    @inbounds for trace_index in 2:length(move_trace)
+        phase = move_trace[trace_index]
+        read_index = read_index_trace[trace_index]
+        observed_position = read_index + k - 1
+        if phase == :M
+            1 <= observed_position <= n_quality || return nothing
+            push!(corrected_quality, quality_chars[observed_position])
+        elseif phase == :I
+            # The read consumed an extra observed base without advancing the graph;
+            # the corrected latent sequence therefore emits no base or quality.
+            continue
+        elseif phase == :D
+            left_position = clamp(observed_position, 1, n_quality)
+            right_position = clamp(observed_position + 1, 1, n_quality)
+            push!(corrected_quality,
+                min(quality_chars[left_position], quality_chars[right_position]))
         else
-            # A non-matching diagonal can tie an insertion/deletion pair. Prefer it
-            # only after the gap moves so an internal indel retains flanking matches.
-            push!(aligned_reversed, quality_chars[i])
-            i -= 1
-            j -= 1
+            return nothing
         end
     end
-    reverse!(aligned_reversed)
-    return String(aligned_reversed)
+    length(corrected_quality) == corrected_length || return nothing
+    return String(corrected_quality)
 end
 
 # =============================================================================
@@ -2870,9 +2840,12 @@ function finalize_iterative_assembly(output_dir::String, k_progression::Vector{I
     # so a caller can detect a corrector that reported 0 improvements because it
     # never actually ran, distinct from "ran and found nothing to fix".
     corrector_errors = diagnostics === nothing ?
-                       Dict(:structural => 0, :unkmerizable => 0) :
+                       Dict(:structural => 0, :unkmerizable => 0,
+        :indel_decodes => 0, :window_divergences => 0) :
                        Dict(:structural => diagnostics.structural_errors[],
-        :unkmerizable => diagnostics.unkmerizable_reads[])
+        :unkmerizable => diagnostics.unkmerizable_reads[],
+        :indel_decodes => diagnostics.indel_decodes[],
+        :window_divergences => diagnostics.window_divergences[])
 
     # Per-pass skip-fraction summary (FIX 6): min/mean/max across every k+iteration
     # pass, not just the last. `last_skip_fraction` is retained for back-compat.
@@ -3182,11 +3155,7 @@ function try_viterbi_path_improvement(read::FASTX.FASTQ.Record,
         if corrected_path === nothing || isempty(corrected_path)
             return nothing
         end
-        if indel_params !== nothing && diagnostics !== nothing
-            path_diagnostics = only(correction.paths).diagnostics
-            get(path_diagnostics, :algorithm, nothing) == :viterbi_indel_pair_hmm &&
-                Threads.atomic_add!(diagnostics.indel_decodes, 1)
-        end
+        path_diagnostics = only(correction.paths).diagnostics
 
         # Soft-EM E-step (td-e70t v2): build this read's COMPETING candidate paths
         # (the observed read path + a consensus alternative re-routed through the
@@ -3264,12 +3233,25 @@ function try_viterbi_path_improvement(read::FASTX.FASTQ.Record,
                 FASTX.quality(read), corrected_sequence_string, likelihood)
             quality, likelihood
         else
-            quality = Mycelia._align_corrected_quality(
-                sequence_string, String(FASTX.quality(read)), corrected_sequence_string)
-            scores = Int8.(Int.(collect(codeunits(quality))) .- 33)
+            quality = Mycelia._quality_from_indel_trace(
+                String(FASTX.quality(read)),
+                get(path_diagnostics, :move_trace, Symbol[]),
+                get(path_diagnostics, :read_index_trace, Int[]),
+                k,
+                length(corrected_sequence_string))
+            if quality === nothing ||
+               get(path_diagnostics, :algorithm, nothing) != :viterbi_indel_pair_hmm
+                diagnostics === nothing ||
+                    Threads.atomic_add!(diagnostics.structural_errors, 1)
+                return nothing
+            end
+            diagnostics === nothing ||
+                Threads.atomic_add!(diagnostics.indel_decodes, 1)
+            aligned_quality = quality::String
+            scores = Int8.(Int.(collect(codeunits(aligned_quality))) .- 33)
             likelihood = Mycelia.calculate_sequence_likelihood(
                 corrected_sequence_string, scores, graph, k; graph_mode = graph_mode)
-            quality, likelihood
+            aligned_quality, likelihood
         end
         improved_record = FASTX.FASTQ.Record(
             FASTX.identifier(read), corrected_sequence_string, improved_quality)

--- a/src/iterative-assembly.jl
+++ b/src/iterative-assembly.jl
@@ -1496,8 +1496,12 @@ function improve_read_likelihood_windowed_detail(read::FASTX.FASTQ.Record, graph
             # Indel decode changes length by design. Reconcile the quality vector to
             # the corrected sequence length defensively (the decode already returns a
             # matched record; this guards a malformed one), then accept unconditionally.
+            # An EMPTY corrected quality is handled explicitly: _reconcile_quality_length
+            # would take its `n == 0` branch and evaluate `zero(Char)` (undefined), so a
+            # malformed empty-quality window is padded with a neutral Q40 ('I') instead.
             if length(dqual) != length(dseq)
-                dqual = String(_reconcile_quality_length(collect(dqual), length(dseq)))
+                dqual = isempty(dqual) ? repeat("I", length(dseq)) :
+                        String(_reconcile_quality_length(collect(dqual), length(dseq)))
             end
             push!(accepted, (w, dseq, dqual))
         end
@@ -1521,10 +1525,31 @@ function improve_read_likelihood_windowed_detail(read::FASTX.FASTQ.Record, graph
         return corrected, true, decoded_windows, divergent_windows
     end
 
-    # Indel: rebuild the read from ORIGINAL-coordinate segments — solid gap, corrected
-    # window (possibly a different length), solid gap, … — so a window's length change
-    # cannot shift a later window's range. `accepted` is in window order (windows are
-    # sorted, non-overlapping after the _hard_window_ranges merge).
+    # Indel: rebuild the read from ORIGINAL-coordinate segments (see
+    # `_splice_indel_windows`) so a window's length change cannot shift a later
+    # window's range.
+    corrected = _splice_indel_windows(id, seq_chars, qual_chars, accepted)
+    return corrected, true, decoded_windows, divergent_windows
+end
+
+"""
+    _splice_indel_windows(id, seq_chars, qual_chars, accepted) -> FASTX.FASTQ.Record
+
+Rebuild a read from ORIGINAL-coordinate segments for the indel (length-changing)
+windowed decode. `seq_chars` / `qual_chars` are the ORIGINAL read's characters;
+`accepted` is a vector of `(window_range, corrected_seq, corrected_qual)` triples in
+window order (windows sorted and non-overlapping — see `_hard_window_ranges`). Each
+window's original span is replaced by its (possibly different-length) corrected
+sequence; the solid gaps BETWEEN windows and the trailing span are copied verbatim
+from the original. Because segments are cut at ORIGINAL coordinates (not a running
+offset), an earlier window's length change cannot shift a later window's range.
+Exposed for a deterministic unit test of the coordinate math (adjacent / gap /
+trailing / length-changing windows) independent of the decoder.
+"""
+function _splice_indel_windows(id::AbstractString,
+        seq_chars::Vector{Char}, qual_chars::Vector{Char},
+        accepted::AbstractVector{<:Tuple{
+            UnitRange{Int}, <:AbstractString, <:AbstractString}})
     out_seq = IOBuffer()
     out_qual = IOBuffer()
     prev = 0
@@ -1539,8 +1564,7 @@ function improve_read_likelihood_windowed_detail(read::FASTX.FASTQ.Record, graph
     end
     print(out_seq, String(seq_chars[(prev + 1):end]))            # trailing solid span
     print(out_qual, String(qual_chars[(prev + 1):end]))
-    corrected = FASTX.FASTQ.Record(id, String(take!(out_seq)), String(take!(out_qual)))
-    return corrected, true, decoded_windows, divergent_windows
+    return FASTX.FASTQ.Record(id, String(take!(out_seq)), String(take!(out_qual)))
 end
 
 """

--- a/src/iterative-assembly.jl
+++ b/src/iterative-assembly.jl
@@ -1824,6 +1824,7 @@ function improve_read_set_likelihood(reads::Vector{<:FASTX.FASTQ.Record}, graph,
     # when `diag` is a shared accumulator threaded across many passes.
     struct_before = diag.structural_errors[]
     unk_before = diag.unkmerizable_reads[]
+    indel_decodes_before = diag.indel_decodes[]
     truncated_before = diag.truncated_decodes[]
     trace_contract_before = diag.trace_contract_errors[]
     gate_skipped_before = diag.gate_skipped[]
@@ -2097,10 +2098,14 @@ function improve_read_set_likelihood(reads::Vector{<:FASTX.FASTQ.Record}, graph,
               "decode(s) before correction or soft-EM side effects." total_reads trace_contract_errors = trace_contract_this_pass
     end
     truncated_this_pass = diag.truncated_decodes[] - truncated_before
-    if total_reads > 0 && truncated_this_pass / total_reads >= 0.5
+    successful_indel_this_pass = diag.indel_decodes[] - indel_decodes_before
+    completed_indel_outcomes = successful_indel_this_pass + truncated_this_pass +
+                               trace_contract_this_pass
+    if completed_indel_outcomes > 0 &&
+       truncated_this_pass / completed_indel_outcomes >= 0.5
         @warn "iterative corrector: high truncated pair-HMM decode fraction; prefix-only " *
-              "paths were rejected before correction or soft-EM side effects." total_reads truncated_decodes = truncated_this_pass fraction = round(
-            truncated_this_pass / total_reads, digits = 3)
+              "paths were rejected before correction or soft-EM side effects." total_reads completed_indel_outcomes truncated_decodes = truncated_this_pass fraction = round(
+            truncated_this_pass / completed_indel_outcomes, digits = 3)
     end
 
     # A requested calibrated gate that silently fell open on a substitution decode

--- a/src/iterative-assembly.jl
+++ b/src/iterative-assembly.jl
@@ -1607,6 +1607,10 @@ parallel (`@threads`) read loop increments them race-free.
   ambiguous base (e.g. `N`) that the 2-bit k-mer iterator cannot encode. The
   read is SKIPPED (passes through uncorrected), never crashed on.
 - `indel_decodes`      : successful decodes stamped by the pair-HMM kernel.
+- `truncated_decodes`  : pair-HMM frontiers that returned only a decoded prefix;
+  rejected before correction or soft-EM side effects.
+- `trace_contract_errors` : malformed/missing pair-HMM traceback telemetry;
+  an internal decoder contract regression rather than a data-dependent miss.
 - `window_divergences` : substitution windows rejected for violating the
   length-preserving splice contract.
 """
@@ -1619,11 +1623,14 @@ mutable struct CorrectorDiagnostics
     # means the opt-in gate disabled itself — a regression signal, not data loss.
     gate_skipped::Threads.Atomic{Int}
     indel_decodes::Threads.Atomic{Int}
+    truncated_decodes::Threads.Atomic{Int}
+    trace_contract_errors::Threads.Atomic{Int}
     window_divergences::Threads.Atomic{Int}
 end
 function CorrectorDiagnostics()
     CorrectorDiagnostics(Threads.Atomic{Int}(0), Threads.Atomic{Int}(0),
-        Threads.Atomic{Int}(0), Threads.Atomic{Int}(0), Threads.Atomic{Int}(0))
+        Threads.Atomic{Int}(0), Threads.Atomic{Int}(0), Threads.Atomic{Int}(0),
+        Threads.Atomic{Int}(0), Threads.Atomic{Int}(0))
 end
 
 # Previously-proven-tractable finite beam (td-63qy: beam 256 completed on the
@@ -1817,6 +1824,8 @@ function improve_read_set_likelihood(reads::Vector{<:FASTX.FASTQ.Record}, graph,
     # when `diag` is a shared accumulator threaded across many passes.
     struct_before = diag.structural_errors[]
     unk_before = diag.unkmerizable_reads[]
+    truncated_before = diag.truncated_decodes[]
+    trace_contract_before = diag.trace_contract_errors[]
     gate_skipped_before = diag.gate_skipped[]
     window_divergences_before = diag.window_divergences[]
     total_reads = length(reads)
@@ -2080,6 +2089,18 @@ function improve_read_set_likelihood(reads::Vector{<:FASTX.FASTQ.Record}, graph,
             "passed through uncorrected (not conflated with 'no likelihood gain')." total_reads structural_errors=struct_swallowed unkmerizable_reads=unk_swallowed fraction=round(
                 frac, digits = 3)
         end
+    end
+
+    trace_contract_this_pass = diag.trace_contract_errors[] - trace_contract_before
+    if trace_contract_this_pass > 0
+        @warn "iterative corrector: pair-HMM traceback contract failed; rejected " *
+              "decode(s) before correction or soft-EM side effects." total_reads trace_contract_errors = trace_contract_this_pass
+    end
+    truncated_this_pass = diag.truncated_decodes[] - truncated_before
+    if total_reads > 0 && truncated_this_pass / total_reads >= 0.5
+        @warn "iterative corrector: high truncated pair-HMM decode fraction; prefix-only " *
+              "paths were rejected before correction or soft-EM side effects." total_reads truncated_decodes = truncated_this_pass fraction = round(
+            truncated_this_pass / total_reads, digits = 3)
     end
 
     # A requested calibrated gate that silently fell open on a substitution decode
@@ -2883,10 +2904,13 @@ function finalize_iterative_assembly(output_dir::String, k_progression::Vector{I
     # never actually ran, distinct from "ran and found nothing to fix".
     corrector_errors = diagnostics === nothing ?
                        Dict(:structural => 0, :unkmerizable => 0,
-        :indel_decodes => 0, :window_divergences => 0) :
+        :indel_decodes => 0, :truncated_decodes => 0,
+        :trace_contract_errors => 0, :window_divergences => 0) :
                        Dict(:structural => diagnostics.structural_errors[],
         :unkmerizable => diagnostics.unkmerizable_reads[],
         :indel_decodes => diagnostics.indel_decodes[],
+        :truncated_decodes => diagnostics.truncated_decodes[],
+        :trace_contract_errors => diagnostics.trace_contract_errors[],
         :window_divergences => diagnostics.window_divergences[])
 
     # Per-pass skip-fraction summary (FIX 6): min/mean/max across every k+iteration
@@ -3198,6 +3222,34 @@ function try_viterbi_path_improvement(read::FASTX.FASTQ.Record,
             return nothing
         end
         path_diagnostics = only(correction.paths).diagnostics
+        corrected_sequence = Mycelia.Rhizomorph.path_to_sequence(corrected_path, graph)
+        corrected_sequence_string = corrected_sequence isa AbstractString ?
+                                    corrected_sequence :
+                                    string(corrected_sequence)
+        aligned_indel_quality::Union{Nothing, String} = nothing
+        if indel_params !== nothing
+            if get(path_diagnostics, :algorithm, nothing) != :viterbi_indel_pair_hmm
+                diagnostics === nothing ||
+                    Threads.atomic_add!(diagnostics.trace_contract_errors, 1)
+                return nothing
+            end
+            if get(path_diagnostics, :truncated, false) === true
+                diagnostics === nothing ||
+                    Threads.atomic_add!(diagnostics.truncated_decodes, 1)
+                return nothing
+            end
+            aligned_indel_quality = Mycelia._quality_from_indel_trace(
+                String(FASTX.quality(read)),
+                get(path_diagnostics, :move_trace, Symbol[]),
+                get(path_diagnostics, :read_index_trace, Int[]),
+                k,
+                length(corrected_sequence_string))
+            if aligned_indel_quality === nothing
+                diagnostics === nothing ||
+                    Threads.atomic_add!(diagnostics.trace_contract_errors, 1)
+                return nothing
+            end
+        end
 
         # Soft-EM E-step (td-e70t v2): build this read's COMPETING candidate paths
         # (the observed read path + a consensus alternative re-routed through the
@@ -3225,10 +3277,6 @@ function try_viterbi_path_improvement(read::FASTX.FASTQ.Record,
                                   _SOFT_EM_ALT_SUCCESSOR_BOUND)
         end
 
-        corrected_sequence = Mycelia.Rhizomorph.path_to_sequence(corrected_path, graph)
-        corrected_sequence_string = corrected_sequence isa AbstractString ?
-                                    corrected_sequence :
-                                    string(corrected_sequence)
         # Calibrated gate is a SUBSTITUTION-ONLY tool: the positional revert
         # `corrected_chars[i+k] = original_chars[i+k]` requires a stable base<->column
         # map, which only a length-preserving substitution decode provides. Under
@@ -3275,22 +3323,9 @@ function try_viterbi_path_improvement(read::FASTX.FASTQ.Record,
                 FASTX.quality(read), corrected_sequence_string, likelihood)
             quality, likelihood
         else
-            quality = Mycelia._quality_from_indel_trace(
-                String(FASTX.quality(read)),
-                get(path_diagnostics, :move_trace, Symbol[]),
-                get(path_diagnostics, :read_index_trace, Int[]),
-                k,
-                length(corrected_sequence_string))
-            if quality === nothing ||
-               get(path_diagnostics, :algorithm, nothing) != :viterbi_indel_pair_hmm ||
-               get(path_diagnostics, :truncated, false) === true
-                diagnostics === nothing ||
-                    Threads.atomic_add!(diagnostics.structural_errors, 1)
-                return nothing
-            end
             diagnostics === nothing ||
                 Threads.atomic_add!(diagnostics.indel_decodes, 1)
-            aligned_quality = quality::String
+            aligned_quality = aligned_indel_quality::String
             scores = Int8.(Int.(collect(codeunits(aligned_quality))) .- 33)
             likelihood = Mycelia.calculate_sequence_likelihood(
                 corrected_sequence_string, scores, graph, k; graph_mode = graph_mode)

--- a/src/iterative-assembly.jl
+++ b/src/iterative-assembly.jl
@@ -2688,6 +2688,7 @@ function _quality_from_indel_trace(
         elseif phase == :I
             # The read consumed an extra observed base without advancing the graph;
             # the corrected latent sequence therefore emits no base or quality.
+            previous_read_index = read_index
             continue
         elseif phase == :D
             left_position = observed_position

--- a/src/iterative-assembly.jl
+++ b/src/iterative-assembly.jl
@@ -1395,12 +1395,16 @@ function improve_read_likelihood_windowed(read::FASTX.FASTQ.Record, graph, k::In
         weighted_graph = nothing,
         diagnostics = nothing,  # ::Union{Nothing, CorrectorDiagnostics}; struct defined below
         pad::Union{Int, Nothing} = nothing,
-        max_window::Int = 500)::Tuple{FASTX.FASTQ.Record, Bool}
-    record, improved, _decoded, _divergent = improve_read_likelihood_windowed_detail(
+        max_window::Int = 500,
+        indel_params::Union{Nothing, IndelDecodeParams} = nothing)::Tuple{
+        FASTX.FASTQ.Record, Bool}
+    record, improved,
+    _decoded,
+    _divergent = improve_read_likelihood_windowed_detail(
         read, graph, k, hard_vertices;
         graph_mode = graph_mode, beam_width = beam_width, soft_weights = soft_weights,
         weighted_graph = weighted_graph, diagnostics = diagnostics,
-        pad = pad, max_window = max_window)
+        pad = pad, max_window = max_window, indel_params = indel_params)
     return record, improved
 end
 
@@ -1411,10 +1415,19 @@ end
 Windowed-decode core (see `improve_read_likelihood_windowed`). Returns
 `(record, improved, decoded_windows, divergent_windows)` where `decoded_windows`
 is the number of hard windows that reached a Viterbi decode and `divergent_windows`
-is the number dropped for a length mismatch (defensive guard; expected 0 since the
-window decode is length-preserving). Exposed for the windowed-decode correctness
-test, which compares the spliced windows against a whole-read decode on the same
-hard region.
+is the number dropped for a length mismatch.
+
+`indel_params` (td-jt7r): `nothing` ⇒ SUBSTITUTION decode. The window ML path has
+one vertex per window k-mer, so the decode is length-preserving and each accepted
+window is spliced back IN PLACE; a window whose corrected length differs is DROPPED
+(defensive `divergent_windows` guard; expected 0). Non-`nothing` ⇒ the INDEL
+pair-HMM decode, which emits I/D moves and thus CHANGES a window's length by design
+— the length delta is the correction, not a defect. Those windows are accepted at
+their new length and the read is reassembled by ORIGINAL-coordinate segment
+rebuild, so an earlier window's length change cannot shift a later window's range.
+The substitution path (`indel_params === nothing`) is byte-for-byte unchanged
+(oracle preservation). Exposed for the windowed-decode correctness test, which
+compares the spliced windows against a whole-read decode on the same hard region.
 """
 function improve_read_likelihood_windowed_detail(read::FASTX.FASTQ.Record, graph, k::Int,
         hard_vertices::AbstractSet;
@@ -1424,22 +1437,28 @@ function improve_read_likelihood_windowed_detail(read::FASTX.FASTQ.Record, graph
         weighted_graph = nothing,
         diagnostics = nothing,  # ::Union{Nothing, CorrectorDiagnostics}; struct defined below
         pad::Union{Int, Nothing} = nothing,
-        max_window::Int = 500)::Tuple{FASTX.FASTQ.Record, Bool, Int, Int}
+        max_window::Int = 500,
+        indel_params::Union{Nothing, IndelDecodeParams} = nothing)::Tuple{
+        FASTX.FASTQ.Record, Bool, Int, Int}
     # Anchor each window with a full solid k-mer flank by default (`pad === nothing`
     # ⇒ `k`): a pad of `k` bases guarantees the window's first/last k-mer clears the
     # hard k-mer's span, so the boundary start/target vertices are SOLID anchors and
     # the hard vertices sit in the window INTERIOR where the ML decode can re-route
     # them (a 1-base pad can pin the decode to an error k-mer at the boundary).
     effective_pad = pad === nothing ? k : pad
-    windows = _hard_window_ranges(read, k, hard_vertices; pad = effective_pad, max_window = max_window)
+    windows = _hard_window_ranges(
+        read, k, hard_vertices; pad = effective_pad, max_window = max_window)
     isempty(windows) && return read, false, 0, 0
 
     seq_chars = collect(FASTX.sequence(String, read))
     qual_chars = collect(FASTX.quality(read))   # ASCII quality string, one char/base
     id = FASTX.identifier(read)
-    any_improved = false
     decoded_windows = 0
     divergent_windows = 0
+    # Accepted (window range, corrected seq, corrected qual) triples, spliced AFTER
+    # the loop. Deferring the splice lets the indel path (length-changing) reassemble
+    # from original coordinates; the substitution path splices these in place.
+    accepted = Tuple{UnitRange{Int}, String, String}[]
 
     for w in windows
         lo = first(w)
@@ -1453,34 +1472,74 @@ function improve_read_likelihood_windowed_detail(read::FASTX.FASTQ.Record, graph
         decoded_windows += 1
         # Decode ONLY this window. `improve_read_likelihood` runs the boundary-
         # constrained Viterbi (window first/last k-mer ⇒ start/target vertex,
-        # max_steps = n_window_obs - 1) over the bounded window graph_states.
+        # max_steps = n_window_obs - 1) over the bounded window graph_states. The
+        # indel pair-HMM (indel_params !== nothing) runs on the SHORT window, so its
+        # cost scales with the window size, not the read length (the whole point).
         decoded_sub,
         improved = improve_read_likelihood(
             sub_read, graph, k; graph_mode = graph_mode,
             beam_width = beam_width, soft_weights = soft_weights,
-            weighted_graph = weighted_graph, diagnostics = diagnostics)
+            weighted_graph = weighted_graph, diagnostics = diagnostics,
+            indel_params = indel_params)
         improved || continue
         dseq = FASTX.sequence(String, decoded_sub)
-        dqual = FASTX.quality(decoded_sub)
-        # Length-preserving splice: the window ML path has one vertex per window
-        # k-mer, so a well-formed decode reconstructs exactly `win_len` bases. A
-        # divergent length would corrupt downstream read coordinates, so drop it.
-        if length(dseq) == win_len && length(dqual) == win_len
-            dseq_chars = collect(dseq)
-            dqual_chars = collect(dqual)
-            @inbounds for (j, p) in enumerate(lo:hi)
-                seq_chars[p] = dseq_chars[j]
-                qual_chars[p] = dqual_chars[j]
+        dqual = String(FASTX.quality(decoded_sub))
+        if indel_params === nothing
+            # Length-preserving splice: a divergent length would corrupt read
+            # coordinates for the in-place splice below, so drop it (expected 0).
+            if length(dseq) == win_len && length(dqual) == win_len
+                push!(accepted, (w, dseq, dqual))
+            else
+                divergent_windows += 1
             end
-            any_improved = true
         else
-            divergent_windows += 1
+            # Indel decode changes length by design. Reconcile the quality vector to
+            # the corrected sequence length defensively (the decode already returns a
+            # matched record; this guards a malformed one), then accept unconditionally.
+            if length(dqual) != length(dseq)
+                dqual = String(_reconcile_quality_length(collect(dqual), length(dseq)))
+            end
+            push!(accepted, (w, dseq, dqual))
         end
     end
 
-    any_improved ||
+    isempty(accepted) &&
         return read, false, decoded_windows, divergent_windows
-    corrected = FASTX.FASTQ.Record(id, String(seq_chars), String(qual_chars))
+
+    if indel_params === nothing
+        # Substitution: length-preserving in-place overwrite (byte-identical to the
+        # pre-indel path — oracle preservation).
+        for (w, dseq, dqual) in accepted
+            dseq_chars = collect(dseq)
+            dqual_chars = collect(dqual)
+            @inbounds for (j, p) in enumerate(first(w):last(w))
+                seq_chars[p] = dseq_chars[j]
+                qual_chars[p] = dqual_chars[j]
+            end
+        end
+        corrected = FASTX.FASTQ.Record(id, String(seq_chars), String(qual_chars))
+        return corrected, true, decoded_windows, divergent_windows
+    end
+
+    # Indel: rebuild the read from ORIGINAL-coordinate segments — solid gap, corrected
+    # window (possibly a different length), solid gap, … — so a window's length change
+    # cannot shift a later window's range. `accepted` is in window order (windows are
+    # sorted, non-overlapping after the _hard_window_ranges merge).
+    out_seq = IOBuffer()
+    out_qual = IOBuffer()
+    prev = 0
+    for (w, dseq, dqual) in accepted
+        lo = first(w)
+        hi = last(w)
+        print(out_seq, String(seq_chars[(prev + 1):(lo - 1)]))   # solid gap before window
+        print(out_qual, String(qual_chars[(prev + 1):(lo - 1)]))
+        print(out_seq, dseq)                                     # corrected window
+        print(out_qual, dqual)
+        prev = hi
+    end
+    print(out_seq, String(seq_chars[(prev + 1):end]))            # trailing solid span
+    print(out_qual, String(qual_chars[(prev + 1):end]))
+    corrected = FASTX.FASTQ.Record(id, String(take!(out_seq)), String(take!(out_qual)))
     return corrected, true, decoded_windows, divergent_windows
 end
 
@@ -1493,11 +1552,11 @@ exceeds `_AUTO_BEAM_EXACT_THRESHOLD`, the same line above which the whole-read
 Viterbi is bounded (beam-pruned, hence inexact) to stay tractable. For such long
 reads, windowing to `<=max_window` sub-windows is BOTH cheaper (the #375 long-read
 term) AND more accurate (each window is exactly decodable again). At/below the
-threshold whole-read decode is exact and cheap, so windowing — which decodes only
-a small hard sub-span and thus discards the read's broader context — would only
-LOSE quality (a short read's hard window is tiny). Those reads keep whole-read
-decode as the fallback. This is why the :scalable quality gate (100 bp reads)
-never regresses: those reads are below the threshold and are decoded whole.
+threshold whole-read decode is exact and cheap, so windowing — which decodes only a
+small hard sub-span and thus discards the read's broader context — would only LOSE
+quality (a short read's hard window is tiny). Those reads keep whole-read decode as
+the fallback. This is why the :scalable quality gate (100 bp reads) never regresses:
+those reads are below the threshold and are decoded whole.
 """
 function _windowed_decode_read_is_long(read::FASTX.FASTQ.Record, k::Int)::Bool
     n_obs = length(FASTX.sequence(read)) - k + 1
@@ -1883,7 +1942,7 @@ function improve_read_set_likelihood(reads::Vector{<:FASTX.FASTQ.Record}, graph,
                                    improve_read_likelihood_windowed(
                         read, graph, k, hard_vertices; graph_mode = graph_mode,
                         beam_width = beam_width, weighted_graph = pass_weighted_graph,
-                        diagnostics = diag) :
+                        diagnostics = diag, indel_params = indel_params) :
                                    improve_read_likelihood(
                         read, graph, k; graph_mode = graph_mode,
                         beam_width = beam_width, weighted_graph = pass_weighted_graph,
@@ -1916,7 +1975,7 @@ function improve_read_set_likelihood(reads::Vector{<:FASTX.FASTQ.Record}, graph,
                     read, graph, k, hard_vertices; graph_mode = graph_mode,
                     beam_width = beam_width, soft_weights = soft_weights,
                     weighted_graph = pass_weighted_graph,
-                    diagnostics = diag) :
+                    diagnostics = diag, indel_params = indel_params) :
                                improve_read_likelihood(
                     read, graph, k; graph_mode = graph_mode,
                     beam_width = beam_width, soft_weights = soft_weights,

--- a/src/iterative-assembly.jl
+++ b/src/iterative-assembly.jl
@@ -1356,15 +1356,13 @@ end
 
 Stage 3c WINDOWED decode (td-nn6l). Instead of decoding a hard read end-to-end,
 decode ONLY the hard sub-window(s) — the k-mer span(s) around the read's hard
-vertices from `_hard_window_ranges` (each `<= max_window` bases) — with
-start/target boundary constraints, then splice each corrected window back into the
-read. Each window is decoded as its own `improve_read_likelihood` sub-read, so
-`correct_observations` derives the decode's `start_vertex` from the window's first
-k-mer, its `target_vertex` from the window's last k-mer, and bounds `max_steps`
-to `n_window_obs - 1` (the window's `graph_states` are bounded to the window; see
-`_decode_observation_bounds`). This makes the per-read decode cost scale with the
-hard-window size (`O(max_window)`) rather than the read length (`O(read_length)`)
-— the dominant super-linear per-read term for long reads (#375).
+vertices from `_hard_window_ranges` (each `<= max_window` bases) — then splice
+each corrected window back into the read. Each window is decoded as its own
+`improve_read_likelihood` sub-read. Quality-wrapped observations leave the target
+vertex free so the decoder can correct the window's last k-mer; the window bounds
+the observation-length axis of the decode, not the full graph frontier. This makes
+the read-length contribution scale with the hard-window size rather than the full
+read length, but graph density remains a separate cost driver (#375, td-2rxh).
 
 With `indel_params === nothing`, the window Viterbi is length-preserving (the
 corrected ML path has one vertex per window k-mer), so each accepted window is
@@ -1476,11 +1474,10 @@ function improve_read_likelihood_windowed_detail(read::FASTX.FASTQ.Record, graph
         sub_qual = String(qual_chars[lo:hi])
         sub_read = FASTX.FASTQ.Record("$(id)_win$(lo)_$(hi)", sub_seq, sub_qual)
         decoded_windows += 1
-        # Decode ONLY this window. `improve_read_likelihood` runs the boundary-
-        # constrained Viterbi (window first/last k-mer ⇒ start/target vertex,
-        # max_steps = n_window_obs - 1) over the bounded window graph_states. The
-        # indel pair-HMM (indel_params !== nothing) runs on the SHORT window, so its
-        # cost scales with the window size, not the read length (the whole point).
+        # Decode ONLY this window. Quality-wrapped observations keep the target
+        # endpoint free; the window bounds observation length, while graph density
+        # remains an independent frontier-cost driver (td-2rxh). The pair-HMM runs
+        # on the short window rather than the full read.
         decoded_sub,
         improved = improve_read_likelihood(
             sub_read, graph, k; graph_mode = graph_mode,
@@ -1498,18 +1495,15 @@ function improve_read_likelihood_windowed_detail(read::FASTX.FASTQ.Record, graph
                 push!(accepted, (w, dseq, dqual))
             else
                 divergent_windows += 1
+                diagnostics === nothing ||
+                    Threads.atomic_add!(diagnostics.window_divergences, 1)
             end
         else
-            # Indel decode changes length by design. Reconcile the quality vector to
-            # the corrected sequence length defensively (the decode already returns a
-            # matched record; this guards a malformed one), then accept unconditionally.
-            # An EMPTY corrected quality is handled explicitly: _reconcile_quality_length
-            # would take its `n == 0` branch and evaluate `zero(Char)` (undefined), so a
-            # malformed empty-quality window is padded with a neutral Q40 ('I') instead.
-            if length(dqual) != length(dseq)
-                dqual = isempty(dqual) ? repeat("I", length(dseq)) :
-                        String(_reconcile_quality_length(collect(dqual), length(dseq)))
-            end
+            # Indel decode changes length by design. Rebuild quality coordinates from
+            # a deterministic minimum-edit alignment so an internal insertion or
+            # deletion cannot shift every downstream base-quality pair in the window.
+            # This also defends against a malformed quality returned by a lower layer.
+            dqual = _align_corrected_quality(sub_seq, sub_qual, dseq)
             push!(accepted, (w, dseq, dqual))
         end
     end
@@ -1615,6 +1609,9 @@ parallel (`@threads`) read loop increments them race-free.
 - `unkmerizable_reads` : `BioSequences.EncodeError` — a read carrying an
   ambiguous base (e.g. `N`) that the 2-bit k-mer iterator cannot encode. The
   read is SKIPPED (passes through uncorrected), never crashed on.
+- `indel_decodes`      : successful decodes stamped by the pair-HMM kernel.
+- `window_divergences` : substitution windows rejected for violating the
+  length-preserving splice contract.
 """
 mutable struct CorrectorDiagnostics
     structural_errors::Threads.Atomic{Int}
@@ -1624,10 +1621,12 @@ mutable struct CorrectorDiagnostics
     # decode. On a healthy substitution decode this is always 0; a nonzero value
     # means the opt-in gate disabled itself — a regression signal, not data loss.
     gate_skipped::Threads.Atomic{Int}
+    indel_decodes::Threads.Atomic{Int}
+    window_divergences::Threads.Atomic{Int}
 end
 function CorrectorDiagnostics()
     CorrectorDiagnostics(Threads.Atomic{Int}(0), Threads.Atomic{Int}(0),
-        Threads.Atomic{Int}(0))
+        Threads.Atomic{Int}(0), Threads.Atomic{Int}(0), Threads.Atomic{Int}(0))
 end
 
 # Previously-proven-tractable finite beam (td-63qy: beam 256 completed on the
@@ -2640,6 +2639,91 @@ function adjust_quality_scores(
     end
 end
 
+"""
+    _align_corrected_quality(original_sequence, original_quality, corrected_sequence)
+
+Map the original per-base FASTQ qualities onto a length-changing corrected
+sequence with a deterministic minimum-edit alignment. Diagonal match/substitution
+steps inherit the corresponding observed quality, deletion steps drop the deleted
+base's quality, and insertion steps receive the lower-quality adjacent observation
+(`'!'` when no observation exists). Match diagonals win ties, followed by other
+diagonals, insertions, and deletions, making repeated-sequence ambiguity
+deterministic. The helper is a no-op for an unchanged sequence.
+"""
+function _align_corrected_quality(
+        original_sequence::AbstractString,
+        original_quality::AbstractString,
+        corrected_sequence::AbstractString
+)::String
+    original_chars = collect(original_sequence)
+    quality_chars = collect(original_quality)
+    corrected_chars = collect(corrected_sequence)
+    length(original_chars) == length(quality_chars) ||
+        throw(ArgumentError("original sequence and quality lengths must match"))
+    original_chars == corrected_chars && return String(quality_chars)
+
+    n_original = length(original_chars)
+    n_corrected = length(corrected_chars)
+    costs = Matrix{Int}(undef, n_original + 1, n_corrected + 1)
+    @inbounds for i in 0:n_original
+        costs[i + 1, 1] = i
+    end
+    @inbounds for j in 0:n_corrected
+        costs[1, j + 1] = j
+    end
+    @inbounds for i in 1:n_original
+        for j in 1:n_corrected
+            substitution = costs[i, j] + (original_chars[i] == corrected_chars[j] ? 0 : 1)
+            deletion = costs[i, j + 1] + 1
+            insertion = costs[i + 1, j] + 1
+            costs[i + 1, j + 1] = min(substitution, deletion, insertion)
+        end
+    end
+
+    aligned_reversed = Char[]
+    i = n_original
+    j = n_corrected
+    while i > 0 || j > 0
+        current = costs[i + 1, j + 1]
+        diagonal = i > 0 && j > 0 &&
+                   current == costs[i, j] +
+                              (original_chars[i] == corrected_chars[j] ? 0 : 1)
+        matching_diagonal = diagonal && original_chars[i] == corrected_chars[j]
+        insertion = j > 0 && current == costs[i + 1, j] + 1
+        deletion = i > 0 && current == costs[i, j + 1] + 1
+
+        if matching_diagonal || (diagonal && !insertion && !deletion)
+            push!(aligned_reversed, quality_chars[i])
+            i -= 1
+            j -= 1
+        elseif insertion
+            left_quality = i > 0 ? quality_chars[i] : nothing
+            right_quality = i < n_original ? quality_chars[i + 1] : nothing
+            inserted_quality = if left_quality === nothing && right_quality === nothing
+                '!'
+            elseif left_quality === nothing
+                right_quality
+            elseif right_quality === nothing
+                left_quality
+            else
+                min(left_quality, right_quality)
+            end
+            push!(aligned_reversed, inserted_quality)
+            j -= 1
+        elseif deletion
+            i -= 1
+        else
+            # A non-matching diagonal can tie an insertion/deletion pair. Prefer it
+            # only after the gap moves so an internal indel retains flanking matches.
+            push!(aligned_reversed, quality_chars[i])
+            i -= 1
+            j -= 1
+        end
+    end
+    reverse!(aligned_reversed)
+    return String(aligned_reversed)
+end
+
 # =============================================================================
 # Decision Making and Termination Conditions
 # =============================================================================
@@ -3098,6 +3182,11 @@ function try_viterbi_path_improvement(read::FASTX.FASTQ.Record,
         if corrected_path === nothing || isempty(corrected_path)
             return nothing
         end
+        if indel_params !== nothing && diagnostics !== nothing
+            path_diagnostics = only(correction.paths).diagnostics
+            get(path_diagnostics, :algorithm, nothing) == :viterbi_indel_pair_hmm &&
+                Threads.atomic_add!(diagnostics.indel_decodes, 1)
+        end
 
         # Soft-EM E-step (td-e70t v2): build this read's COMPETING candidate paths
         # (the observed read path + a consensus alternative re-routed through the
@@ -3167,10 +3256,21 @@ function try_viterbi_path_improvement(read::FASTX.FASTQ.Record,
                 Threads.atomic_add!(diagnostics.gate_skipped, 1)
             end
         end
-        improved_likelihood = Mycelia.calculate_sequence_likelihood(
-            corrected_sequence_string, quality_scores, graph, k; graph_mode = graph_mode)
-        improved_quality = Mycelia.adjust_quality_scores(
-            FASTX.quality(read), corrected_sequence_string, improved_likelihood)
+        improved_quality, improved_likelihood = if indel_params === nothing
+            likelihood = Mycelia.calculate_sequence_likelihood(
+                corrected_sequence_string, quality_scores, graph, k;
+                graph_mode = graph_mode)
+            quality = Mycelia.adjust_quality_scores(
+                FASTX.quality(read), corrected_sequence_string, likelihood)
+            quality, likelihood
+        else
+            quality = Mycelia._align_corrected_quality(
+                sequence_string, String(FASTX.quality(read)), corrected_sequence_string)
+            scores = Int8.(Int.(collect(codeunits(quality))) .- 33)
+            likelihood = Mycelia.calculate_sequence_likelihood(
+                corrected_sequence_string, scores, graph, k; graph_mode = graph_mode)
+            quality, likelihood
+        end
         improved_record = FASTX.FASTQ.Record(
             FASTX.identifier(read), corrected_sequence_string, improved_quality)
         return (improved_record, improved_likelihood)

--- a/src/iterative-assembly.jl
+++ b/src/iterative-assembly.jl
@@ -1366,13 +1366,14 @@ to `n_window_obs - 1` (the window's `graph_states` are bounded to the window; se
 hard-window size (`O(max_window)`) rather than the read length (`O(read_length)`)
 — the dominant super-linear per-read term for long reads (#375).
 
-The window Viterbi is length-preserving (the corrected ML path has one vertex per
-window k-mer, so `path_to_sequence` reconstructs the same base count), so each
-accepted window is spliced in as a same-length substitution. As a defensive guard,
-a window whose corrected length differs from the original is DROPPED (left
-uncorrected) rather than shifting the read's coordinates; the returned
-`divergent_windows` count surfaces any such case. Windows shorter than `k` (which
-cannot be k-merized) are skipped.
+With `indel_params === nothing`, the window Viterbi is length-preserving (the
+corrected ML path has one vertex per window k-mer), so each accepted window is
+spliced in as a same-length substitution. A length mismatch on that path is
+dropped defensively and counted in `divergent_windows`. With non-`nothing`
+`indel_params`, the pair-HMM may emit insertions or deletions; those intentional
+length changes are accepted and spliced by rebuilding the read from original
+window coordinates. Windows shorter than `k` (which cannot be k-merized) are
+skipped.
 
 A read with no hard window (empty ranges) returns unchanged (`false`) — this only
 occurs for reads the caller's gate already classified as skip, so the whole-read

--- a/src/iterative-assembly.jl
+++ b/src/iterative-assembly.jl
@@ -2228,7 +2228,13 @@ function find_optimal_sequence_path(read::FASTX.FASTQ.Record, graph, k::Int;
     end
 
     viterbi_read, viterbi_likelihood = viterbi_result
-    improvement = viterbi_likelihood - original_likelihood
+    improvement = _comparable_likelihood_improvement(
+        original_likelihood,
+        viterbi_likelihood,
+        length(FASTX.sequence(read)),
+        length(FASTX.sequence(viterbi_read)),
+        k;
+        length_normalized = indel_params !== nothing)
     # Accept the ML path only when it is at least as likely as the original; a
     # non-positive delta means the ML path is not an improvement, so report none
     # (never return a strictly-worse read). This is the ADR's "trust the ML path
@@ -2250,6 +2256,34 @@ function calculate_read_likelihood(
     quality_scores = collect(FASTX.quality_scores(read))
     return calculate_sequence_likelihood(
         sequence, quality_scores, graph, k; graph_mode = graph_mode)
+end
+
+"""
+    _comparable_likelihood_improvement(original_likelihood, corrected_likelihood,
+        original_length, corrected_length, k; length_normalized=false)
+
+Compare graph log-likelihoods without giving a mechanical advantage to a shorter
+length-changing correction. Substitution mode keeps the historical raw-sum
+difference exactly. Indel mode compares mean log-likelihood per emitted k-mer;
+the pair-HMM has already applied its affine gap priors while choosing the decoded
+path, and this secondary acceptance gate therefore tests graph support on a
+length-comparable scale.
+"""
+function _comparable_likelihood_improvement(
+        original_likelihood::Float64,
+        corrected_likelihood::Float64,
+        original_length::Int,
+        corrected_length::Int,
+        k::Int;
+        length_normalized::Bool = false
+)::Float64
+    if !length_normalized
+        return corrected_likelihood - original_likelihood
+    end
+    original_terms = max(original_length - k + 1, 1)
+    corrected_terms = max(corrected_length - k + 1, 1)
+    return corrected_likelihood / corrected_terms -
+           original_likelihood / original_terms
 end
 
 """
@@ -3248,7 +3282,8 @@ function try_viterbi_path_improvement(read::FASTX.FASTQ.Record,
                 k,
                 length(corrected_sequence_string))
             if quality === nothing ||
-               get(path_diagnostics, :algorithm, nothing) != :viterbi_indel_pair_hmm
+               get(path_diagnostics, :algorithm, nothing) != :viterbi_indel_pair_hmm ||
+               get(path_diagnostics, :truncated, false) === true
                 diagnostics === nothing ||
                     Threads.atomic_add!(diagnostics.structural_errors, 1)
                 return nothing

--- a/src/iterative-assembly.jl
+++ b/src/iterative-assembly.jl
@@ -1374,11 +1374,12 @@ A read with no hard window (empty ranges) returns unchanged (`false`) — this o
 occurs for reads the caller's gate already classified as skip, so the whole-read
 fallback (`windowed_decode=false`) is the caller's, not this function's.
 
-Each window includes a solid k-mer flank (`pad === nothing` ⇒ `k` bases), keeping
-hard vertices in the window interior and providing solid boundary context. The
-quality-aware decoder may use the first k-mer as its start but deliberately leaves
-the target endpoint free so the last k-mer remains correctable. This function
-windows unconditionally; the caller decides WHEN to window.
+Each window requests a k-mer-width flank (`pad === nothing` ⇒ `k` bases), keeping
+hard vertices away from a boundary when read ends and `max_window` permit. Padding
+is contextual rather than a solidity guarantee. The quality-aware decoder may use
+the first k-mer as its start but deliberately leaves the target endpoint free so
+the last k-mer remains correctable. This function windows unconditionally; the
+caller decides WHEN to window.
 
 Returns `(record, improved)` where `improved` is `true` iff `>= 1` window was
 corrected and spliced. The lower-level `improve_read_likelihood_windowed_detail`
@@ -1442,10 +1443,10 @@ function improve_read_likelihood_windowed_detail(read::FASTX.FASTQ.Record, graph
         indel_params::Union{Nothing, IndelDecodeParams} = nothing)::Tuple{
         FASTX.FASTQ.Record, Bool, Int, Int}
     # Anchor each window with a full solid k-mer flank by default (`pad === nothing`
-    # ⇒ `k`): a pad of `k` bases guarantees the window's first/last k-mer clears the
-    # hard k-mer's span, providing solid boundary context while hard vertices remain
-    # in the interior. Quality-aware decoding leaves the target endpoint free so the
-    # last k-mer remains correctable.
+    # ⇒ `k`): request a k-mer-width flank around the hard span when read boundaries
+    # and `max_window` allow it. This is contextual padding, not a guarantee that a
+    # boundary k-mer is solid. Quality-aware decoding leaves the target endpoint free
+    # so the last k-mer remains correctable.
     effective_pad = pad === nothing ? k : pad
     windows = _hard_window_ranges(
         read, k, hard_vertices; pad = effective_pad, max_window = max_window)
@@ -1575,7 +1576,7 @@ Gate for WHEN to use windowed decode (td-nn6l Stage 3c). Returns `true` only whe
 the read's observation count exceeds `_AUTO_BEAM_EXACT_THRESHOLD`, bounding the
 read-length axis by decoding `<=max_window` sub-windows. Exactness still depends on
 graph density and any explicit beam override: a short window on a graph with more
-than `_AUTO_BEAM_EXACT_GRAPH_VERTICES` vertices remains beam-bounded. Reads below
+than `_AUTO_BEAM_BOUNDED_WIDTH` vertices remains beam-bounded. Reads below
 the length threshold keep whole-read context unless another caller policy (such as
 staged indel decoding, td-2rxh) explicitly forces windowing.
 """
@@ -2665,30 +2666,36 @@ function _quality_from_indel_trace(
     quality_chars = collect(original_quality)
     n_quality = length(quality_chars)
     if k <= 0 || n_quality < k || isempty(move_trace) ||
-       length(move_trace) != length(read_index_trace) || first(move_trace) != :M
+       length(move_trace) != length(read_index_trace) || first(move_trace) != :M ||
+       first(read_index_trace) != 1
         return nothing
     end
 
     corrected_quality = copy(quality_chars[1:k])
+    n_observations = n_quality - k + 1
+    previous_read_index = 1
     @inbounds for trace_index in 2:length(move_trace)
         phase = move_trace[trace_index]
         read_index = read_index_trace[trace_index]
+        expected_read_index = phase == :D ? previous_read_index : previous_read_index + 1
+        if phase ∉ (:M, :I, :D) || read_index != expected_read_index ||
+           !(1 <= read_index <= n_observations)
+            return nothing
+        end
         observed_position = read_index + k - 1
         if phase == :M
-            1 <= observed_position <= n_quality || return nothing
             push!(corrected_quality, quality_chars[observed_position])
         elseif phase == :I
             # The read consumed an extra observed base without advancing the graph;
             # the corrected latent sequence therefore emits no base or quality.
             continue
         elseif phase == :D
-            left_position = clamp(observed_position, 1, n_quality)
-            right_position = clamp(observed_position + 1, 1, n_quality)
+            left_position = observed_position
+            right_position = min(observed_position + 1, n_quality)
             push!(corrected_quality,
                 min(quality_chars[left_position], quality_chars[right_position]))
-        else
-            return nothing
         end
+        previous_read_index = read_index
     end
     length(corrected_quality) == corrected_length || return nothing
     return String(corrected_quality)

--- a/src/rhizomorph/assembly.jl
+++ b/src/rhizomorph/assembly.jl
@@ -1337,6 +1337,12 @@ function _assemble_with_iterative_corrector(reads, config::AssemblyConfig)
         assembly.assembly_stats["hard_window"] = get(_corr_meta, :hard_window, false)
         assembly.assembly_stats["hard_read_gate"] = get(_corr_meta, :hard_read_gate, false)
         assembly.assembly_stats["windowed_decode"] = get(_corr_meta, :windowed_decode, false)
+        corrector_errors = get(_corr_meta, :corrector_errors, Dict{Symbol, Int}())
+        assembly.assembly_stats["corrector_errors"] = corrector_errors
+        assembly.assembly_stats["indel_decodes"] =
+            get(corrector_errors, :indel_decodes, 0)
+        assembly.assembly_stats["window_divergences"] =
+            get(corrector_errors, :window_divergences, 0)
         # soft-EM v1 is record-only ⇒ "scaffold-v1-record-only" (or false on
         # :exhaustive), never a bare `true` (FIX 1/5).
         assembly.assembly_stats["soft_em"] = get(_corr_meta, :soft_em, false)

--- a/src/rhizomorph/assembly.jl
+++ b/src/rhizomorph/assembly.jl
@@ -1341,6 +1341,10 @@ function _assemble_with_iterative_corrector(reads, config::AssemblyConfig)
         assembly.assembly_stats["corrector_errors"] = corrector_errors
         assembly.assembly_stats["indel_decodes"] =
             get(corrector_errors, :indel_decodes, 0)
+        assembly.assembly_stats["truncated_decodes"] =
+            get(corrector_errors, :truncated_decodes, 0)
+        assembly.assembly_stats["trace_contract_errors"] =
+            get(corrector_errors, :trace_contract_errors, 0)
         assembly.assembly_stats["window_divergences"] =
             get(corrector_errors, :window_divergences, 0)
         # soft-EM v1 is record-only ⇒ "scaffold-v1-record-only" (or false on

--- a/src/viterbi-next.jl
+++ b/src/viterbi-next.jl
@@ -1936,12 +1936,18 @@ function _viterbi_correct_observation_indel(
     reverse!(chain)
 
     path_states = State[]
-    for (index, (_, state, phase)) in enumerate(chain)
+    move_trace = Symbol[]
+    read_index_trace = Int[]
+    for (index, (read_index, state, phase)) in enumerate(chain)
         diagnostics[:move_counts][phase] += 1
+        push!(move_trace, phase)
+        push!(read_index_trace, read_index)
         if index == 1 || phase != :I
             push!(path_states, state)
         end
     end
+    diagnostics[:move_trace] = move_trace
+    diagnostics[:read_index_trace] = read_index_trace
 
     path = Rhizomorph._build_graph_path_from_vertices(graph, path_states)
     diagnostics[:path_length] = length(path.steps)

--- a/src/viterbi-next.jl
+++ b/src/viterbi-next.jl
@@ -1619,6 +1619,11 @@ Affine transition masses come from the error model: `δ_I = ε·f_ins`,
 `γ_I`, `γ_D`. Setting the indel fractions to 0 sends every gap transition to
 `log(0) = -Inf`, so the reachable frontier collapses to the pure-M substitution
 path — Illumina falls out as the special case.
+
+The result diagnostics include `:move_counts`, the ordered `:move_trace`, and the
+parallel `:read_index_trace`. The latter two preserve the exact pair-HMM traceback
+used to reconstruct length-changing per-base qualities. `:decoded_read_index` and
+`:truncated` report whether the frontier consumed the complete observation.
 """
 function _viterbi_correct_observation_indel(
         graph::MetaGraphsNext.MetaGraph,

--- a/test/4_assembly/indel_profile_assembly_test.jl
+++ b/test/4_assembly/indel_profile_assembly_test.jl
@@ -166,6 +166,8 @@ Test.@testset "indel-aware correction wired via sequencing-tech error profile" b
         # The provenance stamp proves the indel decode path was engaged.
         Test.@test np.assembly_stats["indel_moves"] == true
         Test.@test np.assembly_stats["sequencing_tech"] == "nanopore"
+        Test.@test np.assembly_stats["indel_decodes"] >= 0
+        Test.@test np.assembly_stats["window_divergences"] >= 0
     end
 
     # -- END-TO-END correction proof (PR #408 review, FIX 2) -------------------
@@ -190,6 +192,7 @@ Test.@testset "indel-aware correction wired via sequencing-tech error profile" b
         id_np = Float64[]
         id_il = Float64[]
         np_indel_moves = Bool[]
+        np_indel_decodes = Int[]
         np_nonempty = Bool[]
         for seed in seeds
             reads,
@@ -202,6 +205,7 @@ Test.@testset "indel-aware correction wired via sequencing-tech error profile" b
             push!(id_np, _best_identity_to_ref(np.contigs, refseq))
             push!(id_il, _best_identity_to_ref(il.contigs, refseq))
             push!(np_indel_moves, np.assembly_stats["indel_moves"] == true)
+            push!(np_indel_decodes, np.assembly_stats["indel_decodes"])
             push!(np_nonempty, !isempty(np.contigs))
         end
         mean_np = Statistics.mean(id_np)
@@ -211,6 +215,7 @@ Test.@testset "indel-aware correction wired via sequencing-tech error profile" b
 
         # The nanopore arm actually engaged the indel decode and produced contigs.
         Test.@test all(np_indel_moves)
+        Test.@test all(>(0), np_indel_decodes)
         Test.@test all(np_nonempty)
         # DIFFERENTIAL (the PR's value): indel-aware correction lands closer to the
         # truth than substitution-only on the SAME nanopore reads, on average.

--- a/test/4_assembly/indel_profile_assembly_test.jl
+++ b/test/4_assembly/indel_profile_assembly_test.jl
@@ -167,6 +167,8 @@ Test.@testset "indel-aware correction wired via sequencing-tech error profile" b
         Test.@test np.assembly_stats["indel_moves"] == true
         Test.@test np.assembly_stats["sequencing_tech"] == "nanopore"
         Test.@test np.assembly_stats["indel_decodes"] >= 0
+        Test.@test np.assembly_stats["truncated_decodes"] >= 0
+        Test.@test np.assembly_stats["trace_contract_errors"] == 0
         Test.@test np.assembly_stats["window_divergences"] >= 0
     end
 

--- a/test/4_assembly/viterbi_indel_decoder_test.jl
+++ b/test/4_assembly/viterbi_indel_decoder_test.jl
@@ -533,7 +533,9 @@ Test.@testset "Indel-aware pair-HMM Viterbi correction" begin
             beam_width = typemax(Int), diagnostics = diagnostics,
             indel_params = params)
         Test.@test result === nothing
-        Test.@test diagnostics.structural_errors[] == 1
+        Test.@test diagnostics.structural_errors[] == 0
+        Test.@test diagnostics.truncated_decodes[] == 1
+        Test.@test diagnostics.trace_contract_errors[] == 0
         Test.@test diagnostics.indel_decodes[] == 0
     end
 end

--- a/test/4_assembly/viterbi_indel_decoder_test.jl
+++ b/test/4_assembly/viterbi_indel_decoder_test.jl
@@ -528,11 +528,14 @@ Test.@testset "Indel-aware pair-HMM Viterbi correction" begin
         params = Mycelia.IndelDecodeParams(
             0.10, 0.30, 0.30, 0.10, 0.10, 1, 0, 16)
         diagnostics = Mycelia.CorrectorDiagnostics()
+        soft_weights = Mycelia.Rhizomorph.SoftEdgeWeightAccumulator()
         result = Mycelia.try_viterbi_path_improvement(
             observed, graph, 5; graph_mode = :doublestrand,
-            beam_width = typemax(Int), diagnostics = diagnostics,
+            beam_width = typemax(Int), soft_weights = soft_weights,
+            diagnostics = diagnostics,
             indel_params = params)
         Test.@test result === nothing
+        Test.@test isempty(soft_weights.weights)
         Test.@test diagnostics.structural_errors[] == 0
         Test.@test diagnostics.truncated_decodes[] == 1
         Test.@test diagnostics.trace_contract_errors[] == 0

--- a/test/4_assembly/viterbi_indel_decoder_test.jl
+++ b/test/4_assembly/viterbi_indel_decoder_test.jl
@@ -86,6 +86,22 @@ Test.@testset "Indel-aware pair-HMM Viterbi correction" begin
         Test.@test cfg2.band_width == 12
     end
 
+    Test.@testset "length-changing acceptance compares mean k-mer support" begin
+        comparable = Mycelia._comparable_likelihood_improvement
+        # Ten original terms at -1 each. A deletion with nine terms and an
+        # insertion with eleven terms have identical mean support, not a raw-sum
+        # advantage/penalty caused solely by length.
+        Test.@test comparable(-10.0, -9.0, 22, 21, 13;
+            length_normalized = true) == 0.0
+        Test.@test comparable(-10.0, -11.0, 22, 23, 13;
+            length_normalized = true) == 0.0
+        Test.@test comparable(-10.0, -8.1, 22, 21, 13;
+            length_normalized = true) ≈ 0.1
+        # The substitution oracle retains the historical raw-sum comparison.
+        Test.@test comparable(-10.0, -9.0, 22, 21, 13;
+            length_normalized = false) == 1.0
+    end
+
     # Shared OLC fixture (mirrors viterbi_variable_length_graph_correction_test.jl):
     # a 5-vertex overlap-3 chain ATGCG -> GCGTA -> GTACC -> ACCGT -> CGTAA. The true
     # read under test covers only the FIRST THREE vertices; the graph deliberately
@@ -502,5 +518,22 @@ Test.@testset "Indel-aware pair-HMM Viterbi correction" begin
         full_diag = only(full.paths).diagnostics
         Test.@test full_diag[:truncated] == false
         Test.@test full_diag[:decoded_read_index] == length(full_observed)
+    end
+
+    Test.@testset "truncated read corrections fail closed" begin
+        reference = indel_quality_record("ref", "CGTAA", fill(40, 5))
+        graph = Mycelia.Rhizomorph.build_qualmer_graph(
+            [reference], 5; mode = :doublestrand)
+        observed = indel_quality_record("obs", "CGTAAT", fill(40, 6))
+        params = Mycelia.IndelDecodeParams(
+            0.10, 0.30, 0.30, 0.10, 0.10, 1, 0, 16)
+        diagnostics = Mycelia.CorrectorDiagnostics()
+        result = Mycelia.try_viterbi_path_improvement(
+            observed, graph, 5; graph_mode = :doublestrand,
+            beam_width = typemax(Int), diagnostics = diagnostics,
+            indel_params = params)
+        Test.@test result === nothing
+        Test.@test diagnostics.structural_errors[] == 1
+        Test.@test diagnostics.indel_decodes[] == 0
     end
 end

--- a/test/4_assembly/viterbi_indel_decoder_test.jl
+++ b/test/4_assembly/viterbi_indel_decoder_test.jl
@@ -191,6 +191,8 @@ Test.@testset "Indel-aware pair-HMM Viterbi correction" begin
         Test.@test diag[:indel_moves] == true
         # The deletion was bridged by >=1 D-move.
         Test.@test diag[:move_counts][:D] >= 1
+        Test.@test count(==(:D), diag[:move_trace]) >= 1
+        Test.@test length(diag[:move_trace]) == length(diag[:read_index_trace])
 
         ins_result = Mycelia.correct_observations(
             graph,
@@ -199,6 +201,8 @@ Test.@testset "Indel-aware pair-HMM Viterbi correction" begin
             config = _indel_config())
         ins_diag = only(ins_result.paths).diagnostics
         Test.@test ins_diag[:move_counts][:I] >= 1
+        Test.@test count(==(:I), ins_diag[:move_trace]) >= 1
+        Test.@test length(ins_diag[:move_trace]) == length(ins_diag[:read_index_trace])
     end
 
     Test.@testset "Milestone C: bounding knobs actually bite" begin

--- a/test/4_assembly/windowed_decode_test.jl
+++ b/test/4_assembly/windowed_decode_test.jl
@@ -200,11 +200,19 @@ end
 # splice is generalized to a length-changing (indel) correction. This testset asserts
 # the PLUMBING is correct and oracle-preserving; it does NOT assert an end-to-end
 # nanopore correction WIN — that is gated on staging the (dense-graph-expensive) indel
-# decode to sparse rungs, tracked separately under td-jt7r.
+# decode to sparse rungs, tracked separately under td-2rxh.
 Test.@testset "windowed indel decode plumbing (td-jt7r)" begin
     R = Mycelia.Rhizomorph
     k = 13
     mode = :doublestrand
+
+    Test.@testset "indel quality alignment preserves base coordinates" begin
+        align_quality = Mycelia._align_corrected_quality
+        Test.@test align_quality("ACGT", "BCDE", "ACGT") == "BCDE"
+        Test.@test align_quality("ACGT", "BCDE", "AGT") == "BDE"
+        Test.@test align_quality("ACGT", "BCDE", "ACGAT") == "BCDDE"
+        Test.@test_throws ArgumentError align_quality("ACGT", "BCD", "ACGT")
+    end
 
     # (A) POSITIVE CONTROL — the ORIGINAL-COORDINATE segment rebuild (the risky new
     # length-changing code) tested DIRECTLY against hand-computed expectations, so an
@@ -245,6 +253,7 @@ Test.@testset "windowed indel decode plumbing (td-jt7r)" begin
         graph = R.build_qualmer_graph(fx.reads, k; mode = mode)
         hard = Mycelia._hard_vertex_set(graph, k)
         Test.@test !isempty(hard)
+        diagnostics = Mycelia.CorrectorDiagnostics()
         profile = Mycelia.indel_error_profile(:nanopore)
         ip = Mycelia.IndelDecodeParams(
             profile.base_error_rate, profile.insertion_fraction, profile.deletion_fraction,
@@ -255,7 +264,8 @@ Test.@testset "windowed indel decode plumbing (td-jt7r)" begin
                 rec_ind, _imp,
                 ndec_ind,
                 _ndiv = Mycelia.improve_read_likelihood_windowed_detail(
-                    r, graph, k, hard; graph_mode = mode, beam_width = 64, indel_params = ip)
+                    r, graph, k, hard; graph_mode = mode, beam_width = 64,
+                    diagnostics = diagnostics, indel_params = ip)
                 sind = FASTX.sequence(String, rec_ind)
                 Test.@test length(sind) == length(FASTX.quality(rec_ind))   # well-formed
                 Test.@test all(c -> c in ('A', 'C', 'G', 'T'), sind)
@@ -268,5 +278,9 @@ Test.@testset "windowed indel decode plumbing (td-jt7r)" begin
                 end
             end
         end
+        # This counter is stamped from the decoder result's algorithm diagnostic,
+        # so the smoke fails if `indel_params` is dropped and the substitution
+        # kernel runs instead.
+        Test.@test diagnostics.indel_decodes[] >= 1
     end
 end

--- a/test/4_assembly/windowed_decode_test.jl
+++ b/test/4_assembly/windowed_decode_test.jl
@@ -96,9 +96,12 @@ Test.@testset "windowed decode (td-nn6l Stage 3c)" begin
                 orig = FASTX.sequence(String, r)
                 wins = Mycelia._hard_window_ranges(r, k, hard; pad = k, max_window = 500)
 
-                rec_w, imp_w = Mycelia.improve_read_likelihood(
+                rec_w,
+                imp_w = Mycelia.improve_read_likelihood(
                     r, graph, k; graph_mode = mode, beam_width = typemax(Int))
-                rec_win, imp_win, ndec, ndiv = Mycelia.improve_read_likelihood_windowed_detail(
+                rec_win, imp_win,
+                ndec,
+                ndiv = Mycelia.improve_read_likelihood_windowed_detail(
                     r, graph, k, hard; graph_mode = mode, beam_width = typemax(Int))
 
                 sw = FASTX.sequence(String, rec_w)
@@ -155,9 +158,9 @@ Test.@testset "windowed decode (td-nn6l Stage 3c)" begin
                     r, graph, k, hard; graph_mode = mode, beam_width = typemax(Int))
             end
             n = length(fx.err_reads)
-            @info "windowed-decode per-hard-read time" readlen = length(FASTX.sequence(probe)) whole_per_read_ms = round(
-                t_whole / n * 1000, digits = 1) windowed_per_read_ms = round(
-                t_win / n * 1000, digits = 1) speedup = round(t_whole / t_win, digits = 2)
+            @info "windowed-decode per-hard-read time" readlen=length(FASTX.sequence(probe)) whole_per_read_ms=round(
+                t_whole/n*1000, digits = 1) windowed_per_read_ms=round(
+                t_win/n*1000, digits = 1) speedup=round(t_whole/t_win, digits = 2)
             # Bounding a ~3 kb read's decode to its <=500 bp hard windows is a large,
             # robust margin (~4-5x here); assert strict improvement.
             Test.@test t_win < t_whole
@@ -170,7 +173,8 @@ Test.@testset "windowed decode (td-nn6l Stage 3c)" begin
         clean_probe = FASTX.FASTQ.Record(
             "clean_probe", fx.ref[100:(100 + 199)], String(fill('I', 200)))
         Test.@test Mycelia.should_decode_read(clean_probe, k, hard) == false
-        rec, improved = Mycelia.improve_read_likelihood_windowed(
+        rec,
+        improved = Mycelia.improve_read_likelihood_windowed(
             clean_probe, graph, k, hard; graph_mode = mode, beam_width = typemax(Int))
         Test.@test improved == false
         Test.@test FASTX.sequence(String, rec) == fx.ref[100:(100 + 199)]
@@ -187,5 +191,69 @@ Test.@testset "windowed decode (td-nn6l Stage 3c)" begin
         Test.@test res.assembly_stats["hard_window"] == true
         skip = res.assembly_stats["skip_fraction"]
         Test.@test 0.0 < skip <= 1.0
+    end
+end
+
+# Composition plumbing for the INDEL pair-HMM through the windowed decode (td-jt7r).
+# The windowed decode now threads `indel_params` into each per-window sub-read decode
+# (so a hard window is corrected by the indel kernel, not substitution-only) and the
+# splice is generalized to a length-changing (indel) correction. This testset asserts
+# the PLUMBING is correct and oracle-preserving; it does NOT assert an end-to-end
+# nanopore correction WIN — that is gated on staging the (dense-graph-expensive) indel
+# decode to sparse rungs, tracked separately under td-jt7r.
+Test.@testset "windowed indel decode plumbing (td-jt7r)" begin
+    R = Mycelia.Rhizomorph
+    k = 13
+    mode = :doublestrand
+    fx = _wd_long_read_fixture()
+    graph = R.build_qualmer_graph(fx.reads, k; mode = mode)
+    hard = Mycelia._hard_vertex_set(graph, k)
+    Test.@test !isempty(hard)
+
+    profile = Mycelia.indel_error_profile(:nanopore)
+    ip = Mycelia.IndelDecodeParams(
+        profile.base_error_rate, profile.insertion_fraction, profile.deletion_fraction,
+        profile.insertion_extend_probability, profile.deletion_extend_probability,
+        3, 3, 16)
+
+    Logging.with_logger(Logging.NullLogger()) do
+        for r in fx.err_reads
+            # (1) ORACLE: passing indel_params=nothing is byte-identical to the default
+            # (no-kwarg) windowed decode — the substitution path is untouched.
+            rec_def, imp_def,
+            ndec_def,
+            ndiv_def = Mycelia.improve_read_likelihood_windowed_detail(
+                r, graph, k, hard; graph_mode = mode, beam_width = 64)
+            rec_nil, imp_nil,
+            ndec_nil,
+            ndiv_nil = Mycelia.improve_read_likelihood_windowed_detail(
+                r, graph, k, hard; graph_mode = mode, beam_width = 64, indel_params = nothing)
+            Test.@test FASTX.sequence(String, rec_nil) == FASTX.sequence(String, rec_def)
+            Test.@test FASTX.quality(rec_nil) == FASTX.quality(rec_def)
+            Test.@test (imp_nil, ndec_nil, ndiv_nil) == (imp_def, ndec_def, ndiv_def)
+
+            # (2) INDEL PLUMBING: the indel path reaches the kernel and returns a
+            # WELL-FORMED record (sequence and quality lengths agree, valid DNA), and
+            # the splice does not corrupt the read. The corrected length MAY differ
+            # from the input (a spliced indel correction) — that is allowed, unlike the
+            # substitution path which is length-preserving.
+            rec_ind, imp_ind,
+            ndec_ind,
+            ndiv_ind = Mycelia.improve_read_likelihood_windowed_detail(
+                r, graph, k, hard; graph_mode = mode, beam_width = 64, indel_params = ip)
+            sind = FASTX.sequence(String, rec_ind)
+            Test.@test length(sind) == length(FASTX.quality(rec_ind))
+            Test.@test all(c -> c in ('A', 'C', 'G', 'T'), sind)
+            Test.@test ndec_ind >= 1                       # at least one hard window decoded
+
+            # (3) LOCALITY: the solid prefix before the first hard window is copied
+            # verbatim from the original read (windowing only rewrites hard windows).
+            wins = Mycelia._hard_window_ranges(r, k, hard; pad = k, max_window = 500)
+            if !isempty(wins)
+                lo1 = first(first(wins))
+                orig = FASTX.sequence(String, r)
+                Test.@test sind[1:(lo1 - 1)] == orig[1:(lo1 - 1)]
+            end
+        end
     end
 end

--- a/test/4_assembly/windowed_decode_test.jl
+++ b/test/4_assembly/windowed_decode_test.jl
@@ -206,12 +206,17 @@ Test.@testset "windowed indel decode plumbing (td-jt7r)" begin
     k = 13
     mode = :doublestrand
 
-    Test.@testset "indel quality alignment preserves base coordinates" begin
-        align_quality = Mycelia._align_corrected_quality
-        Test.@test align_quality("ACGT", "BCDE", "ACGT") == "BCDE"
-        Test.@test align_quality("ACGT", "BCDE", "AGT") == "BDE"
-        Test.@test align_quality("ACGT", "BCDE", "ACGAT") == "BCDDE"
-        Test.@test_throws ArgumentError align_quality("ACGT", "BCD", "ACGT")
+    Test.@testset "pair-HMM traceback preserves quality coordinates" begin
+        traced_quality = Mycelia._quality_from_indel_trace
+        Test.@test traced_quality("BCDE", [:M, :M, :M], [1, 2, 3], 2, 4) == "BCDE"
+        # I consumes observed position 3 without emitting a corrected base.
+        Test.@test traced_quality("BCDE", [:M, :I, :M], [1, 2, 3], 2, 3) == "BCE"
+        # D emits a corrected base after observed position 3 with conservative
+        # adjacent quality min('D', 'E') == 'D'.
+        Test.@test traced_quality(
+            "BCDE", [:M, :M, :D, :M], [1, 2, 2, 3], 2, 5) == "BCDDE"
+        Test.@test traced_quality("BCDE", [:I], [1], 2, 3) === nothing
+        Test.@test traced_quality("BCDE", [:M], [1, 2], 2, 2) === nothing
     end
 
     # (A) POSITIVE CONTROL — the ORIGINAL-COORDINATE segment rebuild (the risky new

--- a/test/4_assembly/windowed_decode_test.jl
+++ b/test/4_assembly/windowed_decode_test.jl
@@ -205,54 +205,67 @@ Test.@testset "windowed indel decode plumbing (td-jt7r)" begin
     R = Mycelia.Rhizomorph
     k = 13
     mode = :doublestrand
-    fx = _wd_long_read_fixture()
-    graph = R.build_qualmer_graph(fx.reads, k; mode = mode)
-    hard = Mycelia._hard_vertex_set(graph, k)
-    Test.@test !isempty(hard)
 
-    profile = Mycelia.indel_error_profile(:nanopore)
-    ip = Mycelia.IndelDecodeParams(
-        profile.base_error_rate, profile.insertion_fraction, profile.deletion_fraction,
-        profile.insertion_extend_probability, profile.deletion_extend_probability,
-        3, 3, 16)
+    # (A) POSITIVE CONTROL — the ORIGINAL-COORDINATE segment rebuild (the risky new
+    # length-changing code) tested DIRECTLY against hand-computed expectations, so an
+    # off-by-one / dropped / duplicated base is caught independent of the decoder.
+    # Each `accepted` triple is (original-window-range, corrected-seq, corrected-qual);
+    # gaps between windows + the trailing span must be copied verbatim from the
+    # ORIGINAL, and a window's length change must NOT shift a later window's range.
+    Test.@testset "segment rebuild: length-changing / multi-window / edges" begin
+        splice = Mycelia._splice_indel_windows
+        # single INSERTION (window 5:8 "CCCC" -> "CCACC", +1) + trailing span preserved
+        r1 = splice("r", collect("AAAACCCCGGGGTTTT"), collect(repeat("I", 16)),
+            [(5:8, "CCACC", "IIIII")])
+        Test.@test FASTX.sequence(String, r1) == "AAAACCACCGGGGTTTT"
+        Test.@test FASTX.quality(r1) == repeat("I", 17)
+        # two windows, DELETION then INSERTION, empty prefix + interior gap + trailing.
+        # w2=9:12 uses ORIGINAL coords even though w1 shortened the read (the invariant).
+        r2 = splice("r", collect("AAAACCCCGGGGTTTT"), collect(repeat("I", 16)),
+            [(1:4, "AA", "II"), (9:12, "GGAGG", "IIIII")])
+        Test.@test FASTX.sequence(String, r2) == "AACCCCGGAGGTTTT"   # AA|CCCC|GGAGG|TTTT
+        Test.@test FASTX.quality(r2) == repeat("I", 15)
+        # whole-read window (no gaps, no trailing), shortened
+        r3 = splice("r", collect("AAAACCCC"), collect(repeat("I", 8)), [(
+            1:8, "AAACCC", "IIIIII")])
+        Test.@test FASTX.sequence(String, r3) == "AAACCC"
+        # adjacent windows separated by a single original base (the minimum post-merge gap)
+        r4 = splice("r", collect("ACGTACGT"), collect(repeat("I", 8)),
+            [(1:3, "AC", "II"), (5:7, "ACGT", "IIII")])
+        Test.@test FASTX.sequence(String, r4) == "ACTACGTT"          # AC|T|ACGT|T
+        Test.@test FASTX.quality(r4) == repeat("I", 8)
+    end
 
-    Logging.with_logger(Logging.NullLogger()) do
-        for r in fx.err_reads
-            # (1) ORACLE: passing indel_params=nothing is byte-identical to the default
-            # (no-kwarg) windowed decode — the substitution path is untouched.
-            rec_def, imp_def,
-            ndec_def,
-            ndiv_def = Mycelia.improve_read_likelihood_windowed_detail(
-                r, graph, k, hard; graph_mode = mode, beam_width = 64)
-            rec_nil, imp_nil,
-            ndec_nil,
-            ndiv_nil = Mycelia.improve_read_likelihood_windowed_detail(
-                r, graph, k, hard; graph_mode = mode, beam_width = 64, indel_params = nothing)
-            Test.@test FASTX.sequence(String, rec_nil) == FASTX.sequence(String, rec_def)
-            Test.@test FASTX.quality(rec_nil) == FASTX.quality(rec_def)
-            Test.@test (imp_nil, ndec_nil, ndiv_nil) == (imp_def, ndec_def, ndiv_def)
-
-            # (2) INDEL PLUMBING: the indel path reaches the kernel and returns a
-            # WELL-FORMED record (sequence and quality lengths agree, valid DNA), and
-            # the splice does not corrupt the read. The corrected length MAY differ
-            # from the input (a spliced indel correction) — that is allowed, unlike the
-            # substitution path which is length-preserving.
-            rec_ind, imp_ind,
-            ndec_ind,
-            ndiv_ind = Mycelia.improve_read_likelihood_windowed_detail(
-                r, graph, k, hard; graph_mode = mode, beam_width = 64, indel_params = ip)
-            sind = FASTX.sequence(String, rec_ind)
-            Test.@test length(sind) == length(FASTX.quality(rec_ind))
-            Test.@test all(c -> c in ('A', 'C', 'G', 'T'), sind)
-            Test.@test ndec_ind >= 1                       # at least one hard window decoded
-
-            # (3) LOCALITY: the solid prefix before the first hard window is copied
-            # verbatim from the original read (windowing only rewrites hard windows).
-            wins = Mycelia._hard_window_ranges(r, k, hard; pad = k, max_window = 500)
-            if !isempty(wins)
-                lo1 = first(first(wins))
-                orig = FASTX.sequence(String, r)
-                Test.@test sind[1:(lo1 - 1)] == orig[1:(lo1 - 1)]
+    # (B) INTEGRATION SMOKE — the indel path threads through the real decoder,
+    # returns a well-formed record, and only rewrites hard windows. (Substitution
+    # byte-identity is covered by the td-nn6l testset above; the E2E correction WIN
+    # is gated on staging the dense-graph-expensive decode to sparse rungs, td-2rxh.)
+    Test.@testset "indel path threads through the real decoder (well-formed + local)" begin
+        fx = _wd_long_read_fixture()
+        graph = R.build_qualmer_graph(fx.reads, k; mode = mode)
+        hard = Mycelia._hard_vertex_set(graph, k)
+        Test.@test !isempty(hard)
+        profile = Mycelia.indel_error_profile(:nanopore)
+        ip = Mycelia.IndelDecodeParams(
+            profile.base_error_rate, profile.insertion_fraction, profile.deletion_fraction,
+            profile.insertion_extend_probability, profile.deletion_extend_probability,
+            3, 3, 16)
+        Logging.with_logger(Logging.NullLogger()) do
+            for r in fx.err_reads
+                rec_ind, _imp,
+                ndec_ind,
+                _ndiv = Mycelia.improve_read_likelihood_windowed_detail(
+                    r, graph, k, hard; graph_mode = mode, beam_width = 64, indel_params = ip)
+                sind = FASTX.sequence(String, rec_ind)
+                Test.@test length(sind) == length(FASTX.quality(rec_ind))   # well-formed
+                Test.@test all(c -> c in ('A', 'C', 'G', 'T'), sind)
+                Test.@test ndec_ind >= 1                                    # a window reached decode
+                wins = Mycelia._hard_window_ranges(r, k, hard; pad = k, max_window = 500)
+                if !isempty(wins)
+                    lo1 = first(first(wins))
+                    orig = FASTX.sequence(String, r)
+                    Test.@test sind[1:(lo1 - 1)] == orig[1:(lo1 - 1)]       # locality
+                end
             end
         end
     end


### PR DESCRIPTION
## Summary

- The windowed decode (#378) predates the indel pair-HMM (#407/#408), so it decoded each hard window **substitution-only**. This threads `indel_params` into `improve_read_likelihood_windowed[_detail]` and its per-window sub-read decode, so a hard window is corrected by the indel kernel when the profile enables indels.
- Generalizes the window splice to a **length-changing** (indel) correction via an original-coordinate segment rebuild; the substitution path (`indel_params=nothing`) keeps the in-place length-preserving splice and is **byte-for-byte unchanged** (oracle preservation).
- **Composition plumbing only** — it does NOT yet deliver the end-to-end nanopore correction win. The indel decode is ~3s/read on the dense low-k graphs `:scalable` builds from error-laden reads, so the density gate still vetoes it. Staging the indel decode to sparse rungs (where it is affordable) is tracked under **td-2rxh** (epic td-jt7r).

## Test Plan

- [x] `windowed_decode_test.jl` — 23173 (substitution windowed path unchanged) + new **windowed indel plumbing** testset 57/57 (oracle byte-identity for `indel_params=nothing`, well-formed length-changing splice, locality)
- [x] Regression green: `reassembly_graph_reuse` (oracle 20/20), `rhizomorph_iterative_corrector_wiring`, `scalable_corrector_strategy` (42), `viterbi_indel_decoder` (56), `indel_profile_assembly` (44 incl E2E)

## Related

- Epic td-jt7r; follow-up td-2rxh (stage indel decode to sparse rungs — the E2E win)
- Builds on #378 (windowed decode), #407/#408 (indel pair-HMM)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added indel-aware Stage 3c windowed decoding, including support for insertions and deletions during correction.
  * Improved quality reconstruction for indel-based corrections so corrected reads keep consistent sequence/quality alignment.
  * Extended correction telemetry to report window divergence and indel decode activity.
* **Bug Fixes**
  * Fixed reassembly so earlier window length shifts no longer misplace later corrections.
  * In substitution mode, mismatched sequence/quality window outputs are safely discarded and counted as divergences.
* **Tests**
  * Added targeted unit and integration coverage for indel decode plumbing, splicing behavior, and diagnostics/move-trace validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->