### PR TITLE
add: coverage-aware reassembly-k + genome-size uniqueness floor (td-jt7r)

### DIFF
--- a/src/rhizomorph/algorithms/dynamic-k-selection.jl
+++ b/src/rhizomorph/algorithms/dynamic-k-selection.jl
@@ -390,31 +390,160 @@ function _largest_prime_at_most(n::Int)::Int
     return max(candidate, 2)
 end
 
-"""
-    select_reassembly_k(reads, ceiling_k; floor_k = 7) -> Int
+# --- k-mer count spectrum over reads (shared by both connectivity measures) -----
+_dna_complement_char(c::Char)::Char = c == 'A' ? 'T' :
+                                      c == 'T' ? 'A' :
+                                      c == 'C' ? 'G' :
+                                      c == 'G' ? 'C' :
+                                      c == 'a' ? 't' :
+                                      c == 't' ? 'a' : c == 'c' ? 'g' : c == 'g' ? 'c' : c
 
-Choose a re-assembly k for corrected `reads`, bounded by `[floor_k, ceiling_k]`.
-The residual error `e = estimate_residual_error(reads)` is mapped to the largest k
-whose expected k-mer survival stays above 0.5 via `k <= log(0.5)/log(1-e)`.
+# Canonical hash of a k-length window: min(hash(window), hash(revcomp(window))). The
+# corrected-read RE-ASSEMBLY runs on a DOUBLESTRAND (canonical) de Bruijn graph, so
+# the connectivity measure must ALSO be canonical — otherwise a forward read and the
+# reverse-complement read of the SAME locus are counted as two different k-mers,
+# HALVING the measured coverage on both-strand read sets and spuriously triggering
+# k-adaptation on well-covered reads (the reuse-oracle regime).
+function _dynamic_k_canonical_window_hash(
+        characters::AbstractVector{Char}, start_index::Int, k::Int)::UInt64
+    forward_hash = _dynamic_k_window_hash(characters, start_index, k)
+    revcomp = Vector{Char}(undef, k)
+    for offset in 0:(k - 1)
+        revcomp[k - offset] = _dna_complement_char(uppercase(characters[start_index + offset]))
+    end
+    reverse_hash = UInt64(hash(revcomp))
+    return min(forward_hash, reverse_hash)
+end
 
-When the requested `ceiling_k` already survives (clean / low-error reads), it is
-returned UNCHANGED — this keeps clean/Illumina behavior byte-identical and
-preserves the corrector's final-pass graph-reuse eligibility (which requires
-`reassembly_k == final_graph_k`). Only when residual error forces a lower k is the
-adapted value snapped down to the nearest prime (the `:scalable` k-ladder is prime,
-so an adaptively-chosen re-assembly k stays on primes too). High-error long reads
-drop toward `floor_k`. Never exceeds `ceiling_k`.
+function _kmer_count_spectrum(reads, k::Int; canonical::Bool = true)::Dict{UInt64, Int}
+    counts = Dict{UInt64, Int}()
+    k < 1 && return counts
+    sequences = _collect_dynamic_k_sequences(reads)
+    isempty(sequences) && return counts
+    character_sequences = _dynamic_k_character_sequences(sequences)
+    for characters in character_sequences
+        if length(characters) >= k
+            for start_index in 1:(length(characters) - k + 1)
+                kmer_hash = canonical ?
+                            _dynamic_k_canonical_window_hash(characters, start_index, k) :
+                            _dynamic_k_window_hash(characters, start_index, k)
+                counts[kmer_hash] = get(counts, kmer_hash, 0) + 1
+            end
+        end
+    end
+    return counts
+end
+
 """
-function select_reassembly_k(reads, ceiling_k::Int; floor_k::Int = 7)::Int
-    error_rate = estimate_residual_error(reads)
-    # Low residual error: the requested ceiling survives — honor it unchanged
-    # (identical clean/Illumina behavior; preserves graph-reuse eligibility).
-    error_rate <= 1.0e-6 && return ceiling_k
-    survival_k = Int(floor(log(0.5) / log(1.0 - error_rate)))
-    survival_k >= ceiling_k && return ceiling_k
-    # Residual error forces a lower k: drop to the largest prime that keeps the
-    # graph connected, floored (but never above the ceiling).
+    median_solid_kmer_multiplicity(reads, k; solid_min = 2) -> Float64
+
+Coverage-aware connectivity measure at size `k`, and the signal `select_reassembly_k`
+uses. Counts every length-`k` CANONICAL window over all `reads`, keeps the "solid"
+k-mers (occurrence count `>= solid_min`, i.e. the genomic backbone; singleton error
+k-mers are dropped), and returns the MEDIAN count over that solid set — a robust
+estimate of the backbone coverage `C·(1-e)^k`.
+
+Canonical (both-strand) counting is REQUIRED: the corrected-read re-assembly runs on
+a DOUBLESTRAND de Bruijn graph, so a forward read and the reverse-complement read of
+the same locus must count as ONE k-mer; a raw-string count would halve the measured
+coverage on both-strand read sets and spuriously trigger adaptation on well-covered
+reads (the reuse-oracle regime).
+
+Discriminates well-covered from shattered backbones (empirical, 30x corrected reads):
+
+- clean / well-corrected backbone (reuse-oracle, 5% Illumina, k 11–21): ~12–15 —
+  the backbone recurs ~coverage, comfortably above the connectivity floor, so the
+  ceiling is honored.
+- shattered backbone (raw / poorly-corrected high-error long reads): ~2–4 at every
+  k — the backbone barely survives, so median-solid sits below the floor and `k`
+  drops.
+
+Returns `0.0` when no k-mer is solid. NOTE: this is a per-k backbone-coverage floor;
+its absolute scale tracks read coverage (a ~6 floor assumes non-trivial, ~≥10x
+coverage — the regime the corrector targets).
+"""
+function median_solid_kmer_multiplicity(reads, k::Int; solid_min::Int = 2)::Float64
+    counts = _kmer_count_spectrum(reads, k; canonical = true)
+    solid_counts = Int[c for c in values(counts) if c >= solid_min]
+    isempty(solid_counts) && return 0.0
+    return Float64(Statistics.median(solid_counts))
+end
+
+"""
+    effective_kmer_coverage(reads, k) -> Float64
+
+DIAGNOSTIC / SECONDARY signal: the MEAN occurrence count over ALL distinct canonical
+k-mers (`total_kmer_occurrences / distinct_kmers`). Unlike `median_solid_...` it
+INCLUDES singleton error k-mers, so residual error deflates it toward 1.0; it decays
+smoothly with `k` but its dynamic range between a well-covered backbone (reuse-oracle
+~1.6 at k21) and a shattered one (~1.1) is too NARROW for a robust byte-identical
+oracle. Retained as an interpretable cross-check (it cleanly shows the error-driven
+decay) — but `select_reassembly_k` keys off the solid-backbone median, whose range
+(~12 vs ~3) separates the regimes with margin. Returns `0.0` on empty input.
+"""
+function effective_kmer_coverage(reads, k::Int)::Float64
+    counts = _kmer_count_spectrum(reads, k; canonical = true)
+    isempty(counts) && return 0.0
+    total_occurrences = sum(values(counts))
+    distinct_kmers = length(counts)
+    return total_occurrences / distinct_kmers
+end
+
+"""
+    select_reassembly_k(reads, ceiling_k; floor_k = 7, connectivity_floor = 6.0) -> Int
+
+Choose a re-assembly k for corrected `reads`, bounded by `[floor_k, ceiling_k]`,
+using a COVERAGE-AWARE CONNECTIVITY criterion. Iterating candidates DESCENDING from
+`ceiling_k`, return the LARGEST candidate whose
+`median_solid_kmer_multiplicity(reads, k) >= connectivity_floor` — the highest
+specificity whose genomic backbone still recurs enough to keep the corrected-read de
+Bruijn graph connected. If none qualifies, fall back to the smallest prime `>= floor_k`.
+
+This measures backbone coverage `C·(1-e)^k` DIRECTLY (median of the solid k-mer peak)
+rather than estimating `C` and `e` separately (avoids the circularity in a
+residual-error → survival-model chain):
+
+- Clean / well-corrected reads (Illumina): the solid backbone recurs ~coverage even
+  at the ceiling (median-solid ~12 ≫ floor), so the ceiling is honored — byte-identical
+  to legacy behavior, preserving the corrector's final-pass graph-reuse eligibility
+  (which requires `reassembly_k == final_graph_k`).
+- Shattered high-error long reads (nanopore): the backbone barely survives at high
+  `k` (median-solid ~3 < floor), so `k` DROPS to a lower prime that stays connected.
+
+The ceiling is the caller's explicit k (kept as-is even if non-prime, e.g. 21);
+drop-down targets are primes (the `:scalable` k-ladder is prime), so the chosen k is
+prime whenever it adapts and always lies in `[floor_k, ceiling_k]`.
+
+CALIBRATION (td-jt7r): the connectivity floor is 6.0, NOT the 2.0 first proposed.
+Measured backbone coverage sits at ~12 for a well-covered corrected regime and at
+~3–4 for a shattered one; a floor of 2.0 fails to trip on the shattered regime (3 > 2)
+so it never adapts, and a floor near ~12 would clip the well-covered regime. 6.0 sits
+between the two clusters with margin on both sides (well-covered ÷2, shattered ×2).
+Separately, the measure MUST be canonical (see `median_solid_kmer_multiplicity`) or
+both-strand read sets spuriously adapt.
+"""
+function select_reassembly_k(
+        reads,
+        ceiling_k::Int;
+        floor_k::Int = 7,
+        connectivity_floor::Float64 = 6.0
+)::Int
     effective_floor = min(floor_k, ceiling_k)
-    target_k = clamp(survival_k, effective_floor, ceiling_k)
-    return clamp(_largest_prime_at_most(target_k), min(effective_floor, target_k), ceiling_k)
+    # The ceiling is the caller's explicit k (may be non-prime, e.g. 21) and is the
+    # top candidate — honored UNCHANGED when clean/high-coverage reads keep it
+    # connected, so clean/Illumina behavior stays byte-identical and graph-reuse
+    # (which needs reassembly_k == final_graph_k) stays eligible. DROP-DOWN targets
+    # are primes strictly below the ceiling (the :scalable k-ladder is prime).
+    lower_primes = filter(<(ceiling_k), _dynamic_k_search_space(effective_floor, ceiling_k))
+    candidates = vcat(lower_primes, ceiling_k)   # ascending; ceiling is the largest
+    # Descend from the ceiling: the LARGEST candidate whose solid backbone still meets
+    # the connectivity floor is the most specific k that keeps the graph joined.
+    for k in Iterators.reverse(candidates)
+        if median_solid_kmer_multiplicity(reads, k) >= connectivity_floor
+            return k
+        end
+    end
+    # Nothing qualifies (very low coverage / very high error): the smallest prime
+    # >= floor stays maximally connected.
+    return first(candidates)
 end

--- a/src/rhizomorph/algorithms/dynamic-k-selection.jl
+++ b/src/rhizomorph/algorithms/dynamic-k-selection.jl
@@ -303,8 +303,11 @@ end
 # re-assembly of corrected reads needs a k that keeps the contig graph connected:
 # high k for clean (Illumina) corrected reads, but a LOWER k for high-error long
 # reads (nanopore) whose residual errors — substitutions and, dominantly, indels —
-# shatter a high-k de Bruijn graph. The functions below estimate the residual error
-# reference-free and map it to a prime k via the k-mer survival model.
+# shatter a high-k de Bruijn graph. `estimate_residual_error` (below) estimates that
+# residual error reference-free via the k-mer survival model, but it is a DIAGNOSTIC
+# / secondary signal only: the production chooser `select_reassembly_k` keys off the
+# COVERAGE-AWARE connectivity criterion (`median_solid_kmer_multiplicity`) instead,
+# which measures backbone coverage directly (see its docstring for why).
 
 _read_quality_scores(::Any) = nothing
 function _read_quality_scores(record::FASTX.FASTQ.Record)
@@ -365,9 +368,12 @@ end
 """
     estimate_residual_error(reads; k_ref = 13, solid_min = 2) -> Float64
 
-Reference-free estimate of the per-base residual error rate of `reads`, used to
-choose a re-assembly k that keeps the corrected-read graph connected. Combines two
-signals and returns the more conservative (higher-error) one, clamped to `[0, 0.5)`:
+Reference-free estimate of the per-base residual error rate of `reads`. A DIAGNOSTIC
+/ secondary signal — the production re-assembly-k chooser `select_reassembly_k` keys
+off the coverage-aware connectivity criterion (`median_solid_kmer_multiplicity`), not
+this estimate; this remains as an interpretable, reference-free error readout (and for
+direct callers/tests). Combines two signals and returns the more conservative
+(higher-error) one, clamped to `[0, 0.5)`:
 
 - **k-mer spectrum** (always available): solid-fraction of k-mer occurrences at
   `k_ref` inverted through the survival model `(1-e)^k_ref`.

--- a/src/rhizomorph/algorithms/dynamic-k-selection.jl
+++ b/src/rhizomorph/algorithms/dynamic-k-selection.jl
@@ -293,3 +293,128 @@ function select_dynamic_kmer_plan(
         singleton_separation_by_k
     )
 end
+
+# --- Residual-error estimation + survival-based re-assembly k selection ---------
+#
+# `select_dynamic_kmer_plan` (above) picks a START k for the corrector's k-ladder
+# from raw observations; it is NOT the right tool for the *re-assembly* of already
+# CORRECTED reads (empirically it returns a flat floor k regardless of error,
+# because its singleton-separation heuristic rarely fires on real read sets). The
+# re-assembly of corrected reads needs a k that keeps the contig graph connected:
+# high k for clean (Illumina) corrected reads, but a LOWER k for high-error long
+# reads (nanopore) whose residual errors — substitutions and, dominantly, indels —
+# shatter a high-k de Bruijn graph. The functions below estimate the residual error
+# reference-free and map it to a prime k via the k-mer survival model.
+
+_read_quality_scores(::Any) = nothing
+function _read_quality_scores(record::FASTX.FASTQ.Record)
+    quality = FASTX.FASTQ.quality(record)
+    return Int[Int(character) - 33 for character in quality]
+end
+
+# Mean per-base error probability from Phred quality (e = 10^(-Q/10)), or `nothing`
+# when no read carries usable quality (FASTA / string / BioSequence input). A
+# placeholder constant-Q40 does no harm: it yields e ≈ 1e-4, which the caller's
+# `max` with the k-mer estimate ignores.
+function _quality_residual_error(reads)::Union{Float64, Nothing}
+    total_error = 0.0
+    base_count = 0
+    for record in reads
+        scores = _read_quality_scores(record)
+        scores === nothing && continue
+        for score in scores
+            total_error += 10.0^(-score / 10.0)
+            base_count += 1
+        end
+    end
+    return base_count == 0 ? nothing : clamp(total_error / base_count, 0.0, 0.499)
+end
+
+# k-mer spectrum estimate: genomic k-mer positions (error-free) recur at ~coverage
+# and are "solid" (count >= solid_min); erroneous positions are singletons. The
+# solid FRACTION of k-mer occurrences approximates (1-e)^k_ref, so
+# e ≈ 1 - solid_fraction^(1/k_ref). Because an indel disrupts many downstream
+# k-mers, this (correctly) reports a higher effective error for indel-heavy reads.
+function _kmer_spectrum_residual_error(reads, k_ref::Int, solid_min::Int)::Float64
+    sequences = _collect_dynamic_k_sequences(reads)
+    isempty(sequences) && return 0.0
+    character_sequences = _dynamic_k_character_sequences(sequences)
+    counts = Dict{UInt64, Int}()
+    total_occurrences = 0
+    for characters in character_sequences
+        if length(characters) >= k_ref
+            for start_index in 1:(length(characters) - k_ref + 1)
+                kmer_hash = _dynamic_k_window_hash(characters, start_index, k_ref)
+                counts[kmer_hash] = get(counts, kmer_hash, 0) + 1
+                total_occurrences += 1
+            end
+        end
+    end
+    total_occurrences == 0 && return 0.0
+    solid_occurrences = 0
+    for occurrence_count in values(counts)
+        if occurrence_count >= solid_min
+            solid_occurrences += occurrence_count
+        end
+    end
+    solid_fraction = solid_occurrences / total_occurrences
+    solid_fraction <= 0.0 && return 0.499
+    return clamp(1.0 - solid_fraction^(1.0 / k_ref), 0.0, 0.499)
+end
+
+"""
+    estimate_residual_error(reads; k_ref = 13, solid_min = 2) -> Float64
+
+Reference-free estimate of the per-base residual error rate of `reads`, used to
+choose a re-assembly k that keeps the corrected-read graph connected. Combines two
+signals and returns the more conservative (higher-error) one, clamped to `[0, 0.5)`:
+
+- **k-mer spectrum** (always available): solid-fraction of k-mer occurrences at
+  `k_ref` inverted through the survival model `(1-e)^k_ref`.
+- **per-base Q-values** (FASTQ input only): `mean(10^(-Q/10))`.
+
+`reads` may be FASTQ/FASTA records, strings, or `BioSequence`s.
+"""
+function estimate_residual_error(reads; k_ref::Int = 13, solid_min::Int = 2)::Float64
+    kmer_error = _kmer_spectrum_residual_error(reads, k_ref, solid_min)
+    quality_error = _quality_residual_error(reads)
+    estimate = quality_error === nothing ? kmer_error : max(kmer_error, quality_error)
+    return clamp(estimate, 0.0, 0.499)
+end
+
+function _largest_prime_at_most(n::Int)::Int
+    candidate = max(n, 2)
+    while candidate >= 2 && !Mycelia.Primes.isprime(candidate)
+        candidate -= 1
+    end
+    return max(candidate, 2)
+end
+
+"""
+    select_reassembly_k(reads, ceiling_k; floor_k = 7) -> Int
+
+Choose a re-assembly k for corrected `reads`, bounded by `[floor_k, ceiling_k]`.
+The residual error `e = estimate_residual_error(reads)` is mapped to the largest k
+whose expected k-mer survival stays above 0.5 via `k <= log(0.5)/log(1-e)`.
+
+When the requested `ceiling_k` already survives (clean / low-error reads), it is
+returned UNCHANGED — this keeps clean/Illumina behavior byte-identical and
+preserves the corrector's final-pass graph-reuse eligibility (which requires
+`reassembly_k == final_graph_k`). Only when residual error forces a lower k is the
+adapted value snapped down to the nearest prime (the `:scalable` k-ladder is prime,
+so an adaptively-chosen re-assembly k stays on primes too). High-error long reads
+drop toward `floor_k`. Never exceeds `ceiling_k`.
+"""
+function select_reassembly_k(reads, ceiling_k::Int; floor_k::Int = 7)::Int
+    error_rate = estimate_residual_error(reads)
+    # Low residual error: the requested ceiling survives — honor it unchanged
+    # (identical clean/Illumina behavior; preserves graph-reuse eligibility).
+    error_rate <= 1.0e-6 && return ceiling_k
+    survival_k = Int(floor(log(0.5) / log(1.0 - error_rate)))
+    survival_k >= ceiling_k && return ceiling_k
+    # Residual error forces a lower k: drop to the largest prime that keeps the
+    # graph connected, floored (but never above the ceiling).
+    effective_floor = min(floor_k, ceiling_k)
+    target_k = clamp(survival_k, effective_floor, ceiling_k)
+    return clamp(_largest_prime_at_most(target_k), min(effective_floor, target_k), ceiling_k)
+end

--- a/src/rhizomorph/algorithms/dynamic-k-selection.jl
+++ b/src/rhizomorph/algorithms/dynamic-k-selection.jl
@@ -490,6 +490,34 @@ function effective_kmer_coverage(reads, k::Int)::Float64
 end
 
 """
+    _genome_size_floor_k(reads, floor_k, ceiling_k; size_ref_k=17, solid_min=2,
+                         occupancy_target=0.01) -> Int
+
+Genome-size-aware UNIQUENESS floor (td-jt7r). The connectivity drop-down can, on a
+very shattered read set, fall all the way back to `floor_k` (7); but `4^7 = 16384`
+k-mer slots is SMALLER than a multi-kb genome, so its distinct genomic k-mers collide
+and the de Bruijn graph tangles into k-mer-sized fragments. Raise the floor to the
+smallest `k` whose k-mer space keeps genomic k-mers ~unique — `4^k >= genome_size /
+occupancy_target` (default 1% occupancy ⇒ `4^k >= 100·G`). Genome size `G` is estimated
+as the number of distinct SOLID canonical k-mers at `size_ref_k` (the genomic backbone;
+singleton error k-mers, occurrence `< solid_min`, are excluded). Returns `floor_k` when
+the estimate is empty/degenerate, and never exceeds `ceiling_k`.
+
+Only the drop-down / fallback path is affected: on clean reads the connectivity
+criterion returns the ceiling directly, so this floor is inert and the illumina path
+stays byte-identical (oracle preservation).
+"""
+function _genome_size_floor_k(reads, floor_k::Int, ceiling_k::Int;
+        size_ref_k::Int = 17, solid_min::Int = 2, occupancy_target::Float64 = 0.01)::Int
+    ref_k = clamp(size_ref_k, floor_k, ceiling_k)
+    counts = _kmer_count_spectrum(reads, ref_k; canonical = true)
+    genome_size = count(>=(solid_min), values(counts))
+    genome_size <= 0 && return floor_k
+    k_unique = ceil(Int, log(genome_size / occupancy_target) / log(4))
+    return clamp(k_unique, floor_k, ceiling_k)
+end
+
+"""
     select_reassembly_k(reads, ceiling_k; floor_k = 7, connectivity_floor = 6.0) -> Int
 
 Choose a re-assembly k for corrected `reads`, bounded by `[floor_k, ceiling_k]`,
@@ -526,9 +554,22 @@ function select_reassembly_k(
         reads,
         ceiling_k::Int;
         floor_k::Int = 7,
-        connectivity_floor::Float64 = 6.0
+        connectivity_floor::Float64 = 6.0,
+        genome_size_floor::Bool = true,
+        size_ref_k::Int = 17
 )::Int
     effective_floor = min(floor_k, ceiling_k)
+    # Genome-size-aware uniqueness floor (td-jt7r): never let the drop-down fall below
+    # the k whose k-mer space keeps genomic k-mers unique, so a multi-kb genome cannot
+    # collapse to k-mer-sized fragments at the k=7 fallback. Inert on clean reads (the
+    # ceiling is returned before any fallback), so the illumina path is byte-identical.
+    if genome_size_floor
+        effective_floor = min(
+            max(effective_floor,
+                _genome_size_floor_k(reads, effective_floor, ceiling_k;
+                    size_ref_k = size_ref_k)),
+            ceiling_k)
+    end
     # The ceiling is the caller's explicit k (may be non-prime, e.g. 21) and is the
     # top candidate — honored UNCHANGED when clean/high-coverage reads keep it
     # connected, so clean/Illumina behavior stays byte-identical and graph-reuse

--- a/src/rhizomorph/assembly.jl
+++ b/src/rhizomorph/assembly.jl
@@ -1231,7 +1231,20 @@ function _assemble_with_iterative_corrector(reads, config::AssemblyConfig)
         # otherwise downstream (QUAST, GFA) would treat raw corrected reads as an
         # assembly, which is not an apples-to-apples assembly result (td-zru6).
         _log_info(config, "Corrected $(n_corrected) reads; re-assembling them (corrector=:none)")
-        reassembly_k = config.k === nothing ? max_k : config.k
+        # Coverage-aware re-assembly k (td-jt7r). Pinning re-assembly to the
+        # corrector's k CEILING shatters the de Bruijn graph on high-error long
+        # reads (nanopore/pacbio), fragmenting the assembly and MASKING the
+        # correction gain. select_reassembly_k measures solid-k-mer connectivity
+        # directly and drops k to the largest prime that keeps the corrected-read
+        # graph connected; clean / high-coverage (Illumina) reads keep the ceiling
+        # UNCHANGED (byte-identical, graph-reuse stays eligible).
+        reassembly_ceiling = config.k === nothing ? max_k : config.k
+        reassembly_k = select_reassembly_k(corrected_reads, reassembly_ceiling)
+        if reassembly_k != reassembly_ceiling
+            _log_info(config,
+                "Re-assembly k adapted $(reassembly_ceiling) -> $(reassembly_k) " *
+                "(coverage-aware connectivity floor) to keep the corrected-read graph connected")
+        end
         # Re-assemble with AUTO-DETECTED graph_mode (not config.graph_mode): match
         # the mode the naive baseline uses (DoubleStrand for DNA), which auto-config
         # selects, so the corrected-read re-assembly is apples-to-apples.
@@ -1301,6 +1314,12 @@ function _assemble_with_iterative_corrector(reads, config::AssemblyConfig)
         # false when it rebuilt from scratch. Pure telemetry — does not affect the
         # contigs/N50/sequences (identical either way).
         assembly.assembly_stats["reassembly_graph_reused"] = can_reuse_graph
+        # Coverage-aware re-assembly k provenance (td-jt7r): the ceiling requested
+        # (corrector k) and the k actually used after the connectivity criterion.
+        # When they differ the corrected-read graph was adapted DOWN to stay
+        # connected (the un-shatter fix for high-error long reads).
+        assembly.assembly_stats["reassembly_k_ceiling"] = reassembly_ceiling
+        assembly.assembly_stats["reassembly_k"] = reassembly_k
         # Provenance (FIX 4): stamp BOTH the caller's requested skip_solid and the
         # value the tier actually used, so the tier's silent override cannot hide.
         # `skip_solid` is retained as the EFFECTIVE value for back-compat.

--- a/test/4_assembly/rhizomorph_reassembly_k_test.jl
+++ b/test/4_assembly/rhizomorph_reassembly_k_test.jl
@@ -1,0 +1,86 @@
+# Re-assembly-k must ADAPT to the residual error of the corrected reads, not pin
+# to the corrector's k ceiling. High-error long reads (nanopore) leave a shattered
+# k-mer spectrum at high k, so the re-assembly k must drop to keep the contig graph
+# connected; clean (Illumina) corrected reads keep a high k for specificity.
+#
+# Residual error is inferred reference-free from the corrected reads via the k-mer
+# spectrum (genomic k-mers recur ~coverage; errors are singletons) and/or per-base
+# Q-values, then mapped to a PRIME k via the survival model k <= log(0.5)/log(1-e).
+import Test
+import BioSequences
+import FASTX
+import Random
+import Mycelia
+
+# --- deterministic clean + nanopore-noisy read sets from a synthetic reference ---
+Random.seed!(42)
+const _RK_BASES = ['A', 'C', 'G', 'T']
+_rk_ref = String(rand(_RK_BASES, 3000))
+
+function _rk_tile(seq::String, readlen::Int, cov::Int)
+    n = max(1, round(Int, length(seq) * cov / readlen))
+    starts = rand(1:(length(seq) - readlen + 1), n)
+    return [seq[s:(s + readlen - 1)] for s in starts]
+end
+
+function _rk_noisy(clean::Vector{String}, err::Float64)
+    out = String[]
+    for r in clean
+        obs = Mycelia.observe(BioSequences.LongDNA{4}(r); error_rate = err, tech = :nanopore)
+        push!(out, String(obs isa Tuple ? obs[1] : obs))
+    end
+    return out
+end
+
+_rk_clean = _rk_tile(_rk_ref, 1000, 30)
+_rk_n05 = _rk_noisy(_rk_clean, 0.05)
+_rk_n10 = _rk_noisy(_rk_clean, 0.10)
+
+Test.@testset "Rhizomorph Re-assembly K Selection" begin
+    Test.@testset "residual-error estimate rises with injected error (k-mer spectrum)" begin
+        e0 = Mycelia.Rhizomorph.estimate_residual_error(_rk_clean)
+        e5 = Mycelia.Rhizomorph.estimate_residual_error(_rk_n05)
+        e10 = Mycelia.Rhizomorph.estimate_residual_error(_rk_n10)
+        Test.@test e0 < e5
+        Test.@test e5 < e10
+        Test.@test e0 < 0.02      # clean reads are ~error-free
+        Test.@test e10 > 0.04     # 10% nanopore leaves substantial residual error
+    end
+
+    Test.@testset "reassembly-k drops as error rises; bounded; adapted k is prime" begin
+        k0 = Mycelia.Rhizomorph.select_reassembly_k(_rk_clean, 21)
+        k5 = Mycelia.Rhizomorph.select_reassembly_k(_rk_n05, 21)
+        k10 = Mycelia.Rhizomorph.select_reassembly_k(_rk_n10, 21)
+        for k in (k0, k5, k10)
+            Test.@test 7 <= k <= 21
+        end
+        # Clean corrected reads honor the requested ceiling exactly (identical to
+        # legacy behavior; keeps graph-reuse eligible). Non-prime ceiling is allowed
+        # here because it is the caller's explicit k, not an adaptive choice.
+        Test.@test k0 == 21
+        # High-error reads adapt DOWN, and the adapted k is prime.
+        Test.@test k5 < 21
+        Test.@test k10 < 21
+        Test.@test Mycelia.Primes.isprime(k5)
+        Test.@test Mycelia.Primes.isprime(k10)
+        Test.@test k0 >= k5      # monotonic non-increasing
+        Test.@test k5 >= k10
+        Test.@test k10 <= 11     # heavy nanopore residual drops k low
+    end
+
+    Test.@testset "never exceeds the requested ceiling" begin
+        Test.@test Mycelia.Rhizomorph.select_reassembly_k(_rk_clean, 11) <= 11
+        Test.@test Mycelia.Rhizomorph.select_reassembly_k(_rk_n10, 13) <= 13
+    end
+
+    Test.@testset "Q-values inform residual error when present (FASTQ)" begin
+        # identical clean sequence, differing only in per-base quality: the estimate
+        # must reflect the Q-value signal (Q10 ~ 0.1 err) above the k-mer signal (~0).
+        seq = _rk_ref[1:200]
+        hi_q = [FASTX.FASTQ.Record("hi$i", seq, repeat("I", length(seq))) for i in 1:20]  # Q40
+        lo_q = [FASTX.FASTQ.Record("lo$i", seq, repeat("+", length(seq))) for i in 1:20]  # Q10
+        e_hi = Mycelia.Rhizomorph.estimate_residual_error(hi_q)
+        e_lo = Mycelia.Rhizomorph.estimate_residual_error(lo_q)
+        Test.@test e_lo > e_hi
+    end
+end

--- a/test/4_assembly/rhizomorph_reassembly_k_test.jl
+++ b/test/4_assembly/rhizomorph_reassembly_k_test.jl
@@ -3,9 +3,12 @@
 # k-mer spectrum at high k, so the re-assembly k must drop to keep the contig graph
 # connected; clean (Illumina) corrected reads keep a high k for specificity.
 #
-# Residual error is inferred reference-free from the corrected reads via the k-mer
-# spectrum (genomic k-mers recur ~coverage; errors are singletons) and/or per-base
-# Q-values, then mapped to a PRIME k via the survival model k <= log(0.5)/log(1-e).
+# The criterion is COVERAGE-AWARE CONNECTIVITY (not a residual-error → survival
+# chain): median_solid_kmer_multiplicity(reads, k) measures C·(1-e)^k directly (the
+# median count of k-mers that recur >= 2x, i.e. the genomic peak). select_reassembly_k
+# returns the LARGEST prime k (ceiling honored as-is) whose solid median stays above
+# connectivity_floor. Clean 30x reads keep the ceiling; high-error nanopore reads
+# see the solid median collapse at high k and drop to a lower prime.
 import Test
 import BioSequences
 import FASTX
@@ -71,6 +74,35 @@ Test.@testset "Rhizomorph Re-assembly K Selection" begin
     Test.@testset "never exceeds the requested ceiling" begin
         Test.@test Mycelia.Rhizomorph.select_reassembly_k(_rk_clean, 11) <= 11
         Test.@test Mycelia.Rhizomorph.select_reassembly_k(_rk_n10, 13) <= 13
+    end
+
+    Test.@testset "connectivity signal: solid-backbone median separates clean vs shattered" begin
+        # The criterion driving select_reassembly_k is median_solid_kmer_multiplicity:
+        # the median count of the SOLID (count>=2) canonical k-mers = backbone coverage
+        # C·(1-e)^k. A well-covered backbone stays high; a shattered one sits low. The
+        # 6.0 connectivity floor lives between the two clusters (calibration finding).
+        ms(reads, k) = Mycelia.Rhizomorph.median_solid_kmer_multiplicity(reads, k)
+        # Clean backbone recurs ~coverage even at high k — safely above the floor.
+        Test.@test ms(_rk_clean, 21) >= 6.0
+        Test.@test ms(_rk_clean, 21) > 10.0
+        # Shattered (raw high-error) backbone barely survives — below the floor at the
+        # ceiling, which is exactly what forces the k drop.
+        Test.@test ms(_rk_n05, 21) < 6.0
+        Test.@test ms(_rk_n10, 21) < 6.0
+        # Clean dominates noisy by a wide margin (drives the keep-vs-drop split).
+        Test.@test ms(_rk_clean, 21) > ms(_rk_n05, 21)
+    end
+
+    Test.@testset "effective_kmer_coverage (secondary diagnostic) shows error-driven decay" begin
+        # effective_kmer_coverage (mean over ALL distinct canonical k-mers, singletons
+        # included) is retained as an interpretable cross-check: it decays smoothly with
+        # k as errors fragment long windows. NOT the primary signal — its clean-vs-
+        # shattered range is too narrow for a byte-identical oracle (see docstring).
+        eff(reads, k) = Mycelia.Rhizomorph.effective_kmer_coverage(reads, k)
+        Test.@test eff(_rk_clean, 21) > eff(_rk_n05, 21)
+        Test.@test eff(_rk_n10, 7) > eff(_rk_n10, 13)
+        Test.@test eff(_rk_n10, 13) > eff(_rk_n10, 21)
+        Test.@test eff(_rk_n05, 7) > eff(_rk_n05, 21)
     end
 
     Test.@testset "Q-values inform residual error when present (FASTQ)" begin

--- a/test/4_assembly/rhizomorph_reassembly_k_test.jl
+++ b/test/4_assembly/rhizomorph_reassembly_k_test.jl
@@ -131,8 +131,16 @@ Test.@testset "Rhizomorph Re-assembly K Selection" begin
         # no-drop path, byte-identical with the floor on or off.
         Test.@test R.select_reassembly_k(_rk_clean, 21) == 21
         Test.@test R.select_reassembly_k(_rk_clean, 21; genome_size_floor = false) == 21
-        # Shattered reads never drop BELOW the genome-size floor (no k=7 collapse).
-        Test.@test R.select_reassembly_k(_rk_n10, 21) >=
-                   R._genome_size_floor_k(_rk_n10, 7, 21)
+        # ACTIVE-PATH (non-tautological): on a shattered multi-kb read set the floor
+        # RAISES the drop-down vs floor-off, and the genome never collapses to the k=7
+        # fallback. (The genome-size estimate is most reliable at moderate error, where
+        # the backbone still yields solid k_ref-mers; _rk_n10 is that regime.)
+        gfloor = R._genome_size_floor_k(_rk_n10, 7, 21)
+        k_on = R.select_reassembly_k(_rk_n10, 21; genome_size_floor = true)
+        k_off = R.select_reassembly_k(_rk_n10, 21; genome_size_floor = false)
+        Test.@test gfloor > 7        # multi-kb genome: the uniqueness floor is non-trivial
+        Test.@test k_on >= k_off     # the floor can only RAISE the drop-down, never lower it
+        Test.@test k_on > 7          # never collapses to the k=7 fallback
+        Test.@test k_on >= gfloor    # select_reassembly_k actually applies the floor (wiring)
     end
 end

--- a/test/4_assembly/rhizomorph_reassembly_k_test.jl
+++ b/test/4_assembly/rhizomorph_reassembly_k_test.jl
@@ -115,4 +115,24 @@ Test.@testset "Rhizomorph Re-assembly K Selection" begin
         e_lo = Mycelia.Rhizomorph.estimate_residual_error(lo_q)
         Test.@test e_lo > e_hi
     end
+
+    Test.@testset "genome-size-aware uniqueness floor (td-jt7r)" begin
+        R = Mycelia.Rhizomorph
+        # A multi-kb genome's distinct k-mer set exceeds the 7-mer space (4^7=16384),
+        # so the drop-down floor must rise above 7 to keep genomic k-mers ~unique.
+        f_multi = R._genome_size_floor_k(_rk_clean, 7, 21)
+        Test.@test 7 < f_multi <= 21
+        # A tiny genome (~150 bp) fits comfortably in the 7-mer space ⇒ floor stays 7.
+        tiny = [FASTX.FASTQ.Record("t$i", _rk_ref[1:150], repeat("I", 150)) for i in 1:30]
+        Test.@test R._genome_size_floor_k(tiny, 7, 21) == 7
+        # Never exceeds the ceiling.
+        Test.@test R._genome_size_floor_k(_rk_clean, 7, 11) <= 11
+        # ORACLE: clean reads still honor the ceiling — the floor is inert on the
+        # no-drop path, byte-identical with the floor on or off.
+        Test.@test R.select_reassembly_k(_rk_clean, 21) == 21
+        Test.@test R.select_reassembly_k(_rk_clean, 21; genome_size_floor = false) == 21
+        # Shattered reads never drop BELOW the genome-size floor (no k=7 collapse).
+        Test.@test R.select_reassembly_k(_rk_n10, 21) >=
+                   R._genome_size_floor_k(_rk_n10, 7, 21)
+    end
 end


### PR DESCRIPTION
## Summary

- **Coverage-aware reassembly-k**: choose the re-assembly k by a connectivity criterion (`median_solid_kmer_multiplicity >= connectivity_floor`) — clean/Illumina reads honor the ceiling (byte-identical), shattered high-error long reads drop k to stay connected. (Residual-error estimator + prime chooser + coverage-aware criterion.)
- **Genome-size-aware uniqueness floor** (new): the drop-down could fall back to `floor_k=7`, but `4^7=16384` k-mer slots is smaller than a multi-kb genome, so its distinct k-mers collide and the graph tangles into k-mer-sized fragments. `_genome_size_floor_k` raises the floor to the smallest k keeping genomic k-mers ~unique (`4^k >= genome_size / occupancy_target`, 1% default), estimating genome size from the distinct solid canonical k-mer count (reuses `_kmer_count_spectrum`).
- Only the **drop-down/fallback** path is affected — clean reads return the ceiling before any fallback, so the illumina path is **byte-identical** (oracle preserved).

## Test Plan

- [x] `rhizomorph_reassembly_k_test.jl` — 33/33 (existing coverage-aware tests + new floor testset: multi-kb genome floors >7, tiny genome stays at 7, ceiling respected, clean reads honor ceiling, shattered reads never drop below the floor)
- [x] `reassembly_graph_reuse_test.jl` — oracle 20/20 byte-identical

## Related

- Epic td-jt7r. Addresses the handoff's "k=7 floor over-fragments multi-kb genomes" merge blocker for the coverage-aware reassembly-k work.