### PR TITLE
add: hybrid-OLC long-read arm (flye/metaflye/canu/hifiasm) + taxonomy single-source (td-wvto)

### DIFF
--- a/src/rhizomorph/assembly.jl
+++ b/src/rhizomorph/assembly.jl
@@ -314,8 +314,11 @@ struct AssemblyConfig
 
         # Validation: sequencing_tech must be a recognized error profile (validate
         # unconditionally so a typo is caught at construction, even for
-        # corrector=:none where it is not consulted).
-        _valid_seq_techs = (:illumina, :nanopore, :pacbio, :ultima)
+        # corrector=:none where it is not consulted). Derived from the OLC taxonomy
+        # so the short/long partition `:auto` resolution depends on stays a single
+        # source of truth — adding a tech in one place can't silently mislabel it.
+        _seq_tax = _olc_taxonomy()
+        _valid_seq_techs = (_seq_tax.short_read_techs..., _seq_tax.long_read_techs...)
         if !(sequencing_tech in _valid_seq_techs)
             error("sequencing_tech must be one of $(_valid_seq_techs), got :$(sequencing_tech)")
         end
@@ -444,7 +447,8 @@ struct AssemblyConfig
             # that collides with a route-managed keyword would redirect the assembler
             # (wrong output dir → broken cleanup + megahit's recursive rm; wrong fastq
             # → bypasses the Stage-1 corrected handoff). Reject those keys up front.
-            _reserved_olc_keys = (:fastq1, :fastq2, :fastq, :outdir, :out_dir, :executor)
+            _reserved_olc_keys = (:fastq1, :fastq2, :fastq, :outdir, :out_dir,
+                :executor, :read_type)
             for _k in keys(olc_options)
                 _k in _reserved_olc_keys && error("olc_options key :$(_k) is managed by " *
                       "the hybrid-OLC route and cannot be overridden; drop it from olc_options.")
@@ -1990,11 +1994,13 @@ end
 
 Single source of truth for the hybrid-OLC tool taxonomy: which sequencing techs
 are short- vs long-read, and which external assemblers serve each class. The
-constructor validation, `:auto` resolution, and the per-tool adapter all read from
-THIS table so they cannot drift out of sync. (Drift is exactly what let a stale
-`:metaflye` branch masquerade as "wired" before td-yymj's review.) The consistency
-test in `hybrid_olc_config_test.jl` asserts every tool here is handled by
-`_run_olc_tool`.
+constructor validation (`_valid_seq_techs`, `:auto` resolution) and the per-tool
+adapter all read from THIS table so they cannot drift out of sync. (Drift is
+exactly what let a stale `:metaflye` branch masquerade as "wired" before td-yymj's
+review.) The "taxonomy single-source" test in `hybrid_olc_config_test.jl` asserts
+`:auto` resolves to a member of the wired-tool set for every valid tech, and that
+`_run_olc_tool` rejects a tool not in it. (A stronger test iterating every wired
+tool through `_run_olc_tool` needs an external-wrapper stub — a follow-up.)
 """
 function _olc_taxonomy()
     return (
@@ -2023,10 +2029,37 @@ end
     _flye_read_type(sequencing_tech::Symbol) -> String
 
 Map the corrector's read tech to a Flye/metaFlye `--read-type` flag. The reads are
-Stage-1 corrector output, so the error-corrected (`-corr`) profiles fit.
+Stage-1 corrector output, so the error-corrected (`-corr`) profiles fit. NOTE this
+means a native PacBio-HiFi set is assembled as `pacbio-corr`, not `pacbio-hifi` —
+`:pacbio` does not distinguish HiFi from CLR (finer tech granularity is a
+follow-up). Fails loud on an unexpected tech rather than silently defaulting.
 """
 function _flye_read_type(sequencing_tech::Symbol)
-    sequencing_tech == :nanopore ? "nano-corr" : "pacbio-corr"
+    if sequencing_tech == :nanopore
+        return "nano-corr"
+    elseif sequencing_tech == :pacbio
+        return "pacbio-corr"
+    else
+        error("_flye_read_type: unexpected sequencing_tech :$(sequencing_tech) " *
+              "(expected :nanopore or :pacbio).")
+    end
+end
+
+"""
+    _canu_read_type(sequencing_tech::Symbol) -> String
+
+Canu's coarse read-type flag (`nanopore` | `pacbio`). Fails loud on an unexpected
+tech rather than silently defaulting to PacBio.
+"""
+function _canu_read_type(sequencing_tech::Symbol)
+    if sequencing_tech == :nanopore
+        return "nanopore"
+    elseif sequencing_tech == :pacbio
+        return "pacbio"
+    else
+        error("_canu_read_type: unexpected sequencing_tech :$(sequencing_tech) " *
+              "(expected :nanopore or :pacbio).")
+    end
 end
 
 """
@@ -2041,45 +2074,39 @@ assemblers take a single `fastq` plus a read-type flag derived from
 than a return field; Flye/metaFlye/Canu return their assembly under `.assembly`.
 
 `config.olc_options` is splatted in FIRST so the route's managed keywords
-(`fastq1`/`fastq`/`outdir`) always win over a caller-supplied option — Julia
-resolves duplicate keywords rightmost-wins, so managed keys must come last. (The
-constructor also rejects reserved keys, but this ordering keeps the invariant even
-if that guard is ever relaxed.)
+(`fastq1`/`fastq`/`outdir`/`read_type`) always win over a caller-supplied option —
+Julia resolves duplicate keywords rightmost-wins, so managed keys must come last.
+(The constructor also rejects reserved keys — incl. `:read_type` — but this
+ordering keeps the invariant even if that guard is ever relaxed.)
 """
 function _run_olc_tool(tool::Symbol, corrected_fastq::AbstractString,
         outdir::AbstractString, config::AssemblyConfig)::String
+    fastq = String(corrected_fastq)
+    out = String(outdir)
     if tool == :megahit
-        result = Mycelia.run_megahit(; config.olc_options...,
-            fastq1 = corrected_fastq, outdir = outdir)
+        result = Mycelia.run_megahit(; config.olc_options..., fastq1 = fastq, outdir = out)
         return result.contigs
     elseif tool == :metaspades
-        result = Mycelia.run_metaspades(; config.olc_options...,
-            fastq1 = corrected_fastq, outdir = outdir)
+        result = Mycelia.run_metaspades(; config.olc_options..., fastq1 = fastq, outdir = out)
         return result.contigs
     elseif tool == :flye
-        result = Mycelia.run_flye(; config.olc_options...,
-            fastq = String(corrected_fastq), outdir = String(outdir),
+        result = Mycelia.run_flye(; config.olc_options..., fastq = fastq, outdir = out,
             read_type = _flye_read_type(config.sequencing_tech))
         return result.assembly
     elseif tool == :metaflye
-        result = Mycelia.run_metaflye(; config.olc_options...,
-            fastq = String(corrected_fastq), outdir = String(outdir),
+        result = Mycelia.run_metaflye(; config.olc_options..., fastq = fastq, outdir = out,
             read_type = _flye_read_type(config.sequencing_tech))
         return result.assembly
     elseif tool == :canu
-        # canu's read_type is coarse (pacbio|nanopore); genome_size comes from
-        # olc_options (required — the constructor validated its presence).
-        canu_read_type = config.sequencing_tech == :nanopore ? "nanopore" : "pacbio"
-        result = Mycelia.run_canu(; config.olc_options...,
-            fastq = String(corrected_fastq), outdir = String(outdir),
-            read_type = canu_read_type)
+        # genome_size comes from olc_options (required — constructor-validated).
+        result = Mycelia.run_canu(; config.olc_options..., fastq = fastq, outdir = out,
+            read_type = _canu_read_type(config.sequencing_tech))
         return result.assembly
     elseif tool == :hifiasm
-        result = Mycelia.run_hifiasm(; config.olc_options...,
-            fastq = String(corrected_fastq), outdir = String(outdir))
+        result = Mycelia.run_hifiasm(; config.olc_options..., fastq = fastq, outdir = out)
         contigs = Mycelia.hifiasm_primary_contigs(result)
         contigs === nothing && error("_run_olc_tool: hifiasm produced no primary " *
-              "contigs (.p_ctg.fa) in $(outdir)")
+              "contigs (.p_ctg.fa) in $(out)")
         return contigs
     else
         _tax = _olc_taxonomy()

--- a/src/rhizomorph/assembly.jl
+++ b/src/rhizomorph/assembly.jl
@@ -207,11 +207,10 @@ struct AssemblyConfig
 
     # Which external assembler the `:olc` layout dispatches to. `:auto` (default)
     # picks by read type (sequencing_tech): short-read techs (:illumina, :ultima)
-    # → a short-read layout assembler, long-read techs (:nanopore, :pacbio) → a
-    # long-read assembler. An explicit tool must match the corrected read type.
-    # This PR wires only the SHORT-read arm (:megahit, :metaspades); long-read tools
-    # (:hifiasm/:flye/:canu/:metaflye) and long-read :auto are validated-but-rejected
-    # at construction until the long-read arm lands (td-wvto).
+    # → :megahit, long-read techs (:nanopore, :pacbio) → :flye. Explicit tools:
+    # short-read :megahit/:metaspades (td-yymj), long-read :flye/:metaflye/:canu/
+    # :hifiasm (td-wvto). An explicit tool must match the corrected read type
+    # (hifiasm is PacBio-HiFi only; canu also needs an olc_options genome_size).
     olc_tool::Symbol
 
     # Pass-through options forwarded to the external-assembler wrapper (e.g.
@@ -396,13 +395,13 @@ struct AssemblyConfig
         if !(layout in (:native, :olc))
             error("layout must be :native or :olc, got :$(layout)")
         end
-        # Read-type <-> tool taxonomy. sequencing_tech is the read-type proxy:
-        # short-read techs run short-read layout assemblers, long-read techs run
-        # long-read assemblers (design doc "Read-type mapping").
-        _short_read_techs = (:illumina, :ultima)
-        _short_read_tools = (:megahit, :metaspades)
-        _long_read_tools = (:hifiasm, :flye, :canu, :metaflye)
-        _valid_olc_tools = (:auto, _short_read_tools..., _long_read_tools...)
+        # Read-type <-> tool taxonomy from the SINGLE source of truth (_olc_taxonomy).
+        # sequencing_tech is the read-type proxy: short-read techs run short-read
+        # layout assemblers, long-read techs run long-read assemblers (design doc
+        # "Read-type mapping"). Both arms are wired (short-read td-yymj, long-read
+        # td-wvto).
+        _tax = _olc_taxonomy()
+        _valid_olc_tools = (:auto, _tax.short_read_tools..., _tax.long_read_tools...)
         if layout == :olc
             # An OLC layout with no correction is just the plain external assembler,
             # reachable via the wrapper directly — the route exists to compose Stage-1
@@ -415,25 +414,31 @@ struct AssemblyConfig
             if !(olc_tool in _valid_olc_tools)
                 error("olc_tool must be one of $(_valid_olc_tools), got :$(olc_tool)")
             end
-            is_short = sequencing_tech in _short_read_techs
+            is_short = sequencing_tech in _tax.short_read_techs
             if olc_tool == :auto
-                # :auto resolves by read type; only the short-read resolution is wired
-                # in this PR (td-yymj). A long-read tech would resolve to a long-read
-                # assembler (td-wvto), so reject it up front.
-                is_short ||
-                    error("olc_tool=:auto with sequencing_tech=:$(sequencing_tech) " *
-                          "resolves to a long-read assembler, which is not yet wired in the OLC " *
-                          "route (see td-wvto). Use a short-read sequencing_tech (:illumina/:ultima) " *
-                          "or await the long-read arm.")
-            elseif olc_tool in _short_read_tools
+                # :auto always resolves to a WIRED tool (short-read tech → :megahit,
+                # long-read tech → :flye), so no rejection is needed here.
+                nothing
+            elseif olc_tool in _tax.short_read_tools
                 is_short || error("olc_tool=:$(olc_tool) is a short-read assembler but " *
                       "sequencing_tech=:$(sequencing_tech) is a long-read tech; pair a short-read " *
                       "tool with a short-read tech.")
-            elseif olc_tool in _long_read_tools
-                # Long-read tools are validated as known but NOT yet wired here.
-                error("olc_tool=:$(olc_tool) (long-read assembler) is not yet wired in the " *
-                      "OLC route; this PR (td-yymj) wires the short-read arm (:megahit, " *
-                      ":metaspades). The long-read arm is tracked in td-wvto.")
+            elseif olc_tool in _tax.long_read_tools
+                sequencing_tech in _tax.long_read_techs ||
+                    error("olc_tool=:$(olc_tool) is a " *
+                          "long-read assembler but sequencing_tech=:$(sequencing_tech) is a short-read " *
+                          "tech; pair a long-read tool with :nanopore or :pacbio.")
+                # hifiasm assembles PacBio HiFi reads specifically — not Nanopore.
+                if olc_tool == :hifiasm && sequencing_tech != :pacbio
+                    error("olc_tool=:hifiasm assembles PacBio HiFi reads; " *
+                          "sequencing_tech=:$(sequencing_tech) is not HiFi. Use :flye or :canu " *
+                          "for :nanopore.")
+                end
+                # canu requires an estimated genome size (the wrapper has no default).
+                if olc_tool == :canu && !haskey(olc_options, :genome_size)
+                    error("olc_tool=:canu requires an estimated genome size; pass it via " *
+                          "olc_options=(; genome_size=\"5m\").")
+                end
             end
             # Reserved-key guard: olc_options is splatted into the wrapper, so a key
             # that collides with a route-managed keyword would redirect the assembler
@@ -1933,8 +1938,9 @@ after reading the contigs; when the caller supplied `output_dir`, both are left 
 place under it. Dispatched only via `assemble_genome` when `config.layout == :olc`
 (the constructor guarantees that implies `corrector == :iterative`).
 
-Only the short-read arm (:megahit/:metaspades) is reachable in this PR; the
-long-read arm is gated off at construction until td-wvto.
+Both arms are wired: short-read (:megahit/:metaspades, td-yymj) and long-read
+(:flye/:metaflye/:canu/:hifiasm, td-wvto), routed by sequencing_tech. The
+two-read-set hybrid arm (short+long combined) is td-06er.
 """
 function _assemble_hybrid_olc(reads, config::AssemblyConfig)
     tool = _resolve_olc_tool(config)
@@ -1980,35 +1986,65 @@ function _assemble_hybrid_olc(reads, config::AssemblyConfig)
 end
 
 """
+    _olc_taxonomy() -> NamedTuple
+
+Single source of truth for the hybrid-OLC tool taxonomy: which sequencing techs
+are short- vs long-read, and which external assemblers serve each class. The
+constructor validation, `:auto` resolution, and the per-tool adapter all read from
+THIS table so they cannot drift out of sync. (Drift is exactly what let a stale
+`:metaflye` branch masquerade as "wired" before td-yymj's review.) The consistency
+test in `hybrid_olc_config_test.jl` asserts every tool here is handled by
+`_run_olc_tool`.
+"""
+function _olc_taxonomy()
+    return (
+        short_read_techs = (:illumina, :ultima),
+        long_read_techs = (:nanopore, :pacbio),
+        short_read_tools = (:megahit, :metaspades),
+        long_read_tools = (:flye, :metaflye, :canu, :hifiasm)
+    )
+end
+
+"""
     _resolve_olc_tool(config::AssemblyConfig) -> Symbol
 
 Resolve `config.olc_tool` to a concrete external assembler. An explicit tool is
 returned as-is (the constructor already validated it against `sequencing_tech`).
-`:auto` picks by read type; the constructor guarantees `:auto` is only reachable
-for a short-read tech in this PR, so it resolves to `:megahit` (the single-end-
-robust short-read layout assembler). Long-read `:auto` resolution lands with the
-long-read arm (td-wvto).
+`:auto` picks by read type: a short-read tech → `:megahit` (single-end-robust
+short-read layout), a long-read tech → `:flye` (general long-read assembler that
+handles both Nanopore and PacBio via its read-type flag).
 """
 function _resolve_olc_tool(config::AssemblyConfig)
     config.olc_tool == :auto || return config.olc_tool
-    return :megahit
+    return config.sequencing_tech in _olc_taxonomy().short_read_techs ? :megahit : :flye
+end
+
+"""
+    _flye_read_type(sequencing_tech::Symbol) -> String
+
+Map the corrector's read tech to a Flye/metaFlye `--read-type` flag. The reads are
+Stage-1 corrector output, so the error-corrected (`-corr`) profiles fit.
+"""
+function _flye_read_type(sequencing_tech::Symbol)
+    sequencing_tech == :nanopore ? "nano-corr" : "pacbio-corr"
 end
 
 """
     _run_olc_tool(tool, corrected_fastq, outdir, config) -> contigs_fasta_path::String
 
 Per-tool argument adapter: the external-assembler wrappers have non-uniform
-signatures, so map each WIRED `tool` onto its wrapper call and return the path to
-its primary-contigs FASTA. This PR wires the short-read arm (`:megahit`,
-`:metaspades`); the long-read arm (metaFlye et al.) lands in td-wvto. The corrector
-emits a SINGLE corrected FASTQ, so short-read assemblers run in single-end mode
-(`fastq1` only).
+signatures, so map each wired `tool` onto its wrapper call and return the path to
+its primary-contigs FASTA. Short-read assemblers (`:megahit`, `:metaspades`) take
+`fastq1` (single-end — the corrector emits ONE corrected FASTQ); long-read
+assemblers take a single `fastq` plus a read-type flag derived from
+`sequencing_tech`. hifiasm exposes contigs via `hifiasm_primary_contigs` rather
+than a return field; Flye/metaFlye/Canu return their assembly under `.assembly`.
 
 `config.olc_options` is splatted in FIRST so the route's managed keywords
-(`fastq1`/`outdir`) always win over a caller-supplied option — Julia resolves
-duplicate keywords rightmost-wins, so managed keys must come last. (The constructor
-also rejects reserved keys, but this ordering keeps the invariant even if that
-guard is ever relaxed.)
+(`fastq1`/`fastq`/`outdir`) always win over a caller-supplied option — Julia
+resolves duplicate keywords rightmost-wins, so managed keys must come last. (The
+constructor also rejects reserved keys, but this ordering keeps the invariant even
+if that guard is ever relaxed.)
 """
 function _run_olc_tool(tool::Symbol, corrected_fastq::AbstractString,
         outdir::AbstractString, config::AssemblyConfig)::String
@@ -2020,9 +2056,35 @@ function _run_olc_tool(tool::Symbol, corrected_fastq::AbstractString,
         result = Mycelia.run_metaspades(; config.olc_options...,
             fastq1 = corrected_fastq, outdir = outdir)
         return result.contigs
+    elseif tool == :flye
+        result = Mycelia.run_flye(; config.olc_options...,
+            fastq = String(corrected_fastq), outdir = String(outdir),
+            read_type = _flye_read_type(config.sequencing_tech))
+        return result.assembly
+    elseif tool == :metaflye
+        result = Mycelia.run_metaflye(; config.olc_options...,
+            fastq = String(corrected_fastq), outdir = String(outdir),
+            read_type = _flye_read_type(config.sequencing_tech))
+        return result.assembly
+    elseif tool == :canu
+        # canu's read_type is coarse (pacbio|nanopore); genome_size comes from
+        # olc_options (required — the constructor validated its presence).
+        canu_read_type = config.sequencing_tech == :nanopore ? "nanopore" : "pacbio"
+        result = Mycelia.run_canu(; config.olc_options...,
+            fastq = String(corrected_fastq), outdir = String(outdir),
+            read_type = canu_read_type)
+        return result.assembly
+    elseif tool == :hifiasm
+        result = Mycelia.run_hifiasm(; config.olc_options...,
+            fastq = String(corrected_fastq), outdir = String(outdir))
+        contigs = Mycelia.hifiasm_primary_contigs(result)
+        contigs === nothing && error("_run_olc_tool: hifiasm produced no primary " *
+              "contigs (.p_ctg.fa) in $(outdir)")
+        return contigs
     else
-        error("_run_olc_tool: :$(tool) is not wired; expected :megahit or " *
-              ":metaspades (the short-read arm). Long-read tools are tracked in td-wvto.")
+        _tax = _olc_taxonomy()
+        error("_run_olc_tool: :$(tool) is not a wired OLC tool; expected one of " *
+              "$((_tax.short_read_tools..., _tax.long_read_tools...)).")
     end
 end
 

--- a/test/4_assembly/hybrid_olc_config_test.jl
+++ b/test/4_assembly/hybrid_olc_config_test.jl
@@ -57,25 +57,44 @@ Test.@testset "hybrid-OLC route (a) config + routing (td-yymj)" begin
             corrector = :iterative, strategy = :scalable, layout = :olc,
             olc_tool = :megahit, sequencing_tech = :nanopore)
 
-        # Long-read tools are not wired in this PR (td-wvto): rejected at construction.
-        for tool in (:hifiasm, :flye, :canu, :metaflye)
-            Test.@test_throws ErrorException R.AssemblyConfig(; k = 13,
-                corrector = :iterative, strategy = :scalable, layout = :olc,
-                olc_tool = tool, sequencing_tech = :pacbio)
+        # Long-read tools (td-wvto) are accepted with a compatible long-read tech.
+        for (tool, tech, opts) in ((:flye, :nanopore, (;)), (:flye, :pacbio, (;)),
+            (:metaflye, :nanopore, (;)), (:hifiasm, :pacbio, (;)),
+            (:canu, :pacbio, (; genome_size = "5m")))
+            cfg = R.AssemblyConfig(; k = 13, corrector = :iterative,
+                strategy = :scalable, layout = :olc, olc_tool = tool,
+                sequencing_tech = tech, olc_options = opts)
+            Test.@test cfg.olc_tool == tool
         end
 
-        # :auto with a long-read tech resolves to a not-yet-wired long-read assembler.
+        # Long-read tool with a short-read tech is a mismatch.
         Test.@test_throws ErrorException R.AssemblyConfig(; k = 13,
             corrector = :iterative, strategy = :scalable, layout = :olc,
-            olc_tool = :auto, sequencing_tech = :nanopore)
+            olc_tool = :flye, sequencing_tech = :illumina)
+
+        # hifiasm is PacBio-HiFi-specific: a Nanopore tech is rejected.
+        Test.@test_throws ErrorException R.AssemblyConfig(; k = 13,
+            corrector = :iterative, strategy = :scalable, layout = :olc,
+            olc_tool = :hifiasm, sequencing_tech = :nanopore)
+
+        # canu requires an estimated genome_size in olc_options.
+        Test.@test_throws ErrorException R.AssemblyConfig(; k = 13,
+            corrector = :iterative, strategy = :scalable, layout = :olc,
+            olc_tool = :canu, sequencing_tech = :pacbio)  # no genome_size → error
     end
 
     Test.@testset ":auto tool resolution" begin
-        # :auto resolves to :megahit for a short-read tech.
-        cfg_auto = R.AssemblyConfig(; k = 13, corrector = :iterative,
+        # :auto resolves to :megahit for a short-read tech, :flye for a long-read tech.
+        cfg_short = R.AssemblyConfig(; k = 13, corrector = :iterative,
             strategy = :scalable, layout = :olc, olc_tool = :auto,
             sequencing_tech = :illumina)
-        Test.@test R._resolve_olc_tool(cfg_auto) == :megahit
+        Test.@test R._resolve_olc_tool(cfg_short) == :megahit
+        for tech in (:nanopore, :pacbio)
+            cfg_long = R.AssemblyConfig(; k = 13, corrector = :iterative,
+                strategy = :scalable, layout = :olc, olc_tool = :auto,
+                sequencing_tech = tech)
+            Test.@test R._resolve_olc_tool(cfg_long) == :flye
+        end
 
         # An explicit tool passes through unchanged.
         cfg_ms = R.AssemblyConfig(; k = 13, corrector = :iterative,
@@ -84,13 +103,22 @@ Test.@testset "hybrid-OLC route (a) config + routing (td-yymj)" begin
         Test.@test R._resolve_olc_tool(cfg_ms) == :metaspades
     end
 
-    Test.@testset "adapter guard for unwired tools" begin
+    Test.@testset "taxonomy single-source + adapter guard" begin
+        tax = R._olc_taxonomy()
+        wired = (tax.short_read_tools..., tax.long_read_tools...)
+        # :auto resolves to a WIRED tool for every valid tech (no drift between the
+        # taxonomy, the resolver, and the reject-list).
+        for tech in (tax.short_read_techs..., tax.long_read_techs...)
+            cfg = R.AssemblyConfig(; k = 13, corrector = :iterative,
+                strategy = :scalable, layout = :olc, olc_tool = :auto,
+                sequencing_tech = tech)
+            Test.@test R._resolve_olc_tool(cfg) in wired
+        end
+        # An unknown tool fails loud in the adapter (guards a routing bug reaching
+        # _run_olc_tool with a tool that has no wrapper branch).
         cfg = R.AssemblyConfig(; k = 13, corrector = :iterative,
             strategy = :scalable, layout = :olc, sequencing_tech = :illumina)
-        # _run_olc_tool only wires :megahit / :metaspades; anything else fails loud
-        # rather than silently doing nothing (guards against a future routing bug
-        # reaching the adapter with a long-read tool before td-wvto lands).
-        Test.@test_throws ErrorException R._run_olc_tool(:flye, "unused.fastq",
+        Test.@test_throws ErrorException R._run_olc_tool(:bogus_tool, "unused.fastq",
             mktempdir(), cfg)
     end
 

--- a/test/4_assembly/hybrid_olc_config_test.jl
+++ b/test/4_assembly/hybrid_olc_config_test.jl
@@ -106,8 +106,11 @@ Test.@testset "hybrid-OLC route (a) config + routing (td-yymj)" begin
     Test.@testset "taxonomy single-source + adapter guard" begin
         tax = R._olc_taxonomy()
         wired = (tax.short_read_tools..., tax.long_read_tools...)
-        # :auto resolves to a WIRED tool for every valid tech (no drift between the
-        # taxonomy, the resolver, and the reject-list).
+        # This testset verifies what it can WITHOUT external tools: (1) :auto
+        # resolves to a member of the wired-tool set for every valid tech, and
+        # (2) _run_olc_tool rejects a tool not in the taxonomy. (A stronger check
+        # that every wired tool has a live _run_olc_tool branch needs a wrapper
+        # stub — a follow-up.)
         for tech in (tax.short_read_techs..., tax.long_read_techs...)
             cfg = R.AssemblyConfig(; k = 13, corrector = :iterative,
                 strategy = :scalable, layout = :olc, olc_tool = :auto,
@@ -120,6 +123,30 @@ Test.@testset "hybrid-OLC route (a) config + routing (td-yymj)" begin
             strategy = :scalable, layout = :olc, sequencing_tech = :illumina)
         Test.@test_throws ErrorException R._run_olc_tool(:bogus_tool, "unused.fastq",
             mktempdir(), cfg)
+
+        # read-type mappers: pure functions, deterministic, cover the pacbio path
+        # the gated flye run never exercises. Fail loud on an unexpected tech.
+        Test.@test R._flye_read_type(:nanopore) == "nano-corr"
+        Test.@test R._flye_read_type(:pacbio) == "pacbio-corr"
+        Test.@test_throws ErrorException R._flye_read_type(:illumina)
+        Test.@test R._canu_read_type(:nanopore) == "nanopore"
+        Test.@test R._canu_read_type(:pacbio) == "pacbio"
+        Test.@test_throws ErrorException R._canu_read_type(:illumina)
+
+        # Partition invariant (single source of truth): the corrector's accepted
+        # techs are exactly the taxonomy's short ∪ long, so :auto can never see a
+        # tech the resolver/read-type maps don't classify.
+        Test.@test Set((tax.short_read_techs..., tax.long_read_techs...)) ==
+                   Set((:illumina, :ultima, :nanopore, :pacbio))
+    end
+
+    Test.@testset "read_type is a reserved olc_options key" begin
+        # read_type is route-managed (derived from sequencing_tech) — a caller
+        # cannot override it via olc_options.
+        Test.@test_throws ErrorException R.AssemblyConfig(; k = 13,
+            corrector = :iterative, strategy = :scalable, layout = :olc,
+            olc_tool = :flye, sequencing_tech = :nanopore,
+            olc_options = (; read_type = "nano-hq"))
     end
 
     Test.@testset "discoverability + incompatibility warnings" begin

--- a/test/4_assembly/third_party_assemblers_hybrid_olc_route.jl
+++ b/test/4_assembly/third_party_assemblers_hybrid_olc_route.jl
@@ -88,5 +88,34 @@ Test.@testset "hybrid-OLC route (a) end-to-end (td-yymj)" begin
                 Test.@test isdir(joinpath(outdir, "olc_megahit"))
             end
         end
+
+        # Long-read arm (td-wvto): corrected Nanopore reads -> Flye via :auto. Flye
+        # needs a larger genome + more coverage than the short-read toy, so use a
+        # fresh ~50 kb reference and 40x simulated Nanopore reads.
+        mktempdir() do lrdir
+            lrng = StableRNGs.StableRNG(7)
+            lr_genome = BioSequences.randdnaseq(lrng, 50_000)
+            lr_ref = joinpath(lrdir, "lr_ref.fasta")
+            Mycelia.write_fasta(outfile = lr_ref,
+                records = [FASTX.FASTA.Record("lr_ref", lr_genome)])
+            lr_gz = Mycelia.simulate_nanopore_reads(fasta = lr_ref,
+                quantity = "40x", quiet = true, seed = 7)
+            lr_reads = collect(Mycelia.open_fastx(lr_gz))
+            Test.@test !isempty(lr_reads)
+
+            Test.@testset "layout=:olc olc_tool=:auto (nanopore -> flye)" begin
+                config = R.AssemblyConfig(; k = 13, corrector = :iterative,
+                    strategy = :scalable, sequencing_tech = :nanopore,
+                    layout = :olc, olc_tool = :auto,  # :auto -> :flye for long-read
+                    olc_options = (; threads = threads))
+                asm = R.assemble_genome(lr_reads, config)
+                Test.@test asm isa R.AssemblyResult
+                Test.@test asm.gfa_compatible == false
+                Test.@test !isempty(asm.contigs)
+                Test.@test asm.assembly_stats["olc_tool"] == "flye"
+                Test.@test asm.assembly_stats["sequencing_tech"] == "nanopore"
+                Test.@test asm.assembly_stats["corrected_read_count"] > 0
+            end
+        end
     end
 end


### PR DESCRIPTION
## Summary

- **Work-breakdown item #2b** (long-read arm) of the hybrid-OLC deconvolution route. Wires corrected **Nanopore/PacBio** reads → an external long-read assembler, completing the route (a) tool set alongside the short-read arm (#410).
- **Single source of truth** `_olc_taxonomy()` (tech classes + tool classes). The constructor validation, `:auto` resolution, and the `_run_olc_tool` adapter all read from it — paying down the duplicated-taxonomy drift risk two reviewers flagged on #410 (the drift that had let a stale `:metaflye` branch masquerade as "wired"). A test asserts the taxonomy stays the single source.
- **Long-read adapter branches** with correct wrapper calls: `run_flye`/`run_metaflye` (`fastq` + `read_type` via `_flye_read_type` → `.assembly`), `run_canu` (`genome_size` from `olc_options` → `.assembly`), `run_hifiasm` (`hifiasm_primary_contigs`). `olc_options` still splatted-first so route-managed keys win.
- `_resolve_olc_tool`: `:auto` → `:megahit` (short-read tech) / `:flye` (long-read tech).
- Constructor validation: long-read tools accepted for long-read techs; long/short tool↔tech mismatch rejected; **hifiasm restricted to PacBio HiFi**; **canu requires an `olc_options` genome_size**.

## Test Plan

- [x] **Un-gated config test** `hybrid_olc_config_test.jl` — **38/38** (default CI): long-read tool acceptance, tool↔tech compatibility, hifiasm-PacBio-only + canu-genome_size validation, `:auto`→`:flye` resolution, taxonomy single-source + adapter guard.
- [x] **Native equivalence unchanged** (the validation refactor is behavior-neutral for the native path): graph-reuse **20/20**, corrector wiring **17/17**.
- [x] **Gated long-read end-to-end** `third_party_assemblers_hybrid_olc_route.jl` (`MYCELIA_RUN_EXTERNAL=true`) — the `nanopore -> flye` arm ran locally: **6/6**, real **Flye 2.9.6** on 50 kb / 40× corrected Nanopore reads → `assembly.fasta`.

**Note:** the gated test's **megahit** short-read arms intermittently segfault on Apple Silicon (`megahit_core exit -11` — a known megahit CPU-dispatch flakiness, not this route's code; they passed 16/16 on #410 and run fine on Linux CI/HPC).

## Related

- Design: `docs/design/2026-07-hybrid-olc-deconvolution-route.md` route (a), "Read-type mapping"
- Depends on: #410 (td-yymj, the config surface + short-read arm) and #409 (td-ohob, the `_run_stage1_correction` seam)
- Follow-on: td-06er (dual-input hybrid arm), td-yehe (paired-end metaSPAdes + insert-size QC), td-6jwl (validation harness)