### PR TITLE
add: calibrate per-base correction confidence

### DIFF
--- a/benchmarking/calibration_metrics.jl
+++ b/benchmarking/calibration_metrics.jl
@@ -21,6 +21,26 @@
 # measure CALIBRATION and require `confidences` already mapped to [0,1]
 # probabilities (fit a Platt/isotonic map first for a raw signal).
 
+function _validate_probability_inputs(confidences::AbstractVector{<:Real},
+        labels::AbstractVector{Bool})::Nothing
+    length(confidences) == length(labels) ||
+        throw(ArgumentError("confidences and labels must have equal length"))
+    all(isfinite, confidences) ||
+        throw(ArgumentError("confidences must be finite"))
+    all(confidence -> 0.0 <= confidence <= 1.0, confidences) ||
+        throw(ArgumentError("confidences must lie in [0, 1]"))
+    return nothing
+end
+
+function _stable_sigmoid(linear_predictor::Real)::Float64
+    z = Float64(linear_predictor)
+    isfinite(z) || throw(ArgumentError("logistic linear predictor must be finite"))
+    probability = z >= 0.0 ? 1.0 / (1.0 + exp(-z)) : exp(z) / (1.0 + exp(z))
+    isfinite(probability) ||
+        throw(ArgumentError("logistic probability must be finite"))
+    return probability
+end
+
 """
     reliability_bins(confidences, labels; nbins=10) -> Vector{NamedTuple}
 
@@ -32,8 +52,7 @@ every bin.
 """
 function reliability_bins(confidences::AbstractVector{<:Real},
         labels::AbstractVector{Bool}; nbins::Int = 10)
-    length(confidences) == length(labels) ||
-        throw(ArgumentError("confidences and labels must have equal length"))
+    _validate_probability_inputs(confidences, labels)
     nbins >= 1 || throw(ArgumentError("nbins must be >= 1"))
     edges = range(0.0, 1.0; length = nbins + 1)
     out = NamedTuple[]
@@ -61,9 +80,9 @@ ECE = sum over bins of (bin_count / N) * |bin_accuracy - bin_mean_confidence|.
 """
 function expected_calibration_error(confidences::AbstractVector{<:Real},
         labels::AbstractVector{Bool}; nbins::Int = 10)
+    bins = reliability_bins(confidences, labels; nbins = nbins)
     n = length(confidences)
     n == 0 && return NaN
-    bins = reliability_bins(confidences, labels; nbins = nbins)
     return sum(bin.count / n * abs(bin.accuracy - bin.mean_conf) for bin in bins; init = 0.0)
 end
 
@@ -98,10 +117,9 @@ label is 1.0 for true / 0.0 for false. 0 is best; combines calibration and
 refinement. Requires `confidences` in [0,1].
 """
 function brier_score(confidences::AbstractVector{<:Real}, labels::AbstractVector{Bool})
+    _validate_probability_inputs(confidences, labels)
     n = length(confidences)
     n == 0 && return NaN
-    length(confidences) == length(labels) ||
-        throw(ArgumentError("confidences and labels must have equal length"))
     return sum((confidences[i] - (labels[i] ? 1.0 : 0.0))^2 for i in 1:n) / n
 end
 
@@ -180,41 +198,33 @@ end
 
 Fit a Platt-style single-feature logistic probability map
 `P(true | score) = 1 / (1 + exp(-(a + b*score)))` by gradient descent on the
-standardized score, folded back to raw-score space. Returns `(a, b)` — the
-raw-space intercept and slope. Mirrors the standardize→fit→unfold structure of
-the repo's `fit_logistic_fusion`, but with a single feature and no Mycelia
-dependency. Two parameters, strictly monotone, so it inverts cleanly to a single
-raw gap cutoff (see `logistic_gap_for_probability`).
+standardized score, folded back to raw-score space. Returns `(a, b)` with the
+raw-space intercept and slope. Set `return_diagnostics=true` to additionally
+return convergence, final-loss, gradient, and regularization diagnostics
+without changing the default model schema. Mirrors the standardize→fit→unfold
+structure of the repo's `fit_logistic_fusion`, but with a single feature and no
+Mycelia dependency. Two parameters, strictly monotone, so it inverts cleanly to
+a single raw gap cutoff (see `logistic_gap_for_probability`).
 """
 function fit_logistic_map(scores::AbstractVector{<:Real},
-        labels::AbstractVector{Bool}; iters::Int = 500, lr::Float64 = 0.1)::NamedTuple
+        labels::AbstractVector{Bool}; iters::Int = 500, lr::Float64 = 0.1,
+        l2::Float64 = 0.0,
+        gradient_tolerance::Float64 = 1.0e-8,
+        return_diagnostics::Bool = false)::NamedTuple
     length(scores) == length(labels) ||
         throw(ArgumentError("scores and labels must have equal length"))
     isempty(scores) && throw(ArgumentError("scores and labels must be non-empty"))
     all(isfinite, scores) || throw(ArgumentError("scores must be finite"))
-    x = Float64.(scores)
-    y = [l ? 1.0 : 0.0 for l in labels]
-    n = length(x)
-    μ = sum(x) / n
-    σ = sqrt(max(sum((xi - μ)^2 for xi in x) / n, eps()))
-    z = (x .- μ) ./ σ
-    α = 0.0
-    β = 0.0
-    for _ in 1:iters
-        gα = 0.0
-        gβ = 0.0
-        for i in 1:n
-            p = 1.0 / (1.0 + exp(-(α + β * z[i])))
-            err = p - y[i]
-            gα += err
-            gβ += err * z[i]
-        end
-        α -= lr * gα / n
-        β -= lr * gβ / n
-    end
-    # Fold the standardized (α, β) back to raw-score space:
-    # α + β*(x-μ)/σ = (α - β*μ/σ) + (β/σ)*x.
-    return (a = α - β * μ / σ, b = β / σ)
+    matrix_model = fit_logistic_map(
+        reshape(Float64.(scores), :, 1), labels;
+        iters = iters,
+        lr = lr,
+        l2 = l2,
+        gradient_tolerance = gradient_tolerance,
+        return_diagnostics = true)
+    model = (a = matrix_model.a, b = only(matrix_model.b))
+    return return_diagnostics ?
+           merge(model, (diagnostics = matrix_model.diagnostics,)) : model
 end
 
 """
@@ -224,10 +234,15 @@ Fit a multi-feature logistic probability map with samples in rows and features
 in columns. Each feature is standardized independently during optimization and
 the fitted coefficients are folded back to raw-feature space. Returns
 `(a, b::Vector{Float64})`, where `a` is the intercept and `b[j]` multiplies
-`features[:, j]`. Constant columns receive a zero raw-space coefficient.
+`features[:, j]`. Constant columns receive a zero raw-space coefficient. Set
+`return_diagnostics=true` to additionally report convergence, final penalized
+log loss, gradient norm, iteration count, and the L2 setting.
 """
 function fit_logistic_map(features::AbstractMatrix{<:Real},
-        labels::AbstractVector{Bool}; iters::Int = 500, lr::Float64 = 0.1)::NamedTuple
+        labels::AbstractVector{Bool}; iters::Int = 500, lr::Float64 = 0.1,
+        l2::Float64 = 0.0,
+        gradient_tolerance::Float64 = 1.0e-8,
+        return_diagnostics::Bool = false)::NamedTuple
     n_samples, n_features = size(features)
     n_samples == length(labels) ||
         throw(ArgumentError("feature rows and labels must have equal length"))
@@ -236,6 +251,9 @@ function fit_logistic_map(features::AbstractMatrix{<:Real},
     all(isfinite, features) || throw(ArgumentError("features must be finite"))
     iters >= 1 || throw(ArgumentError("iters must be >= 1"))
     isfinite(lr) && lr > 0.0 || throw(ArgumentError("lr must be finite and > 0"))
+    isfinite(l2) && l2 >= 0.0 || throw(ArgumentError("l2 must be finite and >= 0"))
+    isfinite(gradient_tolerance) && gradient_tolerance >= 0.0 ||
+        throw(ArgumentError("gradient_tolerance must be finite and >= 0"))
 
     x = Float64.(features)
     y = [label ? 1.0 : 0.0 for label in labels]
@@ -256,7 +274,9 @@ function fit_logistic_map(features::AbstractMatrix{<:Real},
     intercept = 0.0
     coefficients = zeros(Float64, n_features)
     coefficient_gradient = zeros(Float64, n_features)
-    for _ in 1:iters
+    iterations_run = 0
+    converged = false
+    for iteration in 1:iters
         intercept_gradient = 0.0
         fill!(coefficient_gradient, 0.0)
         for i in 1:n_samples
@@ -264,29 +284,98 @@ function fit_logistic_map(features::AbstractMatrix{<:Real},
             for j in 1:n_features
                 linear_predictor += coefficients[j] * standardized[i, j]
             end
-            probability = 1.0 / (1.0 + exp(-linear_predictor))
+            probability = _stable_sigmoid(linear_predictor)
             residual = probability - y[i]
             intercept_gradient += residual
             for j in 1:n_features
                 coefficient_gradient[j] += residual * standardized[i, j]
             end
         end
-        intercept -= lr * intercept_gradient / n_samples
+        intercept_gradient /= n_samples
         for j in 1:n_features
-            coefficients[j] -= lr * coefficient_gradient[j] / n_samples
+            coefficient_gradient[j] =
+                coefficient_gradient[j] / n_samples + l2 * coefficients[j]
         end
+        gradient_norm = sqrt(intercept_gradient^2 +
+                             sum(abs2, coefficient_gradient))
+        isfinite(gradient_norm) ||
+            throw(ArgumentError("logistic optimizer gradient must be finite"))
+        iterations_run = iteration
+        if gradient_norm <= gradient_tolerance
+            converged = true
+            break
+        end
+        intercept -= lr * intercept_gradient
+        for j in 1:n_features
+            coefficients[j] -= lr * coefficient_gradient[j]
+        end
+        isfinite(intercept) && all(isfinite, coefficients) ||
+            throw(ArgumentError("logistic optimizer coefficients must remain finite"))
     end
 
+    final_loss = 0.0
+    final_intercept_gradient = 0.0
+    fill!(coefficient_gradient, 0.0)
+    for i in 1:n_samples
+        linear_predictor = intercept
+        for j in 1:n_features
+            linear_predictor += coefficients[j] * standardized[i, j]
+        end
+        isfinite(linear_predictor) ||
+            throw(ArgumentError("logistic optimizer linear predictor must be finite"))
+        probability = _stable_sigmoid(linear_predictor)
+        final_loss += max(linear_predictor, 0.0) -
+                      y[i] * linear_predictor + log1p(exp(-abs(linear_predictor)))
+        residual = probability - y[i]
+        final_intercept_gradient += residual
+        for j in 1:n_features
+            coefficient_gradient[j] += residual * standardized[i, j]
+        end
+    end
+    final_loss = final_loss / n_samples + l2 * sum(abs2, coefficients) / 2.0
+    final_intercept_gradient /= n_samples
+    for j in 1:n_features
+        coefficient_gradient[j] =
+            coefficient_gradient[j] / n_samples + l2 * coefficients[j]
+    end
+    final_gradient_norm = sqrt(final_intercept_gradient^2 +
+                               sum(abs2, coefficient_gradient))
+    all(isfinite, (final_loss, final_gradient_norm)) ||
+        throw(ArgumentError("logistic optimizer diagnostics must be finite"))
+    converged |= final_gradient_norm <= gradient_tolerance
     raw_coefficients = coefficients ./ scales
     raw_intercept = intercept -
                     sum(coefficients[j] * means[j] / scales[j] for j in 1:n_features)
-    return (a = raw_intercept, b = raw_coefficients)
+    model = (a = raw_intercept, b = raw_coefficients)
+    diagnostics = (
+        converged = converged,
+        iterations = iterations_run,
+        final_loss = final_loss,
+        gradient_norm = final_gradient_norm,
+        l2 = l2,
+        learning_rate = lr,
+        gradient_tolerance = gradient_tolerance
+    )
+    return return_diagnostics ? merge(model, (; diagnostics)) : model
 end
 
 """Map raw `scores` through a fitted logistic probability map."""
 function predict_logistic(model::NamedTuple,
         scores::AbstractVector{<:Real})::Vector{Float64}
-    return [1.0 / (1.0 + exp(-(model.a + model.b * Float64(score)))) for score in scores]
+    hasproperty(model, :a) && hasproperty(model, :b) ||
+        throw(ArgumentError("logistic model must contain a and b"))
+    model.b isa Real ||
+        throw(ArgumentError("single-feature logistic model b must be scalar"))
+    isfinite(model.a) && isfinite(model.b) ||
+        throw(ArgumentError("logistic model coefficients must be finite"))
+    all(isfinite, scores) || throw(ArgumentError("scores must be finite"))
+    probabilities = Vector{Float64}(undef, length(scores))
+    for i in eachindex(scores)
+        linear_predictor = Float64(model.a) +
+                           Float64(model.b) * Float64(scores[i])
+        probabilities[i] = _stable_sigmoid(linear_predictor)
+    end
+    return probabilities
 end
 
 """Map raw row-oriented `features` through a fitted multi-feature logistic map."""
@@ -308,7 +397,7 @@ function predict_logistic(model::NamedTuple,
         for j in axes(features, 2)
             linear_predictor += Float64(model.b[j]) * Float64(features[i, j])
         end
-        probabilities[i] = 1.0 / (1.0 + exp(-linear_predictor))
+        probabilities[i] = _stable_sigmoid(linear_predictor)
     end
     return probabilities
 end

--- a/benchmarking/calibration_metrics.jl
+++ b/benchmarking/calibration_metrics.jl
@@ -217,10 +217,100 @@ function fit_logistic_map(scores::AbstractVector{<:Real},
     return (a = α - β * μ / σ, b = β / σ)
 end
 
+"""
+    fit_logistic_map(features, labels; iters=500, lr=0.1) -> NamedTuple
+
+Fit a multi-feature logistic probability map with samples in rows and features
+in columns. Each feature is standardized independently during optimization and
+the fitted coefficients are folded back to raw-feature space. Returns
+`(a, b::Vector{Float64})`, where `a` is the intercept and `b[j]` multiplies
+`features[:, j]`. Constant columns receive a zero raw-space coefficient.
+"""
+function fit_logistic_map(features::AbstractMatrix{<:Real},
+        labels::AbstractVector{Bool}; iters::Int = 500, lr::Float64 = 0.1)::NamedTuple
+    n_samples, n_features = size(features)
+    n_samples == length(labels) ||
+        throw(ArgumentError("feature rows and labels must have equal length"))
+    n_samples >= 1 || throw(ArgumentError("features and labels must be non-empty"))
+    n_features >= 1 || throw(ArgumentError("features must have at least one column"))
+    all(isfinite, features) || throw(ArgumentError("features must be finite"))
+    iters >= 1 || throw(ArgumentError("iters must be >= 1"))
+    isfinite(lr) && lr > 0.0 || throw(ArgumentError("lr must be finite and > 0"))
+
+    x = Float64.(features)
+    y = [label ? 1.0 : 0.0 for label in labels]
+    means = zeros(Float64, n_features)
+    scales = ones(Float64, n_features)
+    standardized = zeros(Float64, n_samples, n_features)
+    for j in 1:n_features
+        means[j] = sum(x[:, j]) / n_samples
+        variance = sum((x[i, j] - means[j])^2 for i in 1:n_samples) / n_samples
+        if variance > eps(Float64)
+            scales[j] = sqrt(variance)
+            for i in 1:n_samples
+                standardized[i, j] = (x[i, j] - means[j]) / scales[j]
+            end
+        end
+    end
+
+    intercept = 0.0
+    coefficients = zeros(Float64, n_features)
+    coefficient_gradient = zeros(Float64, n_features)
+    for _ in 1:iters
+        intercept_gradient = 0.0
+        fill!(coefficient_gradient, 0.0)
+        for i in 1:n_samples
+            linear_predictor = intercept
+            for j in 1:n_features
+                linear_predictor += coefficients[j] * standardized[i, j]
+            end
+            probability = 1.0 / (1.0 + exp(-linear_predictor))
+            residual = probability - y[i]
+            intercept_gradient += residual
+            for j in 1:n_features
+                coefficient_gradient[j] += residual * standardized[i, j]
+            end
+        end
+        intercept -= lr * intercept_gradient / n_samples
+        for j in 1:n_features
+            coefficients[j] -= lr * coefficient_gradient[j] / n_samples
+        end
+    end
+
+    raw_coefficients = coefficients ./ scales
+    raw_intercept = intercept -
+                    sum(coefficients[j] * means[j] / scales[j] for j in 1:n_features)
+    return (a = raw_intercept, b = raw_coefficients)
+end
+
 """Map raw `scores` through a fitted logistic probability map."""
 function predict_logistic(model::NamedTuple,
         scores::AbstractVector{<:Real})::Vector{Float64}
     return [1.0 / (1.0 + exp(-(model.a + model.b * Float64(score)))) for score in scores]
+end
+
+"""Map raw row-oriented `features` through a fitted multi-feature logistic map."""
+function predict_logistic(model::NamedTuple,
+        features::AbstractMatrix{<:Real})::Vector{Float64}
+    hasproperty(model, :a) && hasproperty(model, :b) ||
+        throw(ArgumentError("logistic model must contain a and b"))
+    model.b isa AbstractVector ||
+        throw(ArgumentError("multi-feature logistic model b must be a vector"))
+    size(features, 2) == length(model.b) ||
+        throw(ArgumentError("feature columns must match model coefficients"))
+    all(isfinite, features) || throw(ArgumentError("features must be finite"))
+    isfinite(model.a) && all(isfinite, model.b) ||
+        throw(ArgumentError("logistic model coefficients must be finite"))
+
+    probabilities = Vector{Float64}(undef, size(features, 1))
+    for i in axes(features, 1)
+        linear_predictor = Float64(model.a)
+        for j in axes(features, 2)
+            linear_predictor += Float64(model.b[j]) * Float64(features[i, j])
+        end
+        probabilities[i] = 1.0 / (1.0 + exp(-linear_predictor))
+    end
+    return probabilities
 end
 
 """

--- a/benchmarking/rhizomorph_correction_pr_curve.jl
+++ b/benchmarking/rhizomorph_correction_pr_curve.jl
@@ -126,7 +126,7 @@ benchmark logistic coefficients to the runtime model's fixed feature order.
 The calibration cohort uses a disjoint seed and never sees frontier truth.
 """
 function fit_frontier_probability_model(errs::Vector{Float64}, readlen::Int,
-        coverage::Float64, k::Int, seed::Int)::NamedTuple
+        coverage::Float64, k::Int, seed::Int, assigned_q::Int)::NamedTuple
     results_root = joinpath(@__DIR__, "results")
     mkpath(results_root)
     calibration_results_dir = mktempdir(
@@ -137,6 +137,7 @@ function fit_frontier_probability_model(errs::Vector{Float64}, readlen::Int,
         readlen = readlen,
         coverage = max(1, round(Int, coverage)),
         error_rates = errs,
+        assigned_q = assigned_q,
         seed = seed + 10_000,
         results_dir = calibration_results_dir,
         return_artifact = true)
@@ -155,7 +156,8 @@ function fit_frontier_probability_model(errs::Vector{Float64}, readlen::Int,
         throw(ArgumentError("multi-feature logistic has wrong coefficient count"))
     runtime_model = Mycelia.CorrectionConfidenceModel(model.a, model.b...)
     println("Calibration cohort: multi-feature model fitted with grouped holdout; " *
-            "seed=$(seed + 10_000), n_train=$(length(artifact.training.labels)), " *
+            "seed=$(seed + 10_000), assigned_q=$(assigned_q), " *
+            "n_train=$(length(artifact.training.labels)), " *
             "n_heldout=$(length(artifact.heldout.labels)), " *
             "artifacts=$(calibration_results_dir)")
     println("Calibration coefficients: intercept=$(runtime_model.intercept), " *
@@ -226,6 +228,7 @@ function run_pr_curve(;
     coverage = parse(Float64, get(ENV, "MYCELIA_RPC_COVERAGE", smoke ? "15" : "30"))
     k = parse(Int, get(ENV, "MYCELIA_RPC_K", "21"))
     assigned_q = parse(Int, get(ENV, "MYCELIA_RPC_ASSIGNED_Q", "20"))
+    _validate_assigned_q(assigned_q)
     seed = parse(Int, get(ENV, "MYCELIA_RPC_SEED", "42"))
     want = strip(get(ENV, "MYCELIA_RPC_POINTS", ""))
     all_points = vcat(
@@ -250,7 +253,7 @@ function run_pr_curve(;
     if any(startswith(point.name, "calibrated-prob-") for point in points)
         effective_probability_model = if probability_model === nothing
             fit = fit_frontier_probability_model(
-                errs, readlens[1], coverage, k, seed)
+                errs, readlens[1], coverage, k, seed, assigned_q)
             calibration_artifact = fit.results_dir
             fit.model
         else
@@ -342,10 +345,9 @@ function run_pr_curve(;
         end
     end
     # The multi-feature probability family is the td-21eg decision surface. Report
-    # both requested error rates separately; only err=0.10 is the completion gate.
+    # every requested error rate separately; err=0.10 is the completion gate.
     if any(startswith(point.name, "calibrated-prob-") for point in points)
-        for err in (0.05, 0.10)
-            err in errs || continue
+        for err in errs
             dom = assess_frontier_dominance(
                 rows; err = err, candidate_prefix = "calibrated-prob-")
             if hasproperty(dom, :reason)

--- a/benchmarking/rhizomorph_correction_pr_curve.jl
+++ b/benchmarking/rhizomorph_correction_pr_curve.jl
@@ -2,24 +2,25 @@
 # ===============================================
 #
 # The per-base accuracy benchmark (rhizomorph_correction_accuracy_benchmark.jl)
-# measures ONE operating point — the wired :scalable corrector — and finds
-# precision=1.0 / over-correction=0 but conservative recall (0.99 -> 0.06 as error
-# density rises). The recall shortfall is an EDIT-AGGRESSIVENESS property of the
-# corrector's decision knobs, NOT the calibration map. This harness maps the
-# precision-recall FRONTIER by re-running the SAME corrector at several
-# aggressiveness operating points, so we can see whether recall can be bought back
-# and at what precision / over-correction cost.
+# measures ONE operating point — the wired :scalable corrector. A preliminary,
+# partial-cohort run suggested that dropping the decode gate could lift recall
+# toward 1.0, but that observation is not a supported full-cohort conclusion.
+# This harness maps the precision-recall FRONTIER by re-running the SAME corrector
+# at several aggressiveness operating points, so we can see whether recall can be
+# bought back and at what precision / over-correction cost.
 #
-# Operating points (all exposed knobs — NO src changes):
+# Operating points (wired knobs plus the opt-in calibrated gates):
 #   scalable        skip_solid=true,  cheap_correct=true, hard_window=true,  iter=2   (the wired default)
 #   noskip          skip_solid=FALSE, cheap_correct=true, hard_window=true,  iter=2   (isolates the skip_solid lever)
 #   noskip+nogate   skip_solid=FALSE, cheap_correct=true, hard_window=FALSE, iter=2   (also drops the decode gate)
+#   calibrated-gap-*  noskip+nogate plus the legacy raw-gap gate family
+#   calibrated-prob-* noskip+nogate plus the multi-feature probability family
 #
-# A smoke run localized the recall lever to the hard_window DECODE GATE, not
-# skip_solid: turning skip_solid off alone leaves recall unchanged; dropping the
-# gate too lifts recall from ~0.24 to ~1.0 (at a precision cost that grows with
-# error rate). Exact-beam / more-iteration points are dropped — the former is
-# intractable on the dense low-k graph, the latter is a no-op once converged.
+# The full threshold sweep is exploratory. Any selected threshold must be locked
+# before evaluation on a disjoint confirmatory cohort; this script does not treat
+# same-sweep threshold selection as confirmatory evidence. Exact-beam /
+# more-iteration points are dropped — the former is intractable on the dense
+# low-k graph, the latter is a no-op once converged.
 #
 # Reuses simulate_substitution_reads + per_base_metrics from the merged accuracy
 # harness. Reports (precision, recall, over_correction, mis_fixes, correction_rate,
@@ -39,6 +40,7 @@
 
 import Dates
 import Pkg
+import SHA
 if isinteractive()
     Pkg.activate(joinpath(@__DIR__, ".."))
 end
@@ -48,12 +50,12 @@ include(joinpath(@__DIR__, "viterbi_gap_calibration.jl"))
 
 # === Operating points (named knob presets) ==================================
 
-# Three informative points span the frontier (a smoke run localized the recall
-# limiter to the hard_window decode gate, NOT skip_solid): the wired default, the
-# skip_solid-off variant (isolates that lever), and both gates off. A prior
-# exact-beam "exhaustive" point is dropped — it is intractable on the dense low-k
-# graph (times out) and adds nothing once noskip+nogate reaches recall ~1.0. The
-# auto-bounded Viterbi beam (256) applies to every point, so these stay tractable.
+# Three informative points probe the preliminary partial-cohort signal: the
+# wired default, the skip_solid-off variant (isolates that lever), and both gates
+# off. This is an exploratory comparison, not proof that hard_window is the
+# unique recall limiter. A prior exact-beam "exhaustive" point is dropped because
+# it is intractable on the dense low-k graph (times out). The auto-bounded Viterbi
+# beam (256) applies to every point, so these stay tractable.
 const PR_OPERATING_POINTS = [
     (name = "scalable", skip_solid = true, cheap_correct = true, hard_window = true,
         soft_em = true, n_k_rungs = 3, max_iterations_per_k = 2, beam_width = nothing,
@@ -98,6 +100,54 @@ function calibrated_probability_points()::Vector
             ) for threshold in thresholds]
 end
 
+"""
+Select named operating points from `MYCELIA_RPC_POINTS` input. Unknown names,
+empty tokens, and an empty resulting set are configuration errors rather than a
+silent zero-row benchmark.
+"""
+function select_operating_points(
+        all_points::AbstractVector, requested_names::AbstractString)::Vector
+    isempty(all_points) &&
+        throw(ArgumentError("no precision-recall operating points are configured"))
+    isempty(strip(requested_names)) && return collect(all_points)
+
+    requested = strip.(split(requested_names, ","))
+    any(isempty, requested) &&
+        throw(ArgumentError("MYCELIA_RPC_POINTS contains an empty point name"))
+    available = Set(String(point.name) for point in all_points)
+    unknown = sort!(collect(setdiff(Set(requested), available)))
+    isempty(unknown) || throw(ArgumentError(
+        "unknown MYCELIA_RPC_POINTS name(s): $(join(unknown, ", "))"))
+    selected = filter(point -> point.name in requested, all_points)
+    isempty(selected) &&
+        throw(ArgumentError("MYCELIA_RPC_POINTS selected no operating points"))
+    return collect(selected)
+end
+
+"""Compute a stable SHA-256 digest for one file or a directory tree."""
+function artifact_digest(path::AbstractString)::String
+    isempty(path) && return ""
+    if isfile(path)
+        return SHA.bytes2hex(SHA.sha256(read(path)))
+    elseif !isdir(path)
+        throw(ArgumentError("cannot digest missing artifact path: $(path)"))
+    end
+
+    context = SHA.SHA2_256_CTX()
+    files = String[]
+    for (root, _directories, names) in walkdir(path)
+        append!(files, joinpath.(root, names))
+    end
+    for file in sort!(files; by = file -> relpath(file, path))
+        relative = relpath(file, path)
+        SHA.update!(context, collect(codeunits(relative)))
+        SHA.update!(context, UInt8[0x00])
+        SHA.update!(context, read(file))
+        SHA.update!(context, UInt8[0x00])
+    end
+    return SHA.bytes2hex(SHA.digest!(context))
+end
+
 function persist_runtime_probability_model(
         model::Mycelia.CorrectionConfidenceModel,
         results_dir::AbstractString)::String
@@ -121,13 +171,15 @@ function persist_runtime_probability_model(
 end
 
 """
-Fit the probability gate on an independent synthetic cohort and convert the
-benchmark logistic coefficients to the runtime model's fixed feature order.
-The calibration cohort uses a disjoint seed and never sees frontier truth.
+Fit the probability gate on a separately seeded synthetic cohort and convert
+the benchmark logistic coefficients to the runtime model's fixed feature order.
+The calibration cohort never sees frontier labels, but shares the simulator and
+design; it is therefore within-design exploratory evidence rather than an
+independent graph-regime confirmation.
 """
 function fit_frontier_probability_model(errs::Vector{Float64}, readlen::Int,
-        coverage::Float64, k::Int, seed::Int, assigned_q::Int)::NamedTuple
-    results_root = joinpath(@__DIR__, "results")
+        coverage::Float64, k::Int, seed::Int, assigned_q::Int;
+        results_root::AbstractString = joinpath(@__DIR__, "results"))::NamedTuple
     mkpath(results_root)
     calibration_results_dir = mktempdir(
         results_root; prefix = "td21eg_calibration_", cleanup = false)
@@ -151,10 +203,17 @@ function fit_frontier_probability_model(errs::Vector{Float64}, readlen::Int,
     artifact.feature_names == expected_features ||
         throw(ArgumentError("calibration/runtime feature-order mismatch: " *
                             "expected $(expected_features), got $(artifact.feature_names)"))
+    _require_converged_logistic(
+        artifact.multifeature_model, "frontier multi-feature")
+    _require_converged_logistic(artifact.gap_model, "frontier gap-only")
     model = artifact.multifeature_model
     length(model.b) == length(expected_features) ||
         throw(ArgumentError("multi-feature logistic has wrong coefficient count"))
     runtime_model = Mycelia.CorrectionConfidenceModel(model.a, model.b...)
+    runtime_model_path = persist_runtime_probability_model(
+        runtime_model, calibration_results_dir)
+    model_digest = artifact_digest(runtime_model_path)
+    calibration_digest = artifact_digest(calibration_results_dir)
     println("Calibration cohort: multi-feature model fitted with grouped holdout; " *
             "seed=$(seed + 10_000), assigned_q=$(assigned_q), " *
             "n_train=$(length(artifact.training.labels)), " *
@@ -166,56 +225,122 @@ function fit_frontier_probability_model(errs::Vector{Float64}, readlen::Int,
             "stage0_solid=$(runtime_model.stage0_solid_weight), " *
             "competing_branch=$(runtime_model.branch_support_ratio_weight), " *
             "collapsed_frontier=$(runtime_model.collapsed_frontier_weight)")
-    return (model = runtime_model, results_dir = calibration_results_dir)
+    return (model = runtime_model, results_dir = calibration_results_dir,
+        model_digest = model_digest, artifact_digest = calibration_digest)
 end
 
 """
 Correct `records` with an explicit knob preset `pt` (a PR_OPERATING_POINTS entry),
-returning `corrected_by_id`. Mirrors correct_reads_scalable but with the point's
-knobs instead of the hardwired :scalable set.
+returning `corrected_by_id`. With `return_metadata=true`, return corrected reads
+plus a copied metadata/diagnostics payload for audit columns. Temporary FASTQ and
+corrector output directories are removed before return. Mirrors
+`correct_reads_scalable` but with the point's knobs instead of the hardwired
+`:scalable` set.
 """
 function correct_reads_at_point(records::Vector{FASTX.FASTQ.Record}, k::Int,
-        pt::NamedTuple)::Dict{String, String}
-    input_dir = mktempdir()
-    output_dir = mktempdir()
-    temp_fastq = joinpath(input_dir, "corrector_input.fastq")
-    open(FASTX.FASTQ.Writer, temp_fastq) do w
-        for r in records
-            write(w, r)
+        pt::NamedTuple; return_metadata::Bool = false)::Union{Dict{String, String}, NamedTuple}
+    return mktempdir() do temporary_dir
+        input_dir = joinpath(temporary_dir, "input")
+        output_dir = joinpath(temporary_dir, "output")
+        mkpath(input_dir)
+        mkpath(output_dir)
+        temp_fastq = joinpath(input_dir, "corrector_input.fastq")
+        open(FASTX.FASTQ.Writer, temp_fastq) do writer
+            for record in records
+                write(writer, record)
+            end
         end
+        probability_model = hasproperty(pt, :calibrated_probability_model) ?
+                            pt.calibrated_probability_model : nothing
+        probability_threshold = hasproperty(pt, :calibrated_probability_threshold) ?
+                                pt.calibrated_probability_threshold : 0.5
+        gap_threshold = hasproperty(pt, :calibrated_gap_threshold) ?
+                        pt.calibrated_gap_threshold : nothing
+        result = Mycelia.mycelia_iterative_assemble(
+            temp_fastq;
+            max_k = max(k, 13),
+            skip_solid = pt.skip_solid,
+            graph_mode = :doublestrand,
+            n_k_rungs = pt.n_k_rungs,
+            max_iterations_per_k = pt.max_iterations_per_k,
+            hard_window = pt.hard_window,
+            soft_em = pt.soft_em,
+            cheap_correct = pt.cheap_correct,
+            beam_width = pt.beam_width,
+            calibrated_gap_threshold = gap_threshold,
+            calibrated_probability_model = probability_model,
+            calibrated_probability_threshold = probability_threshold,
+            verbose = false,
+            enable_checkpointing = false,
+            output_dir = output_dir
+        )
+        metadata = copy(result[:metadata])
+        corrected_fastq = get(metadata, :final_fastq_file, nothing)
+        (corrected_fastq === nothing || !isfile(corrected_fastq)) &&
+            error("corrector produced no :final_fastq_file at point $(pt.name)")
+        corrected_by_id = Dict{String, String}()
+        open(FASTX.FASTQ.Reader, corrected_fastq) do reader
+            for record in reader
+                corrected_by_id[FASTX.identifier(record)] = String(
+                    FASTX.sequence(BioSequences.LongDNA{4}, record))
+            end
+        end
+        !isempty(records) && isempty(corrected_by_id) && error(
+            "corrector produced zero reads at point $(pt.name)")
+        diagnostics = copy(get(metadata, :corrector_errors, Dict{Symbol, Int}()))
+        payload = (corrected_by_id = corrected_by_id, metadata = metadata,
+            diagnostics = diagnostics)
+        return return_metadata ? payload : corrected_by_id
     end
-    probability_model = hasproperty(pt, :calibrated_probability_model) ?
-                        pt.calibrated_probability_model : nothing
-    probability_threshold = hasproperty(pt, :calibrated_probability_threshold) ?
-                            pt.calibrated_probability_threshold : 0.5
-    result = Mycelia.mycelia_iterative_assemble(
-        temp_fastq;
-        max_k = max(k, 13),
-        skip_solid = pt.skip_solid,
-        graph_mode = :doublestrand,
-        n_k_rungs = pt.n_k_rungs,
-        max_iterations_per_k = pt.max_iterations_per_k,
-        hard_window = pt.hard_window,
-        soft_em = pt.soft_em,
-        cheap_correct = pt.cheap_correct,
-        beam_width = pt.beam_width,
-        calibrated_gap_threshold = pt.calibrated_gap_threshold,
-        calibrated_probability_model = probability_model,
-        calibrated_probability_threshold = probability_threshold,
-        verbose = false,
-        enable_checkpointing = false,
-        output_dir = output_dir
+end
+
+function _metadata_counter(metadata::AbstractDict,
+        keys::Tuple{Vararg{Symbol}}; default::Int = 0)::Int
+    for key in keys
+        haskey(metadata, key) && return Int(get(metadata, key, default))
+    end
+    return default
+end
+
+function _point_gate_requested(point::NamedTuple)::Bool
+    gap_threshold = hasproperty(point, :calibrated_gap_threshold) ?
+                    point.calibrated_gap_threshold : nothing
+    probability_model = hasproperty(point, :calibrated_probability_model) ?
+                        point.calibrated_probability_model : nothing
+    return gap_threshold !== nothing || probability_model !== nothing
+end
+
+"""Extract stable, schema-tolerant runtime provenance for one frontier row."""
+function point_runtime_provenance(point::NamedTuple, metadata::AbstractDict;
+        model_digest::AbstractString = "",
+        calibration_digest::AbstractString = "")::NamedTuple
+    requested_default = _point_gate_requested(point)
+    candidate_evaluations = _metadata_counter(metadata,
+        (:calibrated_gate_candidate_evaluations,
+            :calibrated_candidate_evaluations, :gate_candidate_evaluations))
+    feature_events = _metadata_counter(metadata,
+        (:calibrated_feature_events, :calibrated_gate_feature_events, :feature_events))
+    gate_reverts = _metadata_counter(metadata,
+        (:calibrated_gate_reverts, :gate_reverts))
+    requested = Bool(get(metadata, :calibrated_gate_requested, requested_default))
+    effective = Bool(get(metadata, :calibrated_gate_effective, requested))
+    executed = Bool(get(
+        metadata, :calibrated_gate_executed, candidate_evaluations > 0))
+    diagnostics = get(metadata, :corrector_errors, Dict{Symbol, Int}())
+    return (
+        gate_requested = requested,
+        gate_effective = effective,
+        gate_executed = executed,
+        feature_contract_skips = _metadata_counter(
+            metadata, (:calibrated_feature_contract_skips,)),
+        candidate_evaluations = candidate_evaluations,
+        feature_events = feature_events,
+        gate_reverts = gate_reverts,
+        structural_errors = Int(get(diagnostics, :structural, 0)),
+        unkmerizable_errors = Int(get(diagnostics, :unkmerizable, 0)),
+        model_digest = String(model_digest),
+        artifact_digest = String(calibration_digest)
     )
-    corrected_fastq = get(result[:metadata], :final_fastq_file, nothing)
-    (corrected_fastq === nothing || !isfile(corrected_fastq)) &&
-        error("corrector produced no :final_fastq_file at point $(pt.name)")
-    corrected_by_id = Dict{String, String}()
-    open(FASTX.FASTQ.Reader, corrected_fastq) do reader
-        for rec in reader
-            corrected_by_id[FASTX.identifier(rec)] = String(FASTX.sequence(BioSequences.LongDNA{4}, rec))
-        end
-    end
-    return corrected_by_id
 end
 
 function run_pr_curve(;
@@ -233,34 +358,45 @@ function run_pr_curve(;
     want = strip(get(ENV, "MYCELIA_RPC_POINTS", ""))
     all_points = vcat(
         PR_OPERATING_POINTS, calibrated_gap_points(), calibrated_probability_points())
-    points = isempty(want) ? all_points :
-             filter(p -> p.name in split(want, ","), all_points)
+    points = select_operating_points(all_points, want)
     calibration_artifact = ""
-    results_dir = joinpath(@__DIR__, "results")
-    mkpath(results_dir)
+    calibration_digest = ""
+    probability_model_digest = ""
+    results_root = joinpath(@__DIR__, "results")
+    mkpath(results_root)
+    results_dir = mktempdir(
+        results_root; prefix = "rhizomorph_correction_pr_curve_", cleanup = false)
 
     println("=== Rhizomorph Correction Precision-Recall Frontier ===")
     println("Start: $(Dates.now())   error rates: $errs   coverage: $(coverage)x   k: $k")
     println("Operating points: $(join([p.name for p in points], ", "))")
 
-    workdir = mktempdir(prefix = "rpc_")
-    refseq, _rp,
-    ref_label = acquire_reference(
-        smoke = smoke, accession = accession, smoke_len = smoke_len, seed = seed, workdir = workdir)
+    refseq, ref_label = mktempdir(; prefix = "rpc_") do workdir
+        sequence, _reference_path, label = acquire_reference(
+            smoke = smoke, accession = accession, smoke_len = smoke_len,
+            seed = seed, workdir = workdir)
+        return sequence, label
+    end
     glen = length(refseq)
     println("Reference: $ref_label ($glen bp)")
     k = min(k, minimum(readlens), glen)
     if any(startswith(point.name, "calibrated-prob-") for point in points)
         effective_probability_model = if probability_model === nothing
             fit = fit_frontier_probability_model(
-                errs, readlens[1], coverage, k, seed, assigned_q)
+                errs, readlens[1], coverage, k, seed, assigned_q;
+                results_root = results_dir)
             calibration_artifact = fit.results_dir
+            calibration_digest = fit.artifact_digest
+            probability_model_digest = fit.model_digest
             fit.model
         else
             supplied_dir = mktempdir(
                 results_dir; prefix = "td21eg_caller_model_", cleanup = false)
-            persist_runtime_probability_model(probability_model, supplied_dir)
+            supplied_model_path = persist_runtime_probability_model(
+                probability_model, supplied_dir)
             calibration_artifact = supplied_dir
+            probability_model_digest = artifact_digest(supplied_model_path)
+            calibration_digest = artifact_digest(supplied_dir)
             probability_model
         end
         points = [startswith(point.name, "calibrated-prob-") ?
@@ -275,7 +411,11 @@ function run_pr_curve(;
         reads_scored = Int[], injected = Int[], true_fixes = Int[], mis_fixes = Int[],
         over_corrections = Int[], recall = Float64[], precision = Float64[],
         over_correction_rate = Float64[], correction_rate = Float64[], runtime_s = Float64[],
-        calibration_artifact = String[])
+        calibration_artifact = String[], gate_requested = Bool[],
+        gate_effective = Bool[], gate_executed = Bool[],
+        feature_contract_skips = Int[], candidate_evaluations = Int[],
+        feature_events = Int[], gate_reverts = Int[], structural_errors = Int[],
+        unkmerizable_errors = Int[], model_digest = String[], artifact_digest = String[])
 
     for err in errs
         # SAME reads for every operating point at this error rate (fair comparison).
@@ -293,25 +433,44 @@ function run_pr_curve(;
             Random.seed!(seed)
             t0 = time()
             local corrected
+            local runtime_metadata
             ok = true
             try
-                corrected = correct_reads_at_point(records, k, pt)
+                correction_result = correct_reads_at_point(
+                    records, k, pt; return_metadata = true)
+                corrected = correction_result.corrected_by_id
+                runtime_metadata = correction_result.metadata
             catch e
                 e isa InterruptException && rethrow()
                 @warn "point failed" point=pt.name err exception=(e, catch_backtrace())
                 ok = false
                 corrected = Dict{String, String}()
+                runtime_metadata = Dict{Symbol, Any}()
             end
             rt = round(time() - t0; digits = 2)
             m = per_base_metrics(truth_by_id, observed_by_id, corrected)
+            probability_point = startswith(pt.name, "calibrated-prob-")
+            provenance = point_runtime_provenance(pt, runtime_metadata;
+                model_digest = probability_point ? probability_model_digest : "",
+                calibration_digest = probability_point ? calibration_digest : "")
             push!(rows,
                 (error_rate = err, point = pt.name, ok = ok, n_reads = length(records),
                     reads_scored = m.reads_scored, injected = m.injected, true_fixes = m.tp,
                     mis_fixes = m.mis_fixes, over_corrections = m.over, recall = m.recall,
                     precision = m.precision, over_correction_rate = m.over_rate,
                     correction_rate = m.correction_rate, runtime_s = rt,
-                    calibration_artifact = startswith(pt.name, "calibrated-prob-") ?
-                                           calibration_artifact : ""))
+                    calibration_artifact = probability_point ? calibration_artifact : "",
+                    gate_requested = provenance.gate_requested,
+                    gate_effective = provenance.gate_effective,
+                    gate_executed = provenance.gate_executed,
+                    feature_contract_skips = provenance.feature_contract_skips,
+                    candidate_evaluations = provenance.candidate_evaluations,
+                    feature_events = provenance.feature_events,
+                    gate_reverts = provenance.gate_reverts,
+                    structural_errors = provenance.structural_errors,
+                    unkmerizable_errors = provenance.unkmerizable_errors,
+                    model_digest = provenance.model_digest,
+                    artifact_digest = provenance.artifact_digest))
             println("  $(rpad(pt.name, 15)) recall=$(rpad(round(m.recall; digits=4), 8)) " *
                     "precision=$(rpad(round(m.precision; digits=4), 8)) " *
                     "over_rate=$(rpad(round(m.over_rate; digits=6), 10)) " *
@@ -319,8 +478,7 @@ function run_pr_curve(;
         end
     end
 
-    ts = Dates.format(Dates.now(), "yyyymmdd_HHMMSS")
-    csv = joinpath(results_dir, "rhizomorph_correction_pr_curve_$(ts).csv")
+    csv = joinpath(results_dir, "frontier.csv")
     CSV.write(csv, rows)
     println("\nCSV: $csv")
 
@@ -374,12 +532,12 @@ function run_pr_curve(;
     println("+ ~zero over_correction is a strict improvement (the corrector was over-conservative).")
     println("A point that trades precision/over-correction for recall exposes the real tradeoff.")
     println("=== done: $(Dates.now()) ===")
-    return (; csv, rows)
+    return (; csv, rows, results_dir)
 end
 
 """
     assess_frontier_dominance(rows; err=0.10, recall_eps=0.02,
-        candidate_prefix="calibrated-gap-") -> NamedTuple
+        candidate_prefix="calibrated-gap-", max_contract_skips=0) -> NamedTuple
 
 Programmatic frontier-dominance check (previously eyeballed from the CSV). At
 error rate `err`, decide whether any operating point selected by `candidate_prefix` DOMINATES
@@ -389,21 +547,30 @@ tie: recall retained (>= baseline recall − `recall_eps`), over-correction
 over-correction criterion is load-bearing — each family's zero-threshold point
 is by definition the ungated baseline (threshold 0 reverts nothing), so it TIES
 every metric; a non-strict predicate would report it as "dominating" itself. Returns
-`(dominates, baseline, best, candidates)`. A non-finite baseline or non-finite
-candidate metrics (zero-denominator rows) are treated as non-dominating. A row
-is eligible only when its run succeeded (`ok`) and scored every simulated read
-(`reads_scored == n_reads`); partial or failed runs cannot establish dominance.
+`(dominates, baseline, best, candidates)`. The verdict fails closed with an
+explicit incomplete-sweep reason when the requested family is absent or any
+requested candidate is failed, partial, zero-read, non-finite, or unauditable.
+A candidate must also match the baseline's read count and injected-error count.
+A candidate gate must have been requested, effective, executed, and evaluated
+at least one substitution candidate. Feature-contract skips may not exceed
+`max_contract_skips` (zero by default). This prevents a partial survivor set or
+a configured-but-inactive gate from being summarized as a valid "no winner".
 """
 function assess_frontier_dominance(rows::DataFrames.DataFrame;
         err::Float64 = 0.10, recall_eps::Float64 = 0.02,
-        candidate_prefix::AbstractString = "calibrated-gap-")::NamedTuple
+        candidate_prefix::AbstractString = "calibrated-gap-",
+        max_contract_skips::Int = 0)::NamedTuple
+    max_contract_skips >= 0 ||
+        throw(ArgumentError("max_contract_skips must be non-negative"))
+    isempty(candidate_prefix) &&
+        throw(ArgumentError("candidate_prefix must not be empty"))
     at = rows[[isapprox(r, err; atol = 1e-9) for r in rows.error_rate], :]
     base_idx = findfirst(==("noskip+nogate"), at.point)
     base_idx === nothing && return (dominates = false,
         reason = "no noskip+nogate baseline at err=$(err)",
         baseline = nothing, best = nothing, candidates = NamedTuple[])
     base = at[base_idx, :]
-    if !(base.ok && base.reads_scored == base.n_reads)
+    if !(base.ok && base.n_reads > 0 && base.reads_scored == base.n_reads)
         return (dominates = false,
             reason = "failed or partial noskip+nogate baseline at err=$(err): " *
                      "ok=$(base.ok), reads_scored=$(base.reads_scored)/$(base.n_reads)",
@@ -419,12 +586,85 @@ function assess_frontier_dominance(rows::DataFrames.DataFrame;
                 over_rate = base.over_correction_rate),
             best = nothing, candidates = NamedTuple[])
     end
+
+    candidate_rows = [row for row in DataFrames.eachrow(at)
+                      if startswith(row.point, candidate_prefix)]
+    if isempty(candidate_rows)
+        return (dominates = false,
+            reason = "incomplete candidate sweep at err=$(err): no " *
+                     "$(candidate_prefix)* rows were requested/scored",
+            baseline = (recall = base.recall, precision = base.precision,
+                over_rate = base.over_correction_rate),
+            best = nothing, candidates = NamedTuple[])
+    end
+
+    activity_columns = (
+        :gate_requested,
+        :gate_effective,
+        :gate_executed,
+        :feature_contract_skips,
+        :candidate_evaluations
+    )
+    incomplete = String[]
+    for row in candidate_rows
+        if !(row.ok && row.n_reads > 0 && row.reads_scored == row.n_reads)
+            push!(incomplete,
+                "$(row.point): failed or partial (ok=$(row.ok), " *
+                "reads_scored=$(row.reads_scored)/$(row.n_reads))")
+            continue
+        end
+        if row.n_reads != base.n_reads
+            push!(incomplete,
+                "$(row.point): cohort-size mismatch " *
+                "(candidate=$(row.n_reads), baseline=$(base.n_reads))")
+            continue
+        end
+        if !hasproperty(row, :injected) || !hasproperty(base, :injected)
+            push!(incomplete,
+                "$(row.point): missing injected-error cohort audit")
+            continue
+        elseif row.injected != base.injected
+            push!(incomplete,
+                "$(row.point): injected-error mismatch " *
+                "(candidate=$(row.injected), baseline=$(base.injected))")
+            continue
+        end
+        if !(isfinite(row.recall) && isfinite(row.precision) &&
+             isfinite(row.over_correction_rate))
+            push!(incomplete, "$(row.point): non-finite metrics")
+            continue
+        end
+        missing_columns = [column for column in activity_columns
+                           if !hasproperty(row, column)]
+        if !isempty(missing_columns)
+            push!(incomplete,
+                "$(row.point): missing gate audit columns " *
+                "$(join(string.(missing_columns), ","))")
+            continue
+        end
+        if !row.gate_requested
+            push!(incomplete, "$(row.point): calibrated gate was not requested")
+        elseif !row.gate_effective
+            push!(incomplete, "$(row.point): calibrated gate was not effective")
+        elseif !row.gate_executed || row.candidate_evaluations <= 0
+            push!(incomplete,
+                "$(row.point): calibrated gate evaluated zero candidates")
+        elseif row.feature_contract_skips > max_contract_skips
+            push!(incomplete,
+                "$(row.point): feature-contract skips $(row.feature_contract_skips) " *
+                "exceed bound $(max_contract_skips)")
+        end
+    end
+    if !isempty(incomplete)
+        return (dominates = false,
+            reason = "incomplete candidate sweep at err=$(err): " * join(incomplete, "; "),
+            baseline = (recall = base.recall, precision = base.precision,
+                over_rate = base.over_correction_rate),
+            best = nothing, candidates = NamedTuple[])
+    end
+
     winners = NamedTuple[]
-    for row in DataFrames.eachrow(at)
-        startswith(row.point, candidate_prefix) || continue
-        (row.ok && row.reads_scored == row.n_reads) || continue
-        (isfinite(row.recall) && isfinite(row.precision) &&
-         isfinite(row.over_correction_rate)) || continue
+    for row in candidate_rows
         # STRICT improvement: retain recall, strictly reduce over-correction, keep
         # precision. The strict `<` on over-correction excludes the gap-0.0 tie.
         if row.recall >= base.recall - recall_eps &&

--- a/benchmarking/rhizomorph_correction_pr_curve.jl
+++ b/benchmarking/rhizomorph_correction_pr_curve.jl
@@ -33,7 +33,9 @@
 #   MYCELIA_RPC_ERR (default 0.05,0.10), MYCELIA_RPC_READLEN (default 150),
 #   MYCELIA_RPC_COVERAGE (default 30; smoke default 15), MYCELIA_RPC_K (default 21),
 #   MYCELIA_RPC_ASSIGNED_Q (default 20), MYCELIA_RPC_SEED (default 42),
-#   MYCELIA_RPC_POINTS (comma list of point names; default all)
+#   MYCELIA_RPC_POINTS (comma list of point names; default all),
+#   MYCELIA_RPC_GAP_THRESHOLDS (default 0,0.5,1,2,4),
+#   MYCELIA_RPC_PROB_THRESHOLDS (dense near zero, where recall changes fastest)
 
 import Pkg
 if isinteractive()
@@ -41,6 +43,7 @@ if isinteractive()
 end
 
 include(joinpath(@__DIR__, "rhizomorph_correction_accuracy_benchmark.jl"))
+include(joinpath(@__DIR__, "viterbi_gap_calibration.jl"))
 
 # === Operating points (named knob presets) ==================================
 
@@ -53,25 +56,87 @@ include(joinpath(@__DIR__, "rhizomorph_correction_accuracy_benchmark.jl"))
 const PR_OPERATING_POINTS = [
     (name = "scalable", skip_solid = true, cheap_correct = true, hard_window = true,
         soft_em = true, n_k_rungs = 3, max_iterations_per_k = 2, beam_width = nothing,
-        calibrated_gap_threshold = nothing),
+        calibrated_gap_threshold = nothing, calibrated_probability_model = nothing,
+        calibrated_probability_threshold = 0.5),
     (name = "noskip", skip_solid = false, cheap_correct = true, hard_window = true,
         soft_em = true, n_k_rungs = 3, max_iterations_per_k = 2, beam_width = nothing,
-        calibrated_gap_threshold = nothing),
+        calibrated_gap_threshold = nothing, calibrated_probability_model = nothing,
+        calibrated_probability_threshold = 0.5),
     (name = "noskip+nogate", skip_solid = false,
         cheap_correct = true, hard_window = false,
         soft_em = true, n_k_rungs = 3, max_iterations_per_k = 2, beam_width = nothing,
-        calibrated_gap_threshold = nothing)
+        calibrated_gap_threshold = nothing, calibrated_probability_model = nothing,
+        calibrated_probability_threshold = 0.5)
 ]
 
-function calibrated_gap_points()
+function calibrated_gap_points()::Vector
     thresholds = _parse_float_list(
         get(ENV, "MYCELIA_RPC_GAP_THRESHOLDS", "0.0,0.5,1.0,2.0,4.0"), Float64[])
     return [(
                 name = "calibrated-gap-$(threshold)", skip_solid = false,
                 cheap_correct = true, hard_window = false, soft_em = true,
                 n_k_rungs = 3, max_iterations_per_k = 2, beam_width = nothing,
-                calibrated_gap_threshold = threshold
+                calibrated_gap_threshold = threshold, calibrated_probability_model = nothing,
+                calibrated_probability_threshold = 0.5
             ) for threshold in thresholds]
+end
+
+function calibrated_probability_points()::Vector
+    thresholds = _parse_float_list(
+        get(ENV, "MYCELIA_RPC_PROB_THRESHOLDS",
+            "0.0,0.01,0.025,0.05,0.075,0.1,0.15,0.2,0.25,0.5,0.75,0.9"),
+        Float64[])
+    all(threshold -> 0.0 <= threshold <= 1.0, thresholds) ||
+        throw(ArgumentError("MYCELIA_RPC_PROB_THRESHOLDS values must be in [0, 1]"))
+    return [(
+                name = "calibrated-prob-$(threshold)", skip_solid = false,
+                cheap_correct = true, hard_window = false, soft_em = true,
+                n_k_rungs = 3, max_iterations_per_k = 2, beam_width = nothing,
+                calibrated_gap_threshold = nothing, calibrated_probability_model = nothing,
+                calibrated_probability_threshold = threshold
+            ) for threshold in thresholds]
+end
+
+"""
+Fit the probability gate on an independent synthetic cohort and convert the
+benchmark logistic coefficients to the runtime model's fixed feature order.
+The calibration cohort uses a disjoint seed and never sees frontier truth.
+"""
+function fit_frontier_probability_model(errs::Vector{Float64}, readlen::Int,
+        coverage::Float64, k::Int, seed::Int)::Mycelia.CorrectionConfidenceModel
+    calibration_results_dir = joinpath(@__DIR__, "results", "td21eg_calibration")
+    artifact = run_gap_calibration(
+        k = k,
+        genome_length = max(1200, 10 * readlen),
+        readlen = readlen,
+        coverage = max(1, round(Int, coverage)),
+        error_rates = errs,
+        seed = seed + 10_000,
+        results_dir = calibration_results_dir,
+        return_artifact = true)
+    expected_features = (
+        :raw_gap,
+        :min_kmer_support,
+        :all_stage0_solid,
+        :competing_branch_support_ratio
+    )
+    artifact.feature_names == expected_features ||
+        throw(ArgumentError("calibration/runtime feature-order mismatch: " *
+                            "expected $(expected_features), got $(artifact.feature_names)"))
+    model = artifact.multifeature_model
+    length(model.b) == length(expected_features) ||
+        throw(ArgumentError("multi-feature logistic must have four coefficients"))
+    runtime_model = Mycelia.CorrectionConfidenceModel(model.a, model.b...)
+    println("Calibration cohort: multi-feature model fitted with grouped holdout; " *
+            "seed=$(seed + 10_000), n_train=$(length(artifact.training.labels)), " *
+            "n_heldout=$(length(artifact.heldout.labels)), " *
+            "artifacts=$(calibration_results_dir)")
+    println("Calibration coefficients: intercept=$(runtime_model.intercept), " *
+            "gap=$(runtime_model.gap_weight), " *
+            "min_support=$(runtime_model.min_kmer_support_weight), " *
+            "stage0_solid=$(runtime_model.stage0_solid_weight), " *
+            "competing_branch=$(runtime_model.branch_support_ratio_weight)")
+    return runtime_model
 end
 
 """
@@ -79,7 +144,8 @@ Correct `records` with an explicit knob preset `pt` (a PR_OPERATING_POINTS entry
 returning `corrected_by_id`. Mirrors correct_reads_scalable but with the point's
 knobs instead of the hardwired :scalable set.
 """
-function correct_reads_at_point(records::Vector{FASTX.FASTQ.Record}, k::Int, pt)
+function correct_reads_at_point(records::Vector{FASTX.FASTQ.Record}, k::Int,
+        pt::NamedTuple)::Dict{String, String}
     input_dir = mktempdir()
     output_dir = mktempdir()
     temp_fastq = joinpath(input_dir, "corrector_input.fastq")
@@ -88,6 +154,10 @@ function correct_reads_at_point(records::Vector{FASTX.FASTQ.Record}, k::Int, pt)
             write(w, r)
         end
     end
+    probability_model = hasproperty(pt, :calibrated_probability_model) ?
+                        pt.calibrated_probability_model : nothing
+    probability_threshold = hasproperty(pt, :calibrated_probability_threshold) ?
+                            pt.calibrated_probability_threshold : 0.5
     result = Mycelia.mycelia_iterative_assemble(
         temp_fastq;
         max_k = max(k, 13),
@@ -100,6 +170,8 @@ function correct_reads_at_point(records::Vector{FASTX.FASTQ.Record}, k::Int, pt)
         cheap_correct = pt.cheap_correct,
         beam_width = pt.beam_width,
         calibrated_gap_threshold = pt.calibrated_gap_threshold,
+        calibrated_probability_model = probability_model,
+        calibrated_probability_threshold = probability_threshold,
         verbose = false,
         enable_checkpointing = false,
         output_dir = output_dir
@@ -116,7 +188,8 @@ function correct_reads_at_point(records::Vector{FASTX.FASTQ.Record}, k::Int, pt)
     return corrected_by_id
 end
 
-function run_pr_curve()
+function run_pr_curve(;
+        probability_model::Union{Nothing, Mycelia.CorrectionConfidenceModel} = nothing)::NamedTuple
     smoke = _truthy(get(ENV, "MYCELIA_RPC_SMOKE", "false"))
     accession = get(ENV, "MYCELIA_RPC_ACCESSION", "NC_001416")
     smoke_len = parse(Int, get(ENV, "MYCELIA_RPC_SMOKE_GENOME_LEN", "2000"))
@@ -127,7 +200,8 @@ function run_pr_curve()
     assigned_q = parse(Int, get(ENV, "MYCELIA_RPC_ASSIGNED_Q", "20"))
     seed = parse(Int, get(ENV, "MYCELIA_RPC_SEED", "42"))
     want = strip(get(ENV, "MYCELIA_RPC_POINTS", ""))
-    all_points = vcat(PR_OPERATING_POINTS, calibrated_gap_points())
+    all_points = vcat(
+        PR_OPERATING_POINTS, calibrated_gap_points(), calibrated_probability_points())
     points = isempty(want) ? all_points :
              filter(p -> p.name in split(want, ","), all_points)
 
@@ -142,6 +216,15 @@ function run_pr_curve()
     glen = length(refseq)
     println("Reference: $ref_label ($glen bp)")
     k = min(k, minimum(readlens), glen)
+    if any(startswith(point.name, "calibrated-prob-") for point in points)
+        effective_probability_model = probability_model === nothing ?
+                                      fit_frontier_probability_model(
+            errs, readlens[1], coverage, k, seed) : probability_model
+        points = [startswith(point.name, "calibrated-prob-") ?
+                  merge(point,
+                      (calibrated_probability_model = effective_probability_model,)) :
+                  point for point in points]
+    end
     rng = Random.MersenneTwister(seed)
 
     rows = DataFrames.DataFrame(
@@ -170,6 +253,7 @@ function run_pr_curve()
             try
                 corrected = correct_reads_at_point(records, k, pt)
             catch e
+                e isa InterruptException && rethrow()
                 @warn "point failed" point=pt.name err exception=(e, catch_backtrace())
                 ok = false
                 corrected = Dict{String, String}()
@@ -196,11 +280,10 @@ function run_pr_curve()
     CSV.write(csv, rows)
     println("\nCSV: $csv")
 
-    # Programmatic dominance verdict at the high-error rate (if the sweep covered
-    # it AND included calibrated points), replacing the eyeball read of the CSV.
+    # Preserve the legacy raw-gap verdict for comparison.
     if 0.10 in errs && any(startswith(p.name, "calibrated-gap-") for p in points)
         dom = assess_frontier_dominance(rows; err = 0.10)
-        if dom.baseline === nothing
+        if hasproperty(dom, :reason)
             println("\n[dominance] $(dom.reason)")
         elseif dom.dominates
             println("\n[dominance] err=0.10 CALIBRATED GATE DOMINATES noskip+nogate: " *
@@ -214,7 +297,34 @@ function run_pr_curve()
             println("\n[dominance] err=0.10 NO calibrated point dominates noskip+nogate " *
                     "(baseline recall=$(round(dom.baseline.recall; digits = 4)) " *
                     "precision=$(round(dom.baseline.precision; digits = 4)) " *
-                    "over_rate=$(round(dom.baseline.over_rate; digits = 6))) — widen thresholds.")
+                    "over_rate=$(round(dom.baseline.over_rate; digits = 6)))")
+        end
+    end
+    # The multi-feature probability family is the td-21eg decision surface. Report
+    # both requested error rates separately; only err=0.10 is the completion gate.
+    if any(startswith(point.name, "calibrated-prob-") for point in points)
+        for err in (0.05, 0.10)
+            err in errs || continue
+            dom = assess_frontier_dominance(
+                rows; err = err, candidate_prefix = "calibrated-prob-")
+            if hasproperty(dom, :reason)
+                println("\n[probability dominance] $(dom.reason)")
+            elseif dom.dominates
+                println("\n[probability dominance] err=$(err) CALIBRATED PROBABILITY " *
+                        "DOMINATES noskip+nogate: $(dom.best.point) " *
+                        "recall=$(round(dom.best.recall; digits = 4)) " *
+                        "precision=$(round(dom.best.precision; digits = 4)) " *
+                        "over_rate=$(round(dom.best.over_rate; digits = 6)) " *
+                        "(baseline recall=$(round(dom.baseline.recall; digits = 4)) " *
+                        "precision=$(round(dom.baseline.precision; digits = 4)) " *
+                        "over_rate=$(round(dom.baseline.over_rate; digits = 6)))")
+            else
+                println("\n[probability dominance] err=$(err) NO calibrated-prob point " *
+                        "strictly dominates noskip+nogate (baseline recall=" *
+                        "$(round(dom.baseline.recall; digits = 4)) precision=" *
+                        "$(round(dom.baseline.precision; digits = 4)) over_rate=" *
+                        "$(round(dom.baseline.over_rate; digits = 6)))")
+            end
         end
     end
     println("\nRead the frontier per error rate: a point with HIGHER recall at ~equal precision")
@@ -225,27 +335,39 @@ function run_pr_curve()
 end
 
 """
-    assess_frontier_dominance(rows; err=0.10, recall_eps=0.02) -> NamedTuple
+    assess_frontier_dominance(rows; err=0.10, recall_eps=0.02,
+        candidate_prefix="calibrated-gap-") -> NamedTuple
 
 Programmatic frontier-dominance check (previously eyeballed from the CSV). At
-error rate `err`, decide whether any `calibrated-gap-*` operating point DOMINATES
+error rate `err`, decide whether any operating point selected by `candidate_prefix` DOMINATES
 the `noskip+nogate` baseline. Dominance requires a STRICT up-and-right move, not a
 tie: recall retained (>= baseline recall − `recall_eps`), over-correction
 **strictly** below baseline, and precision not below baseline. The strict
-over-correction criterion is load-bearing — `calibrated-gap-0.0` is by definition
-the ungated baseline (threshold 0 reverts nothing), so it TIES every metric; a
-non-strict predicate would report it as "dominating" itself. Returns
+over-correction criterion is load-bearing — each family's zero-threshold point
+is by definition the ungated baseline (threshold 0 reverts nothing), so it TIES
+every metric; a non-strict predicate would report it as "dominating" itself. Returns
 `(dominates, baseline, best, candidates)`. A non-finite baseline or non-finite
-candidate metrics (zero-denominator rows) are treated as non-dominating.
+candidate metrics (zero-denominator rows) are treated as non-dominating. A row
+is eligible only when its run succeeded (`ok`) and scored every simulated read
+(`reads_scored == n_reads`); partial or failed runs cannot establish dominance.
 """
 function assess_frontier_dominance(rows::DataFrames.DataFrame;
-        err::Float64 = 0.10, recall_eps::Float64 = 0.02)
+        err::Float64 = 0.10, recall_eps::Float64 = 0.02,
+        candidate_prefix::AbstractString = "calibrated-gap-")::NamedTuple
     at = rows[[isapprox(r, err; atol = 1e-9) for r in rows.error_rate], :]
     base_idx = findfirst(==("noskip+nogate"), at.point)
     base_idx === nothing && return (dominates = false,
         reason = "no noskip+nogate baseline at err=$(err)",
         baseline = nothing, best = nothing, candidates = NamedTuple[])
     base = at[base_idx, :]
+    if !(base.ok && base.reads_scored == base.n_reads)
+        return (dominates = false,
+            reason = "failed or partial noskip+nogate baseline at err=$(err): " *
+                     "ok=$(base.ok), reads_scored=$(base.reads_scored)/$(base.n_reads)",
+            baseline = (recall = base.recall, precision = base.precision,
+                over_rate = base.over_correction_rate),
+            best = nothing, candidates = NamedTuple[])
+    end
     if !(isfinite(base.recall) && isfinite(base.precision) &&
          isfinite(base.over_correction_rate))
         return (dominates = false,
@@ -256,7 +378,8 @@ function assess_frontier_dominance(rows::DataFrames.DataFrame;
     end
     winners = NamedTuple[]
     for row in DataFrames.eachrow(at)
-        startswith(row.point, "calibrated-gap-") || continue
+        startswith(row.point, candidate_prefix) || continue
+        (row.ok && row.reads_scored == row.n_reads) || continue
         (isfinite(row.recall) && isfinite(row.precision) &&
          isfinite(row.over_correction_rate)) || continue
         # STRICT improvement: retain recall, strictly reduce over-correction, keep

--- a/benchmarking/rhizomorph_correction_pr_curve.jl
+++ b/benchmarking/rhizomorph_correction_pr_curve.jl
@@ -37,6 +37,7 @@
 #   MYCELIA_RPC_GAP_THRESHOLDS (default 0,0.5,1,2,4),
 #   MYCELIA_RPC_PROB_THRESHOLDS (dense near zero, where recall changes fastest)
 
+import Dates
 import Pkg
 if isinteractive()
     Pkg.activate(joinpath(@__DIR__, ".."))
@@ -97,14 +98,39 @@ function calibrated_probability_points()::Vector
             ) for threshold in thresholds]
 end
 
+function persist_runtime_probability_model(
+        model::Mycelia.CorrectionConfidenceModel,
+        results_dir::AbstractString)::String
+    mkpath(results_dir)
+    model_path = joinpath(results_dir, "runtime_probability_model.csv")
+    coefficients = (
+        intercept = model.intercept,
+        raw_gap = model.gap_weight,
+        min_kmer_support = model.min_kmer_support_weight,
+        all_stage0_solid = model.stage0_solid_weight,
+        competing_branch_support_ratio = model.branch_support_ratio_weight,
+        collapsed_frontier = model.collapsed_frontier_weight
+    )
+    open(model_path, "w") do io
+        println(io, "term,coefficient")
+        for term in keys(coefficients)
+            println(io, "$(term),$(getproperty(coefficients, term))")
+        end
+    end
+    return model_path
+end
+
 """
 Fit the probability gate on an independent synthetic cohort and convert the
 benchmark logistic coefficients to the runtime model's fixed feature order.
 The calibration cohort uses a disjoint seed and never sees frontier truth.
 """
 function fit_frontier_probability_model(errs::Vector{Float64}, readlen::Int,
-        coverage::Float64, k::Int, seed::Int)::Mycelia.CorrectionConfidenceModel
-    calibration_results_dir = joinpath(@__DIR__, "results", "td21eg_calibration")
+        coverage::Float64, k::Int, seed::Int)::NamedTuple
+    results_root = joinpath(@__DIR__, "results")
+    mkpath(results_root)
+    calibration_results_dir = mktempdir(
+        results_root; prefix = "td21eg_calibration_", cleanup = false)
     artifact = run_gap_calibration(
         k = k,
         genome_length = max(1200, 10 * readlen),
@@ -118,14 +144,15 @@ function fit_frontier_probability_model(errs::Vector{Float64}, readlen::Int,
         :raw_gap,
         :min_kmer_support,
         :all_stage0_solid,
-        :competing_branch_support_ratio
+        :competing_branch_support_ratio,
+        :collapsed_frontier
     )
     artifact.feature_names == expected_features ||
         throw(ArgumentError("calibration/runtime feature-order mismatch: " *
                             "expected $(expected_features), got $(artifact.feature_names)"))
     model = artifact.multifeature_model
     length(model.b) == length(expected_features) ||
-        throw(ArgumentError("multi-feature logistic must have four coefficients"))
+        throw(ArgumentError("multi-feature logistic has wrong coefficient count"))
     runtime_model = Mycelia.CorrectionConfidenceModel(model.a, model.b...)
     println("Calibration cohort: multi-feature model fitted with grouped holdout; " *
             "seed=$(seed + 10_000), n_train=$(length(artifact.training.labels)), " *
@@ -135,8 +162,9 @@ function fit_frontier_probability_model(errs::Vector{Float64}, readlen::Int,
             "gap=$(runtime_model.gap_weight), " *
             "min_support=$(runtime_model.min_kmer_support_weight), " *
             "stage0_solid=$(runtime_model.stage0_solid_weight), " *
-            "competing_branch=$(runtime_model.branch_support_ratio_weight)")
-    return runtime_model
+            "competing_branch=$(runtime_model.branch_support_ratio_weight), " *
+            "collapsed_frontier=$(runtime_model.collapsed_frontier_weight)")
+    return (model = runtime_model, results_dir = calibration_results_dir)
 end
 
 """
@@ -204,6 +232,9 @@ function run_pr_curve(;
         PR_OPERATING_POINTS, calibrated_gap_points(), calibrated_probability_points())
     points = isempty(want) ? all_points :
              filter(p -> p.name in split(want, ","), all_points)
+    calibration_artifact = ""
+    results_dir = joinpath(@__DIR__, "results")
+    mkpath(results_dir)
 
     println("=== Rhizomorph Correction Precision-Recall Frontier ===")
     println("Start: $(Dates.now())   error rates: $errs   coverage: $(coverage)x   k: $k")
@@ -217,9 +248,18 @@ function run_pr_curve(;
     println("Reference: $ref_label ($glen bp)")
     k = min(k, minimum(readlens), glen)
     if any(startswith(point.name, "calibrated-prob-") for point in points)
-        effective_probability_model = probability_model === nothing ?
-                                      fit_frontier_probability_model(
-            errs, readlens[1], coverage, k, seed) : probability_model
+        effective_probability_model = if probability_model === nothing
+            fit = fit_frontier_probability_model(
+                errs, readlens[1], coverage, k, seed)
+            calibration_artifact = fit.results_dir
+            fit.model
+        else
+            supplied_dir = mktempdir(
+                results_dir; prefix = "td21eg_caller_model_", cleanup = false)
+            persist_runtime_probability_model(probability_model, supplied_dir)
+            calibration_artifact = supplied_dir
+            probability_model
+        end
         points = [startswith(point.name, "calibrated-prob-") ?
                   merge(point,
                       (calibrated_probability_model = effective_probability_model,)) :
@@ -231,7 +271,8 @@ function run_pr_curve(;
         error_rate = Float64[], point = String[], ok = Bool[], n_reads = Int[],
         reads_scored = Int[], injected = Int[], true_fixes = Int[], mis_fixes = Int[],
         over_corrections = Int[], recall = Float64[], precision = Float64[],
-        over_correction_rate = Float64[], correction_rate = Float64[], runtime_s = Float64[])
+        over_correction_rate = Float64[], correction_rate = Float64[], runtime_s = Float64[],
+        calibration_artifact = String[])
 
     for err in errs
         # SAME reads for every operating point at this error rate (fair comparison).
@@ -265,7 +306,9 @@ function run_pr_curve(;
                     reads_scored = m.reads_scored, injected = m.injected, true_fixes = m.tp,
                     mis_fixes = m.mis_fixes, over_corrections = m.over, recall = m.recall,
                     precision = m.precision, over_correction_rate = m.over_rate,
-                    correction_rate = m.correction_rate, runtime_s = rt))
+                    correction_rate = m.correction_rate, runtime_s = rt,
+                    calibration_artifact = startswith(pt.name, "calibrated-prob-") ?
+                                           calibration_artifact : ""))
             println("  $(rpad(pt.name, 15)) recall=$(rpad(round(m.recall; digits=4), 8)) " *
                     "precision=$(rpad(round(m.precision; digits=4), 8)) " *
                     "over_rate=$(rpad(round(m.over_rate; digits=6), 10)) " *
@@ -273,8 +316,6 @@ function run_pr_curve(;
         end
     end
 
-    results_dir = joinpath(@__DIR__, "results")
-    mkpath(results_dir)
     ts = Dates.format(Dates.now(), "yyyymmdd_HHMMSS")
     csv = joinpath(results_dir, "rhizomorph_correction_pr_curve_$(ts).csv")
     CSV.write(csv, rows)

--- a/benchmarking/viterbi_gap_calibration.jl
+++ b/benchmarking/viterbi_gap_calibration.jl
@@ -1,13 +1,10 @@
-# Tier-2 per-base Viterbi-gap calibration (td-4osf).
+# Tier-2 per-base Viterbi correction-confidence calibration (td-21eg).
 #
-# Stage 2 (Route a, self-contained): drive `correct_observations` directly with
-# `record_position_gaps=true` on a controlled singlestrand graph, align each
-# finite per-position Viterbi gap to the corrected base, label it against truth,
-# and fit + compare THREE calibration models head-to-head (isotonic, logistic,
-# binned). AUROC (discrimination) is a property of the raw gap ranking — reported
-# ONCE, identical across models; ECE/Brier (calibration) isolate where the models
-# differ. Not a CI test (drives many whole-graph decodes); the CI-fast assertions
-# live in test/4_assembly/viterbi_gap_calibration_test.jl.
+# `collect_gap_truth` keeps a focused decoder-level contract test, while
+# `run_gap_calibration` learns exclusively from telemetry emitted by the same
+# iterative-corrector configuration used by the frontier. The logistic model is
+# fit on proposed substitutions only and evaluated on a deterministic,
+# read-grouped holdout so bases from one read never leak across the split.
 
 import Mycelia
 import Random
@@ -16,22 +13,60 @@ import FASTX
 include(joinpath(@__DIR__, "calibration_metrics.jl"))
 include(joinpath(@__DIR__, "benchmark_kmer_graph_fixture.jl"))
 
+const CORRECTION_CONFIDENCE_FEATURES = (
+    :raw_gap,
+    :min_kmer_support,
+    :all_stage0_solid,
+    :competing_branch_support_ratio
+)
+
+function correction_calibration_serving_config(k::Int)::NamedTuple
+    return (
+        max_k = max(k, 13),
+        skip_solid = false,
+        graph_mode = :doublestrand,
+        n_k_rungs = 3,
+        max_iterations_per_k = 2,
+        hard_window = false,
+        soft_em = true,
+        cheap_correct = true,
+        beam_width = nothing
+    )
+end
+
 """
-    collect_gap_truth(fixture, observed_sequence, truth_sequence; config)
+    collect_gap_truth(fixture, observed_sequence, truth_sequence;
+        config, solid_kmers, quality_scores)
 
 Decode one fixed-length observation and align `position_gaps[i]` with
 `path.steps[i + 1]`. A k-mer transition contributes the newly emitted base at
 read position `i + k`; its label is true iff that corrected base matches truth.
-Collapsed-frontier `Inf` sentinels are excluded before calibration.
+For each finite-gap base, emit the fixed feature vector
+`(raw_gap, min_kmer_support, all_stage0_solid, competing_branch_support_ratio)` plus a
+`candidate_edit` flag. The support/solidity window is
+`path.steps[i + 1:min(i + k, nsteps)]`, the decoded k-mers overlapping that
+base. Collapsed-frontier `Inf` sentinels are excluded before calibration.
 """
 function collect_gap_truth(fixture::NamedTuple,
         observed_sequence::AbstractString,
         truth_sequence::AbstractString;
         config::Mycelia.ViterbiCorrectionConfig =
-        Mycelia.ViterbiCorrectionConfig(record_position_gaps = true))::NamedTuple
+        Mycelia.ViterbiCorrectionConfig(record_position_gaps = true),
+        solid_kmers::Union{Nothing, AbstractSet} = nothing,
+        quality_scores::Union{Nothing, AbstractVector{<:Integer}} = nothing)::NamedTuple
     length(observed_sequence) == length(truth_sequence) ||
         throw(ArgumentError("observed and truth sequences must have equal length"))
-    observation = fixture.to_observation(observed_sequence)
+    raw_observation = fixture.to_observation(observed_sequence)
+    observation = if quality_scores === nothing
+        raw_observation
+    else
+        length(quality_scores) == length(observed_sequence) ||
+            throw(ArgumentError("quality scores must align with the observed sequence"))
+        observation_k = length(String(first(raw_observation)))
+        [Mycelia.QualityObservation(raw_observation[i],
+             UInt8.(@view quality_scores[i:(i + observation_k - 1)]))
+         for i in eachindex(raw_observation)]
+    end
     result = Mycelia.correct_observations(fixture.graph, [observation]; config = config)
     # NB: `something(x, throw(e))` would raise EAGERLY (throw is an argument,
     # evaluated before `something` runs) — use a lazy nothing-check so we only
@@ -42,19 +77,46 @@ function collect_gap_truth(fixture::NamedTuple,
     length(gaps) == length(path.steps) - 1 ||
         throw(ArgumentError("position-gap/path alignment contract violated"))
     k = length(String(path.steps[1].vertex_label))
+    corrected_sequence = String(Mycelia.Rhizomorph.path_to_sequence(path, fixture.graph))
+    length(corrected_sequence) == length(observed_sequence) ||
+        throw(ArgumentError("decoded sequence must preserve observation length"))
+    solid = solid_kmers === nothing ? Mycelia._solid_kmer_set(fixture.graph) : solid_kmers
     scores = Float64[]
     labels = Bool[]
     positions = Int[]
+    candidate_edits = Bool[]
+    feature_rows = NamedTuple[]
     for i in eachindex(gaps)
         isfinite(gaps[i]) || continue
-        corrected_kmer = String(path.steps[i + 1].vertex_label)
         position = i + k
         position <= lastindex(truth_sequence) || continue
-        push!(scores, gaps[i])
-        push!(labels, corrected_kmer[end] == truth_sequence[position])
+        shared_features = Mycelia.correction_confidence_features(
+            fixture.graph, path, i, k, solid, Float64(gaps[i]))
+        features = (
+            raw_gap = shared_features.raw_gap,
+            min_kmer_support = shared_features.min_kmer_support,
+            all_stage0_solid = shared_features.all_stage0_solid,
+            competing_branch_support_ratio =
+            shared_features.competing_branch_support_ratio
+        )
+        push!(scores, features.raw_gap)
+        push!(labels, corrected_sequence[position] == truth_sequence[position])
         push!(positions, position)
+        push!(candidate_edits,
+            corrected_sequence[position] != observed_sequence[position])
+        push!(feature_rows, features)
     end
-    return (; scores, labels, positions, result)
+    features = Matrix{Float64}(undef, length(feature_rows),
+        length(CORRECTION_CONFIDENCE_FEATURES))
+    for (row_index, row) in enumerate(feature_rows)
+        features[row_index, :] .= (
+            row.raw_gap,
+            row.min_kmer_support,
+            row.all_stage0_solid ? 1.0 : 0.0,
+            row.competing_branch_support_ratio
+        )
+    end
+    return (; scores, labels, positions, candidate_edits, features, feature_rows, result)
 end
 
 # The three calibration models compared head-to-head. Each is a (fit, predict)
@@ -101,6 +163,118 @@ function compare_gap_calibrations(scores::AbstractVector{<:Real},
                 for r in rows])
 end
 
+"""
+    grouped_read_split(rows; holdout_fraction=0.2, seed=42) -> NamedTuple
+
+Split finite-gap rows by `(error_rate, read_id)`, stratified by error rate. The
+split is deterministic under `seed`; every error rate with at least two read
+groups contributes at least one held-out and one training group.
+"""
+function grouped_read_split(rows::AbstractVector{<:NamedTuple};
+        holdout_fraction::Float64 = 0.2, seed::Int = 42)::NamedTuple
+    0.0 < holdout_fraction < 1.0 ||
+        throw(ArgumentError("holdout_fraction must be in the open interval (0, 1)"))
+    rng = Random.MersenneTwister(seed)
+    heldout_groups = Set{Tuple{Float64, String}}()
+    training_groups = Set{Tuple{Float64, String}}()
+    for error_rate in sort!(unique(Float64(row.error_rate) for row in rows))
+        read_ids = sort!(unique(String(row.read_id)
+        for row in rows
+        if row.error_rate == error_rate))
+        Random.shuffle!(rng, read_ids)
+        if length(read_ids) < 2
+            foreach(read_id -> push!(training_groups, (error_rate, read_id)), read_ids)
+            continue
+        end
+        n_heldout = clamp(round(Int, holdout_fraction * length(read_ids)),
+            1, length(read_ids) - 1)
+        foreach(read_id -> push!(heldout_groups, (error_rate, read_id)),
+            @view read_ids[1:n_heldout])
+        foreach(read_id -> push!(training_groups, (error_rate, read_id)),
+            @view read_ids[(n_heldout + 1):end])
+    end
+    training_indices = [i
+                        for (i, row) in enumerate(rows)
+                        if (
+        Float64(row.error_rate), String(row.read_id)) in training_groups]
+    heldout_indices = [i
+                       for (i, row) in enumerate(rows)
+                       if (Float64(row.error_rate), String(row.read_id)) in heldout_groups]
+    return (; training_indices, heldout_indices, training_groups, heldout_groups)
+end
+
+function _feature_matrix(rows::AbstractVector{<:NamedTuple})::Matrix{Float64}
+    features = Matrix{Float64}(undef, length(rows),
+        length(CORRECTION_CONFIDENCE_FEATURES))
+    for (i, row) in enumerate(rows)
+        features[i, :] .= (
+            row.raw_gap,
+            row.min_kmer_support,
+            row.all_stage0_solid ? 1.0 : 0.0,
+            row.competing_branch_support_ratio
+        )
+    end
+    return features
+end
+
+function _calibration_partition(rows::AbstractVector{<:NamedTuple},
+        indices::AbstractVector{<:Integer})::NamedTuple
+    candidate_indices = [i for i in indices if rows[i].candidate_edit]
+    candidate_rows = rows[candidate_indices]
+    return (
+        n = length(candidate_rows),
+        rows = candidate_rows,
+        indices = candidate_indices,
+        features = _feature_matrix(candidate_rows),
+        scores = Float64[row.raw_gap for row in candidate_rows],
+        labels = Bool[row.label for row in candidate_rows],
+        groups = Tuple{Float64, String}[(Float64(row.error_rate), String(row.read_id))
+                                        for row in candidate_rows]
+    )
+end
+
+function _metric_row(model_name::String, scope::String,
+        error_rate::Union{Nothing, Float64}, probabilities::Vector{Float64},
+        labels::Vector{Bool}; nbins::Int)::NamedTuple
+    return (
+        scope = scope,
+        error_rate = error_rate,
+        model = model_name,
+        n = length(labels),
+        positive_frac = isempty(labels) ? NaN : count(labels) / length(labels),
+        auroc = auroc(probabilities, labels),
+        ece = expected_calibration_error(probabilities, labels; nbins = nbins),
+        brier = brier_score(probabilities, labels),
+        reliability = reliability_bins(probabilities, labels; nbins = nbins)
+    )
+end
+
+function _heldout_metric_rows(multifeature_model::NamedTuple, gap_model::NamedTuple,
+        heldout::NamedTuple; nbins::Int)::Vector{NamedTuple}
+    rows = NamedTuple[]
+    scopes = Tuple{String, Union{Nothing, Float64}, Vector{Int}}[
+    (
+        "pooled", nothing, collect(eachindex(heldout.labels))),
+]
+    for error_rate in sort!(unique(row.error_rate for row in heldout.rows))
+        indices = findall(row -> row.error_rate == error_rate, heldout.rows)
+        push!(scopes, ("error-rate", Float64(error_rate), indices))
+    end
+    for (scope, error_rate, indices) in scopes
+        labels = heldout.labels[indices]
+        multifeature_probabilities = predict_logistic(
+            multifeature_model, heldout.features[indices, :])
+        gap_probabilities = predict_logistic(gap_model, heldout.scores[indices])
+        push!(rows,
+            _metric_row("multifeature-logistic", scope, error_rate,
+                multifeature_probabilities, labels; nbins = nbins))
+        push!(rows,
+            _metric_row("gap-only-logistic", scope, error_rate,
+                gap_probabilities, labels; nbins = nbins))
+    end
+    return rows
+end
+
 # Substitute each base with prob `rate` to a DIFFERENT base (length-preserving),
 # so the observed read aligns 1:1 with its truth for per-position labeling.
 function _inject_substitutions(seq::AbstractString, rate::Float64, rng)::String
@@ -131,22 +305,31 @@ calibration signal; the coverage graph is what the production gate actually
 decodes against.
 """
 function build_coverage_fixture(reads::Vector{<:FASTX.FASTQ.Record}, k::Int;
-        moltype::Symbol = :DNA)::NamedTuple
+        moltype::Symbol = :DNA, graph_mode::Symbol = :doublestrand)::NamedTuple
     graph = Mycelia.Rhizomorph.build_kmer_graph(reads, k;
-        dataset_id = "gapcal", mode = :singlestrand)
+        dataset_id = "gapcal", mode = graph_mode)
     to_observation = seq -> _bench_convert_kmers(_bench_sequence_kmers(seq, k), k, moltype)
     return (graph = graph, to_observation = to_observation)
 end
 
 """
-    run_gap_calibration(; kwargs...) -> Vector
+    run_gap_calibration(; kwargs...) -> Union{Vector, NamedTuple}
 
-At each error rate (through err=0.10): simulate a substitution read set from a
-controlled genome, build the read-COVERAGE k-mer graph (where the Viterbi margin
-is finite — see `build_coverage_fixture`), decode each read collecting finite
-per-position gaps with truth labels, then fit + compare all three calibration
-models. Prints a head-to-head table and writes
+At each error rate (through err=0.10), simulate a substitution-only Q20 read
+cohort and run it through the exact iterative-corrector configuration used by
+the frontier probability family: doublestrand graphs, `skip_solid=false`,
+`cheap_correct=true`, `soft_em=true`, `hard_window=false`, three k rungs, two
+iterations per rung, and the automatic beam. Candidate-substitution telemetry is
+collected through `correction_feature_sink`, so training and serving share one
+feature extractor and the same graph/decoder path. A pooled multi-feature
+logistic and a gap-only logistic baseline are fit on identical candidate-bearing
+read groups and evaluated on a deterministic 20% grouped holdout, pooled and by
+error rate. Prints a head-to-head table and writes
 `results/rhizomorph_gap_calibration.csv`. Deterministic under `seed`.
+
+By default, returns the metric-row vector for backward compatibility. With
+`return_artifact=true`, returns the fitted models, partitions, and all finite
+rows needed by the correction-frontier benchmark.
 """
 function run_gap_calibration(;
         k::Int = 11,
@@ -156,86 +339,219 @@ function run_gap_calibration(;
         error_rates::Vector{Float64} = [0.05, 0.08, 0.10],
         seed::Int = 42,
         nbins::Int = 10,
-        results_dir::String = joinpath(@__DIR__, "results"))::Vector
+        holdout_fraction::Float64 = 0.2,
+        replicates::Int = 5,
+        max_contract_skip_fraction::Float64 = 0.25,
+        results_dir::String = joinpath(@__DIR__, "results"),
+        return_artifact::Bool = false)::Union{Vector{NamedTuple}, NamedTuple}
+    isempty(error_rates) && throw(ArgumentError("error_rates must not be empty"))
+    all(error_rate -> 0.0 <= error_rate <= 1.0, error_rates) ||
+        throw(ArgumentError("error_rates must lie in [0, 1]"))
+    length(unique(error_rates)) == length(error_rates) ||
+        throw(ArgumentError("error_rates must be unique"))
+    genome_length >= readlen ||
+        throw(ArgumentError("genome_length must be at least readlen"))
+    replicates >= 1 || throw(ArgumentError("replicates must be at least 1"))
+    0.0 <= max_contract_skip_fraction <= 1.0 ||
+        throw(ArgumentError("max_contract_skip_fraction must be in [0, 1]"))
     rng = Random.MersenneTwister(seed)
-    truth_genome = String(rand(rng, ['A', 'C', 'G', 'T'], genome_length))
     n_reads = max(1, ceil(Int, coverage * genome_length / readlen))
+    serving_config = correction_calibration_serving_config(k)
     mkpath(results_dir)
-    out_rows = NamedTuple[]
-    println("=== Rhizomorph Tier-2 gap calibration (3-model head-to-head) ===")
+    dataset = NamedTuple[]
+    contract_skips = Dict{Float64, Int}()
+    contract_read_passes = Dict{Float64, Int}()
+    println("=== Rhizomorph multi-feature correction-confidence calibration ===")
     println("genome=$(genome_length)  k=$(k)  readlen=$(readlen)  coverage=$(coverage)x  " *
-            "n_reads=$(n_reads)  seed=$(seed)")
+            "n_reads=$(n_reads)  replicates=$(replicates)  seed=$(seed)")
     for er in error_rates
-        # Errored read set + each read's own clean truth (substitution-only, so the
-        # observed read aligns 1:1 with its truth for per-position labeling).
-        reads = FASTX.FASTQ.Record[]
-        truths = String[]
-        for i in 1:n_reads
-            st = rand(rng, 1:(genome_length - readlen + 1))
-            clean = truth_genome[st:(st + readlen - 1)]
-            observed = _inject_substitutions(clean, er, rng)
-            push!(reads, FASTX.FASTQ.Record("r$(i)", observed, String(fill('I', readlen))))
-            push!(truths, clean)
-        end
-        cov = build_coverage_fixture(reads, k)
-        cfg = Mycelia.ViterbiCorrectionConfig(record_position_gaps = true, error_rate = er)
-        scores = Float64[]
-        labels = Bool[]
-        n_failed = 0
-        first_error = nothing
-        for (rec, clean) in zip(reads, truths)
-            gt = try
-                collect_gap_truth(cov, FASTX.sequence(String, rec), clean; config = cfg)
-            catch e
-                # Skip ONLY the expected "no path" decode failure; a contract
-                # violation, BoundsError, or any other defect is a real bug that must
-                # surface, not be silently averaged out of the calibration sample.
-                if e isa ArgumentError && occursin("decode produced no path", e.msg)
-                    n_failed += 1
-                    first_error === nothing && (first_error = e)
-                    continue
-                end
-                rethrow()
+        contract_skips[er] = 0
+        contract_read_passes[er] = 0
+        rate_event_count = 0
+        rate_groups = Set{String}()
+        for replicate in 1:replicates
+            truth_genome = String(rand(rng, ['A', 'C', 'G', 'T'], genome_length))
+            reads = FASTX.FASTQ.Record[]
+            truth_by_id = Dict{String, String}()
+            for i in 1:n_reads
+                start = rand(rng, 1:(genome_length - readlen + 1))
+                clean = truth_genome[start:(start + readlen - 1)]
+                observed = _inject_substitutions(clean, er, rng)
+                read_id = "rep$(replicate)-err$(er)-r$(i)"
+                push!(reads,
+                    FASTX.FASTQ.Record(read_id, observed, String(fill('5', readlen))))
+                truth_by_id[read_id] = clean
             end
-            append!(scores, gt.scores)
-            append!(labels, gt.labels)
+            event_rows = NamedTuple[]
+            function feature_sink(
+                    event::Mycelia.CorrectionFeatureObservation)::Nothing
+                haskey(truth_by_id, event.read_id) ||
+                    throw(ArgumentError(
+                        "feature event has unknown read id $(event.read_id)"))
+                truth = truth_by_id[event.read_id]
+                1 <= event.position <= lastindex(truth) ||
+                    throw(ArgumentError(
+                        "feature-event position is outside its truth read"))
+                features = event.features
+                push!(event_rows,
+                    (
+                        error_rate = er,
+                        read_id = event.read_id,
+                        k = event.k,
+                        position = event.position,
+                        raw_gap = features.raw_gap,
+                        min_kmer_support = features.min_kmer_support,
+                        all_stage0_solid = features.all_stage0_solid,
+                        competing_branch_support_ratio =
+                        features.competing_branch_support_ratio,
+                        label = event.corrected_base == truth[event.position],
+                        candidate_edit = event.corrected_base != event.observed_base
+                    ))
+                return nothing
+            end
+            input_dir = mktempdir(prefix = "gapcal_input_")
+            output_dir = mktempdir(prefix = "gapcal_output_")
+            input_fastq = joinpath(input_dir, "calibration.fastq")
+            open(FASTX.FASTQ.Writer, input_fastq) do writer
+                for read in reads
+                    write(writer, read)
+                end
+            end
+            Random.seed!(seed + 1_000_000 * replicate + round(Int, er * 1_000_000))
+            correction_result = Mycelia.mycelia_iterative_assemble(
+                input_fastq;
+                serving_config...,
+                correction_feature_sink = feature_sink,
+                verbose = false,
+                enable_checkpointing = false,
+                output_dir = output_dir)
+            contract_skips[er] += Int(get(
+                correction_result[:metadata], :calibrated_feature_contract_skips, 0))
+            contract_read_passes[er] +=
+                n_reads * Int(correction_result[:metadata][:total_iterations])
+            append!(dataset, event_rows)
+            rate_event_count += length(event_rows)
+            union!(rate_groups, (row.read_id for row in event_rows))
         end
-        # Distinguish systematic/partial DECODE FAILURE (a real bug or a biased
-        # survivor subset) from mere class imbalance — a bare `catch;continue` would
-        # otherwise misattribute an all-fail run to "insufficient class balance".
-        if n_failed > 0
-            @warn "gap calibration: $(n_failed)/$(length(reads)) reads failed to " *
-                  "decode at err=$(er) (calibration fit on the surviving subset — " *
-                  "possible bias)." first_error
-        end
-        if n_failed == length(reads)
-            println("err=$(er): ALL $(length(reads)) reads failed to decode — no signal, skipped")
-            continue
-        end
-        if isempty(scores) || all(labels) || !any(labels)
-            println("err=$(er): insufficient class balance (n=$(length(scores))) — skipped")
-            continue
-        end
-        cmp = compare_gap_calibrations(scores, labels; nbins = nbins)
-        println("err=$(er): AUROC=$(round(cmp.auroc; digits = 3))  n=$(length(scores))  " *
-                "positive_frac=$(round(count(labels) / length(labels); digits = 3))")
-        for r in cmp.rows
-            println("   $(rpad(r.model, 9))  ECE=$(round(r.ece; digits = 4))  " *
-                    "Brier=$(round(r.brier; digits = 4))")
-            push!(out_rows,
-                (error_rate = er, model = r.model, n = length(scores),
-                    auroc = cmp.auroc, ece = r.ece, brier = r.brier))
-        end
+        println("err=$(er): candidate_events=$(rate_event_count)  " *
+                "candidate-bearing_reads=$(length(rate_groups))  " *
+                "feature_contract_skips=$(contract_skips[er])")
+        contract_skip_fraction = contract_read_passes[er] == 0 ? 0.0 :
+                                 contract_skips[er] / contract_read_passes[er]
+        contract_skip_fraction <= max_contract_skip_fraction ||
+            throw(ArgumentError("error rate $(er) feature-contract skip fraction " *
+                                "$(contract_skip_fraction) exceeds configured bound " *
+                                "$(max_contract_skip_fraction)"))
+    end
+
+    isempty(dataset) &&
+        throw(ArgumentError("no finite candidate-substitution events available"))
+    all(row.candidate_edit for row in dataset) ||
+        throw(ArgumentError("correction feature sink emitted a non-candidate event"))
+    split = grouped_read_split(dataset;
+        holdout_fraction = holdout_fraction, seed = seed + 1)
+    for error_rate in error_rates
+        candidate_groups = Set((row.error_rate, row.read_id)
+        for row in dataset
+        if row.error_rate == error_rate)
+        length(candidate_groups) >= 2 ||
+            throw(ArgumentError("error rate $(error_rate) needs at least two " *
+                                "candidate-bearing read groups"))
+        any(group -> group[1] == error_rate, split.training_groups) ||
+            throw(ArgumentError("error rate $(error_rate) has no training groups"))
+        any(group -> group[1] == error_rate, split.heldout_groups) ||
+            throw(ArgumentError("error rate $(error_rate) has no held-out groups"))
+    end
+    training = _calibration_partition(dataset, split.training_indices)
+    heldout = _calibration_partition(dataset, split.heldout_indices)
+    isempty(training.labels) &&
+        throw(ArgumentError("no candidate edits in training groups"))
+    isempty(heldout.labels) && throw(ArgumentError("no candidate edits in held-out groups"))
+    (all(training.labels) || !any(training.labels)) &&
+        throw(ArgumentError("candidate-edit training labels need both classes"))
+
+    multifeature_model = fit_logistic_map(training.features, training.labels)
+    gap_model = fit_logistic_map(training.scores, training.labels)
+    out_rows = _heldout_metric_rows(
+        multifeature_model, gap_model, heldout; nbins = nbins)
+    println("train candidate edits=$(training.n)  held-out=$(heldout.n)  " *
+            "train groups=$(length(unique(training.groups)))  " *
+            "held-out groups=$(length(unique(heldout.groups)))")
+    for row in out_rows
+        rate_label = row.error_rate === nothing ? "pooled" : "err=$(row.error_rate)"
+        println("$(rpad(rate_label, 10)) $(rpad(row.model, 23)) " *
+                "AUROC=$(round(row.auroc; digits = 3))  " *
+                "ECE=$(round(row.ece; digits = 4))  " *
+                "Brier=$(round(row.brier; digits = 4))  n=$(row.n)")
     end
     csv_path = joinpath(results_dir, "rhizomorph_gap_calibration.csv")
     open(csv_path, "w") do io
-        println(io, "error_rate,model,n,auroc,ece,brier")
+        println(io, "scope,error_rate,model,n,positive_frac,auroc,ece,brier")
         for r in out_rows
-            println(io, join((r.error_rate, r.model, r.n, r.auroc, r.ece, r.brier), ","))
+            error_rate = r.error_rate === nothing ? "" : string(r.error_rate)
+            println(io,
+                join(
+                    (r.scope, error_rate, r.model, r.n, r.positive_frac,
+                        r.auroc, r.ece, r.brier), ","))
         end
     end
     println("Wrote $(csv_path)")
-    return out_rows
+
+    model_path = joinpath(results_dir, "rhizomorph_gap_calibration_model.csv")
+    open(model_path, "w") do io
+        println(io, "model,term,coefficient")
+        println(io, "multifeature-logistic,intercept,$(multifeature_model.a)")
+        for (feature_name, coefficient) in
+            zip(CORRECTION_CONFIDENCE_FEATURES, multifeature_model.b)
+            println(io,
+                "multifeature-logistic,$(feature_name),$(coefficient)")
+        end
+        println(io, "gap-only-logistic,intercept,$(gap_model.a)")
+        println(io, "gap-only-logistic,raw_gap,$(gap_model.b)")
+    end
+    println("Wrote $(model_path)")
+
+    manifest_path = joinpath(results_dir, "rhizomorph_gap_calibration_manifest.csv")
+    open(manifest_path, "w") do io
+        println(io, "key,value")
+        println(io, "seed,$(seed)")
+        println(io, "k,$(k)")
+        println(io, "genome_length,$(genome_length)")
+        println(io, "readlen,$(readlen)")
+        println(io, "coverage,$(coverage)")
+        println(io, "replicates,$(replicates)")
+        println(io, "holdout_fraction,$(holdout_fraction)")
+        println(io, "max_contract_skip_fraction,$(max_contract_skip_fraction)")
+        println(io, "training_candidate_edits,$(training.n)")
+        println(io, "heldout_candidate_edits,$(heldout.n)")
+        println(io, "error_rates,$(join(error_rates, ';'))")
+        for error_rate in error_rates
+            println(io,
+                "contract_skips_$(error_rate),$(contract_skips[error_rate])")
+            println(io,
+                "contract_read_passes_$(error_rate)," *
+                "$(contract_read_passes[error_rate])")
+        end
+    end
+    println("Wrote $(manifest_path)")
+    return return_artifact ?
+           (
+        rows = out_rows,
+        multifeature_model = multifeature_model,
+        gap_model = gap_model,
+        feature_names = CORRECTION_CONFIDENCE_FEATURES,
+        training = training,
+        heldout = heldout,
+        dataset = dataset,
+        split = split,
+        contract_skips = contract_skips,
+        contract_read_passes = contract_read_passes,
+        max_contract_skip_fraction = max_contract_skip_fraction,
+        metrics_path = csv_path,
+        model_path = model_path,
+        manifest_path = manifest_path,
+        serving_config = merge(serving_config, (assigned_q = 20,))
+    ) : out_rows
 end
 
 # Run when invoked directly (julia benchmarking/viterbi_gap_calibration.jl).

--- a/benchmarking/viterbi_gap_calibration.jl
+++ b/benchmarking/viterbi_gap_calibration.jl
@@ -21,6 +21,23 @@ const CORRECTION_CONFIDENCE_FEATURES = (
     :collapsed_frontier
 )
 
+const MIN_SUPPORTED_PHRED = 0
+const MAX_SUPPORTED_PHRED = 93
+
+function _validate_assigned_q(assigned_q::Int)::Nothing
+    MIN_SUPPORTED_PHRED <= assigned_q <= MAX_SUPPORTED_PHRED ||
+        throw(ArgumentError(
+            "assigned_q must be in the supported Phred range " *
+            "$(MIN_SUPPORTED_PHRED):$(MAX_SUPPORTED_PHRED)"))
+    return nothing
+end
+
+function _uniform_phred_quality_string(n_bases::Int, assigned_q::Int)::String
+    n_bases >= 0 || throw(ArgumentError("n_bases must be non-negative"))
+    _validate_assigned_q(assigned_q)
+    return String(fill(Char(assigned_q + 33), n_bases))
+end
+
 function correction_calibration_serving_config(k::Int)::NamedTuple
     return (
         max_k = max(k, 13),
@@ -348,7 +365,7 @@ end
 """
     run_gap_calibration(; kwargs...) -> Union{Vector, NamedTuple}
 
-At each error rate (through err=0.10), simulate a substitution-only Q20 read
+At each error rate (through err=0.10), simulate a substitution-only uniform-Phred read
 cohort and run it through the exact iterative-corrector configuration used by
 the frontier probability family: doublestrand graphs, `skip_solid=false`,
 `cheap_correct=true`, `soft_em=true`, `hard_window=false`, three k rungs, two
@@ -370,6 +387,7 @@ function run_gap_calibration(;
         readlen::Int = 120,
         coverage::Int = 30,
         error_rates::Vector{Float64} = [0.05, 0.08, 0.10],
+        assigned_q::Int = 20,
         seed::Int = 42,
         nbins::Int = 10,
         holdout_fraction::Float64 = 0.2,
@@ -385,10 +403,12 @@ function run_gap_calibration(;
     genome_length >= readlen ||
         throw(ArgumentError("genome_length must be at least readlen"))
     replicates >= 1 || throw(ArgumentError("replicates must be at least 1"))
+    _validate_assigned_q(assigned_q)
     0.0 <= max_contract_skip_fraction <= 1.0 ||
         throw(ArgumentError("max_contract_skip_fraction must be in [0, 1]"))
     rng = Random.MersenneTwister(seed)
     n_reads = max(1, ceil(Int, coverage * genome_length / readlen))
+    quality_string = _uniform_phred_quality_string(readlen, assigned_q)
     serving_config = correction_calibration_serving_config(k)
     mkpath(results_dir)
     dataset = NamedTuple[]
@@ -396,7 +416,8 @@ function run_gap_calibration(;
     contract_read_passes = Dict{Float64, Int}()
     println("=== Rhizomorph multi-feature correction-confidence calibration ===")
     println("genome=$(genome_length)  k=$(k)  readlen=$(readlen)  coverage=$(coverage)x  " *
-            "n_reads=$(n_reads)  replicates=$(replicates)  seed=$(seed)")
+            "assigned_q=$(assigned_q)  n_reads=$(n_reads)  " *
+            "replicates=$(replicates)  seed=$(seed)")
     for er in error_rates
         contract_skips[er] = 0
         contract_read_passes[er] = 0
@@ -412,7 +433,7 @@ function run_gap_calibration(;
                 observed = _inject_substitutions(clean, er, rng)
                 read_id = "rep$(replicate)-err$(er)-r$(i)"
                 push!(reads,
-                    FASTX.FASTQ.Record(read_id, observed, String(fill('5', readlen))))
+                    FASTX.FASTQ.Record(read_id, observed, quality_string))
                 truth_by_id[read_id] = clean
             end
             event_rows = NamedTuple[]
@@ -443,29 +464,34 @@ function run_gap_calibration(;
                     ))
                 return nothing
             end
-            input_dir = mktempdir(prefix = "gapcal_input_")
-            output_dir = mktempdir(prefix = "gapcal_output_")
-            input_fastq = joinpath(input_dir, "calibration.fastq")
-            open(FASTX.FASTQ.Writer, input_fastq) do writer
-                for read in reads
-                    write(writer, read)
+            mktempdir(prefix = "gapcal_input_") do input_dir
+                mktempdir(prefix = "gapcal_output_") do output_dir
+                    input_fastq = joinpath(input_dir, "calibration.fastq")
+                    open(FASTX.FASTQ.Writer, input_fastq) do writer
+                        for read in reads
+                            write(writer, read)
+                        end
+                    end
+                    Random.seed!(
+                        seed + 1_000_000 * replicate + round(Int, er * 1_000_000))
+                    correction_result = Mycelia.mycelia_iterative_assemble(
+                        input_fastq;
+                        serving_config...,
+                        correction_feature_sink = feature_sink,
+                        verbose = false,
+                        enable_checkpointing = false,
+                        output_dir = output_dir)
+                    contract_skips[er] += Int(get(
+                        correction_result[:metadata],
+                        :calibrated_feature_contract_skips,
+                        0))
+                    contract_read_passes[er] +=
+                        n_reads * Int(correction_result[:metadata][:total_iterations])
+                    append!(dataset, event_rows)
+                    rate_event_count += length(event_rows)
+                    union!(rate_groups, (row.read_id for row in event_rows))
                 end
             end
-            Random.seed!(seed + 1_000_000 * replicate + round(Int, er * 1_000_000))
-            correction_result = Mycelia.mycelia_iterative_assemble(
-                input_fastq;
-                serving_config...,
-                correction_feature_sink = feature_sink,
-                verbose = false,
-                enable_checkpointing = false,
-                output_dir = output_dir)
-            contract_skips[er] += Int(get(
-                correction_result[:metadata], :calibrated_feature_contract_skips, 0))
-            contract_read_passes[er] +=
-                n_reads * Int(correction_result[:metadata][:total_iterations])
-            append!(dataset, event_rows)
-            rate_event_count += length(event_rows)
-            union!(rate_groups, (row.read_id for row in event_rows))
         end
         println("err=$(er): candidate_events=$(rate_event_count)  " *
                 "candidate-bearing_reads=$(length(rate_groups))  " *
@@ -568,6 +594,7 @@ function run_gap_calibration(;
         println(io, "genome_length,$(genome_length)")
         println(io, "readlen,$(readlen)")
         println(io, "coverage,$(coverage)")
+        println(io, "assigned_q,$(assigned_q)")
         println(io, "replicates,$(replicates)")
         println(io, "holdout_fraction,$(holdout_fraction)")
         println(io, "max_contract_skip_fraction,$(max_contract_skip_fraction)")
@@ -603,7 +630,8 @@ function run_gap_calibration(;
         metrics_path = csv_path,
         model_path = model_path,
         manifest_path = manifest_path,
-        serving_config = merge(serving_config, (assigned_q = 20,))
+        assigned_q = assigned_q,
+        serving_config = merge(serving_config, (assigned_q = assigned_q,))
     ) : out_rows
 end
 

--- a/benchmarking/viterbi_gap_calibration.jl
+++ b/benchmarking/viterbi_gap_calibration.jl
@@ -17,7 +17,8 @@ const CORRECTION_CONFIDENCE_FEATURES = (
     :raw_gap,
     :min_kmer_support,
     :all_stage0_solid,
-    :competing_branch_support_ratio
+    :competing_branch_support_ratio,
+    :collapsed_frontier
 )
 
 function correction_calibration_serving_config(k::Int)::NamedTuple
@@ -34,6 +35,21 @@ function correction_calibration_serving_config(k::Int)::NamedTuple
     )
 end
 
+function _contract_skip_fraction(contract_skips::Int, read_passes::Int,
+        maximum_fraction::Float64)::Float64
+    contract_skips >= 0 || throw(ArgumentError("contract_skips must be non-negative"))
+    read_passes >= 0 || throw(ArgumentError("read_passes must be non-negative"))
+    0.0 <= maximum_fraction <= 1.0 ||
+        throw(ArgumentError("maximum contract-skip fraction must be in [0, 1]"))
+    contract_skips <= read_passes ||
+        throw(ArgumentError("contract skips cannot exceed read passes"))
+    fraction = read_passes == 0 ? 0.0 : contract_skips / read_passes
+    fraction <= maximum_fraction ||
+        throw(ArgumentError("feature-contract skip fraction $(fraction) exceeds " *
+                            "configured bound $(maximum_fraction)"))
+    return fraction
+end
+
 """
     collect_gap_truth(fixture, observed_sequence, truth_sequence;
         config, solid_kmers, quality_scores)
@@ -41,11 +57,11 @@ end
 Decode one fixed-length observation and align `position_gaps[i]` with
 `path.steps[i + 1]`. A k-mer transition contributes the newly emitted base at
 read position `i + k`; its label is true iff that corrected base matches truth.
-For each finite-gap base, emit the fixed feature vector
-`(raw_gap, min_kmer_support, all_stage0_solid, competing_branch_support_ratio)` plus a
-`candidate_edit` flag. The support/solidity window is
+For each candidate base, emit the fixed feature vector
+`(raw_gap, min_kmer_support, all_stage0_solid, competing_branch_support_ratio,
+collapsed_frontier)` plus a `candidate_edit` flag. The support/solidity window is
 `path.steps[i + 1:min(i + k, nsteps)]`, the decoded k-mers overlapping that
-base. Collapsed-frontier `Inf` sentinels are excluded before calibration.
+base. Collapsed-frontier `Inf` sentinels are retained as an explicit stratum.
 """
 function collect_gap_truth(fixture::NamedTuple,
         observed_sequence::AbstractString,
@@ -87,7 +103,8 @@ function collect_gap_truth(fixture::NamedTuple,
     candidate_edits = Bool[]
     feature_rows = NamedTuple[]
     for i in eachindex(gaps)
-        isfinite(gaps[i]) || continue
+        (isfinite(gaps[i]) || gaps[i] == Inf) ||
+            throw(ArgumentError("position gaps must be finite or +Inf"))
         position = i + k
         position <= lastindex(truth_sequence) || continue
         shared_features = Mycelia.correction_confidence_features(
@@ -97,7 +114,8 @@ function collect_gap_truth(fixture::NamedTuple,
             min_kmer_support = shared_features.min_kmer_support,
             all_stage0_solid = shared_features.all_stage0_solid,
             competing_branch_support_ratio =
-            shared_features.competing_branch_support_ratio
+            shared_features.competing_branch_support_ratio,
+            collapsed_frontier = shared_features.raw_gap == Inf
         )
         push!(scores, features.raw_gap)
         push!(labels, corrected_sequence[position] == truth_sequence[position])
@@ -110,10 +128,11 @@ function collect_gap_truth(fixture::NamedTuple,
         length(CORRECTION_CONFIDENCE_FEATURES))
     for (row_index, row) in enumerate(feature_rows)
         features[row_index, :] .= (
-            row.raw_gap,
+            row.collapsed_frontier ? 0.0 : row.raw_gap,
             row.min_kmer_support,
             row.all_stage0_solid ? 1.0 : 0.0,
-            row.competing_branch_support_ratio
+            row.competing_branch_support_ratio,
+            row.collapsed_frontier ? 1.0 : 0.0
         )
     end
     return (; scores, labels, positions, candidate_edits, features, feature_rows, result)
@@ -166,7 +185,7 @@ end
 """
     grouped_read_split(rows; holdout_fraction=0.2, seed=42) -> NamedTuple
 
-Split finite-gap rows by `(error_rate, read_id)`, stratified by error rate. The
+Split candidate rows by `(error_rate, read_id)`, stratified by error rate. The
 split is deterministic under `seed`; every error rate with at least two read
 groups contributes at least one held-out and one training group.
 """
@@ -208,10 +227,11 @@ function _feature_matrix(rows::AbstractVector{<:NamedTuple})::Matrix{Float64}
         length(CORRECTION_CONFIDENCE_FEATURES))
     for (i, row) in enumerate(rows)
         features[i, :] .= (
-            row.raw_gap,
+            row.collapsed_frontier ? 0.0 : row.raw_gap,
             row.min_kmer_support,
             row.all_stage0_solid ? 1.0 : 0.0,
-            row.competing_branch_support_ratio
+            row.competing_branch_support_ratio,
+            row.collapsed_frontier ? 1.0 : 0.0
         )
     end
     return features
@@ -227,6 +247,15 @@ function _calibration_partition(rows::AbstractVector{<:NamedTuple},
         indices = candidate_indices,
         features = _feature_matrix(candidate_rows),
         scores = Float64[row.raw_gap for row in candidate_rows],
+        collapsed_frontier = Bool[row.collapsed_frontier for row in candidate_rows],
+        # The gap-only baseline still uses only gap information. Its second
+        # column encodes the `Inf` sentinel state so beam-collapsed candidates
+        # are modeled rather than dropped or treated as certainty.
+        gap_features = hcat(
+            Float64[row.collapsed_frontier ? 0.0 : row.raw_gap
+                    for row in candidate_rows],
+            Float64[row.collapsed_frontier ? 1.0 : 0.0
+                    for row in candidate_rows]),
         labels = Bool[row.label for row in candidate_rows],
         groups = Tuple{Float64, String}[(Float64(row.error_rate), String(row.read_id))
                                         for row in candidate_rows]
@@ -262,9 +291,13 @@ function _heldout_metric_rows(multifeature_model::NamedTuple, gap_model::NamedTu
     end
     for (scope, error_rate, indices) in scopes
         labels = heldout.labels[indices]
+        (all(labels) || !any(labels)) &&
+            throw(ArgumentError(
+                "held-out $(scope) scope needs both correctness classes"))
         multifeature_probabilities = predict_logistic(
             multifeature_model, heldout.features[indices, :])
-        gap_probabilities = predict_logistic(gap_model, heldout.scores[indices])
+        gap_probabilities = predict_logistic(
+            gap_model, heldout.gap_features[indices, :])
         push!(rows,
             _metric_row("multifeature-logistic", scope, error_rate,
                 multifeature_probabilities, labels; nbins = nbins))
@@ -404,6 +437,7 @@ function run_gap_calibration(;
                         all_stage0_solid = features.all_stage0_solid,
                         competing_branch_support_ratio =
                         features.competing_branch_support_ratio,
+                        collapsed_frontier = features.raw_gap == Inf,
                         label = event.corrected_base == truth[event.position],
                         candidate_edit = event.corrected_base != event.observed_base
                     ))
@@ -436,16 +470,18 @@ function run_gap_calibration(;
         println("err=$(er): candidate_events=$(rate_event_count)  " *
                 "candidate-bearing_reads=$(length(rate_groups))  " *
                 "feature_contract_skips=$(contract_skips[er])")
-        contract_skip_fraction = contract_read_passes[er] == 0 ? 0.0 :
-                                 contract_skips[er] / contract_read_passes[er]
-        contract_skip_fraction <= max_contract_skip_fraction ||
-            throw(ArgumentError("error rate $(er) feature-contract skip fraction " *
-                                "$(contract_skip_fraction) exceeds configured bound " *
-                                "$(max_contract_skip_fraction)"))
+        try
+            _contract_skip_fraction(
+                contract_skips[er], contract_read_passes[er],
+                max_contract_skip_fraction)
+        catch error
+            error isa ArgumentError || rethrow()
+            throw(ArgumentError("error rate $(er) $(error.msg)"))
+        end
     end
 
     isempty(dataset) &&
-        throw(ArgumentError("no finite candidate-substitution events available"))
+        throw(ArgumentError("no candidate-substitution events available"))
     all(row.candidate_edit for row in dataset) ||
         throw(ArgumentError("correction feature sink emitted a non-candidate event"))
     split = grouped_read_split(dataset;
@@ -467,16 +503,27 @@ function run_gap_calibration(;
     isempty(training.labels) &&
         throw(ArgumentError("no candidate edits in training groups"))
     isempty(heldout.labels) && throw(ArgumentError("no candidate edits in held-out groups"))
+    any(training.collapsed_frontier) ||
+        throw(ArgumentError(
+            "training groups need collapsed-frontier candidate edits"))
+    any(heldout.collapsed_frontier) ||
+        throw(ArgumentError(
+            "held-out groups need collapsed-frontier candidate edits"))
+    any(!, training.collapsed_frontier) ||
+        throw(ArgumentError("training groups need finite-gap candidate edits"))
+    any(!, heldout.collapsed_frontier) ||
+        throw(ArgumentError("held-out groups need finite-gap candidate edits"))
     (all(training.labels) || !any(training.labels)) &&
         throw(ArgumentError("candidate-edit training labels need both classes"))
-
+    collapsed_training_indices = findall(training.collapsed_frontier)
     multifeature_model = fit_logistic_map(training.features, training.labels)
-    gap_model = fit_logistic_map(training.scores, training.labels)
+    gap_model = fit_logistic_map(training.gap_features, training.labels)
     out_rows = _heldout_metric_rows(
         multifeature_model, gap_model, heldout; nbins = nbins)
     println("train candidate edits=$(training.n)  held-out=$(heldout.n)  " *
             "train groups=$(length(unique(training.groups)))  " *
             "held-out groups=$(length(unique(heldout.groups)))")
+    println("collapsed-frontier training edits=$(length(collapsed_training_indices))")
     for row in out_rows
         rate_label = row.error_rate === nothing ? "pooled" : "err=$(row.error_rate)"
         println("$(rpad(rate_label, 10)) $(rpad(row.model, 23)) " *
@@ -507,7 +554,9 @@ function run_gap_calibration(;
                 "multifeature-logistic,$(feature_name),$(coefficient)")
         end
         println(io, "gap-only-logistic,intercept,$(gap_model.a)")
-        println(io, "gap-only-logistic,raw_gap,$(gap_model.b)")
+        println(io, "gap-only-logistic,raw_gap,$(gap_model.b[1])")
+        println(io,
+            "gap-only-logistic,collapsed_frontier,$(gap_model.b[2])")
     end
     println("Wrote $(model_path)")
 
@@ -524,6 +573,10 @@ function run_gap_calibration(;
         println(io, "max_contract_skip_fraction,$(max_contract_skip_fraction)")
         println(io, "training_candidate_edits,$(training.n)")
         println(io, "heldout_candidate_edits,$(heldout.n)")
+        println(io,
+            "training_collapsed_frontier_edits,$(length(collapsed_training_indices))")
+        println(io,
+            "heldout_collapsed_frontier_edits,$(count(heldout.collapsed_frontier))")
         println(io, "error_rates,$(join(error_rates, ';'))")
         for error_rate in error_rates
             println(io,

--- a/benchmarking/viterbi_gap_calibration.jl
+++ b/benchmarking/viterbi_gap_calibration.jl
@@ -4,11 +4,14 @@
 # `run_gap_calibration` learns exclusively from telemetry emitted by the same
 # iterative-corrector configuration used by the frontier. The logistic model is
 # fit on proposed substitutions only and evaluated on a deterministic,
-# read-grouped holdout so bases from one read never leak across the split.
+# within-cohort read-grouped holdout so bases from one read never leak across
+# the split. This split does not claim generalization to independently generated
+# coverage graphs; that requires a separate whole-replicate/new-graph study.
 
 import Mycelia
 import Random
 import FASTX
+import SHA
 
 include(joinpath(@__DIR__, "calibration_metrics.jl"))
 include(joinpath(@__DIR__, "benchmark_kmer_graph_fixture.jl"))
@@ -20,6 +23,11 @@ const CORRECTION_CONFIDENCE_FEATURES = (
     :competing_branch_support_ratio,
     :collapsed_frontier
 )
+const CORRECTION_CONFIDENCE_FEATURE_SCHEMA_VERSION = "td-21eg-v1"
+const CORRECTION_CONFIDENCE_LOGISTIC_ITERATIONS = 10_000
+const CORRECTION_CONFIDENCE_LOGISTIC_LEARNING_RATE = 0.1
+const CORRECTION_CONFIDENCE_LOGISTIC_L2 = 0.01
+const CORRECTION_CONFIDENCE_LOGISTIC_GRADIENT_TOLERANCE = 1.0e-6
 
 const MIN_SUPPORTED_PHRED = 0
 const MAX_SUPPORTED_PHRED = 93
@@ -36,6 +44,12 @@ function _uniform_phred_quality_string(n_bases::Int, assigned_q::Int)::String
     n_bases >= 0 || throw(ArgumentError("n_bases must be non-negative"))
     _validate_assigned_q(assigned_q)
     return String(fill(Char(assigned_q + 33), n_bases))
+end
+
+function _calibration_fastq_record(identifier::AbstractString,
+        sequence::AbstractString, assigned_q::Int)::FASTX.FASTQ.Record
+    quality = _uniform_phred_quality_string(length(sequence), assigned_q)
+    return FASTX.FASTQ.Record(identifier, sequence, quality)
 end
 
 function correction_calibration_serving_config(k::Int)::NamedTuple
@@ -65,6 +79,187 @@ function _contract_skip_fraction(contract_skips::Int, read_passes::Int,
         throw(ArgumentError("feature-contract skip fraction $(fraction) exceeds " *
                             "configured bound $(maximum_fraction)"))
     return fraction
+end
+
+function _validate_replicate_audit(rows::AbstractVector{<:NamedTuple})::Nothing
+    isempty(rows) && throw(ArgumentError("replicate audit must not be empty"))
+    for row in rows
+        row.read_passes > 0 ||
+            throw(ArgumentError(
+                "error rate $(row.error_rate) replicate $(row.replicate) " *
+                "has no correction read passes"))
+        row.candidate_events > 0 ||
+            throw(ArgumentError(
+                "error rate $(row.error_rate) replicate $(row.replicate) " *
+                "has zero usable candidate events"))
+        row.candidate_bearing_reads > 0 ||
+            throw(ArgumentError(
+                "error rate $(row.error_rate) replicate $(row.replicate) " *
+                "has zero candidate-bearing reads"))
+        _contract_skip_fraction(row.contract_skips, row.read_passes, 1.0)
+    end
+    return nothing
+end
+
+function _require_converged_logistic(
+        model::NamedTuple, model_name::AbstractString)::Nothing
+    hasproperty(model, :diagnostics) ||
+        throw(ArgumentError("$(model_name) logistic model lacks optimizer diagnostics"))
+    diagnostics = model.diagnostics
+    if !hasproperty(diagnostics, :converged) || !diagnostics.converged
+        iterations = get(diagnostics, :iterations, "unknown")
+        gradient_norm = get(diagnostics, :gradient_norm, "unknown")
+        throw(ArgumentError(
+            "$(model_name) logistic optimizer did not converge " *
+            "(iterations=$(iterations), gradient_norm=$(gradient_norm))"))
+    end
+    return nothing
+end
+
+function _source_lineage()::NamedTuple
+    repository_root = normpath(joinpath(@__DIR__, ".."))
+    source_sha = try
+        strip(read(`git -C $(repository_root) rev-parse HEAD`, String))
+    catch
+        "unavailable"
+    end
+    source_dirty = try
+        !isempty(strip(read(
+            `git -C $(repository_root) status --porcelain --untracked-files=no`,
+            String)))
+    catch
+        true
+    end
+    return (; source_sha, source_dirty)
+end
+
+function _dataset_digest(dataset::AbstractVector{<:NamedTuple})::String
+    io = IOBuffer()
+    println(io,
+        "error_rate\treplicate\tread_id\tk\tposition\traw_gap\t" *
+        "min_kmer_support\tall_stage0_solid\t" *
+        "competing_branch_support_ratio\tcollapsed_frontier\tlabel\t" *
+        "candidate_edit")
+    for row in dataset
+        println(io, join((
+            repr(row.error_rate),
+            string(row.replicate),
+            row.read_id,
+            string(row.k),
+            string(row.position),
+            repr(row.raw_gap),
+            repr(row.min_kmer_support),
+            string(row.all_stage0_solid),
+            repr(row.competing_branch_support_ratio),
+            string(row.collapsed_frontier),
+            string(row.label),
+            string(row.candidate_edit)
+        ), '\t'))
+    end
+    return bytes2hex(SHA.sha256(take!(io)))
+end
+
+function _model_digest(multifeature_model::NamedTuple,
+        gap_model::NamedTuple)::String
+    io = IOBuffer()
+    println(io, CORRECTION_CONFIDENCE_FEATURE_SCHEMA_VERSION)
+    println(io, join(string.(CORRECTION_CONFIDENCE_FEATURES), ';'))
+    println(io, repr(multifeature_model.a))
+    for coefficient in multifeature_model.b
+        println(io, repr(coefficient))
+    end
+    println(io, repr(gap_model.a))
+    for coefficient in gap_model.b
+        println(io, repr(coefficient))
+    end
+    return bytes2hex(SHA.sha256(take!(io)))
+end
+
+function _publish_calibration_bundle(results_dir::String,
+        metric_rows::Vector{NamedTuple}, multifeature_model::NamedTuple,
+        gap_model::NamedTuple, replicate_audit::Vector{NamedTuple},
+        manifest_entries::AbstractVector{<:Pair})::NamedTuple
+    _require_converged_logistic(multifeature_model, "multi-feature")
+    _require_converged_logistic(gap_model, "gap-only")
+    mkpath(results_dir)
+    staging_dir = mktempdir(
+        results_dir;
+        prefix = ".rhizomorph_gap_calibration_staging_",
+        cleanup = false)
+    staging_name = basename(staging_dir)
+    run_id = replace(
+        staging_name, ".rhizomorph_gap_calibration_staging_" => "")
+    bundle_path = joinpath(
+        results_dir, "rhizomorph_gap_calibration_$(run_id)")
+    metrics_name = "rhizomorph_gap_calibration.csv"
+    model_name = "rhizomorph_gap_calibration_model.csv"
+    audit_name = "rhizomorph_gap_calibration_replicate_audit.csv"
+    manifest_name = "rhizomorph_gap_calibration_manifest.csv"
+    try
+        open(joinpath(staging_dir, metrics_name), "w") do io
+            println(io, "scope,error_rate,model,n,positive_frac,auroc,ece,brier")
+            for row in metric_rows
+                error_rate = row.error_rate === nothing ? "" : string(row.error_rate)
+                println(io,
+                    join(
+                        (row.scope, error_rate, row.model, row.n,
+                            row.positive_frac, row.auroc, row.ece, row.brier),
+                        ','))
+            end
+        end
+
+        open(joinpath(staging_dir, model_name), "w") do io
+            println(io, "model,term,coefficient")
+            println(io,
+                "multifeature-logistic,intercept,$(multifeature_model.a)")
+            for (feature_name, coefficient) in
+                zip(CORRECTION_CONFIDENCE_FEATURES, multifeature_model.b)
+                println(io,
+                    "multifeature-logistic,$(feature_name),$(coefficient)")
+            end
+            println(io, "gap-only-logistic,intercept,$(gap_model.a)")
+            println(io, "gap-only-logistic,raw_gap,$(gap_model.b[1])")
+            println(io,
+                "gap-only-logistic,collapsed_frontier,$(gap_model.b[2])")
+        end
+
+        open(joinpath(staging_dir, audit_name), "w") do io
+            println(io,
+                "error_rate,replicate,contract_skips,read_passes," *
+                "candidate_events,candidate_bearing_reads")
+            for row in replicate_audit
+                println(io, join((
+                    row.error_rate,
+                    row.replicate,
+                    row.contract_skips,
+                    row.read_passes,
+                    row.candidate_events,
+                    row.candidate_bearing_reads
+                ), ','))
+            end
+        end
+
+        open(joinpath(staging_dir, manifest_name), "w") do io
+            println(io, "key,value")
+            println(io, "artifact_status,publishable")
+            println(io, "run_id,$(run_id)")
+            for entry in manifest_entries
+                println(io, "$(first(entry)),$(last(entry))")
+            end
+        end
+        mv(staging_dir, bundle_path)
+    catch
+        isdir(staging_dir) && rm(staging_dir; recursive = true, force = true)
+        rethrow()
+    end
+    return (
+        run_id = run_id,
+        bundle_path = bundle_path,
+        metrics_path = joinpath(bundle_path, metrics_name),
+        model_path = joinpath(bundle_path, model_name),
+        replicate_audit_path = joinpath(bundle_path, audit_name),
+        manifest_path = joinpath(bundle_path, manifest_name)
+    )
 end
 
 """
@@ -155,17 +350,16 @@ function collect_gap_truth(fixture::NamedTuple,
     return (; scores, labels, positions, candidate_edits, features, feature_rows, result)
 end
 
-# The three calibration models compared head-to-head. Each is a (fit, predict)
-# pair over the same (gap, label) sample; the runtime gate consumes only a raw
-# gap threshold, so these differ only in how they turn the gap RANKING into
-# calibrated probabilities (the ECE/Brier axis).
+# Legacy single-gap calibration comparisons retained for td-4osf compatibility.
+# The td-21eg runtime gate consumes the multi-feature logistic probability model
+# fitted by `run_gap_calibration`, not one of these raw-gap-only maps.
 const CALIBRATION_MODELS = (
     (name = "isotonic", fit = fit_isotonic_map, predict = predict_isotonic),
     (name = "logistic", fit = fit_logistic_map, predict = predict_logistic),
     (name = "binned", fit = fit_binned_map, predict = predict_binned)
 )
 
-"""Fit+evaluate one (fit, predict) calibration model on finite gap/truth pairs."""
+"""Fit+evaluate one legacy single-gap calibration model on finite gap/truth pairs."""
 function calibrate_gap_probability(fit::Function, predict::Function,
         scores::AbstractVector{<:Real}, labels::AbstractVector{Bool};
         nbins::Int = 10)::NamedTuple
@@ -183,7 +377,7 @@ end
 """
     compare_gap_calibrations(scores, labels; nbins=10) -> NamedTuple
 
-Fit all three calibration models on the same finite (gap, label) sample. Returns
+Fit all three legacy calibration models on the same finite (gap, label) sample. Returns
 `(auroc, rows)` where `auroc` is the shared raw-gap discrimination (identical
 across models) and each row is `(model, ece, brier, cal)`. ECE/Brier isolate
 CALIBRATION quality — the only axis on which the models differ.
@@ -299,9 +493,8 @@ function _heldout_metric_rows(multifeature_model::NamedTuple, gap_model::NamedTu
         heldout::NamedTuple; nbins::Int)::Vector{NamedTuple}
     rows = NamedTuple[]
     scopes = Tuple{String, Union{Nothing, Float64}, Vector{Int}}[
-    (
-        "pooled", nothing, collect(eachindex(heldout.labels))),
-]
+        ("pooled", nothing, collect(eachindex(heldout.labels)))
+    ]
     for error_rate in sort!(unique(row.error_rate for row in heldout.rows))
         indices = findall(row -> row.error_rate == error_rate, heldout.rows)
         push!(scopes, ("error-rate", Float64(error_rate), indices))
@@ -365,21 +558,27 @@ end
 """
     run_gap_calibration(; kwargs...) -> Union{Vector, NamedTuple}
 
-At each error rate (through err=0.10), simulate a substitution-only uniform-Phred read
-cohort and run it through the exact iterative-corrector configuration used by
+At each error rate (through err=0.10), simulate a Bernoulli-per-base,
+substitution-only uniform-Phred read cohort and run it through the
+iterative-corrector configuration used by
 the frontier probability family: doublestrand graphs, `skip_solid=false`,
 `cheap_correct=true`, `soft_em=true`, `hard_window=false`, three k rungs, two
 iterations per rung, and the automatic beam. Candidate-substitution telemetry is
 collected through `correction_feature_sink`, so training and serving share one
 feature extractor and the same graph/decoder path. A pooled multi-feature
 logistic and a gap-only logistic baseline are fit on identical candidate-bearing
-read groups and evaluated on a deterministic 20% grouped holdout, pooled and by
-error rate. Prints a head-to-head table and writes
-`results/rhizomorph_gap_calibration.csv`. Deterministic under `seed`.
+read groups and evaluated on a deterministic 20% within-cohort grouped holdout,
+pooled and by error rate. This evaluation does not hold out whole generated
+graphs. Prints a head-to-head table and atomically publishes one uniquely named,
+coherent artifact bundle below `results_dir`. Deterministic under `seed` apart
+from the unique bundle identifier. The serving fit uses L2-regularized logistic
+regression and refuses to publish or serve either model unless the documented
+gradient convergence criterion is met.
 
 By default, returns the metric-row vector for backward compatibility. With
-`return_artifact=true`, returns the fitted models, partitions, and all finite
-rows needed by the correction-frontier benchmark.
+`return_artifact=true`, returns the fitted models, partitions, and candidate rows
+needed by the correction-frontier benchmark. Raw rows retain collapsed-frontier
+`Inf`; model matrices encode that state as zero raw gap plus a separate indicator.
 """
 function run_gap_calibration(;
         k::Int = 11,
@@ -393,6 +592,12 @@ function run_gap_calibration(;
         holdout_fraction::Float64 = 0.2,
         replicates::Int = 5,
         max_contract_skip_fraction::Float64 = 0.25,
+        logistic_iterations::Int = CORRECTION_CONFIDENCE_LOGISTIC_ITERATIONS,
+        logistic_learning_rate::Float64 =
+            CORRECTION_CONFIDENCE_LOGISTIC_LEARNING_RATE,
+        logistic_l2::Float64 = CORRECTION_CONFIDENCE_LOGISTIC_L2,
+        logistic_gradient_tolerance::Float64 =
+            CORRECTION_CONFIDENCE_LOGISTIC_GRADIENT_TOLERANCE,
         results_dir::String = joinpath(@__DIR__, "results"),
         return_artifact::Bool = false)::Union{Vector{NamedTuple}, NamedTuple}
     isempty(error_rates) && throw(ArgumentError("error_rates must not be empty"))
@@ -406,12 +611,21 @@ function run_gap_calibration(;
     _validate_assigned_q(assigned_q)
     0.0 <= max_contract_skip_fraction <= 1.0 ||
         throw(ArgumentError("max_contract_skip_fraction must be in [0, 1]"))
+    logistic_iterations >= 1 ||
+        throw(ArgumentError("logistic_iterations must be >= 1"))
+    isfinite(logistic_learning_rate) && logistic_learning_rate > 0.0 ||
+        throw(ArgumentError("logistic_learning_rate must be finite and > 0"))
+    isfinite(logistic_l2) && logistic_l2 > 0.0 ||
+        throw(ArgumentError("logistic_l2 must be finite and > 0"))
+    isfinite(logistic_gradient_tolerance) && logistic_gradient_tolerance > 0.0 ||
+        throw(ArgumentError(
+            "logistic_gradient_tolerance must be finite and > 0"))
     rng = Random.MersenneTwister(seed)
     n_reads = max(1, ceil(Int, coverage * genome_length / readlen))
-    quality_string = _uniform_phred_quality_string(readlen, assigned_q)
     serving_config = correction_calibration_serving_config(k)
     mkpath(results_dir)
     dataset = NamedTuple[]
+    replicate_audit = NamedTuple[]
     contract_skips = Dict{Float64, Int}()
     contract_read_passes = Dict{Float64, Int}()
     println("=== Rhizomorph multi-feature correction-confidence calibration ===")
@@ -432,8 +646,8 @@ function run_gap_calibration(;
                 clean = truth_genome[start:(start + readlen - 1)]
                 observed = _inject_substitutions(clean, er, rng)
                 read_id = "rep$(replicate)-err$(er)-r$(i)"
-                push!(reads,
-                    FASTX.FASTQ.Record(read_id, observed, quality_string))
+                push!(reads, _calibration_fastq_record(
+                    read_id, observed, assigned_q))
                 truth_by_id[read_id] = clean
             end
             event_rows = NamedTuple[]
@@ -450,6 +664,7 @@ function run_gap_calibration(;
                 push!(event_rows,
                     (
                         error_rate = er,
+                        replicate = replicate,
                         read_id = event.read_id,
                         k = event.k,
                         position = event.position,
@@ -481,12 +696,24 @@ function run_gap_calibration(;
                         verbose = false,
                         enable_checkpointing = false,
                         output_dir = output_dir)
-                    contract_skips[er] += Int(get(
+                    replicate_contract_skips = Int(get(
                         correction_result[:metadata],
                         :calibrated_feature_contract_skips,
                         0))
-                    contract_read_passes[er] +=
+                    replicate_read_passes =
                         n_reads * Int(correction_result[:metadata][:total_iterations])
+                    candidate_bearing_reads = length(
+                        unique(row.read_id for row in event_rows))
+                    push!(replicate_audit, (
+                        error_rate = er,
+                        replicate = replicate,
+                        contract_skips = replicate_contract_skips,
+                        read_passes = replicate_read_passes,
+                        candidate_events = length(event_rows),
+                        candidate_bearing_reads = candidate_bearing_reads
+                    ))
+                    contract_skips[er] += replicate_contract_skips
+                    contract_read_passes[er] += replicate_read_passes
                     append!(dataset, event_rows)
                     rate_event_count += length(event_rows)
                     union!(rate_groups, (row.read_id for row in event_rows))
@@ -506,6 +733,7 @@ function run_gap_calibration(;
         end
     end
 
+    _validate_replicate_audit(replicate_audit)
     isempty(dataset) &&
         throw(ArgumentError("no candidate-substitution events available"))
     all(row.candidate_edit for row in dataset) ||
@@ -542,8 +770,22 @@ function run_gap_calibration(;
     (all(training.labels) || !any(training.labels)) &&
         throw(ArgumentError("candidate-edit training labels need both classes"))
     collapsed_training_indices = findall(training.collapsed_frontier)
-    multifeature_model = fit_logistic_map(training.features, training.labels)
-    gap_model = fit_logistic_map(training.gap_features, training.labels)
+    multifeature_model = fit_logistic_map(
+        training.features, training.labels;
+        iters = logistic_iterations,
+        lr = logistic_learning_rate,
+        l2 = logistic_l2,
+        gradient_tolerance = logistic_gradient_tolerance,
+        return_diagnostics = true)
+    gap_model = fit_logistic_map(
+        training.gap_features, training.labels;
+        iters = logistic_iterations,
+        lr = logistic_learning_rate,
+        l2 = logistic_l2,
+        gradient_tolerance = logistic_gradient_tolerance,
+        return_diagnostics = true)
+    _require_converged_logistic(multifeature_model, "multi-feature")
+    _require_converged_logistic(gap_model, "gap-only")
     out_rows = _heldout_metric_rows(
         multifeature_model, gap_model, heldout; nbins = nbins)
     println("train candidate edits=$(training.n)  held-out=$(heldout.n)  " *
@@ -557,63 +799,80 @@ function run_gap_calibration(;
                 "ECE=$(round(row.ece; digits = 4))  " *
                 "Brier=$(round(row.brier; digits = 4))  n=$(row.n)")
     end
-    csv_path = joinpath(results_dir, "rhizomorph_gap_calibration.csv")
-    open(csv_path, "w") do io
-        println(io, "scope,error_rate,model,n,positive_frac,auroc,ece,brier")
-        for r in out_rows
-            error_rate = r.error_rate === nothing ? "" : string(r.error_rate)
-            println(io,
-                join(
-                    (r.scope, error_rate, r.model, r.n, r.positive_frac,
-                        r.auroc, r.ece, r.brier), ","))
+    dataset_sha256 = _dataset_digest(dataset)
+    model_sha256 = _model_digest(multifeature_model, gap_model)
+    lineage = _source_lineage()
+    mycelia_version = try
+        version = Base.pkgversion(Mycelia)
+        version === nothing ? "unavailable" : string(version)
+    catch
+        "unavailable"
+    end
+    manifest_entries = Pair{String, String}[
+        "evaluation_scope" => "within_cohort_read_grouped_holdout",
+        "whole_graph_holdout" => "false",
+        "independent_graph_generalization_claimed" => "false",
+        "error_generator_distribution" => "bernoulli_per_base",
+        "error_generator_substitution_target" => "uniform_different_acgt_base",
+        "frontier_simulator_parity_claimed" => "false",
+        "seed" => string(seed),
+        "split_seed" => string(seed + 1),
+        "k" => string(k),
+        "genome_length" => string(genome_length),
+        "readlen" => string(readlen),
+        "coverage" => string(coverage),
+        "assigned_q" => string(assigned_q),
+        "replicates" => string(replicates),
+        "holdout_fraction" => string(holdout_fraction),
+        "max_contract_skip_fraction" => string(max_contract_skip_fraction),
+        "logistic_iterations" => string(logistic_iterations),
+        "logistic_learning_rate" => string(logistic_learning_rate),
+        "logistic_l2" => string(logistic_l2),
+        "logistic_gradient_tolerance" => string(logistic_gradient_tolerance),
+        "training_candidate_edits" => string(training.n),
+        "heldout_candidate_edits" => string(heldout.n),
+        "training_collapsed_frontier_edits" =>
+            string(length(collapsed_training_indices)),
+        "heldout_collapsed_frontier_edits" =>
+            string(count(heldout.collapsed_frontier)),
+        "error_rates" => join(error_rates, ';'),
+        "feature_schema_version" => CORRECTION_CONFIDENCE_FEATURE_SCHEMA_VERSION,
+        "feature_order" => join(string.(CORRECTION_CONFIDENCE_FEATURES), ';'),
+        "collapsed_frontier_encoding" => "zero_raw_gap_plus_indicator",
+        "dataset_sha256" => dataset_sha256,
+        "model_sha256" => model_sha256,
+        "source_sha" => lineage.source_sha,
+        "source_worktree_dirty" => string(lineage.source_dirty),
+        "mycelia_version" => mycelia_version,
+        "julia_version" => string(VERSION),
+        "replicate_audit_rows" => string(length(replicate_audit))
+    ]
+    for key in keys(serving_config)
+        push!(manifest_entries,
+            "serving_$(key)" => string(getproperty(serving_config, key)))
+    end
+    for (model_name, diagnostics) in (
+        ("multifeature_logistic", multifeature_model.diagnostics),
+        ("gap_only_logistic", gap_model.diagnostics)
+    )
+        for key in keys(diagnostics)
+            push!(manifest_entries,
+                "optimizer_$(model_name)_$(key)" =>
+                    string(getproperty(diagnostics, key)))
         end
     end
-    println("Wrote $(csv_path)")
-
-    model_path = joinpath(results_dir, "rhizomorph_gap_calibration_model.csv")
-    open(model_path, "w") do io
-        println(io, "model,term,coefficient")
-        println(io, "multifeature-logistic,intercept,$(multifeature_model.a)")
-        for (feature_name, coefficient) in
-            zip(CORRECTION_CONFIDENCE_FEATURES, multifeature_model.b)
-            println(io,
-                "multifeature-logistic,$(feature_name),$(coefficient)")
-        end
-        println(io, "gap-only-logistic,intercept,$(gap_model.a)")
-        println(io, "gap-only-logistic,raw_gap,$(gap_model.b[1])")
-        println(io,
-            "gap-only-logistic,collapsed_frontier,$(gap_model.b[2])")
+    for error_rate in error_rates
+        push!(manifest_entries,
+            "contract_skips_$(error_rate)" =>
+                string(contract_skips[error_rate]))
+        push!(manifest_entries,
+            "contract_read_passes_$(error_rate)" =>
+                string(contract_read_passes[error_rate]))
     end
-    println("Wrote $(model_path)")
-
-    manifest_path = joinpath(results_dir, "rhizomorph_gap_calibration_manifest.csv")
-    open(manifest_path, "w") do io
-        println(io, "key,value")
-        println(io, "seed,$(seed)")
-        println(io, "k,$(k)")
-        println(io, "genome_length,$(genome_length)")
-        println(io, "readlen,$(readlen)")
-        println(io, "coverage,$(coverage)")
-        println(io, "assigned_q,$(assigned_q)")
-        println(io, "replicates,$(replicates)")
-        println(io, "holdout_fraction,$(holdout_fraction)")
-        println(io, "max_contract_skip_fraction,$(max_contract_skip_fraction)")
-        println(io, "training_candidate_edits,$(training.n)")
-        println(io, "heldout_candidate_edits,$(heldout.n)")
-        println(io,
-            "training_collapsed_frontier_edits,$(length(collapsed_training_indices))")
-        println(io,
-            "heldout_collapsed_frontier_edits,$(count(heldout.collapsed_frontier))")
-        println(io, "error_rates,$(join(error_rates, ';'))")
-        for error_rate in error_rates
-            println(io,
-                "contract_skips_$(error_rate),$(contract_skips[error_rate])")
-            println(io,
-                "contract_read_passes_$(error_rate)," *
-                "$(contract_read_passes[error_rate])")
-        end
-    end
-    println("Wrote $(manifest_path)")
+    artifact_paths = _publish_calibration_bundle(
+        results_dir, out_rows, multifeature_model, gap_model,
+        replicate_audit, manifest_entries)
+    println("Wrote atomic calibration bundle $(artifact_paths.bundle_path)")
     return return_artifact ?
            (
         rows = out_rows,
@@ -626,10 +885,18 @@ function run_gap_calibration(;
         split = split,
         contract_skips = contract_skips,
         contract_read_passes = contract_read_passes,
+        replicate_audit = replicate_audit,
         max_contract_skip_fraction = max_contract_skip_fraction,
-        metrics_path = csv_path,
-        model_path = model_path,
-        manifest_path = manifest_path,
+        run_id = artifact_paths.run_id,
+        bundle_path = artifact_paths.bundle_path,
+        metrics_path = artifact_paths.metrics_path,
+        model_path = artifact_paths.model_path,
+        replicate_audit_path = artifact_paths.replicate_audit_path,
+        manifest_path = artifact_paths.manifest_path,
+        dataset_sha256 = dataset_sha256,
+        model_sha256 = model_sha256,
+        feature_schema_version = CORRECTION_CONFIDENCE_FEATURE_SCHEMA_VERSION,
+        evaluation_scope = :within_cohort_read_grouped_holdout,
         assigned_q = assigned_q,
         serving_config = merge(serving_config, (assigned_q = assigned_q,))
     ) : out_rows

--- a/src/iterative-assembly.jl
+++ b/src/iterative-assembly.jl
@@ -386,6 +386,122 @@ struct IndelDecodeParams
     band_width::Union{Nothing, Int}
 end
 
+"""
+$(DocStringExtensions.TYPEDSIGNATURES)
+
+Raw-space coefficients for the calibrated per-base probability that a proposed
+substitution is correct. The fixed feature order is the Viterbi gap, minimum
+support among decoded k-mers overlapping the emitted base, the Stage-0 all-solid
+indicator, and the selected branch's normalized support ratio.
+"""
+struct CorrectionConfidenceModel
+    intercept::Float64
+    gap_weight::Float64
+    min_kmer_support_weight::Float64
+    stage0_solid_weight::Float64
+    branch_support_ratio_weight::Float64
+
+    function CorrectionConfidenceModel(intercept::Real, gap_weight::Real,
+            min_kmer_support_weight::Real, stage0_solid_weight::Real,
+            branch_support_ratio_weight::Real)
+        values = (
+            Float64(intercept),
+            Float64(gap_weight),
+            Float64(min_kmer_support_weight),
+            Float64(stage0_solid_weight),
+            Float64(branch_support_ratio_weight),
+        )
+        all(isfinite, values) ||
+            throw(ArgumentError("correction-confidence coefficients must be finite"))
+        return new(values...)
+    end
+end
+
+"""
+$(DocStringExtensions.TYPEDSIGNATURES)
+
+Typed serving schema for one proposed substitution. `competing_branch_support_ratio`
+is the selected incoming edge's normalized support, not a whole-path posterior. Edge
+support is soft-EM-aware when the graph has responsibility-weighted edges registered.
+"""
+struct CorrectionConfidenceFeatures
+    raw_gap::Float64
+    min_kmer_support::Float64
+    all_stage0_solid::Bool
+    competing_branch_support_ratio::Float64
+
+    function CorrectionConfidenceFeatures(raw_gap::Real, min_kmer_support::Real,
+            all_stage0_solid::Bool, competing_branch_support_ratio::Real)
+        gap = Float64(raw_gap)
+        support = Float64(min_kmer_support)
+        ratio = Float64(competing_branch_support_ratio)
+        all(isfinite, (gap, support, ratio)) ||
+            throw(ArgumentError("correction-confidence features must be finite"))
+        0.0 <= ratio <= 1.0 ||
+            throw(ArgumentError("competing branch support ratio must be in [0, 1]"))
+        return new(gap, support, all_stage0_solid, ratio)
+    end
+end
+
+"""
+$(DocStringExtensions.TYPEDSIGNATURES)
+
+One opt-in training/telemetry observation emitted by the correction serving path.
+"""
+struct CorrectionFeatureObservation
+    read_id::String
+    k::Int
+    position::Int
+    observed_base::Char
+    corrected_base::Char
+    features::CorrectionConfidenceFeatures
+end
+
+struct _CorrectionFeatureSinkError <: Exception
+    message::String
+end
+
+function Base.showerror(io::IO, error::_CorrectionFeatureSinkError)::Nothing
+    print(io, error.message)
+    return nothing
+end
+
+"""
+$(DocStringExtensions.TYPEDSIGNATURES)
+
+Evaluate a [`CorrectionConfidenceModel`](@ref) on one per-base feature vector.
+"""
+function correction_confidence_probability(model::CorrectionConfidenceModel,
+        features::CorrectionConfidenceFeatures)::Float64
+    solid = features.all_stage0_solid ? 1.0 : 0.0
+    z = model.intercept + model.gap_weight * features.raw_gap +
+        model.min_kmer_support_weight * features.min_kmer_support +
+        model.stage0_solid_weight * solid +
+        model.branch_support_ratio_weight * features.competing_branch_support_ratio
+    isnan(z) && throw(ArgumentError("correction-confidence logit must not be NaN"))
+    return z >= 0.0 ? 1.0 / (1.0 + exp(-z)) : exp(z) / (1.0 + exp(z))
+end
+
+function correction_confidence_probability(model::CorrectionConfidenceModel,
+        gap::Real, min_kmer_support::Real, stage0_solid::Bool,
+        branch_support_ratio::Real)::Float64
+    features = CorrectionConfidenceFeatures(
+        gap, min_kmer_support, stage0_solid, branch_support_ratio)
+    return correction_confidence_probability(model, features)
+end
+
+function _validate_correction_gate(calibrated_gap_threshold::Union{Float64, Nothing},
+        calibrated_probability_model::Union{CorrectionConfidenceModel, Nothing},
+        calibrated_probability_threshold::Float64)::Nothing
+    if calibrated_gap_threshold !== nothing && calibrated_probability_model !== nothing
+        throw(ArgumentError(
+            "calibrated_gap_threshold and calibrated_probability_model are mutually exclusive"))
+    end
+    0.0 <= calibrated_probability_threshold <= 1.0 ||
+        throw(ArgumentError("calibrated_probability_threshold must be in [0, 1]"))
+    return nothing
+end
+
 # =============================================================================
 # Core Iterative Assembly Framework
 # =============================================================================
@@ -417,9 +533,14 @@ function mycelia_iterative_assemble(input_fastq::String;
         cheap_correct::Bool = false,
         beam_width::Union{Int, Nothing} = nothing,
         calibrated_gap_threshold::Union{Float64, Nothing} = nothing,
+        calibrated_probability_model::Union{CorrectionConfidenceModel, Nothing} = nothing,
+        calibrated_probability_threshold::Float64 = 0.5,
+        correction_feature_sink::Union{Nothing, Function} = nothing,
         min_decode_k::Union{Int, Nothing} = nothing,
         decode_gate_density::Union{Float64, Nothing} = nothing,
         indel_params::Union{Nothing, IndelDecodeParams} = nothing)
+    _validate_correction_gate(calibrated_gap_threshold,
+        calibrated_probability_model, calibrated_probability_threshold)
     start_time = time()
 
     # Accumulates swallowed decode failures (structural / un-k-merizable) across
@@ -774,6 +895,9 @@ function mycelia_iterative_assemble(input_fastq::String;
                     cheap_correct = cheap_correct,
                     beam_width = beam_width,
                     calibrated_gap_threshold = calibrated_gap_threshold,
+                    calibrated_probability_model = calibrated_probability_model,
+                    calibrated_probability_threshold = calibrated_probability_threshold,
+                    correction_feature_sink = correction_feature_sink,
                     soft_weights = current_soft_weights,
                     hard_vertices = hard_vertices,
                     windowed_decode = windowed_decode,
@@ -953,6 +1077,12 @@ function mycelia_iterative_assemble(input_fastq::String;
         cheap_correction_counts = cheap_correction_counts,
         hard_window = hard_window, windowed_decode = windowed_decode,
         soft_em = soft_em, cheap_correct = cheap_correct,
+        calibrated_gap_threshold = calibrated_gap_threshold,
+        calibrated_probability_model = calibrated_probability_model,
+        calibrated_probability_threshold = calibrated_probability_threshold,
+        correction_feature_sink_active =
+            correction_feature_sink !== nothing && indel_params === nothing,
+        indel_params = indel_params,
         min_decode_k = effective_min_decode_k,
         decode_gate_density = effective_decode_gate_density,
         decode_gated_rungs = decode_gated_rungs,
@@ -1395,6 +1525,10 @@ function improve_read_likelihood_windowed(read::FASTX.FASTQ.Record, graph, k::In
         diagnostics = nothing,  # ::Union{Nothing, CorrectorDiagnostics}; struct defined below
         pad::Union{Int, Nothing} = nothing,
         calibrated_gap_threshold::Union{Float64, Nothing} = nothing,
+        calibrated_probability_model::Union{CorrectionConfidenceModel, Nothing} = nothing,
+        calibrated_probability_threshold::Float64 = 0.5,
+        correction_feature_sink::Union{Nothing, Function} = nothing,
+        solid_kmers::Union{Nothing, AbstractSet} = nothing,
         max_window::Int = 500,
         indel_params::Union{Nothing, IndelDecodeParams} = nothing)::Tuple{
         FASTX.FASTQ.Record, Bool}
@@ -1405,6 +1539,10 @@ function improve_read_likelihood_windowed(read::FASTX.FASTQ.Record, graph, k::In
         graph_mode = graph_mode, beam_width = beam_width, soft_weights = soft_weights,
         weighted_graph = weighted_graph, diagnostics = diagnostics,
         pad = pad, calibrated_gap_threshold = calibrated_gap_threshold,
+        calibrated_probability_model = calibrated_probability_model,
+        calibrated_probability_threshold = calibrated_probability_threshold,
+        correction_feature_sink = correction_feature_sink,
+        solid_kmers = solid_kmers,
         max_window = max_window, indel_params = indel_params)
     return record, improved
 end
@@ -1439,6 +1577,10 @@ function improve_read_likelihood_windowed_detail(read::FASTX.FASTQ.Record, graph
         diagnostics = nothing,  # ::Union{Nothing, CorrectorDiagnostics}; struct defined below
         pad::Union{Int, Nothing} = nothing,
         calibrated_gap_threshold::Union{Float64, Nothing} = nothing,
+        calibrated_probability_model::Union{CorrectionConfidenceModel, Nothing} = nothing,
+        calibrated_probability_threshold::Float64 = 0.5,
+        correction_feature_sink::Union{Nothing, Function} = nothing,
+        solid_kmers::Union{Nothing, AbstractSet} = nothing,
         max_window::Int = 500,
         indel_params::Union{Nothing, IndelDecodeParams} = nothing)::Tuple{
         FASTX.FASTQ.Record, Bool, Int, Int}
@@ -1482,6 +1624,12 @@ function improve_read_likelihood_windowed_detail(read::FASTX.FASTQ.Record, graph
             beam_width = beam_width, soft_weights = soft_weights,
             weighted_graph = weighted_graph, diagnostics = diagnostics,
             calibrated_gap_threshold = calibrated_gap_threshold,
+            calibrated_probability_model = calibrated_probability_model,
+            calibrated_probability_threshold = calibrated_probability_threshold,
+            correction_feature_sink = correction_feature_sink,
+            correction_read_id = String(id),
+            correction_position_offset = lo - 1,
+            solid_kmers = solid_kmers,
             indel_params = indel_params)
         improved || continue
         dseq = FASTX.sequence(String, decoded_sub)
@@ -1617,10 +1765,9 @@ parallel (`@threads`) read loop increments them race-free.
 mutable struct CorrectorDiagnostics
     structural_errors::Threads.Atomic{Int}
     unkmerizable_reads::Threads.Atomic{Int}
-    # Calibrated gate requested (threshold set, substitution mode) but a decode
-    # contract invariant was violated so gating silently fell open to the ungated
-    # decode. On a healthy substitution decode this is always 0; a nonzero value
-    # means the opt-in gate disabled itself — a regression signal, not data loss.
+    # Calibrated gate or feature telemetry requested in substitution mode, but a
+    # full-length gap/path contract was unavailable. The read stays ungated and
+    # emits no feature event; a nonzero value makes that survivor selection visible.
     gate_skipped::Threads.Atomic{Int}
     indel_decodes::Threads.Atomic{Int}
     truncated_decodes::Threads.Atomic{Int}
@@ -1811,6 +1958,9 @@ function improve_read_set_likelihood(reads::Vector{<:FASTX.FASTQ.Record}, graph,
         cheap_correct::Bool = false,
         beam_width::Union{Int, Nothing} = nothing,
         calibrated_gap_threshold::Union{Float64, Nothing} = nothing,
+        calibrated_probability_model::Union{CorrectionConfidenceModel, Nothing} = nothing,
+        calibrated_probability_threshold::Float64 = 0.5,
+        correction_feature_sink::Union{Nothing, Function} = nothing,
         soft_weights::Union{Nothing, Mycelia.Rhizomorph.SoftEdgeWeightAccumulator} = nothing,
         hard_vertices::Union{Nothing, AbstractSet} = nothing,
         windowed_decode::Bool = false,
@@ -1819,6 +1969,8 @@ function improve_read_set_likelihood(reads::Vector{<:FASTX.FASTQ.Record}, graph,
         diagnostics::Union{Nothing, CorrectorDiagnostics} = nothing,
         indel_params::Union{Nothing, IndelDecodeParams} = nothing)::Tuple{
         Vector{FASTX.FASTQ.Record}, Int, Float64, Int, Bool}
+    _validate_correction_gate(calibrated_gap_threshold,
+        calibrated_probability_model, calibrated_probability_threshold)
     diag = diagnostics === nothing ? CorrectorDiagnostics() : diagnostics
     # Snapshot so the per-call @warn reflects THIS pass's swallowed fraction even
     # when `diag` is a shared accumulator threaded across many passes.
@@ -1850,7 +2002,9 @@ function improve_read_set_likelihood(reads::Vector{<:FASTX.FASTQ.Record}, graph,
     end
     # Classify k-mers once if EITHER the skip-solid gate OR the Stage 0 cheap
     # corrector needs the solid set. Compute once, share both consumers.
-    need_solid = (skip_solid || cheap_correct) && graph_mode != :singlestrand
+    feature_collection_active = correction_feature_sink !== nothing && indel_params === nothing
+    need_solid = calibrated_probability_model !== nothing || feature_collection_active ||
+                 ((skip_solid || cheap_correct) && graph_mode != :singlestrand)
     solid_kmers = need_solid ? _solid_kmer_set(graph) : nothing
 
     # Stage 0 CHEAP correction (td-bjnt): fix simple single-substitution errors
@@ -1926,11 +2080,17 @@ function improve_read_set_likelihood(reads::Vector{<:FASTX.FASTQ.Record}, graph,
     # otherwise use the precomputed gate flags.
     _skip_this_read_at = i -> pass_decode_off || base_skip_flags[i]
 
-    # Soft-EM accumulation into `soft_weights` is not thread-safe (shared Dict),
-    # so a soft-EM pass runs sequentially. Otherwise honor the caller's request.
-    use_parallel = enable_parallel && Threads.nthreads() > 1 && soft_weights === nothing
+    # Soft-EM accumulation and the opt-in calibration sink are caller-owned
+    # mutable state, so those passes run sequentially. Otherwise honor the
+    # caller's parallel request.
+    use_parallel = enable_parallel && Threads.nthreads() > 1 &&
+                   soft_weights === nothing && correction_feature_sink === nothing
     if enable_parallel && soft_weights !== nothing && Threads.nthreads() > 1
         @warn "soft-EM edge accumulation is sequential (race-free); ignoring enable_parallel for this pass." maxlog = 1
+    end
+    if enable_parallel && correction_feature_sink !== nothing && Threads.nthreads() > 1
+        @warn "correction feature collection is sequential (race-free); ignoring " *
+              "enable_parallel for this pass." maxlog = 1
     end
 
     if verbose
@@ -1958,6 +2118,14 @@ function improve_read_set_likelihood(reads::Vector{<:FASTX.FASTQ.Record}, graph,
     # expensive/bounded; short reads keep the cheap, exact whole-read decode
     # (so the :scalable short-read quality gate never regresses).
     use_windowed = windowed_decode && hard_vertices !== nothing
+    # Windowed decoding now threads the parent indel profile. The calibrated gates
+    # and feature sink remain substitution-only, so exclude those opt-in controls
+    # when the parent requested indels rather than applying positional reverts to
+    # an alignment whose coordinates can shift.
+    windowed_gap_threshold = indel_params === nothing ? calibrated_gap_threshold : nothing
+    windowed_probability_model = indel_params === nothing ?
+                                   calibrated_probability_model : nothing
+    windowed_feature_sink = indel_params === nothing ? correction_feature_sink : nothing
 
     # Process in batches for memory efficiency. `work_reads` is the Stage 0
     # cheaply-corrected read set (== `reads` when cheap_correct is off), so the
@@ -1989,13 +2157,21 @@ function improve_read_set_likelihood(reads::Vector{<:FASTX.FASTQ.Record}, graph,
                         read, graph, k, hard_vertices; graph_mode = graph_mode,
                         beam_width = beam_width, weighted_graph = pass_weighted_graph,
                         diagnostics = diag,
-                        calibrated_gap_threshold = calibrated_gap_threshold,
+                        calibrated_gap_threshold = windowed_gap_threshold,
+                        calibrated_probability_model = windowed_probability_model,
+                        calibrated_probability_threshold = calibrated_probability_threshold,
+                        correction_feature_sink = windowed_feature_sink,
+                        solid_kmers = solid_kmers,
                         indel_params = indel_params) :
                                    improve_read_likelihood(
                         read, graph, k; graph_mode = graph_mode,
                         beam_width = beam_width, weighted_graph = pass_weighted_graph,
                         diagnostics = diag, indel_params = indel_params,
-                        calibrated_gap_threshold = calibrated_gap_threshold)
+                        calibrated_gap_threshold = calibrated_gap_threshold,
+                        calibrated_probability_model = calibrated_probability_model,
+                        calibrated_probability_threshold = calibrated_probability_threshold,
+                        correction_feature_sink = correction_feature_sink,
+                        solid_kmers = solid_kmers)
                     batch_results[i] = (improved_read, was_improved)
                 end
             end
@@ -2025,14 +2201,22 @@ function improve_read_set_likelihood(reads::Vector{<:FASTX.FASTQ.Record}, graph,
                     beam_width = beam_width, soft_weights = soft_weights,
                     weighted_graph = pass_weighted_graph,
                     diagnostics = diag,
-                    calibrated_gap_threshold = calibrated_gap_threshold,
+                    calibrated_gap_threshold = windowed_gap_threshold,
+                    calibrated_probability_model = windowed_probability_model,
+                    calibrated_probability_threshold = calibrated_probability_threshold,
+                    correction_feature_sink = windowed_feature_sink,
+                    solid_kmers = solid_kmers,
                     indel_params = indel_params) :
                                improve_read_likelihood(
                     read, graph, k; graph_mode = graph_mode,
                     beam_width = beam_width, soft_weights = soft_weights,
                     weighted_graph = pass_weighted_graph,
                     diagnostics = diag, indel_params = indel_params,
-                    calibrated_gap_threshold = calibrated_gap_threshold)
+                    calibrated_gap_threshold = calibrated_gap_threshold,
+                    calibrated_probability_model = calibrated_probability_model,
+                    calibrated_probability_threshold = calibrated_probability_threshold,
+                    correction_feature_sink = correction_feature_sink,
+                    solid_kmers = solid_kmers)
                 updated_reads[batch_start + i - 1] = improved_read
 
                 if was_improved
@@ -2108,15 +2292,14 @@ function improve_read_set_likelihood(reads::Vector{<:FASTX.FASTQ.Record}, graph,
             truncated_this_pass / completed_indel_outcomes, digits = 3)
     end
 
-    # A requested calibrated gate that silently fell open on a substitution decode
-    # is a contract regression (the gate did nothing despite being opted in) — see
-    # CorrectorDiagnostics.gate_skipped. Surface it rather than let the frontier look
-    # like "the gate doesn't help."
+    # A requested calibrated gate or feature sink whose substitution decode did
+    # not satisfy the full-length gap/path contract cannot act on that read. Surface
+    # the skip rather than silently fitting/scoring only an unexplained survivor set.
     gate_skipped_this_pass = diag.gate_skipped[] - gate_skipped_before
     if gate_skipped_this_pass > 0
-        @warn "iterative corrector: calibrated gate fell open (ungated) on " *
-              "$(gate_skipped_this_pass) read(s) despite a substitution decode — the " *
-              "gap/path alignment contract was violated; the gate silently did nothing." total_reads gate_skipped = gate_skipped_this_pass
+        @warn "iterative corrector: calibrated feature/gate contract unavailable on " *
+              "$(gate_skipped_this_pass) read(s); those reads stayed ungated and " *
+              "emitted no calibration features." total_reads gate_skipped = gate_skipped_this_pass
     end
 
     window_divergences_this_pass =
@@ -2144,7 +2327,13 @@ function improve_read_likelihood(read::FASTX.FASTQ.Record, graph, k::Int;
         weighted_graph = nothing,
         diagnostics::Union{Nothing, CorrectorDiagnostics} = nothing,
         indel_params::Union{Nothing, IndelDecodeParams} = nothing,
-        calibrated_gap_threshold::Union{Float64, Nothing} = nothing)::Tuple{
+        calibrated_gap_threshold::Union{Float64, Nothing} = nothing,
+        calibrated_probability_model::Union{CorrectionConfidenceModel, Nothing} = nothing,
+        calibrated_probability_threshold::Float64 = 0.5,
+        correction_feature_sink::Union{Nothing, Function} = nothing,
+        correction_read_id::Union{Nothing, String} = nothing,
+        correction_position_offset::Int = 0,
+        solid_kmers::Union{Nothing, AbstractSet} = nothing)::Tuple{
         FASTX.FASTQ.Record, Bool}
     # Extract sequence and quality
     original_seq = FASTX.sequence(String, read)
@@ -2173,7 +2362,13 @@ function improve_read_likelihood(read::FASTX.FASTQ.Record, graph, k::Int;
         beam_width = beam_width, soft_weights = soft_weights,
         weighted_graph = weighted_graph,
         diagnostics = diagnostics, indel_params = indel_params,
-        calibrated_gap_threshold = calibrated_gap_threshold)
+        calibrated_gap_threshold = calibrated_gap_threshold,
+        calibrated_probability_model = calibrated_probability_model,
+        calibrated_probability_threshold = calibrated_probability_threshold,
+        correction_feature_sink = correction_feature_sink,
+        correction_read_id = correction_read_id,
+        correction_position_offset = correction_position_offset,
+        solid_kmers = solid_kmers)
 
     # Only update if significant improvement
     if likelihood_improvement > 0.01  # Threshold for meaningful improvement
@@ -2210,7 +2405,13 @@ function find_optimal_sequence_path(read::FASTX.FASTQ.Record, graph, k::Int;
         weighted_graph = nothing,
         diagnostics::Union{Nothing, CorrectorDiagnostics} = nothing,
         indel_params::Union{Nothing, IndelDecodeParams} = nothing,
-        calibrated_gap_threshold::Union{Float64, Nothing} = nothing)::Tuple{
+        calibrated_gap_threshold::Union{Float64, Nothing} = nothing,
+        calibrated_probability_model::Union{CorrectionConfidenceModel, Nothing} = nothing,
+        calibrated_probability_threshold::Float64 = 0.5,
+        correction_feature_sink::Union{Nothing, Function} = nothing,
+        correction_read_id::Union{Nothing, String} = nothing,
+        correction_position_offset::Int = 0,
+        solid_kmers::Union{Nothing, AbstractSet} = nothing)::Tuple{
         FASTX.FASTQ.Record, Float64}
     # Trustworthy Viterbi (graph-as-HMM correction core, td-ak6w). Trust the
     # maximum-likelihood path or report no improvement. The prior heuristic
@@ -2243,7 +2444,13 @@ function find_optimal_sequence_path(read::FASTX.FASTQ.Record, graph, k::Int;
         beam_width = beam_width, soft_weights = soft_weights,
         weighted_graph = weighted_graph,
         diagnostics = diagnostics, indel_params = indel_params,
-        calibrated_gap_threshold = calibrated_gap_threshold)
+        calibrated_gap_threshold = calibrated_gap_threshold,
+        calibrated_probability_model = calibrated_probability_model,
+        calibrated_probability_threshold = calibrated_probability_threshold,
+        correction_feature_sink = correction_feature_sink,
+        correction_read_id = correction_read_id,
+        correction_position_offset = correction_position_offset,
+        solid_kmers = solid_kmers)
     if viterbi_result === nothing
         # Viterbi could not decode (empty observation set, structural error, or an
         # un-k-merizable read): report no improvement rather than falling back to a
@@ -2864,6 +3071,11 @@ function finalize_iterative_assembly(output_dir::String, k_progression::Vector{I
         windowed_decode::Bool = false,
         soft_em::Bool = false,
         cheap_correct::Bool = false,
+        calibrated_gap_threshold::Union{Float64, Nothing} = nothing,
+        calibrated_probability_model::Union{CorrectionConfidenceModel, Nothing} = nothing,
+        calibrated_probability_threshold::Float64 = 0.5,
+        correction_feature_sink_active::Bool = false,
+        indel_params::Union{Nothing, IndelDecodeParams} = nothing,
         min_decode_k::Union{Int, Nothing} = nothing,
         decode_gate_density::Union{Float64, Nothing} = nothing,
         decode_gated_rungs::Vector{Int} = Int[],
@@ -3003,6 +3215,33 @@ function finalize_iterative_assembly(output_dir::String, k_progression::Vector{I
         :final_graph_reusable => final_pass_graph_reusable
     )
 
+    # Preserve literal default-off metadata identity. Gate provenance and
+    # feature-contract telemetry are present only when those opt-in paths were
+    # requested.
+    if calibrated_gap_threshold !== nothing
+        metadata[:calibrated_gap_threshold] = calibrated_gap_threshold
+    end
+    if calibrated_probability_model !== nothing
+        metadata[:calibrated_probability_threshold] = calibrated_probability_threshold
+        metadata[:calibrated_probability_model] = Dict{Symbol, Float64}(
+            :intercept => calibrated_probability_model.intercept,
+            :gap_weight => calibrated_probability_model.gap_weight,
+            :min_kmer_support_weight =>
+            calibrated_probability_model.min_kmer_support_weight,
+            :stage0_solid_weight => calibrated_probability_model.stage0_solid_weight,
+            :branch_support_ratio_weight =>
+            calibrated_probability_model.branch_support_ratio_weight,
+        )
+        metadata[:calibrated_gate_requested] = true
+        metadata[:calibrated_gate_effective] = indel_params === nothing
+        metadata[:calibrated_gate_disabled_reason] = indel_params === nothing ?
+                                                        nothing : "indel_params_requested"
+    end
+    if calibrated_probability_model !== nothing || correction_feature_sink_active
+        metadata[:calibrated_feature_contract_skips] = diagnostics === nothing ?
+                                                         0 : diagnostics.gate_skipped[]
+    end
+
     if verbose
         println("Iterative assembly finalized:")
         println("  Total k-mer sizes: $(length(k_progression))")
@@ -3105,6 +3344,37 @@ end
 # =============================================================================
 
 """
+$(DocStringExtensions.TYPEDSIGNATURES)
+
+Extract the typed correction-confidence features for `position_gaps[i]` from a
+decoded substitution path. The corresponding emitted base is at read position `i + k`.
+"""
+function correction_confidence_features(graph::Any, decoded_path::Any, i::Int, k::Int,
+        solid_kmers::AbstractSet, raw_gap::Real)::CorrectionConfidenceFeatures
+    first_step = i + 1
+    last_step = min(i + k, length(decoded_path.steps))
+    first_step <= last_step ||
+        throw(ArgumentError("empty overlapping-k-mer window for correction feature"))
+    min_support = Inf
+    all_solid = true
+    for j in first_step:last_step
+        label = decoded_path.steps[j].vertex_label
+        support = Float64(_vertex_coverage(graph[label]))
+        isfinite(support) ||
+            throw(ArgumentError("k-mer support feature must be finite"))
+        min_support = min(min_support, support)
+        all_solid &= label in solid_kmers
+    end
+    branch_support_ratio = Float64(decoded_path.steps[first_step].probability)
+    isfinite(branch_support_ratio) ||
+        throw(ArgumentError("branch support ratio must be finite"))
+    0.0 <= branch_support_ratio <= 1.0 ||
+        throw(ArgumentError("branch support ratio must be in [0, 1]"))
+    return CorrectionConfidenceFeatures(
+        raw_gap, min_support, all_solid, branch_support_ratio)
+end
+
+"""
 Try to improve FASTQ read using Viterbi algorithm from viterbi-next.jl.
 Returns (improved_read, likelihood) or nothing if no improvement.
 """
@@ -3117,8 +3387,16 @@ function try_viterbi_path_improvement(read::FASTX.FASTQ.Record,
         weighted_graph = nothing,
         diagnostics::Union{Nothing, CorrectorDiagnostics} = nothing,
         indel_params::Union{Nothing, IndelDecodeParams} = nothing,
-        calibrated_gap_threshold::Union{Float64, Nothing} = nothing)::Union{
+        calibrated_gap_threshold::Union{Float64, Nothing} = nothing,
+        calibrated_probability_model::Union{CorrectionConfidenceModel, Nothing} = nothing,
+        calibrated_probability_threshold::Float64 = 0.5,
+        correction_feature_sink::Union{Nothing, Function} = nothing,
+        correction_read_id::Union{Nothing, String} = nothing,
+        correction_position_offset::Int = 0,
+        solid_kmers::Union{Nothing, AbstractSet} = nothing)::Union{
         Tuple{FASTX.FASTQ.Record, Float64}, Nothing}
+    _validate_correction_gate(calibrated_gap_threshold,
+        calibrated_probability_model, calibrated_probability_threshold)
     try
         sequence_string = FASTX.sequence(String, read)
         alphabet = Mycelia.detect_alphabet(sequence_string)
@@ -3178,6 +3456,17 @@ function try_viterbi_path_improvement(read::FASTX.FASTQ.Record,
         beam_is_exact = effective_beam_width == typemax(Int)
         effective_margin = beam_is_exact ? Inf : _AUTO_BEAM_SCORE_MARGIN
         effective_successor_bound = beam_is_exact ? typemax(Int) : _AUTO_SUCCESSOR_BOUND
+        probability_gate_active = calibrated_probability_model !== nothing &&
+                                  indel_params === nothing
+        feature_sink_active = correction_feature_sink !== nothing && indel_params === nothing
+        feature_extraction_active = probability_gate_active || feature_sink_active
+        effective_solid_kmers = if feature_extraction_active
+            solid_kmers === nothing ? _solid_kmer_set(graph) : solid_kmers
+        else
+            nothing
+        end
+        record_position_gaps = calibrated_gap_threshold !== nothing ||
+                               feature_extraction_active
         # Indel-aware wiring (td-9q84 / 4a): when the assembler's error profile
         # enables indels it threads a non-nothing `indel_params`; the config then
         # turns on the pair-HMM gap moves with the profile's gap-open fractions +
@@ -3198,7 +3487,7 @@ function try_viterbi_path_improvement(read::FASTX.FASTQ.Record,
                 beam_width = effective_beam_width,
                 max_successors_per_state = effective_successor_bound,
                 beam_score_margin = effective_margin,
-                record_position_gaps = calibrated_gap_threshold !== nothing
+                record_position_gaps = record_position_gaps
             )
         else
             Mycelia.ViterbiCorrectionConfig(
@@ -3217,7 +3506,7 @@ function try_viterbi_path_improvement(read::FASTX.FASTQ.Record,
                 deletion_max_run = indel_params.deletion_max_run,
                 max_insertion_run = indel_params.max_insertion_run,
                 band_width = indel_params.band_width,
-                record_position_gaps = calibrated_gap_threshold !== nothing
+                record_position_gaps = record_position_gaps
             )
         end
         correction = Mycelia.correct_observations(
@@ -3289,7 +3578,10 @@ function try_viterbi_path_improvement(read::FASTX.FASTQ.Record,
         # net-length-neutral — it would pass a length check yet shift the interior
         # map — so we exclude indel mode entirely rather than trust `length` as a
         # proxy for alignment (review: convergent finding, 3 reviewers).
-        if calibrated_gap_threshold !== nothing && indel_params === nothing
+        gate_active = calibrated_gap_threshold !== nothing ||
+                      calibrated_probability_model !== nothing
+        serving_features_active = gate_active || feature_sink_active
+        if serving_features_active && indel_params === nothing
             path_result = only(correction.paths)
             decoded_path = path_result.path
             gaps = get(path_result.diagnostics, :position_gaps, nothing)
@@ -3303,15 +3595,96 @@ function try_viterbi_path_improvement(read::FASTX.FASTQ.Record,
             if decoded_path !== nothing && gaps !== nothing &&
                length(gaps) == length(decoded_path.steps) - 1 &&
                length(corrected_chars) == length(original_chars)
-                @inbounds for i in eachindex(gaps)
-                    position = i + k
-                    position > length(corrected_chars) && break
-                    if gaps[i] < calibrated_gap_threshold
+                revert_positions = Int[]
+                gate_contract_ok = true
+                try
+                    @inbounds for i in eachindex(gaps)
+                        position = i + k
+                        position > length(corrected_chars) && break
+                        # The gate can only act on a proposed substitution. Training
+                        # and held-out evaluation use this same candidate-edit cohort.
+                        corrected_chars[position] == original_chars[position] && continue
+                        if feature_sink_active && !isfinite(gaps[i]) && gaps[i] != Inf
+                            throw(_CorrectionFeatureSinkError(
+                                "correction feature extraction received a non-finite " *
+                                "Viterbi gap for $(FASTX.identifier(read)) at position " *
+                                "$(position)"))
+                        end
+                        features = if isfinite(gaps[i]) && feature_extraction_active
+                            try
+                                correction_confidence_features(
+                                    graph, decoded_path, i, k,
+                                    effective_solid_kmers, gaps[i])
+                            catch feature_error
+                                feature_sink_active && throw(_CorrectionFeatureSinkError(
+                                    "correction feature extraction failed for " *
+                                    "$(FASTX.identifier(read)) at position $(position): " *
+                                    sprint(showerror, feature_error)))
+                                rethrow()
+                            end
+                        else
+                            nothing
+                        end
+                        if feature_sink_active && features !== nothing
+                            event_read_id = correction_read_id === nothing ?
+                                            String(FASTX.identifier(read)) : correction_read_id
+                            try
+                                correction_feature_sink(CorrectionFeatureObservation(
+                                    event_read_id,
+                                    k,
+                                    position + correction_position_offset,
+                                    original_chars[position],
+                                    corrected_chars[position],
+                                    features,
+                                ))
+                            catch sink_error
+                                throw(_CorrectionFeatureSinkError(
+                                    "correction feature sink failed for " *
+                                    "$(event_read_id) at position " *
+                                    "$(position + correction_position_offset): " *
+                                    sprint(showerror, sink_error)))
+                            end
+                        end
+                        keep_correction = if calibrated_gap_threshold !== nothing
+                            # Preserve the legacy raw-gap gate's fail-open behavior
+                            # for NaN: only an explicitly low gap reverts an edit.
+                            !(gaps[i] < calibrated_gap_threshold)
+                        elseif calibrated_probability_model === nothing
+                            true
+                        elseif gaps[i] == Inf
+                            # A collapsed frontier has no surviving competitor and is
+                            # maximally confident, matching the legacy raw-gap gate.
+                            true
+                        elseif isfinite(gaps[i])
+                            confidence = correction_confidence_probability(
+                                calibrated_probability_model, features)
+                            confidence >= calibrated_probability_threshold
+                        else
+                            throw(ArgumentError(
+                                "probability gate received a non-finite Viterbi gap"))
+                        end
+                        keep_correction || push!(revert_positions, position)
+                    end
+                catch gate_error
+                    gate_error isa _CorrectionFeatureSinkError && rethrow()
+                    # A feature/alignment defect must not partially gate a read. Keep
+                    # the ungated decode and surface the contract miss once.
+                    gate_contract_ok = false
+                    @debug "calibrated probability gate failed open" exception =
+                        (gate_error, catch_backtrace())
+                end
+                if gate_contract_ok
+                    for position in revert_positions
                         corrected_chars[position] = original_chars[position]
                     end
+                    corrected_sequence_string = String(corrected_chars)
+                elseif gate_active && diagnostics !== nothing
+                    Threads.atomic_add!(diagnostics.gate_skipped, 1)
                 end
-                corrected_sequence_string = String(corrected_chars)
-            elseif diagnostics !== nothing
+            elseif feature_sink_active
+                diagnostics === nothing ||
+                    Threads.atomic_add!(diagnostics.gate_skipped, 1)
+            elseif gate_active && diagnostics !== nothing
                 # In substitution mode the decode contract (path present, gaps
                 # recorded, len == steps-1, length preserved) is ALWAYS satisfiable;
                 # a miss means the gate silently fell open to the ungated decode —

--- a/src/iterative-assembly.jl
+++ b/src/iterative-assembly.jl
@@ -2029,7 +2029,9 @@ function improve_read_set_likelihood(reads::Vector{<:FASTX.FASTQ.Record}, graph,
     # Classify k-mers once if EITHER the skip-solid gate OR the Stage 0 cheap
     # corrector needs the solid set. Compute once, share both consumers.
     feature_collection_active = correction_feature_sink !== nothing && indel_params === nothing
-    need_solid = calibrated_probability_model !== nothing || feature_collection_active ||
+    probability_gate_active = calibrated_probability_model !== nothing &&
+                              indel_params === nothing
+    need_solid = probability_gate_active || feature_collection_active ||
                  ((skip_solid || cheap_correct) && graph_mode != :singlestrand)
     solid_kmers = need_solid ? _solid_kmer_set(graph) : nothing
 
@@ -2110,11 +2112,11 @@ function improve_read_set_likelihood(reads::Vector{<:FASTX.FASTQ.Record}, graph,
     # mutable state, so those passes run sequentially. Otherwise honor the
     # caller's parallel request.
     use_parallel = enable_parallel && Threads.nthreads() > 1 &&
-                   soft_weights === nothing && correction_feature_sink === nothing
+                   soft_weights === nothing && !feature_collection_active
     if enable_parallel && soft_weights !== nothing && Threads.nthreads() > 1
         @warn "soft-EM edge accumulation is sequential (race-free); ignoring enable_parallel for this pass." maxlog = 1
     end
-    if enable_parallel && correction_feature_sink !== nothing && Threads.nthreads() > 1
+    if enable_parallel && feature_collection_active && Threads.nthreads() > 1
         @warn "correction feature collection is sequential (race-free); ignoring " *
               "enable_parallel for this pass." maxlog = 1
     end
@@ -2361,6 +2363,8 @@ function improve_read_likelihood(read::FASTX.FASTQ.Record, graph, k::Int;
         correction_position_offset::Int = 0,
         solid_kmers::Union{Nothing, AbstractSet} = nothing)::Tuple{
         FASTX.FASTQ.Record, Bool}
+    _validate_correction_gate(calibrated_gap_threshold,
+        calibrated_probability_model, calibrated_probability_threshold)
     # Extract sequence and quality
     original_seq = FASTX.sequence(String, read)
     original_qual = FASTX.quality(read)
@@ -2439,6 +2443,8 @@ function find_optimal_sequence_path(read::FASTX.FASTQ.Record, graph, k::Int;
         correction_position_offset::Int = 0,
         solid_kmers::Union{Nothing, AbstractSet} = nothing)::Tuple{
         FASTX.FASTQ.Record, Float64}
+    _validate_correction_gate(calibrated_gap_threshold,
+        calibrated_probability_model, calibrated_probability_threshold)
     gate_contract_requested = indel_params === nothing &&
                               (calibrated_gap_threshold !== nothing ||
                                calibrated_probability_model !== nothing ||
@@ -3280,7 +3286,8 @@ function finalize_iterative_assembly(output_dir::String, k_progression::Vector{I
         metadata[:correction_feature_sink_disabled_reason] =
             correction_feature_sink_active ? nothing : "indel_params_requested"
     end
-    if calibrated_probability_model !== nothing || correction_feature_sink_active
+    if calibrated_gap_threshold !== nothing ||
+       calibrated_probability_model !== nothing || correction_feature_sink_active
         metadata[:calibrated_feature_contract_skips] = diagnostics === nothing ?
                                                          0 : diagnostics.gate_skipped[]
     end
@@ -3659,6 +3666,7 @@ function try_viterbi_path_improvement(read::FASTX.FASTQ.Record,
                length(gaps) == length(decoded_path.steps) - 1 &&
                length(corrected_chars) == length(original_chars)
                 revert_positions = Int[]
+                feature_observations = CorrectionFeatureObservation[]
                 gate_contract_ok = true
                 try
                     @inbounds for i in eachindex(gaps)
@@ -3667,48 +3675,32 @@ function try_viterbi_path_improvement(read::FASTX.FASTQ.Record,
                         # The gate can only act on a proposed substitution. Training
                         # and held-out evaluation use this same candidate-edit cohort.
                         corrected_chars[position] == original_chars[position] && continue
-                        if feature_sink_active && !isfinite(gaps[i]) && gaps[i] != Inf
-                            throw(_CorrectionFeatureSinkError(
+                        if feature_extraction_active &&
+                           !isfinite(gaps[i]) && gaps[i] != Inf
+                            throw(ArgumentError(
                                 "correction feature extraction received a non-finite " *
                                 "Viterbi gap for $(FASTX.identifier(read)) at position " *
                                 "$(position)"))
                         end
                         features = if (isfinite(gaps[i]) || gaps[i] == Inf) &&
                                       feature_extraction_active
-                            try
-                                correction_confidence_features(
-                                    graph, decoded_path, i, k,
-                                    effective_solid_kmers, gaps[i])
-                            catch feature_error
-                                feature_sink_active && throw(_CorrectionFeatureSinkError(
-                                    "correction feature extraction failed for " *
-                                    "$(FASTX.identifier(read)) at position $(position): " *
-                                    sprint(showerror, feature_error)))
-                                rethrow()
-                            end
+                            correction_confidence_features(
+                                graph, decoded_path, i, k,
+                                effective_solid_kmers, gaps[i])
                         else
                             nothing
                         end
                         if feature_sink_active && features !== nothing
                             event_read_id = correction_read_id === nothing ?
                                             String(FASTX.identifier(read)) : correction_read_id
-                            try
-                                correction_feature_sink(CorrectionFeatureObservation(
-                                    event_read_id,
-                                    k,
-                                    position + correction_position_offset,
-                                    original_chars[position],
-                                    corrected_chars[position],
-                                    features,
-                                ))
-                            catch sink_error
-                                sink_error isa InterruptException && rethrow()
-                                throw(_CorrectionFeatureSinkError(
-                                    "correction feature sink failed for " *
-                                    "$(event_read_id) at position " *
-                                    "$(position + correction_position_offset): " *
-                                    sprint(showerror, sink_error)))
-                            end
+                            push!(feature_observations, CorrectionFeatureObservation(
+                                event_read_id,
+                                k,
+                                position + correction_position_offset,
+                                original_chars[position],
+                                corrected_chars[position],
+                                features,
+                            ))
                         end
                         keep_correction = if calibrated_gap_threshold !== nothing
                             # Preserve the legacy raw-gap gate's fail-open behavior
@@ -3727,26 +3719,40 @@ function try_viterbi_path_improvement(read::FASTX.FASTQ.Record,
                         keep_correction || push!(revert_positions, position)
                     end
                 catch gate_error
-                    gate_error isa _CorrectionFeatureSinkError && rethrow()
+                    gate_error isa InterruptException && rethrow()
                     # A feature/alignment defect must not partially gate a read. Keep
-                    # the ungated decode and surface the contract miss once.
+                    # the ungated decode, emit no buffered observations, and surface
+                    # the contract miss once.
                     gate_contract_ok = false
                     @debug "calibrated probability gate failed open" exception =
                         (gate_error, catch_backtrace())
                 end
                 if gate_contract_ok
+                    # Feature observations are read-transactional: do not invoke the
+                    # caller-owned sink until every proposed edit has satisfied the
+                    # feature/gate contract. `_CorrectionFeatureSinkError` is
+                    # reserved for callback failures and propagates to the caller.
+                    for observation in feature_observations
+                        try
+                            correction_feature_sink(observation)
+                        catch sink_error
+                            sink_error isa InterruptException && rethrow()
+                            throw(_CorrectionFeatureSinkError(
+                                "correction feature sink failed for " *
+                                "$(observation.read_id) at position " *
+                                "$(observation.position): " *
+                                sprint(showerror, sink_error)))
+                        end
+                    end
                     for position in revert_positions
                         corrected_chars[position] = original_chars[position]
                     end
                     corrected_sequence_string = String(corrected_chars)
-                elseif gate_active
+                elseif serving_features_active
                     _record_gate_contract_miss!(
                         diagnostics, "per-base feature extraction failed")
                 end
-            elseif feature_sink_active
-                _record_gate_contract_miss!(
-                    diagnostics, "path/gap/length contract was incomplete")
-            elseif gate_active
+            elseif serving_features_active
                 # In substitution mode the decode contract (path present, gaps
                 # recorded, len == steps-1, length preserved) is ALWAYS satisfiable;
                 # a miss means the gate silently fell open to the ungated decode —

--- a/src/iterative-assembly.jl
+++ b/src/iterative-assembly.jl
@@ -392,7 +392,8 @@ $(DocStringExtensions.TYPEDSIGNATURES)
 Raw-space coefficients for the calibrated per-base probability that a proposed
 substitution is correct. The fixed feature order is the Viterbi gap, minimum
 support among decoded k-mers overlapping the emitted base, the Stage-0 all-solid
-indicator, and the selected branch's normalized support ratio.
+indicator, and the selected branch's normalized support ratio. A collapsed
+survivor frontier (`gap == Inf`) is represented by its own indicator coefficient.
 """
 struct CorrectionConfidenceModel
     intercept::Float64
@@ -400,16 +401,19 @@ struct CorrectionConfidenceModel
     min_kmer_support_weight::Float64
     stage0_solid_weight::Float64
     branch_support_ratio_weight::Float64
+    collapsed_frontier_weight::Float64
 
     function CorrectionConfidenceModel(intercept::Real, gap_weight::Real,
             min_kmer_support_weight::Real, stage0_solid_weight::Real,
-            branch_support_ratio_weight::Real)
+            branch_support_ratio_weight::Real,
+            collapsed_frontier_weight::Real)
         values = (
             Float64(intercept),
             Float64(gap_weight),
             Float64(min_kmer_support_weight),
             Float64(stage0_solid_weight),
             Float64(branch_support_ratio_weight),
+            Float64(collapsed_frontier_weight),
         )
         all(isfinite, values) ||
             throw(ArgumentError("correction-confidence coefficients must be finite"))
@@ -423,6 +427,8 @@ $(DocStringExtensions.TYPEDSIGNATURES)
 Typed serving schema for one proposed substitution. `competing_branch_support_ratio`
 is the selected incoming edge's normalized support, not a whole-path posterior. Edge
 support is soft-EM-aware when the graph has responsibility-weighted edges registered.
+`raw_gap == Inf` represents a collapsed survivor frontier and is calibrated as a
+separate indicator rather than treated as certainty.
 """
 struct CorrectionConfidenceFeatures
     raw_gap::Float64
@@ -435,8 +441,11 @@ struct CorrectionConfidenceFeatures
         gap = Float64(raw_gap)
         support = Float64(min_kmer_support)
         ratio = Float64(competing_branch_support_ratio)
-        all(isfinite, (gap, support, ratio)) ||
-            throw(ArgumentError("correction-confidence features must be finite"))
+        (isfinite(gap) || gap == Inf) ||
+            throw(ArgumentError(
+                "correction-confidence raw gap must be finite or +Inf"))
+        all(isfinite, (support, ratio)) ||
+            throw(ArgumentError("correction-confidence support features must be finite"))
         0.0 <= ratio <= 1.0 ||
             throw(ArgumentError("competing branch support ratio must be in [0, 1]"))
         return new(gap, support, all_stage0_solid, ratio)
@@ -473,11 +482,14 @@ Evaluate a [`CorrectionConfidenceModel`](@ref) on one per-base feature vector.
 """
 function correction_confidence_probability(model::CorrectionConfidenceModel,
         features::CorrectionConfidenceFeatures)::Float64
+    collapsed = features.raw_gap == Inf
+    raw_gap = collapsed ? 0.0 : features.raw_gap
     solid = features.all_stage0_solid ? 1.0 : 0.0
-    z = model.intercept + model.gap_weight * features.raw_gap +
+    z = model.intercept + model.gap_weight * raw_gap +
         model.min_kmer_support_weight * features.min_kmer_support +
         model.stage0_solid_weight * solid +
-        model.branch_support_ratio_weight * features.competing_branch_support_ratio
+        model.branch_support_ratio_weight * features.competing_branch_support_ratio +
+        model.collapsed_frontier_weight * (collapsed ? 1.0 : 0.0)
     isnan(z) && throw(ArgumentError("correction-confidence logit must not be NaN"))
     return z >= 0.0 ? 1.0 / (1.0 + exp(-z)) : exp(z) / (1.0 + exp(z))
 end
@@ -1080,6 +1092,7 @@ function mycelia_iterative_assemble(input_fastq::String;
         calibrated_gap_threshold = calibrated_gap_threshold,
         calibrated_probability_model = calibrated_probability_model,
         calibrated_probability_threshold = calibrated_probability_threshold,
+        correction_feature_sink_requested = correction_feature_sink !== nothing,
         correction_feature_sink_active =
             correction_feature_sink !== nothing && indel_params === nothing,
         indel_params = indel_params,
@@ -1766,8 +1779,9 @@ mutable struct CorrectorDiagnostics
     structural_errors::Threads.Atomic{Int}
     unkmerizable_reads::Threads.Atomic{Int}
     # Calibrated gate or feature telemetry requested in substitution mode, but a
-    # full-length gap/path contract was unavailable. The read stays ungated and
-    # emits no feature event; a nonzero value makes that survivor selection visible.
+    # usable decode/path/gap contract was unavailable (including no-path,
+    # structural, and un-k-merizable attempts). The read stays ungated and emits
+    # no feature event; a nonzero value makes that survivor selection visible.
     gate_skipped::Threads.Atomic{Int}
     indel_decodes::Threads.Atomic{Int}
     truncated_decodes::Threads.Atomic{Int}
@@ -1778,6 +1792,18 @@ function CorrectorDiagnostics()
     CorrectorDiagnostics(Threads.Atomic{Int}(0), Threads.Atomic{Int}(0),
         Threads.Atomic{Int}(0), Threads.Atomic{Int}(0), Threads.Atomic{Int}(0),
         Threads.Atomic{Int}(0), Threads.Atomic{Int}(0))
+end
+
+function _record_gate_contract_miss!(
+        diagnostics::Union{Nothing, CorrectorDiagnostics},
+        reason::AbstractString)::Nothing
+    if diagnostics === nothing
+        @warn "calibrated feature/gate contract unavailable; returning the " *
+              "ungated read" reason maxlog = 1
+    else
+        Threads.atomic_add!(diagnostics.gate_skipped, 1)
+    end
+    return nothing
 end
 
 # Previously-proven-tractable finite beam (td-63qy: beam 256 completed on the
@@ -2413,6 +2439,10 @@ function find_optimal_sequence_path(read::FASTX.FASTQ.Record, graph, k::Int;
         correction_position_offset::Int = 0,
         solid_kmers::Union{Nothing, AbstractSet} = nothing)::Tuple{
         FASTX.FASTQ.Record, Float64}
+    gate_contract_requested = indel_params === nothing &&
+                              (calibrated_gap_threshold !== nothing ||
+                               calibrated_probability_model !== nothing ||
+                               correction_feature_sink !== nothing)
     # Trustworthy Viterbi (graph-as-HMM correction core, td-ak6w). Trust the
     # maximum-likelihood path or report no improvement. The prior heuristic
     # fallback cascade (0.01 abandon-threshold -> statistical resampling -> local
@@ -2434,6 +2464,10 @@ function find_optimal_sequence_path(read::FASTX.FASTQ.Record, graph, k::Int;
         if error isa BioSequences.EncodeError
             diagnostics === nothing ||
                 Threads.atomic_add!(diagnostics.unkmerizable_reads, 1)
+            if gate_contract_requested
+                _record_gate_contract_miss!(
+                    diagnostics, "input read could not be k-merized")
+            end
             return read, 0.0
         end
         rethrow()
@@ -3074,6 +3108,7 @@ function finalize_iterative_assembly(output_dir::String, k_progression::Vector{I
         calibrated_gap_threshold::Union{Float64, Nothing} = nothing,
         calibrated_probability_model::Union{CorrectionConfidenceModel, Nothing} = nothing,
         calibrated_probability_threshold::Float64 = 0.5,
+        correction_feature_sink_requested::Bool = false,
         correction_feature_sink_active::Bool = false,
         indel_params::Union{Nothing, IndelDecodeParams} = nothing,
         min_decode_k::Union{Int, Nothing} = nothing,
@@ -3231,11 +3266,19 @@ function finalize_iterative_assembly(output_dir::String, k_progression::Vector{I
             :stage0_solid_weight => calibrated_probability_model.stage0_solid_weight,
             :branch_support_ratio_weight =>
             calibrated_probability_model.branch_support_ratio_weight,
+            :collapsed_frontier_weight =>
+            calibrated_probability_model.collapsed_frontier_weight,
         )
         metadata[:calibrated_gate_requested] = true
         metadata[:calibrated_gate_effective] = indel_params === nothing
         metadata[:calibrated_gate_disabled_reason] = indel_params === nothing ?
                                                         nothing : "indel_params_requested"
+    end
+    if correction_feature_sink_requested
+        metadata[:correction_feature_sink_requested] = true
+        metadata[:correction_feature_sink_effective] = correction_feature_sink_active
+        metadata[:correction_feature_sink_disabled_reason] =
+            correction_feature_sink_active ? nothing : "indel_params_requested"
     end
     if calibrated_probability_model !== nothing || correction_feature_sink_active
         metadata[:calibrated_feature_contract_skips] = diagnostics === nothing ?
@@ -3397,6 +3440,17 @@ function try_viterbi_path_improvement(read::FASTX.FASTQ.Record,
         Tuple{FASTX.FASTQ.Record, Float64}, Nothing}
     _validate_correction_gate(calibrated_gap_threshold,
         calibrated_probability_model, calibrated_probability_threshold)
+    if indel_params !== nothing &&
+       (calibrated_gap_threshold !== nothing ||
+        calibrated_probability_model !== nothing ||
+        correction_feature_sink !== nothing)
+        @warn "calibrated gates and feature collection are substitution-only; " *
+              "ignoring the requested gate/sink because indel_params is set" maxlog = 1
+    end
+    gate_contract_requested = indel_params === nothing &&
+                              (calibrated_gap_threshold !== nothing ||
+                               calibrated_probability_model !== nothing ||
+                               correction_feature_sink !== nothing)
     try
         sequence_string = FASTX.sequence(String, read)
         alphabet = Mycelia.detect_alphabet(sequence_string)
@@ -3408,6 +3462,10 @@ function try_viterbi_path_improvement(read::FASTX.FASTQ.Record,
         # in the catch below, NOT a crash of the (threaded) batch (td-63qy family).
         kmers = collect(Mycelia._record_kmer_iterator(sequence_type, k, sequence))
         if isempty(kmers)
+            if gate_contract_requested
+                _record_gate_contract_miss!(
+                    diagnostics, "input read produced no k-mer observations")
+            end
             return nothing
         end
 
@@ -3513,6 +3571,10 @@ function try_viterbi_path_improvement(read::FASTX.FASTQ.Record,
             graph, [observations]; config = config, weighted_graph = weighted_graph)
         corrected_path = only(correction.corrected_observations)
         if corrected_path === nothing || isempty(corrected_path)
+            if gate_contract_requested
+                _record_gate_contract_miss!(
+                    diagnostics, "decoder produced no corrected path")
+            end
             return nothing
         end
         path_diagnostics = only(correction.paths).diagnostics
@@ -3590,8 +3652,9 @@ function try_viterbi_path_improvement(read::FASTX.FASTQ.Record,
             # gaps[i] is the Viterbi margin INTO path.steps[i+1], i.e. read position
             # i+k. Where the margin is below threshold the decode is ambiguous, so
             # revert that base to the observed one — this is what pulls over-correction
-            # back down. `Inf` gaps (collapsed frontier ⇒ maximally confident) clear
-            # any finite threshold and are kept.
+            # back down. Under the legacy raw-gap gate, `Inf` clears any finite
+            # threshold. The probability gate instead uses its fitted collapsed-
+            # frontier probability, because `Inf` is also routine after beam pruning.
             if decoded_path !== nothing && gaps !== nothing &&
                length(gaps) == length(decoded_path.steps) - 1 &&
                length(corrected_chars) == length(original_chars)
@@ -3610,7 +3673,8 @@ function try_viterbi_path_improvement(read::FASTX.FASTQ.Record,
                                 "Viterbi gap for $(FASTX.identifier(read)) at position " *
                                 "$(position)"))
                         end
-                        features = if isfinite(gaps[i]) && feature_extraction_active
+                        features = if (isfinite(gaps[i]) || gaps[i] == Inf) &&
+                                      feature_extraction_active
                             try
                                 correction_confidence_features(
                                     graph, decoded_path, i, k,
@@ -3638,6 +3702,7 @@ function try_viterbi_path_improvement(read::FASTX.FASTQ.Record,
                                     features,
                                 ))
                             catch sink_error
+                                sink_error isa InterruptException && rethrow()
                                 throw(_CorrectionFeatureSinkError(
                                     "correction feature sink failed for " *
                                     "$(event_read_id) at position " *
@@ -3651,11 +3716,7 @@ function try_viterbi_path_improvement(read::FASTX.FASTQ.Record,
                             !(gaps[i] < calibrated_gap_threshold)
                         elseif calibrated_probability_model === nothing
                             true
-                        elseif gaps[i] == Inf
-                            # A collapsed frontier has no surviving competitor and is
-                            # maximally confident, matching the legacy raw-gap gate.
-                            true
-                        elseif isfinite(gaps[i])
+                        elseif isfinite(gaps[i]) || gaps[i] == Inf
                             confidence = correction_confidence_probability(
                                 calibrated_probability_model, features)
                             confidence >= calibrated_probability_threshold
@@ -3678,19 +3739,21 @@ function try_viterbi_path_improvement(read::FASTX.FASTQ.Record,
                         corrected_chars[position] = original_chars[position]
                     end
                     corrected_sequence_string = String(corrected_chars)
-                elseif gate_active && diagnostics !== nothing
-                    Threads.atomic_add!(diagnostics.gate_skipped, 1)
+                elseif gate_active
+                    _record_gate_contract_miss!(
+                        diagnostics, "per-base feature extraction failed")
                 end
             elseif feature_sink_active
-                diagnostics === nothing ||
-                    Threads.atomic_add!(diagnostics.gate_skipped, 1)
-            elseif gate_active && diagnostics !== nothing
+                _record_gate_contract_miss!(
+                    diagnostics, "path/gap/length contract was incomplete")
+            elseif gate_active
                 # In substitution mode the decode contract (path present, gaps
                 # recorded, len == steps-1, length preserved) is ALWAYS satisfiable;
                 # a miss means the gate silently fell open to the ungated decode —
                 # count it so an opt-in gate that disabled itself is visible, not
                 # invisible (fail-open is the right data-safety choice; silence is not).
-                Threads.atomic_add!(diagnostics.gate_skipped, 1)
+                _record_gate_contract_miss!(
+                    diagnostics, "path/gap/length contract was incomplete")
             end
         end
         improved_quality, improved_likelihood = if indel_params === nothing
@@ -3721,6 +3784,10 @@ function try_viterbi_path_improvement(read::FASTX.FASTQ.Record,
             # gain"). See CorrectorDiagnostics + the per-pass @warn.
             diagnostics === nothing ||
                 Threads.atomic_add!(diagnostics.structural_errors, 1)
+            if gate_contract_requested
+                _record_gate_contract_miss!(
+                    diagnostics, "decoder raised a structural error")
+            end
             return nothing
         elseif error isa BioSequences.EncodeError
             # UN-K-MERIZABLE read: the 2-bit k-mer iterator throws EncodeError (NOT
@@ -3730,6 +3797,10 @@ function try_viterbi_path_improvement(read::FASTX.FASTQ.Record,
             # corrector on one N-containing read (td-63qy family).
             diagnostics === nothing ||
                 Threads.atomic_add!(diagnostics.unkmerizable_reads, 1)
+            if gate_contract_requested
+                _record_gate_contract_miss!(
+                    diagnostics, "input read could not be k-merized")
+            end
             return nothing
         end
         rethrow()

--- a/src/iterative-assembly.jl
+++ b/src/iterative-assembly.jl
@@ -441,11 +441,13 @@ struct CorrectionConfidenceFeatures
         gap = Float64(raw_gap)
         support = Float64(min_kmer_support)
         ratio = Float64(competing_branch_support_ratio)
-        (isfinite(gap) || gap == Inf) ||
+        ((isfinite(gap) && gap >= 0.0) || gap == Inf) ||
             throw(ArgumentError(
-                "correction-confidence raw gap must be finite or +Inf"))
+                "correction-confidence raw gap must be nonnegative and finite or +Inf"))
         all(isfinite, (support, ratio)) ||
             throw(ArgumentError("correction-confidence support features must be finite"))
+        support >= 0.0 ||
+            throw(ArgumentError("minimum k-mer support must be nonnegative"))
         0.0 <= ratio <= 1.0 ||
             throw(ArgumentError("competing branch support ratio must be in [0, 1]"))
         return new(gap, support, all_stage0_solid, ratio)
@@ -472,6 +474,26 @@ end
 
 function Base.showerror(io::IO, error::_CorrectionFeatureSinkError)::Nothing
     print(io, error.message)
+    return nothing
+end
+
+struct _CorrectionFeatureContractError <: Exception
+    message::String
+end
+
+function Base.showerror(io::IO, error::_CorrectionFeatureContractError)::Nothing
+    print(io, error.message)
+    return nothing
+end
+
+struct _CorrectionConfidenceServingError <: Exception
+    message::String
+    cause::Exception
+end
+
+function Base.showerror(io::IO, error::_CorrectionConfidenceServingError)::Nothing
+    print(io, error.message, ": ")
+    showerror(io, error.cause)
     return nothing
 end
 
@@ -502,14 +524,20 @@ function correction_confidence_probability(model::CorrectionConfidenceModel,
     return correction_confidence_probability(model, features)
 end
 
-function _validate_correction_gate(calibrated_gap_threshold::Union{Float64, Nothing},
+function _validate_correction_gate(calibrated_gap_threshold::Union{Real, Nothing},
         calibrated_probability_model::Union{CorrectionConfidenceModel, Nothing},
-        calibrated_probability_threshold::Float64)::Nothing
+        calibrated_probability_threshold::Real)::Nothing
     if calibrated_gap_threshold !== nothing && calibrated_probability_model !== nothing
         throw(ArgumentError(
             "calibrated_gap_threshold and calibrated_probability_model are mutually exclusive"))
     end
-    0.0 <= calibrated_probability_threshold <= 1.0 ||
+    if calibrated_gap_threshold !== nothing
+        gap_threshold = Float64(calibrated_gap_threshold)
+        isnan(gap_threshold) &&
+            throw(ArgumentError("calibrated_gap_threshold must not be NaN"))
+    end
+    probability_threshold = Float64(calibrated_probability_threshold)
+    0.0 <= probability_threshold <= 1.0 ||
         throw(ArgumentError("calibrated_probability_threshold must be in [0, 1]"))
     return nothing
 end
@@ -522,6 +550,14 @@ end
 Main iterative maximum likelihood assembly function.
 Processes entire read sets per iteration with complete FASTQ I/O tracking.
 Enhanced with performance optimizations, caching, and progress tracking.
+
+`calibrated_gap_threshold`, `calibrated_probability_model`, and
+`correction_feature_sink` are opt-in, substitution-only controls. They remain off by
+default. When `indel_params !== nothing`, requests are retained in result provenance
+but are not executed because an indel alignment has no stable base-to-column mapping
+for positional reverts or per-base feature labels. Expected per-read feature-contract
+misses fail open to the ungated substitution decode and are counted; callback failures
+and unexpected implementation exceptions propagate.
 """
 function mycelia_iterative_assemble(input_fastq::String;
         max_k::Int = 101,
@@ -544,10 +580,10 @@ function mycelia_iterative_assemble(input_fastq::String;
         soft_em::Bool = false,
         cheap_correct::Bool = false,
         beam_width::Union{Int, Nothing} = nothing,
-        calibrated_gap_threshold::Union{Float64, Nothing} = nothing,
+        calibrated_gap_threshold::Union{Real, Nothing} = nothing,
         calibrated_probability_model::Union{CorrectionConfidenceModel, Nothing} = nothing,
-        calibrated_probability_threshold::Float64 = 0.5,
-        correction_feature_sink::Union{Nothing, Function} = nothing,
+        calibrated_probability_threshold::Real = 0.5,
+        correction_feature_sink::Any = nothing,
         min_decode_k::Union{Int, Nothing} = nothing,
         decode_gate_density::Union{Float64, Nothing} = nothing,
         indel_params::Union{Nothing, IndelDecodeParams} = nothing)
@@ -1537,10 +1573,10 @@ function improve_read_likelihood_windowed(read::FASTX.FASTQ.Record, graph, k::In
         weighted_graph = nothing,
         diagnostics = nothing,  # ::Union{Nothing, CorrectorDiagnostics}; struct defined below
         pad::Union{Int, Nothing} = nothing,
-        calibrated_gap_threshold::Union{Float64, Nothing} = nothing,
+        calibrated_gap_threshold::Union{Real, Nothing} = nothing,
         calibrated_probability_model::Union{CorrectionConfidenceModel, Nothing} = nothing,
-        calibrated_probability_threshold::Float64 = 0.5,
-        correction_feature_sink::Union{Nothing, Function} = nothing,
+        calibrated_probability_threshold::Real = 0.5,
+        correction_feature_sink::Any = nothing,
         solid_kmers::Union{Nothing, AbstractSet} = nothing,
         max_window::Int = 500,
         indel_params::Union{Nothing, IndelDecodeParams} = nothing)::Tuple{
@@ -1589,10 +1625,10 @@ function improve_read_likelihood_windowed_detail(read::FASTX.FASTQ.Record, graph
         weighted_graph = nothing,
         diagnostics = nothing,  # ::Union{Nothing, CorrectorDiagnostics}; struct defined below
         pad::Union{Int, Nothing} = nothing,
-        calibrated_gap_threshold::Union{Float64, Nothing} = nothing,
+        calibrated_gap_threshold::Union{Real, Nothing} = nothing,
         calibrated_probability_model::Union{CorrectionConfidenceModel, Nothing} = nothing,
-        calibrated_probability_threshold::Float64 = 0.5,
-        correction_feature_sink::Union{Nothing, Function} = nothing,
+        calibrated_probability_threshold::Real = 0.5,
+        correction_feature_sink::Any = nothing,
         solid_kmers::Union{Nothing, AbstractSet} = nothing,
         max_window::Int = 500,
         indel_params::Union{Nothing, IndelDecodeParams} = nothing)::Tuple{
@@ -1774,6 +1810,12 @@ parallel (`@threads`) read loop increments them race-free.
   an internal decoder contract regression rather than a data-dependent miss.
 - `window_divergences` : substitution windows rejected for violating the
   length-preserving splice contract.
+- `candidate_substitutions_evaluated` : proposed substitutions reached by an
+  effective gate or feature sink.
+- `feature_events_emitted` : observations successfully delivered to the caller's
+  sink. A later callback failure can occur after earlier external mutations.
+- `gate_reverts` : proposed substitutions reverted by a calibrated gate after the
+  complete read-level feature contract was validated.
 """
 mutable struct CorrectorDiagnostics
     structural_errors::Threads.Atomic{Int}
@@ -1783,6 +1825,11 @@ mutable struct CorrectorDiagnostics
     # structural, and un-k-merizable attempts). The read stays ungated and emits
     # no feature event; a nonzero value makes that survivor selection visible.
     gate_skipped::Threads.Atomic{Int}
+    # Serving activity is tracked separately from configuration provenance so an
+    # enabled gate that saw no candidate edits cannot masquerade as executed.
+    candidate_substitutions_evaluated::Threads.Atomic{Int}
+    feature_events_emitted::Threads.Atomic{Int}
+    gate_reverts::Threads.Atomic{Int}
     indel_decodes::Threads.Atomic{Int}
     truncated_decodes::Threads.Atomic{Int}
     trace_contract_errors::Threads.Atomic{Int}
@@ -1790,6 +1837,7 @@ mutable struct CorrectorDiagnostics
 end
 function CorrectorDiagnostics()
     CorrectorDiagnostics(Threads.Atomic{Int}(0), Threads.Atomic{Int}(0),
+        Threads.Atomic{Int}(0), Threads.Atomic{Int}(0), Threads.Atomic{Int}(0),
         Threads.Atomic{Int}(0), Threads.Atomic{Int}(0), Threads.Atomic{Int}(0),
         Threads.Atomic{Int}(0), Threads.Atomic{Int}(0))
 end
@@ -1975,6 +2023,13 @@ Stage 0 progress. `decode_gated` is `true` iff the per-read decode was gated OFF
 the whole pass (low-k gate, td-9h5r). Callers destructuring only the first
 two/three/four values are unaffected.
 """
+function _correction_pass_uses_parallel(enable_parallel::Bool, nthreads::Int,
+        soft_weights_active::Bool, feature_collection_active::Bool)::Bool
+    nthreads >= 1 || throw(ArgumentError("nthreads must be positive"))
+    return enable_parallel && nthreads > 1 && !soft_weights_active &&
+           !feature_collection_active
+end
+
 function improve_read_set_likelihood(reads::Vector{<:FASTX.FASTQ.Record}, graph, k::Int;
         verbose::Bool = false,
         batch_size::Int = 10000,
@@ -1983,10 +2038,10 @@ function improve_read_set_likelihood(reads::Vector{<:FASTX.FASTQ.Record}, graph,
         skip_solid::Bool = false,
         cheap_correct::Bool = false,
         beam_width::Union{Int, Nothing} = nothing,
-        calibrated_gap_threshold::Union{Float64, Nothing} = nothing,
+        calibrated_gap_threshold::Union{Real, Nothing} = nothing,
         calibrated_probability_model::Union{CorrectionConfidenceModel, Nothing} = nothing,
-        calibrated_probability_threshold::Float64 = 0.5,
-        correction_feature_sink::Union{Nothing, Function} = nothing,
+        calibrated_probability_threshold::Real = 0.5,
+        correction_feature_sink::Any = nothing,
         soft_weights::Union{Nothing, Mycelia.Rhizomorph.SoftEdgeWeightAccumulator} = nothing,
         hard_vertices::Union{Nothing, AbstractSet} = nothing,
         windowed_decode::Bool = false,
@@ -2111,8 +2166,9 @@ function improve_read_set_likelihood(reads::Vector{<:FASTX.FASTQ.Record}, graph,
     # Soft-EM accumulation and the opt-in calibration sink are caller-owned
     # mutable state, so those passes run sequentially. Otherwise honor the
     # caller's parallel request.
-    use_parallel = enable_parallel && Threads.nthreads() > 1 &&
-                   soft_weights === nothing && !feature_collection_active
+    use_parallel = _correction_pass_uses_parallel(
+        enable_parallel, Threads.nthreads(), soft_weights !== nothing,
+        feature_collection_active)
     if enable_parallel && soft_weights !== nothing && Threads.nthreads() > 1
         @warn "soft-EM edge accumulation is sequential (race-free); ignoring enable_parallel for this pass." maxlog = 1
     end
@@ -2355,10 +2411,10 @@ function improve_read_likelihood(read::FASTX.FASTQ.Record, graph, k::Int;
         weighted_graph = nothing,
         diagnostics::Union{Nothing, CorrectorDiagnostics} = nothing,
         indel_params::Union{Nothing, IndelDecodeParams} = nothing,
-        calibrated_gap_threshold::Union{Float64, Nothing} = nothing,
+        calibrated_gap_threshold::Union{Real, Nothing} = nothing,
         calibrated_probability_model::Union{CorrectionConfidenceModel, Nothing} = nothing,
-        calibrated_probability_threshold::Float64 = 0.5,
-        correction_feature_sink::Union{Nothing, Function} = nothing,
+        calibrated_probability_threshold::Real = 0.5,
+        correction_feature_sink::Any = nothing,
         correction_read_id::Union{Nothing, String} = nothing,
         correction_position_offset::Int = 0,
         solid_kmers::Union{Nothing, AbstractSet} = nothing)::Tuple{
@@ -2435,10 +2491,10 @@ function find_optimal_sequence_path(read::FASTX.FASTQ.Record, graph, k::Int;
         weighted_graph = nothing,
         diagnostics::Union{Nothing, CorrectorDiagnostics} = nothing,
         indel_params::Union{Nothing, IndelDecodeParams} = nothing,
-        calibrated_gap_threshold::Union{Float64, Nothing} = nothing,
+        calibrated_gap_threshold::Union{Real, Nothing} = nothing,
         calibrated_probability_model::Union{CorrectionConfidenceModel, Nothing} = nothing,
-        calibrated_probability_threshold::Float64 = 0.5,
-        correction_feature_sink::Union{Nothing, Function} = nothing,
+        calibrated_probability_threshold::Real = 0.5,
+        correction_feature_sink::Any = nothing,
         correction_read_id::Union{Nothing, String} = nothing,
         correction_position_offset::Int = 0,
         solid_kmers::Union{Nothing, AbstractSet} = nothing)::Tuple{
@@ -3111,9 +3167,9 @@ function finalize_iterative_assembly(output_dir::String, k_progression::Vector{I
         windowed_decode::Bool = false,
         soft_em::Bool = false,
         cheap_correct::Bool = false,
-        calibrated_gap_threshold::Union{Float64, Nothing} = nothing,
+        calibrated_gap_threshold::Union{Real, Nothing} = nothing,
         calibrated_probability_model::Union{CorrectionConfidenceModel, Nothing} = nothing,
-        calibrated_probability_threshold::Float64 = 0.5,
+        calibrated_probability_threshold::Real = 0.5,
         correction_feature_sink_requested::Bool = false,
         correction_feature_sink_active::Bool = false,
         indel_params::Union{Nothing, IndelDecodeParams} = nothing,
@@ -3258,12 +3314,21 @@ function finalize_iterative_assembly(output_dir::String, k_progression::Vector{I
 
     # Preserve literal default-off metadata identity. Gate provenance and
     # feature-contract telemetry are present only when those opt-in paths were
-    # requested.
+    # requested. Configuration, effectiveness, and observed execution are distinct:
+    # an enabled gate can legitimately see zero proposed substitutions.
+    gate_requested = calibrated_gap_threshold !== nothing ||
+                     calibrated_probability_model !== nothing
+    gate_effective = gate_requested && indel_params === nothing
+    candidate_evaluations = diagnostics === nothing ?
+                            0 : diagnostics.candidate_substitutions_evaluated[]
+    feature_events = diagnostics === nothing ? 0 : diagnostics.feature_events_emitted[]
+    gate_reverts = diagnostics === nothing ? 0 : diagnostics.gate_reverts[]
     if calibrated_gap_threshold !== nothing
-        metadata[:calibrated_gap_threshold] = calibrated_gap_threshold
+        metadata[:calibrated_gap_threshold] = Float64(calibrated_gap_threshold)
     end
     if calibrated_probability_model !== nothing
-        metadata[:calibrated_probability_threshold] = calibrated_probability_threshold
+        metadata[:calibrated_probability_threshold] =
+            Float64(calibrated_probability_threshold)
         metadata[:calibrated_probability_model] = Dict{Symbol, Float64}(
             :intercept => calibrated_probability_model.intercept,
             :gap_weight => calibrated_probability_model.gap_weight,
@@ -3275,19 +3340,29 @@ function finalize_iterative_assembly(output_dir::String, k_progression::Vector{I
             :collapsed_frontier_weight =>
             calibrated_probability_model.collapsed_frontier_weight,
         )
+    end
+    if gate_requested
+        metadata[:calibrated_gate_kind] = calibrated_gap_threshold === nothing ?
+                                          :probability : :raw_gap
         metadata[:calibrated_gate_requested] = true
-        metadata[:calibrated_gate_effective] = indel_params === nothing
-        metadata[:calibrated_gate_disabled_reason] = indel_params === nothing ?
+        metadata[:calibrated_gate_effective] = gate_effective
+        metadata[:calibrated_gate_executed] =
+            gate_effective && candidate_evaluations > 0
+        metadata[:calibrated_gate_disabled_reason] = gate_effective ?
                                                         nothing : "indel_params_requested"
     end
     if correction_feature_sink_requested
         metadata[:correction_feature_sink_requested] = true
         metadata[:correction_feature_sink_effective] = correction_feature_sink_active
+        metadata[:correction_feature_sink_executed] =
+            correction_feature_sink_active && feature_events > 0
         metadata[:correction_feature_sink_disabled_reason] =
             correction_feature_sink_active ? nothing : "indel_params_requested"
     end
-    if calibrated_gap_threshold !== nothing ||
-       calibrated_probability_model !== nothing || correction_feature_sink_active
+    if gate_requested || correction_feature_sink_requested
+        metadata[:calibrated_gate_candidate_evaluations] = candidate_evaluations
+        metadata[:calibrated_feature_events] = feature_events
+        metadata[:calibrated_gate_reverts] = gate_reverts
         metadata[:calibrated_feature_contract_skips] = diagnostics === nothing ?
                                                          0 : diagnostics.gate_skipped[]
     end
@@ -3393,40 +3468,76 @@ end
 # Integration with Viterbi algorithms and statistical path resampling
 # =============================================================================
 
-"""
-$(DocStringExtensions.TYPEDSIGNATURES)
-
-Extract the typed correction-confidence features for `position_gaps[i]` from a
-decoded substitution path. The corresponding emitted base is at read position `i + k`.
-"""
-function correction_confidence_features(graph::Any, decoded_path::Any, i::Int, k::Int,
-        solid_kmers::AbstractSet, raw_gap::Real)::CorrectionConfidenceFeatures
+function _correction_confidence_features(graph::Any, decoded_path::Any, i::Int, k::Int,
+        solid_kmers::AbstractSet, raw_gap::Real,
+        contract_error::Type{<:Exception})::CorrectionConfidenceFeatures
     first_step = i + 1
     last_step = min(i + k, length(decoded_path.steps))
     first_step <= last_step ||
-        throw(ArgumentError("empty overlapping-k-mer window for correction feature"))
+        throw(contract_error(
+            "empty overlapping-k-mer window for correction feature"))
+    gap = Float64(raw_gap)
+    ((isfinite(gap) && gap >= 0.0) || gap == Inf) ||
+        throw(contract_error(
+            "correction-confidence raw gap must be nonnegative and finite or +Inf"))
     min_support = Inf
     all_solid = true
     for j in first_step:last_step
         label = decoded_path.steps[j].vertex_label
         support = Float64(_vertex_coverage(graph[label]))
         isfinite(support) ||
-            throw(ArgumentError("k-mer support feature must be finite"))
+            throw(contract_error("k-mer support feature must be finite"))
+        support >= 0.0 ||
+            throw(contract_error("k-mer support feature must be nonnegative"))
         min_support = min(min_support, support)
-        all_solid &= label in solid_kmers
+        solid = try
+            label in solid_kmers
+        catch error
+            error isa ArgumentError || rethrow()
+            throw(contract_error(sprint(showerror, error)))
+        end
+        all_solid &= solid
     end
     branch_support_ratio = Float64(decoded_path.steps[first_step].probability)
     isfinite(branch_support_ratio) ||
-        throw(ArgumentError("branch support ratio must be finite"))
+        throw(contract_error("branch support ratio must be finite"))
     0.0 <= branch_support_ratio <= 1.0 ||
-        throw(ArgumentError("branch support ratio must be in [0, 1]"))
+        throw(contract_error("branch support ratio must be in [0, 1]"))
     return CorrectionConfidenceFeatures(
-        raw_gap, min_support, all_solid, branch_support_ratio)
+        gap, min_support, all_solid, branch_support_ratio)
 end
 
 """
-Try to improve FASTQ read using Viterbi algorithm from viterbi-next.jl.
-Returns (improved_read, likelihood) or nothing if no improvement.
+$(DocStringExtensions.TYPEDSIGNATURES)
+
+Extract the typed correction-confidence features for `position_gaps[i]` from a
+decoded substitution path. The corresponding emitted base is at read position `i + k`.
+"""
+function correction_confidence_features(
+        graph::Any, decoded_path::Any, i::Int, k::Int,
+        solid_kmers::AbstractSet, raw_gap::Real)::CorrectionConfidenceFeatures
+    return _correction_confidence_features(
+        graph, decoded_path, i, k, solid_kmers, raw_gap, ArgumentError)
+end
+
+function _gate_correction_confidence_features(
+        graph::Any, decoded_path::Any, i::Int, k::Int,
+        solid_kmers::AbstractSet, raw_gap::Real)::CorrectionConfidenceFeatures
+    return _correction_confidence_features(
+        graph, decoded_path, i, k, solid_kmers, raw_gap,
+        _CorrectionFeatureContractError)
+end
+
+"""
+Try to improve a FASTQ read using the Viterbi decoder.
+Returns `(improved_read, likelihood)` or `nothing` if no path is available.
+
+The raw-gap and probability gates are mutually exclusive, opt-in, and
+substitution-only. Expected feature/data-contract errors fail open for the complete
+read and increment `diagnostics.gate_skipped`; interrupts, resource exhaustion,
+callback failures, and unexpected implementation exceptions propagate. Feature
+extraction is read-transactional, but sink callbacks mutate caller-owned state one
+at a time: callback `N` can fail after callbacks `1:(N - 1)` have completed.
 """
 function try_viterbi_path_improvement(read::FASTX.FASTQ.Record,
         graph,
@@ -3437,10 +3548,10 @@ function try_viterbi_path_improvement(read::FASTX.FASTQ.Record,
         weighted_graph = nothing,
         diagnostics::Union{Nothing, CorrectorDiagnostics} = nothing,
         indel_params::Union{Nothing, IndelDecodeParams} = nothing,
-        calibrated_gap_threshold::Union{Float64, Nothing} = nothing,
+        calibrated_gap_threshold::Union{Real, Nothing} = nothing,
         calibrated_probability_model::Union{CorrectionConfidenceModel, Nothing} = nothing,
-        calibrated_probability_threshold::Float64 = 0.5,
-        correction_feature_sink::Union{Nothing, Function} = nothing,
+        calibrated_probability_threshold::Real = 0.5,
+        correction_feature_sink::Any = nothing,
         correction_read_id::Union{Nothing, String} = nothing,
         correction_position_offset::Int = 0,
         solid_kmers::Union{Nothing, AbstractSet} = nothing)::Union{
@@ -3675,16 +3786,18 @@ function try_viterbi_path_improvement(read::FASTX.FASTQ.Record,
                         # The gate can only act on a proposed substitution. Training
                         # and held-out evaluation use this same candidate-edit cohort.
                         corrected_chars[position] == original_chars[position] && continue
-                        if feature_extraction_active &&
+                        diagnostics === nothing || Threads.atomic_add!(
+                            diagnostics.candidate_substitutions_evaluated, 1)
+                        if serving_features_active &&
                            !isfinite(gaps[i]) && gaps[i] != Inf
-                            throw(ArgumentError(
+                            throw(_CorrectionFeatureContractError(
                                 "correction feature extraction received a non-finite " *
                                 "Viterbi gap for $(FASTX.identifier(read)) at position " *
                                 "$(position)"))
                         end
                         features = if (isfinite(gaps[i]) || gaps[i] == Inf) &&
                                       feature_extraction_active
-                            correction_confidence_features(
+                            _gate_correction_confidence_features(
                                 graph, decoded_path, i, k,
                                 effective_solid_kmers, gaps[i])
                         else
@@ -3703,9 +3816,10 @@ function try_viterbi_path_improvement(read::FASTX.FASTQ.Record,
                             ))
                         end
                         keep_correction = if calibrated_gap_threshold !== nothing
-                            # Preserve the legacy raw-gap gate's fail-open behavior
-                            # for NaN: only an explicitly low gap reverts an edit.
-                            !(gaps[i] < calibrated_gap_threshold)
+                            # A NaN threshold is rejected at configuration validation.
+                            # Malformed per-position gaps were rejected above for every
+                            # gate/sink serving path.
+                            !(gaps[i] < Float64(calibrated_gap_threshold))
                         elseif calibrated_probability_model === nothing
                             true
                         elseif isfinite(gaps[i]) || gaps[i] == Inf
@@ -3713,28 +3827,46 @@ function try_viterbi_path_improvement(read::FASTX.FASTQ.Record,
                                 calibrated_probability_model, features)
                             confidence >= calibrated_probability_threshold
                         else
-                            throw(ArgumentError(
+                            throw(_CorrectionFeatureContractError(
                                 "probability gate received a non-finite Viterbi gap"))
                         end
                         keep_correction || push!(revert_positions, position)
                     end
                 catch gate_error
-                    gate_error isa InterruptException && rethrow()
-                    # A feature/alignment defect must not partially gate a read. Keep
-                    # the ungated decode, emit no buffered observations, and surface
-                    # the contract miss once.
-                    gate_contract_ok = false
-                    @debug "calibrated probability gate failed open" exception =
-                        (gate_error, catch_backtrace())
+                    if gate_error isa _CorrectionFeatureContractError
+                        # Expected feature/data-contract defects must not partially
+                        # gate a read. Keep the ungated decode, emit no buffered
+                        # observations, and surface the contract miss once.
+                        gate_contract_ok = false
+                        @debug "calibrated probability gate failed open" exception =
+                            (gate_error, catch_backtrace())
+                    else
+                        # Interrupts, resource exhaustion, callback defects, and
+                        # unexpected implementation failures are never a safe
+                        # fail-open condition.
+                        if gate_error isa ArgumentError
+                            # The outer decoder boundary intentionally treats legacy
+                            # ArgumentErrors as structural per-read skips. Wrap an
+                            # unexpected serving ArgumentError so that boundary cannot
+                            # silently swallow a numerical/model defect.
+                            throw(_CorrectionConfidenceServingError(
+                                "correction-confidence serving failed for " *
+                                String(FASTX.identifier(read)), gate_error))
+                        end
+                        rethrow()
+                    end
                 end
                 if gate_contract_ok
-                    # Feature observations are read-transactional: do not invoke the
+                    # Feature EXTRACTION is read-transactional: do not invoke the
                     # caller-owned sink until every proposed edit has satisfied the
-                    # feature/gate contract. `_CorrectionFeatureSinkError` is
-                    # reserved for callback failures and propagates to the caller.
+                    # feature/gate contract. Callback delivery cannot roll back
+                    # external mutations: callback N may fail after 1:(N - 1) ran.
+                    # `_CorrectionFeatureSinkError` propagates such failures.
                     for observation in feature_observations
                         try
                             correction_feature_sink(observation)
+                            diagnostics === nothing || Threads.atomic_add!(
+                                diagnostics.feature_events_emitted, 1)
                         catch sink_error
                             sink_error isa InterruptException && rethrow()
                             throw(_CorrectionFeatureSinkError(
@@ -3746,6 +3878,8 @@ function try_viterbi_path_improvement(read::FASTX.FASTQ.Record,
                     end
                     for position in revert_positions
                         corrected_chars[position] = original_chars[position]
+                        diagnostics === nothing ||
+                            Threads.atomic_add!(diagnostics.gate_reverts, 1)
                     end
                     corrected_sequence_string = String(corrected_chars)
                 elseif serving_features_active

--- a/src/rhizomorph/core/evidence-functions.jl
+++ b/src/rhizomorph/core/evidence-functions.jl
@@ -614,17 +614,13 @@ function compute_edge_coverage(edge)
 end
 
 # ============================================================================
-# Soft-EM edge weighting (SCAFFOLD, td-e70t)
+# Soft-EM v2 edge weighting (ACTIVE, td-e70t/td-h6w9)
 # ============================================================================
 #
-# Design note (graph-as-HMM correction redesign). Today the M-step is a HARD
-# assignment: `compute_edge_weight` returns `count_total_observations(edge)` — a
-# raw integer coverage count — and each EM iteration rebuilds the graph from the
-# corrected *sequences*. The graph keeps no path-probability memory, so cleaning
-# only happens because corrected reads stop emitting error k-mers, not because
-# low-probability edges decay on their own.
-#
-# The soft-EM thesis replaces the hard count with probability-weighted evidence:
+# Design note (graph-as-HMM correction redesign). Before v2, the M-step used
+# only hard integer coverage and rebuilt the graph from corrected sequences. The
+# active soft-EM implementation replaces that historical hard assignment with
+# probability-weighted evidence:
 # after Viterbi returns a path + likelihood, the path's RESPONSIBILITY (posterior
 # probability, normalized against competing paths) is accumulated onto each edge
 # it traverses. Summing responsibilities over all reads gives a soft, real-valued
@@ -651,7 +647,7 @@ end
     SoftEdgeWeightAccumulator
 
 Probability-weighted (soft) edge-evidence accumulator for soft-EM correction
-(td-e70t scaffold). Maps an edge identity (e.g. an ordered `(src_label,
+(td-e70t v2). Maps an edge identity (e.g. an ordered `(src_label,
 dst_label)` tuple) to the sum of the responsibilities of the decoded paths that
 traversed it. Unlike `count_total_observations` (a hard integer count), the
 accumulated value is a real-valued soft weight in which a low-probability error

--- a/src/viterbi-next.jl
+++ b/src/viterbi-next.jl
@@ -1570,9 +1570,9 @@ function _viterbi_correct_observation(
         # cases — under target anchoring the loop can run PAST the last on-path depth,
         # leaving trailing gaps for abandoned frontiers. TWO caveats for consumers:
         #   • An entry of `Inf` means "no surviving competitor at that depth" — a
-        #     ROUTINE value on a collapsed/beam-pruned frontier — so consumers MUST
-        #     `filter(isfinite, _)` (or clip) BEFORE any sum-based calibration metric
-        #     (reliability/ECE/Brier); a raw `Inf` silently poisons those to Inf/NaN.
+        #     ROUTINE value on a collapsed/beam-pruned frontier. Legacy sum-based
+        #     metrics must filter or clip it; calibrated serving instead encodes it
+        #     explicitly as a collapsed-frontier indicator with raw gap set to zero.
         #   • Under a finite `beam_width`/`beam_score_margin` this is a SURVIVOR
         #     margin (2nd-best among survivors), not the exact Viterbi margin.
         diagnostics[:position_gaps] = position_gaps[1:min(best_depth, length(position_gaps))]
@@ -2200,9 +2200,9 @@ end
 # Best-minus-second-best of a state->score Dict's values (the per-position Viterbi
 # margin, td-4osf / Tier-2 calibration). Single pass, no allocation. Returns Inf
 # when fewer than two states survive (no competitor => maximally confident). NOTE:
-# Inf is a ROUTINE value (any collapsed frontier), so downstream calibration must
-# filter/clip it before averaging — see the consumption contract at the
-# diagnostics[:position_gaps] stash site.
+# Inf is a ROUTINE value (any collapsed frontier). Legacy aggregate calibration
+# must filter or clip it; calibrated serving may instead encode it explicitly as
+# a collapsed-frontier indicator — see the diagnostics stash-site contract.
 function _top2_score_gap(scores)::Float64
     best = -Inf
     second = -Inf

--- a/test/4_assembly/calibrated_gap_gate_identity_test.jl
+++ b/test/4_assembly/calibrated_gap_gate_identity_test.jl
@@ -21,6 +21,14 @@ import Random
 rec(id, seq) = FASTX.FASTQ.Record(id, seq, String(fill('I', length(seq))))
 seqs(reads) = [FASTX.sequence(String, r) for r in reads]
 mismatches(a, b) = count(x -> x[1] != x[2], zip(collect(a), collect(b)))
+function _gap_throws_message(f::Function, fragment::AbstractString)::Bool
+    try
+        f()
+    catch error
+        return error isa ArgumentError && occursin(fragment, sprint(showerror, error))
+    end
+    return false
+end
 
 Test.@testset "calibrated gap gate: OFF byte-identity + ON reverts to observed" begin
     k = 7
@@ -44,6 +52,16 @@ Test.@testset "calibrated gap gate: OFF byte-identity + ON reverts to observed" 
     off = run_at(nothing)
     permissive = run_at(-Inf)
     strict = run_at(100.0)
+    infinite_strict = run_at(Inf)
+    integer_permissive = run_at(-1)
+
+    # Real-valued public thresholds accept integer/Float32 callers, while NaN is
+    # rejected rather than becoming a silent no-op. Both infinite sentinels remain
+    # valid (`-Inf` permissive, `Inf` strict).
+    Test.@test seqs(integer_permissive) == seqs(off)
+    Test.@test length(infinite_strict) == length(reads)
+    Test.@test _gap_throws_message(
+        () -> run_at(NaN), "calibrated_gap_threshold must not be NaN")
 
     # (1) BYTE-IDENTITY (the core guarantee): gate OFF === gate engaged-but-permissive.
     # Proves the gap-recording telemetry + the no-op gate never perturb the decode.
@@ -59,6 +77,8 @@ Test.@testset "calibrated gap gate: OFF byte-identity + ON reverts to observed" 
     obs = seqs(reads)
     for i in eachindex(reads)
         Test.@test mismatches(seqs(strict)[i], obs[i]) <= mismatches(seqs(off)[i], obs[i])
+        Test.@test mismatches(seqs(infinite_strict)[i], obs[i]) <=
+                   mismatches(seqs(off)[i], obs[i])
     end
 
     # Solid clean reads are untouched under every setting (no spurious edits).
@@ -72,6 +92,8 @@ Test.@testset "calibrated gap gate: OFF byte-identity + ON reverts to observed" 
     # gates and feature sinks.
     diagnostics = Mycelia.CorrectorDiagnostics()
     Base.Threads.atomic_add!(diagnostics.gate_skipped, 2)
+    Base.Threads.atomic_add!(diagnostics.candidate_substitutions_evaluated, 3)
+    Base.Threads.atomic_add!(diagnostics.gate_reverts, 1)
     history = Dict{Int, Vector{Dict{Symbol, Any}}}(
         k => [Dict{Symbol, Any}(
             :timestamp => "raw-gap-contract",
@@ -88,6 +110,30 @@ Test.@testset "calibrated gap gate: OFF byte-identity + ON reverts to observed" 
             diagnostics = diagnostics,
             calibrated_gap_threshold = 1.0,
         )
-        Test.@test result[:metadata][:calibrated_feature_contract_skips] == 2
+        metadata = result[:metadata]
+        Test.@test metadata[:calibrated_gate_kind] == :raw_gap
+        Test.@test metadata[:calibrated_gate_requested] === true
+        Test.@test metadata[:calibrated_gate_effective] === true
+        Test.@test metadata[:calibrated_gate_executed] === true
+        Test.@test metadata[:calibrated_gate_disabled_reason] === nothing
+        Test.@test metadata[:calibrated_gate_candidate_evaluations] == 3
+        Test.@test metadata[:calibrated_gate_reverts] == 1
+        Test.@test metadata[:calibrated_feature_contract_skips] == 2
+
+        default_result = Mycelia.finalize_iterative_assembly(
+            output_dir, [k], history, 0.0; verbose = false,
+            diagnostics = diagnostics)
+        default_metadata = default_result[:metadata]
+        opt_in_keys = (
+            :calibrated_gate_kind,
+            :calibrated_gate_requested,
+            :calibrated_gate_effective,
+            :calibrated_gate_executed,
+            :calibrated_gate_candidate_evaluations,
+            :calibrated_feature_events,
+            :calibrated_gate_reverts,
+            :calibrated_feature_contract_skips,
+        )
+        Test.@test all(!haskey(default_metadata, key) for key in opt_in_keys)
     end
 end

--- a/test/4_assembly/calibrated_gap_gate_identity_test.jl
+++ b/test/4_assembly/calibrated_gap_gate_identity_test.jl
@@ -67,4 +67,27 @@ Test.@testset "calibrated gap gate: OFF byte-identity + ON reverts to observed" 
             Test.@test seqs(out)[i] == clean_seq
         end
     end
+
+    # Raw-gap requests expose the same contract-miss telemetry as probability
+    # gates and feature sinks.
+    diagnostics = Mycelia.CorrectorDiagnostics()
+    Base.Threads.atomic_add!(diagnostics.gate_skipped, 2)
+    history = Dict{Int, Vector{Dict{Symbol, Any}}}(
+        k => [Dict{Symbol, Any}(
+            :timestamp => "raw-gap-contract",
+            :improvements_made => 0,
+        )],
+    )
+    mktempdir() do output_dir
+        result = Mycelia.finalize_iterative_assembly(
+            output_dir,
+            [k],
+            history,
+            0.0;
+            verbose = false,
+            diagnostics = diagnostics,
+            calibrated_gap_threshold = 1.0,
+        )
+        Test.@test result[:metadata][:calibrated_feature_contract_skips] == 2
+    end
 end

--- a/test/4_assembly/calibrated_gate_indel_failopen_test.jl
+++ b/test/4_assembly/calibrated_gate_indel_failopen_test.jl
@@ -81,7 +81,8 @@ Test.@testset "calibrated gate is excluded under indel mode (fail-open)" begin
         (base = base, gated = gated)
     end
 
-    probability_model = Mycelia.CorrectionConfidenceModel(0.0, 0.0, 0.0, 0.0, 0.0)
+    probability_model = Mycelia.CorrectionConfidenceModel(
+        0.0, 0.0, 0.0, 0.0, 0.0, 0.5)
     probability_gated = mktempdir() do d
         _assemble_corrected(_write_fastq(reads, d), k;
             threshold = nothing, indel_params = indel, outdir = mktempdir(),

--- a/test/4_assembly/calibrated_gate_indel_failopen_test.jl
+++ b/test/4_assembly/calibrated_gate_indel_failopen_test.jl
@@ -18,7 +18,8 @@ import Mycelia
 import FASTX
 import Random
 
-function _write_fastq(reads, dir)
+function _write_fastq(
+        reads::AbstractVector{<:FASTX.FASTQ.Record}, dir::AbstractString)::String
     path = joinpath(dir, "in.fastq")
     open(FASTX.FASTQ.Writer, path) do w
         for r in reads
@@ -29,11 +30,12 @@ function _write_fastq(reads, dir)
 end
 
 function _assemble_corrected(fastq::AbstractString, k::Int;
-        threshold::Union{Nothing, Float64},
+        threshold::Union{Nothing, Real},
         indel_params::Union{Nothing, Mycelia.IndelDecodeParams},
         outdir::AbstractString,
         probability_model::Union{Nothing, Mycelia.CorrectionConfidenceModel} = nothing,
-        probability_threshold::Float64 = 0.5)::Dict{String, String}
+        probability_threshold::Real = 0.5,
+        correction_feature_sink::Any = nothing)::NamedTuple
     Random.seed!(42)
     result = Mycelia.mycelia_iterative_assemble(fastq;
         max_k = max(k, 13), skip_solid = false, graph_mode = :doublestrand,
@@ -42,6 +44,7 @@ function _assemble_corrected(fastq::AbstractString, k::Int;
         calibrated_gap_threshold = threshold, indel_params = indel_params,
         calibrated_probability_model = probability_model,
         calibrated_probability_threshold = probability_threshold,
+        correction_feature_sink = correction_feature_sink,
         verbose = false, enable_checkpointing = false, output_dir = outdir)
     corrected_fastq = get(result[:metadata], :final_fastq_file, nothing)
     (corrected_fastq === nothing || !isfile(corrected_fastq)) &&
@@ -52,7 +55,7 @@ function _assemble_corrected(fastq::AbstractString, k::Int;
             out[FASTX.identifier(rec)] = FASTX.sequence(String, rec)
         end
     end
-    return out
+    return (sequences = out, metadata = result[:metadata])
 end
 
 Test.@testset "calibrated gate is excluded under indel mode (fail-open)" begin
@@ -72,25 +75,55 @@ Test.@testset "calibrated gate is excluded under indel mode (fail-open)" begin
     # An indel-capable decode profile (values mirror a modest nanopore-ish setting).
     indel = Mycelia.IndelDecodeParams(0.06, 0.4, 0.4, 0.1, 0.1, 3, 3, nothing)
 
-    corrected = mktempdir() do d
-        base = _assemble_corrected(_write_fastq(reads, d), k;
-            threshold = nothing, indel_params = indel, outdir = mktempdir())
-        # A huge threshold would revert EVERY finite-gap correction if the gate ran.
-        gated = _assemble_corrected(_write_fastq(reads, d), k;
-            threshold = 1.0e6, indel_params = indel, outdir = mktempdir())
-        (base = base, gated = gated)
-    end
-
-    probability_model = Mycelia.CorrectionConfidenceModel(
-        0.0, 0.0, 0.0, 0.0, 0.0, 0.5)
-    probability_gated = mktempdir() do d
-        _assemble_corrected(_write_fastq(reads, d), k;
-            threshold = nothing, indel_params = indel, outdir = mktempdir(),
+    results = mktempdir() do directory
+        fastq = _write_fastq(reads, directory)
+        base = _assemble_corrected(fastq, k;
+            threshold = nothing, indel_params = indel,
+            outdir = joinpath(directory, "base"))
+        # A huge threshold would revert every finite-gap correction if the gate ran.
+        # Attach the sink to this same run so the strengthened provenance checks do
+        # not add a fourth expensive indel assembly to the existing test.
+        sink_calls = Ref(0)
+        raw = _assemble_corrected(fastq, k;
+            threshold = 1.0e6, indel_params = indel,
+            outdir = joinpath(directory, "raw"),
+            correction_feature_sink = _ -> (sink_calls[] += 1))
+        probability_model = Mycelia.CorrectionConfidenceModel(
+            0.0, 0.0, 0.0, 0.0, 0.0, 0.5)
+        probability = _assemble_corrected(fastq, k;
+            threshold = nothing, indel_params = indel,
+            outdir = joinpath(directory, "probability"),
             probability_model = probability_model, probability_threshold = 1.0)
+        (; base, raw, probability, sink_calls = sink_calls[])
     end
 
-    # Under indel mode the gate is excluded, so the threshold changes nothing.
-    Test.@test !isempty(corrected.base)
-    Test.@test corrected.base == corrected.gated
-    Test.@test corrected.base == probability_gated
+    # A real indel decode ran, but all substitution-only controls were disabled.
+    Test.@test results.base.metadata[:corrector_errors][:indel_decodes] > 0
+    Test.@test !isempty(results.base.sequences)
+    Test.@test results.base.sequences == results.raw.sequences
+    Test.@test results.base.sequences == results.probability.sequences
+
+    for (result, kind) in ((results.raw, :raw_gap),
+            (results.probability, :probability))
+        metadata = result.metadata
+        Test.@test metadata[:calibrated_gate_kind] == kind
+        Test.@test metadata[:calibrated_gate_requested] === true
+        Test.@test metadata[:calibrated_gate_effective] === false
+        Test.@test metadata[:calibrated_gate_executed] === false
+        Test.@test metadata[:calibrated_gate_disabled_reason] ==
+                   "indel_params_requested"
+        Test.@test metadata[:calibrated_gate_candidate_evaluations] == 0
+        Test.@test metadata[:calibrated_gate_reverts] == 0
+    end
+    Test.@test results.sink_calls == 0
+    Test.@test results.raw.metadata[:correction_feature_sink_requested] === true
+    Test.@test results.raw.metadata[:correction_feature_sink_effective] === false
+    Test.@test results.raw.metadata[:correction_feature_sink_executed] === false
+    Test.@test results.raw.metadata[:correction_feature_sink_disabled_reason] ==
+               "indel_params_requested"
+    Test.@test results.raw.metadata[:calibrated_feature_events] == 0
+
+    # Default-off assembly metadata remains free of opt-in gate/sink keys.
+    Test.@test !haskey(results.base.metadata, :calibrated_gate_requested)
+    Test.@test !haskey(results.base.metadata, :correction_feature_sink_requested)
 end

--- a/test/4_assembly/calibrated_gate_indel_failopen_test.jl
+++ b/test/4_assembly/calibrated_gate_indel_failopen_test.jl
@@ -28,13 +28,20 @@ function _write_fastq(reads, dir)
     return path
 end
 
-function _assemble_corrected(fastq, k; threshold, indel_params, outdir)
+function _assemble_corrected(fastq::AbstractString, k::Int;
+        threshold::Union{Nothing, Float64},
+        indel_params::Union{Nothing, Mycelia.IndelDecodeParams},
+        outdir::AbstractString,
+        probability_model::Union{Nothing, Mycelia.CorrectionConfidenceModel} = nothing,
+        probability_threshold::Float64 = 0.5)::Dict{String, String}
     Random.seed!(42)
     result = Mycelia.mycelia_iterative_assemble(fastq;
         max_k = max(k, 13), skip_solid = false, graph_mode = :doublestrand,
         n_k_rungs = 1, max_iterations_per_k = 1, hard_window = false,
         soft_em = false, cheap_correct = true, beam_width = nothing,
         calibrated_gap_threshold = threshold, indel_params = indel_params,
+        calibrated_probability_model = probability_model,
+        calibrated_probability_threshold = probability_threshold,
         verbose = false, enable_checkpointing = false, output_dir = outdir)
     corrected_fastq = get(result[:metadata], :final_fastq_file, nothing)
     (corrected_fastq === nothing || !isfile(corrected_fastq)) &&
@@ -74,7 +81,15 @@ Test.@testset "calibrated gate is excluded under indel mode (fail-open)" begin
         (base = base, gated = gated)
     end
 
+    probability_model = Mycelia.CorrectionConfidenceModel(0.0, 0.0, 0.0, 0.0, 0.0)
+    probability_gated = mktempdir() do d
+        _assemble_corrected(_write_fastq(reads, d), k;
+            threshold = nothing, indel_params = indel, outdir = mktempdir(),
+            probability_model = probability_model, probability_threshold = 1.0)
+    end
+
     # Under indel mode the gate is excluded, so the threshold changes nothing.
     Test.@test !isempty(corrected.base)
     Test.@test corrected.base == corrected.gated
+    Test.@test corrected.base == probability_gated
 end

--- a/test/4_assembly/calibrated_probability_gate_identity_test.jl
+++ b/test/4_assembly/calibrated_probability_gate_identity_test.jl
@@ -1,0 +1,108 @@
+# Multi-feature calibrated decode gate (td-21eg): typed-model validation,
+# byte-identity when permissive, and revert-only behavior.
+
+import FASTX
+import Mycelia
+import Random
+import Test
+
+_prob_rec(id::AbstractString,
+    sequence::AbstractString)::FASTX.FASTQ.Record = FASTX.FASTQ.Record(
+    id, sequence, String(fill('I', length(sequence))))
+_prob_sequences(reads::AbstractVector{<:FASTX.FASTQ.Record})::Vector{String} = [FASTX.sequence(
+                                                                                    String,
+                                                                                    read)
+                                                                                for read in
+                                                                                    reads]
+_prob_record_bytes(reads::AbstractVector{<:FASTX.FASTQ.Record})::Vector = [(
+                                                                               identifier = String(FASTX.identifier(read)),
+                                                                               sequence = FASTX.sequence(
+                                                                                   String, read),
+                                                                               quality = String(FASTX.quality(read))
+                                                                           )
+                                                                           for read in
+                                                                               reads]
+_prob_mismatches(a::AbstractString, b::AbstractString)::Int = count(
+    pair -> pair[1] !=
+            pair[2], zip(a, b))
+function _prob_throws_message(f::Function, fragment::AbstractString)::Bool
+    try
+        f()
+    catch error
+        return error isa ArgumentError && occursin(fragment, error.msg)
+    end
+    return false
+end
+
+Test.@testset "calibrated probability gate" begin
+    model = Mycelia.CorrectionConfidenceModel(0.0, 0.0, 0.0, 0.0, 0.0)
+    Test.@test Mycelia.correction_confidence_probability(
+        model, 1.0, 4.0, true, 0.75) == 0.5
+
+    Test.@test _prob_throws_message(
+        () -> Mycelia.CorrectionConfidenceModel(0.0, NaN, 0.0, 0.0, 0.0),
+        "coefficients must be finite")
+
+    k = 7
+    clean = "ATGCGTACGTACGTTAGCCGATACAGGTCA"
+    reads = [_prob_rec("clean$(i)", clean) for i in 1:10]
+    errored_chars = collect(clean)
+    errored_chars[15] = errored_chars[15] == 'A' ? 'C' : 'A'
+    push!(reads, _prob_rec("err1", String(errored_chars)))
+    graph = Mycelia.Rhizomorph.build_qualmer_graph(reads, k;
+        dataset_id = "prob-gate", mode = :canonical, memory_profile = :full)
+
+    function run_gate(model_arg::Union{Nothing, Mycelia.CorrectionConfidenceModel},
+            threshold::Float64)::NamedTuple
+        Random.seed!(11)
+        diagnostics = Mycelia.CorrectorDiagnostics()
+        corrected = FASTX.FASTQ.Record[]
+        for read in reads
+            result = Mycelia.try_viterbi_path_improvement(
+                read, graph, k;
+                graph_mode = :canonical,
+                calibrated_probability_model = model_arg,
+                calibrated_probability_threshold = threshold,
+                diagnostics = diagnostics
+            )
+            push!(corrected, result === nothing ? read : first(result))
+        end
+        return (; corrected, diagnostics)
+    end
+
+    off = run_gate(nothing, 0.5)
+    permissive = run_gate(model, 0.0)
+    strict = run_gate(model, 1.0)
+
+    # Engaging feature extraction and gap recording without rejecting any edit is
+    # byte-identical to the default-off path, including identifiers and qualities.
+    Test.@test _prob_record_bytes(off.corrected) ==
+               _prob_record_bytes(permissive.corrected)
+    Test.@test permissive.diagnostics.gate_skipped[] == 0
+    Test.@test strict.diagnostics.gate_skipped[] == 0
+
+    # A probability gate can only suppress proposed substitutions; it can never
+    # fabricate a new edit relative to the observed input.
+    observed = _prob_sequences(reads)
+    for i in eachindex(reads)
+        Test.@test _prob_mismatches(_prob_sequences(strict.corrected)[i], observed[i]) <=
+                   _prob_mismatches(_prob_sequences(off.corrected)[i], observed[i])
+    end
+    off_edits = sum(_prob_mismatches(sequence, observed[i])
+    for (i, sequence) in enumerate(_prob_sequences(off.corrected)))
+    strict_edits = sum(_prob_mismatches(sequence, observed[i])
+    for (i, sequence) in enumerate(_prob_sequences(strict.corrected)))
+    Test.@test off_edits > 0
+    Test.@test strict_edits < off_edits
+
+    Test.@test _prob_throws_message(
+        () -> Mycelia.improve_read_set_likelihood(
+            reads, graph, k; calibrated_probability_model = model,
+            calibrated_probability_threshold = 1.1),
+        "must be in [0, 1]")
+    Test.@test _prob_throws_message(
+        () -> Mycelia.improve_read_set_likelihood(
+            reads, graph, k; calibrated_gap_threshold = 1.0,
+            calibrated_probability_model = model),
+        "mutually exclusive")
+end

--- a/test/4_assembly/calibrated_probability_gate_identity_test.jl
+++ b/test/4_assembly/calibrated_probability_gate_identity_test.jl
@@ -110,4 +110,21 @@ Test.@testset "calibrated probability gate" begin
             reads, graph, k; calibrated_gap_threshold = 1.0,
             calibrated_probability_model = model),
         "mutually exclusive")
+
+    # Public record entry points validate configuration before data-dependent
+    # early returns (short reads and un-k-merizable ambiguous reads).
+    short_read = _prob_rec("short", "ATG")
+    Test.@test _prob_throws_message(
+        () -> Mycelia.improve_read_likelihood(
+            short_read, graph, k;
+            calibrated_gap_threshold = 1.0,
+            calibrated_probability_model = model),
+        "mutually exclusive")
+    ambiguous_read = _prob_rec("ambiguous", repeat("N", length(clean)))
+    Test.@test _prob_throws_message(
+        () -> Mycelia.find_optimal_sequence_path(
+            ambiguous_read, graph, k;
+            calibrated_gap_threshold = 1.0,
+            calibrated_probability_model = model),
+        "mutually exclusive")
 end

--- a/test/4_assembly/calibrated_probability_gate_identity_test.jl
+++ b/test/4_assembly/calibrated_probability_gate_identity_test.jl
@@ -35,12 +35,17 @@ function _prob_throws_message(f::Function, fragment::AbstractString)::Bool
 end
 
 Test.@testset "calibrated probability gate" begin
-    model = Mycelia.CorrectionConfidenceModel(0.0, 0.0, 0.0, 0.0, 0.0)
+    model = Mycelia.CorrectionConfidenceModel(0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
     Test.@test Mycelia.correction_confidence_probability(
         model, 1.0, 4.0, true, 0.75) == 0.5
 
     Test.@test _prob_throws_message(
-        () -> Mycelia.CorrectionConfidenceModel(0.0, NaN, 0.0, 0.0, 0.0),
+        () -> Mycelia.CorrectionConfidenceModel(
+            0.0, NaN, 0.0, 0.0, 0.0, 0.5),
+        "coefficients must be finite")
+    Test.@test _prob_throws_message(
+        () -> Mycelia.CorrectionConfidenceModel(
+            0.0, 0.0, 0.0, 0.0, 0.0, NaN),
         "coefficients must be finite")
 
     k = 7

--- a/test/4_assembly/calibrated_probability_gate_identity_test.jl
+++ b/test/4_assembly/calibrated_probability_gate_identity_test.jl
@@ -48,6 +48,13 @@ Test.@testset "calibrated probability gate" begin
             0.0, 0.0, 0.0, 0.0, 0.0, NaN),
         "coefficients must be finite")
 
+    Test.@test _prob_throws_message(
+        () -> Mycelia.CorrectionConfidenceFeatures(-0.1, 1.0, true, 0.5),
+        "raw gap must be nonnegative")
+    Test.@test _prob_throws_message(
+        () -> Mycelia.CorrectionConfidenceFeatures(0.1, -1.0, true, 0.5),
+        "minimum k-mer support must be nonnegative")
+
     k = 7
     clean = "ATGCGTACGTACGTTAGCCGATACAGGTCA"
     reads = [_prob_rec("clean$(i)", clean) for i in 1:10]
@@ -58,7 +65,7 @@ Test.@testset "calibrated probability gate" begin
         dataset_id = "prob-gate", mode = :canonical, memory_profile = :full)
 
     function run_gate(model_arg::Union{Nothing, Mycelia.CorrectionConfidenceModel},
-            threshold::Float64)::NamedTuple
+            threshold::Real)::NamedTuple
         Random.seed!(11)
         diagnostics = Mycelia.CorrectorDiagnostics()
         corrected = FASTX.FASTQ.Record[]
@@ -76,13 +83,21 @@ Test.@testset "calibrated probability gate" begin
     end
 
     off = run_gate(nothing, 0.5)
-    permissive = run_gate(model, 0.0)
-    strict = run_gate(model, 1.0)
+    permissive = run_gate(model, Float32(0.0))
+    equality = run_gate(model, Float32(0.5))
+    strict = run_gate(model, 1)
 
     # Engaging feature extraction and gap recording without rejecting any edit is
     # byte-identical to the default-off path, including identifiers and qualities.
     Test.@test _prob_record_bytes(off.corrected) ==
                _prob_record_bytes(permissive.corrected)
+    # The serving predicate is `P >= tau`: equality retains every proposed edit.
+    Test.@test _prob_record_bytes(off.corrected) ==
+               _prob_record_bytes(equality.corrected)
+    Test.@test off.diagnostics.candidate_substitutions_evaluated[] == 0
+    Test.@test permissive.diagnostics.candidate_substitutions_evaluated[] > 0
+    Test.@test equality.diagnostics.gate_reverts[] == 0
+    Test.@test strict.diagnostics.gate_reverts[] > 0
     Test.@test permissive.diagnostics.gate_skipped[] == 0
     Test.@test strict.diagnostics.gate_skipped[] == 0
 

--- a/test/4_assembly/correction_feature_sink_test.jl
+++ b/test/4_assembly/correction_feature_sink_test.jl
@@ -1,4 +1,6 @@
+import BioSequences
 import FASTX
+import Kmers
 import Mycelia
 import Test
 
@@ -26,6 +28,16 @@ function Base.in(::Any, solid_kmers::_FailingSolidKmers)::Bool
     solid_kmers.memberships > solid_kmers.fail_after &&
         throw(solid_kmers.failure)
     return true
+end
+
+mutable struct _CollectingFeatureSink
+    observations::Vector{Mycelia.CorrectionFeatureObservation}
+end
+
+function (sink::_CollectingFeatureSink)(
+        observation::Mycelia.CorrectionFeatureObservation)::Nothing
+    push!(sink.observations, observation)
+    return nothing
 end
 
 Test.@testset "correction feature serving sink" begin
@@ -66,6 +78,21 @@ Test.@testset "correction feature serving sink" begin
             push!(requested_parallel, observation),
     )
     Test.@test requested_parallel == observations
+    # Test the parallel policy independently of the CI worker's actual thread count.
+    Test.@test Mycelia._correction_pass_uses_parallel(true, 2, false, false)
+    Test.@test !Mycelia._correction_pass_uses_parallel(true, 2, false, true)
+    Test.@test !Mycelia._correction_pass_uses_parallel(true, 2, true, false)
+    Test.@test !Mycelia._correction_pass_uses_parallel(true, 1, false, false)
+
+    callable_diagnostics = Mycelia.CorrectorDiagnostics()
+    callable_sink = _CollectingFeatureSink(Mycelia.CorrectionFeatureObservation[])
+    Mycelia.improve_read_set_likelihood(
+        reads, graph, k; graph_mode = :canonical, diagnostics = callable_diagnostics,
+        correction_feature_sink = callable_sink)
+    Test.@test callable_sink.observations == observations
+    Test.@test callable_diagnostics.feature_events_emitted[] == length(observations)
+    Test.@test callable_diagnostics.candidate_substitutions_evaluated[] >=
+               callable_diagnostics.feature_events_emitted[]
 
     Test.@test _sink_throws_message(
         () -> Mycelia.improve_read_set_likelihood(reads, graph, k;
@@ -89,6 +116,57 @@ Test.@testset "correction feature serving sink" begin
     )
     Test.@test length(complete_observations) >= 2
 
+    typed_multi_error = FASTX.sequence(BioSequences.LongDNA{4}, multi_error)
+    kmer_at_15 = collect(Kmers.UnambiguousDNAMers{k}(typed_multi_error))[15][1]
+    hard_vertices = Set([BioSequences.canonical(kmer_at_15)])
+    windows = Mycelia._hard_window_ranges(
+        multi_error, k, hard_vertices; pad = k, max_window = 21)
+    Test.@test only(windows) == 8:28
+    window_observations = Mycelia.CorrectionFeatureObservation[]
+    Mycelia.improve_read_likelihood_windowed_detail(
+        multi_error,
+        graph,
+        k,
+        hard_vertices;
+        graph_mode = :canonical,
+        pad = k,
+        max_window = 21,
+        correction_feature_sink = observation ->
+            push!(window_observations, observation),
+    )
+    Test.@test !isempty(window_observations)
+
+    # Re-run the exact decoded sub-window through the lower-level serving entry
+    # point and splice its candidate into parent coordinates. Equality with the
+    # window wrapper's events proves that it threaded both parent id and `lo - 1`.
+    window = only(windows)
+    original_sequence = FASTX.sequence(String, multi_error)
+    sub_sequence = original_sequence[window]
+    sub_read = _sink_record("sub-window", sub_sequence)
+    direct_observations = Mycelia.CorrectionFeatureObservation[]
+    direct_result = Mycelia.try_viterbi_path_improvement(
+        sub_read,
+        graph,
+        k;
+        graph_mode = :canonical,
+        correction_read_id = "multi-error",
+        correction_position_offset = first(window) - 1,
+        correction_feature_sink = observation ->
+            push!(direct_observations, observation),
+    )
+    Test.@test direct_result !== nothing
+    candidate_chars = collect(original_sequence)
+    candidate_chars[window] = collect(FASTX.sequence(String, first(direct_result)))
+    candidate_sequence = String(candidate_chars)
+    Test.@test window_observations == direct_observations
+    for observation in window_observations
+        Test.@test observation.read_id == "multi-error"
+        Test.@test observation.position in window
+        Test.@test observation.observed_base == original_sequence[observation.position]
+        Test.@test observation.corrected_base == candidate_sequence[observation.position]
+        Test.@test observation.observed_base != observation.corrected_base
+    end
+
     # A later feature-extraction failure invalidates the whole read contract. No
     # observation buffered for an earlier edit may escape to the caller-owned sink.
     transactional_observations = Mycelia.CorrectionFeatureObservation[]
@@ -107,14 +185,97 @@ Test.@testset "correction feature serving sink" begin
     Test.@test isempty(transactional_observations)
     Test.@test transactional_diagnostics.gate_skipped[] == 1
 
-    Test.@test_throws InterruptException Mycelia.try_viterbi_path_improvement(
-        multi_error,
-        graph,
-        k;
-        graph_mode = :canonical,
-        correction_feature_sink = _ -> nothing,
-        solid_kmers = _FailingSolidKmers(0, 0, InterruptException()),
-    )
+    interrupt_error = nothing
+    try
+        Mycelia.try_viterbi_path_improvement(
+            multi_error,
+            graph,
+            k;
+            graph_mode = :canonical,
+            correction_feature_sink = _ -> nothing,
+            solid_kmers = _FailingSolidKmers(0, 0, InterruptException()),
+        )
+    catch error
+        interrupt_error = error
+    end
+    Test.@test interrupt_error isa InterruptException
+
+    unexpected_error = nothing
+    try
+        Mycelia.try_viterbi_path_improvement(
+            multi_error,
+            graph,
+            k;
+            graph_mode = :canonical,
+            correction_feature_sink = _ -> nothing,
+            solid_kmers = _FailingSolidKmers(
+                0, 0, ErrorException("unexpected feature sentinel")),
+        )
+    catch error
+        unexpected_error = error
+    end
+    Test.@test unexpected_error isa ErrorException
+    Test.@test occursin(
+        "unexpected feature sentinel", sprint(showerror, unexpected_error))
+
+    overflow_model = Mycelia.CorrectionConfidenceModel(
+        0.0, floatmax(Float64), -floatmax(Float64), 0.0,
+        floatmax(Float64), floatmax(Float64))
+    serving_numeric_diagnostics = Mycelia.CorrectorDiagnostics()
+    serving_numeric_error = nothing
+    try
+        Mycelia.try_viterbi_path_improvement(
+            multi_error,
+            graph,
+            k;
+            graph_mode = :canonical,
+            diagnostics = serving_numeric_diagnostics,
+            calibrated_probability_model = overflow_model,
+        )
+    catch error
+        serving_numeric_error = error
+    end
+    Test.@test serving_numeric_error isa Mycelia._CorrectionConfidenceServingError
+    Test.@test occursin(
+        "logit must not be NaN", sprint(showerror, serving_numeric_error))
+    Test.@test serving_numeric_diagnostics.structural_errors[] == 0
+    Test.@test serving_numeric_diagnostics.gate_skipped[] == 0
+
+    bounds_diagnostics = Mycelia.CorrectorDiagnostics()
+    bounds_error = nothing
+    try
+        Mycelia.try_viterbi_path_improvement(
+            multi_error,
+            graph,
+            k;
+            graph_mode = :canonical,
+            diagnostics = bounds_diagnostics,
+            correction_feature_sink = _ -> nothing,
+            solid_kmers = _FailingSolidKmers(
+                0, 0, BoundsError([1], 2)),
+        )
+    catch error
+        bounds_error = error
+    end
+    Test.@test bounds_error isa BoundsError
+    Test.@test occursin("BoundsError", sprint(showerror, bounds_error))
+    Test.@test bounds_diagnostics.structural_errors[] == 0
+    Test.@test bounds_diagnostics.gate_skipped[] == 0
+
+    numeric_model_error = nothing
+    try
+        Mycelia.correction_confidence_probability(
+            Mycelia.CorrectionConfidenceModel(
+                0.0, 1.0e308, -1.0e308, 0.0, 0.0, 0.0),
+            Mycelia.CorrectionConfidenceFeatures(
+                1.0e308, 1.0e308, false, 0.5))
+    catch error
+        numeric_model_error = error
+    end
+    Test.@test numeric_model_error isa ArgumentError
+    Test.@test !(numeric_model_error isa Mycelia._CorrectionFeatureContractError)
+    Test.@test occursin(
+        "logit must not be NaN", sprint(showerror, numeric_model_error))
 
     ambiguous = _sink_record("ambiguous", repeat("N", length(clean)))
     ambiguous_diagnostics = Mycelia.CorrectorDiagnostics()
@@ -144,4 +305,8 @@ Test.@testset "correction feature serving sink" begin
         Inf, 3.0, true, 0.8)
     Test.@test Mycelia.correction_confidence_probability(
         collapsed_model, collapsed_features) ≈ 1.0 / (1.0 + exp(-0.2))
+    finite_zero_features = Mycelia.CorrectionConfidenceFeatures(
+        0.0, 3.0, true, 0.8)
+    Test.@test Mycelia.correction_confidence_probability(
+        collapsed_model, finite_zero_features) == 0.5
 end

--- a/test/4_assembly/correction_feature_sink_test.jl
+++ b/test/4_assembly/correction_feature_sink_test.jl
@@ -36,7 +36,8 @@ Test.@testset "correction feature serving sink" begin
         Test.@test observation.k == k
         Test.@test 1 <= observation.position <= length(clean)
         Test.@test observation.observed_base != observation.corrected_base
-        Test.@test isfinite(observation.features.raw_gap)
+        Test.@test isfinite(observation.features.raw_gap) ||
+                   observation.features.raw_gap == Inf
         Test.@test isfinite(observation.features.min_kmer_support)
         Test.@test 0.0 <= observation.features.competing_branch_support_ratio <= 1.0
     end
@@ -59,11 +60,32 @@ Test.@testset "correction feature serving sink" begin
             correction_feature_sink = _ -> error("sink sentinel")),
         "sink sentinel")
 
+    ambiguous = _sink_record("ambiguous", repeat("N", length(clean)))
+    ambiguous_diagnostics = Mycelia.CorrectorDiagnostics()
+    ambiguous_result = Mycelia.find_optimal_sequence_path(
+        ambiguous,
+        graph,
+        k;
+        graph_mode = :canonical,
+        diagnostics = ambiguous_diagnostics,
+        correction_feature_sink = _ -> nothing,
+    )
+    Test.@test first(ambiguous_result) == ambiguous
+    Test.@test ambiguous_diagnostics.unkmerizable_reads[] == 1
+    Test.@test ambiguous_diagnostics.gate_skipped[] == 1
+
     extreme = Mycelia.CorrectionConfidenceModel(
-        0.0, floatmax(Float64), -floatmax(Float64), 0.0, 0.0)
+        0.0, floatmax(Float64), -floatmax(Float64), 0.0, 0.0, 0.5)
     features = Mycelia.CorrectionConfidenceFeatures(
         floatmax(Float64), floatmax(Float64), false, 0.5)
     Test.@test _sink_throws_message(
         () -> Mycelia.correction_confidence_probability(extreme, features),
         "logit must not be NaN")
+
+    collapsed_model = Mycelia.CorrectionConfidenceModel(
+        0.0, 0.0, 0.0, 0.0, 0.0, 0.2)
+    collapsed_features = Mycelia.CorrectionConfidenceFeatures(
+        Inf, 3.0, true, 0.8)
+    Test.@test Mycelia.correction_confidence_probability(
+        collapsed_model, collapsed_features) ≈ 1.0 / (1.0 + exp(-0.2))
 end

--- a/test/4_assembly/correction_feature_sink_test.jl
+++ b/test/4_assembly/correction_feature_sink_test.jl
@@ -1,0 +1,69 @@
+import FASTX
+import Mycelia
+import Test
+
+function _sink_record(id::AbstractString, sequence::AbstractString)::FASTX.FASTQ.Record
+    return FASTX.FASTQ.Record(id, sequence, String(fill('I', length(sequence))))
+end
+
+function _sink_throws_message(f::Function, fragment::AbstractString)::Bool
+    try
+        f()
+    catch error
+        return occursin(fragment, sprint(showerror, error))
+    end
+    return false
+end
+
+Test.@testset "correction feature serving sink" begin
+    k = 7
+    clean = "ATGCGTACGTACGTTAGCCGATACAGGTCA"
+    reads = [_sink_record("clean$(i)", clean) for i in 1:10]
+    errored = collect(clean)
+    errored[15] = errored[15] == 'A' ? 'C' : 'A'
+    push!(reads, _sink_record("err1", String(errored)))
+    graph = Mycelia.Rhizomorph.build_qualmer_graph(reads, k;
+        dataset_id = "feature-sink", mode = :canonical, memory_profile = :full)
+
+    observations = Mycelia.CorrectionFeatureObservation[]
+    Mycelia.improve_read_set_likelihood(reads, graph, k;
+        graph_mode = :canonical,
+        correction_feature_sink = observation -> push!(observations, observation))
+
+    Test.@test !isempty(observations)
+    for observation in observations
+        Test.@test observation.read_id in String.(FASTX.identifier.(reads))
+        Test.@test observation.k == k
+        Test.@test 1 <= observation.position <= length(clean)
+        Test.@test observation.observed_base != observation.corrected_base
+        Test.@test isfinite(observation.features.raw_gap)
+        Test.@test isfinite(observation.features.min_kmer_support)
+        Test.@test 0.0 <= observation.features.competing_branch_support_ratio <= 1.0
+    end
+
+    requested_parallel = Mycelia.CorrectionFeatureObservation[]
+    Mycelia.improve_read_set_likelihood(
+        reads,
+        graph,
+        k;
+        graph_mode = :canonical,
+        enable_parallel = true,
+        correction_feature_sink = observation ->
+            push!(requested_parallel, observation),
+    )
+    Test.@test requested_parallel == observations
+
+    Test.@test _sink_throws_message(
+        () -> Mycelia.improve_read_set_likelihood(reads, graph, k;
+            graph_mode = :canonical,
+            correction_feature_sink = _ -> error("sink sentinel")),
+        "sink sentinel")
+
+    extreme = Mycelia.CorrectionConfidenceModel(
+        0.0, floatmax(Float64), -floatmax(Float64), 0.0, 0.0)
+    features = Mycelia.CorrectionConfidenceFeatures(
+        floatmax(Float64), floatmax(Float64), false, 0.5)
+    Test.@test _sink_throws_message(
+        () -> Mycelia.correction_confidence_probability(extreme, features),
+        "logit must not be NaN")
+end

--- a/test/4_assembly/correction_feature_sink_test.jl
+++ b/test/4_assembly/correction_feature_sink_test.jl
@@ -15,6 +15,19 @@ function _sink_throws_message(f::Function, fragment::AbstractString)::Bool
     return false
 end
 
+mutable struct _FailingSolidKmers <: AbstractSet{Any}
+    memberships::Int
+    fail_after::Int
+    failure::Exception
+end
+
+function Base.in(::Any, solid_kmers::_FailingSolidKmers)::Bool
+    solid_kmers.memberships += 1
+    solid_kmers.memberships > solid_kmers.fail_after &&
+        throw(solid_kmers.failure)
+    return true
+end
+
 Test.@testset "correction feature serving sink" begin
     k = 7
     clean = "ATGCGTACGTACGTTAGCCGATACAGGTCA"
@@ -59,6 +72,49 @@ Test.@testset "correction feature serving sink" begin
             graph_mode = :canonical,
             correction_feature_sink = _ -> error("sink sentinel")),
         "sink sentinel")
+
+    multi_error_chars = collect(clean)
+    for position in (10, 25)
+        multi_error_chars[position] = multi_error_chars[position] == 'A' ? 'C' : 'A'
+    end
+    multi_error = _sink_record("multi-error", String(multi_error_chars))
+    complete_observations = Mycelia.CorrectionFeatureObservation[]
+    Mycelia.try_viterbi_path_improvement(
+        multi_error,
+        graph,
+        k;
+        graph_mode = :canonical,
+        correction_feature_sink = observation ->
+            push!(complete_observations, observation),
+    )
+    Test.@test length(complete_observations) >= 2
+
+    # A later feature-extraction failure invalidates the whole read contract. No
+    # observation buffered for an earlier edit may escape to the caller-owned sink.
+    transactional_observations = Mycelia.CorrectionFeatureObservation[]
+    transactional_diagnostics = Mycelia.CorrectorDiagnostics()
+    Mycelia.try_viterbi_path_improvement(
+        multi_error,
+        graph,
+        k;
+        graph_mode = :canonical,
+        diagnostics = transactional_diagnostics,
+        correction_feature_sink = observation ->
+            push!(transactional_observations, observation),
+        solid_kmers = _FailingSolidKmers(
+            0, k, ArgumentError("solid-kmer membership sentinel")),
+    )
+    Test.@test isempty(transactional_observations)
+    Test.@test transactional_diagnostics.gate_skipped[] == 1
+
+    Test.@test_throws InterruptException Mycelia.try_viterbi_path_improvement(
+        multi_error,
+        graph,
+        k;
+        graph_mode = :canonical,
+        correction_feature_sink = _ -> nothing,
+        solid_kmers = _FailingSolidKmers(0, 0, InterruptException()),
+    )
 
     ambiguous = _sink_record("ambiguous", repeat("N", length(clean)))
     ambiguous_diagnostics = Mycelia.CorrectorDiagnostics()

--- a/test/4_assembly/frontier_dominance_test.jl
+++ b/test/4_assembly/frontier_dominance_test.jl
@@ -53,6 +53,11 @@ Test.@testset "calibrated probability operating points" begin
             calibrated_probability_points()
         end,
         "must be in [0, 1]")
+    Test.@test _frontier_throws_message(
+        () -> withenv("MYCELIA_RPC_ASSIGNED_Q" => "94") do
+            run_pr_curve()
+        end,
+        "supported Phred range 0:93")
 
     model = Mycelia.CorrectionConfidenceModel(
         1.0, 2.0, 3.0, 4.0, 5.0, 6.0)

--- a/test/4_assembly/frontier_dominance_test.jl
+++ b/test/4_assembly/frontier_dominance_test.jl
@@ -14,13 +14,45 @@ include(joinpath(@__DIR__, "..", "..", "benchmarking", "rhizomorph_correction_pr
 
 # Minimal row set the verdict reads: error_rate, point, recall, precision,
 # over_correction_rate. Baseline is always "noskip+nogate".
-function _frontier(rows)
+function _frontier(rows::AbstractVector{<:Tuple})::DataFrames.DataFrame
     DataFrames.DataFrame(
         error_rate = [r[1] for r in rows],
         point = [r[2] for r in rows],
+        ok = [length(r) >= 6 ? r[6] : true for r in rows],
+        n_reads = [length(r) >= 7 ? r[7] : 100 for r in rows],
+        reads_scored = [length(r) >= 8 ? r[8] : 100 for r in rows],
         recall = [r[3] for r in rows],
         precision = [r[4] for r in rows],
         over_correction_rate = [r[5] for r in rows])
+end
+
+function _frontier_throws_message(f::Function, fragment::AbstractString)::Bool
+    try
+        f()
+    catch error
+        return error isa ArgumentError && occursin(fragment, error.msg)
+    end
+    return false
+end
+
+Test.@testset "calibrated probability operating points" begin
+    defaults = withenv("MYCELIA_RPC_PROB_THRESHOLDS" => nothing) do
+        calibrated_probability_points()
+    end
+    Test.@test [point.calibrated_probability_threshold for point in defaults] ==
+               [0.0, 0.01, 0.025, 0.05, 0.075, 0.1, 0.15, 0.2, 0.25, 0.5, 0.75, 0.9]
+    Test.@test all(point -> startswith(point.name, "calibrated-prob-"), defaults)
+
+    overridden = withenv("MYCELIA_RPC_PROB_THRESHOLDS" => "0.4,0.85") do
+        calibrated_probability_points()
+    end
+    Test.@test [point.calibrated_probability_threshold for point in overridden] ==
+               [0.4, 0.85]
+    Test.@test _frontier_throws_message(
+        () -> withenv("MYCELIA_RPC_PROB_THRESHOLDS" => "-0.1,0.5") do
+            calibrated_probability_points()
+        end,
+        "must be in [0, 1]")
 end
 
 Test.@testset "assess_frontier_dominance" begin
@@ -70,4 +102,77 @@ Test.@testset "assess_frontier_dominance" begin
     vmb = assess_frontier_dominance(df_nobase; err = 0.10)
     Test.@test !vmb.dominates
     Test.@test occursin("no noskip+nogate baseline", vmb.reason)
+
+    # --- candidate-prefix parameter selects the probability family independently
+    df_probability = _frontier([
+        (0.05, "noskip+nogate", 0.96, 0.82, 0.020),
+        (0.05, "calibrated-gap-1.0", 0.95, 0.90, 0.005),
+        (0.05, "calibrated-prob-0.0", 0.96, 0.82, 0.020),
+        (0.05, "calibrated-prob-0.8", 0.95, 0.91, 0.004),
+        (0.10, "noskip+nogate", 0.90, 0.70, 0.030),
+        (0.10, "calibrated-prob-0.0", 0.90, 0.70, 0.030),
+        (0.10, "calibrated-prob-0.8", 0.89, 0.81, 0.009)
+    ])
+    default_gap = assess_frontier_dominance(df_probability; err = 0.05)
+    probability_05 = assess_frontier_dominance(
+        df_probability; err = 0.05, candidate_prefix = "calibrated-prob-")
+    probability_10 = assess_frontier_dominance(
+        df_probability; err = 0.10, candidate_prefix = "calibrated-prob-")
+    Test.@test default_gap.dominates
+    Test.@test default_gap.best.point == "calibrated-gap-1.0"
+    Test.@test probability_05.dominates
+    Test.@test probability_05.best.point == "calibrated-prob-0.8"
+    Test.@test probability_10.dominates
+    Test.@test probability_10.best.point == "calibrated-prob-0.8"
+    Test.@test all(candidate -> candidate.point != "calibrated-prob-0.0",
+        probability_10.candidates)
+
+    # --- probability-family NaNs and ties remain non-dominating
+    df_probability_bad = _frontier([
+        (0.10, "noskip+nogate", 0.90, 0.70, 0.030),
+        (0.10, "calibrated-prob-0.0", 0.90, 0.70, 0.030),
+        (0.10, "calibrated-prob-0.9", NaN, NaN, NaN)
+    ])
+    Test.@test !assess_frontier_dominance(
+        df_probability_bad; err = 0.10,
+        candidate_prefix = "calibrated-prob-").dominates
+
+    # --- a superficially winning candidate is ineligible if its run failed
+    df_failed_candidate = _frontier([
+        (0.10, "noskip+nogate", 0.90, 0.70, 0.030),
+        (0.10, "calibrated-prob-0.8", 0.89, 0.81, 0.009, false, 100, 100)
+    ])
+    Test.@test !assess_frontier_dominance(
+        df_failed_candidate; err = 0.10,
+        candidate_prefix = "calibrated-prob-").dominates
+
+    # --- a superficially winning candidate is ineligible if not all reads scored
+    df_partial_candidate = _frontier([
+        (0.10, "noskip+nogate", 0.90, 0.70, 0.030),
+        (0.10, "calibrated-prob-0.8", 0.89, 0.81, 0.009, true, 100, 99)
+    ])
+    Test.@test !assess_frontier_dominance(
+        df_partial_candidate; err = 0.10,
+        candidate_prefix = "calibrated-prob-").dominates
+
+    # --- the baseline itself must be a complete, successful run
+    df_failed_baseline = _frontier([
+        (0.10, "noskip+nogate", 0.90, 0.70, 0.030, false, 100, 100),
+        (0.10, "calibrated-prob-0.8", 0.89, 0.81, 0.009)
+    ])
+    failed_baseline = assess_frontier_dominance(
+        df_failed_baseline; err = 0.10,
+        candidate_prefix = "calibrated-prob-")
+    Test.@test !failed_baseline.dominates
+    Test.@test occursin("failed or partial", failed_baseline.reason)
+
+    df_partial_baseline = _frontier([
+        (0.10, "noskip+nogate", 0.90, 0.70, 0.030, true, 100, 99),
+        (0.10, "calibrated-prob-0.8", 0.89, 0.81, 0.009)
+    ])
+    partial_baseline = assess_frontier_dominance(
+        df_partial_baseline; err = 0.10,
+        candidate_prefix = "calibrated-prob-")
+    Test.@test !partial_baseline.dominates
+    Test.@test occursin("failed or partial", partial_baseline.reason)
 end

--- a/test/4_assembly/frontier_dominance_test.jl
+++ b/test/4_assembly/frontier_dominance_test.jl
@@ -15,15 +15,29 @@ include(joinpath(@__DIR__, "..", "..", "benchmarking", "rhizomorph_correction_pr
 # Minimal row set the verdict reads: error_rate, point, recall, precision,
 # over_correction_rate. Baseline is always "noskip+nogate".
 function _frontier(rows::AbstractVector{<:Tuple})::DataFrames.DataFrame
+    points = [r[2] for r in rows]
+    gate_requested = [startswith(point, "calibrated-") for point in points]
     DataFrames.DataFrame(
         error_rate = [r[1] for r in rows],
-        point = [r[2] for r in rows],
+        point = points,
         ok = [length(r) >= 6 ? r[6] : true for r in rows],
         n_reads = [length(r) >= 7 ? r[7] : 100 for r in rows],
         reads_scored = [length(r) >= 8 ? r[8] : 100 for r in rows],
+        injected = [length(r) >= 9 ? r[9] : 100 for r in rows],
         recall = [r[3] for r in rows],
         precision = [r[4] for r in rows],
-        over_correction_rate = [r[5] for r in rows])
+        over_correction_rate = [r[5] for r in rows],
+        gate_requested = gate_requested,
+        gate_effective = gate_requested,
+        gate_executed = gate_requested,
+        feature_contract_skips = zeros(Int, length(rows)),
+        candidate_evaluations = Int.(gate_requested),
+        feature_events = Int.(gate_requested),
+        gate_reverts = zeros(Int, length(rows)),
+        structural_errors = zeros(Int, length(rows)),
+        unkmerizable_errors = zeros(Int, length(rows)),
+        model_digest = fill("", length(rows)),
+        artifact_digest = fill("", length(rows)))
 end
 
 function _frontier_throws_message(f::Function, fragment::AbstractString)::Bool
@@ -67,7 +81,24 @@ Test.@testset "calibrated probability operating points" begin
         lines = readlines(model_path)
         Test.@test first(lines) == "term,coefficient"
         Test.@test "collapsed_frontier,6.0" in lines
+        digest = artifact_digest(dir)
+        Test.@test length(digest) == 64
+        Test.@test digest == artifact_digest(dir)
+        write(joinpath(dir, "extra.txt"), "digest changes")
+        Test.@test digest != artifact_digest(dir)
     end
+
+    selected = select_operating_points(PR_OPERATING_POINTS, "noskip,scalable")
+    Test.@test [point.name for point in selected] == ["scalable", "noskip"]
+    Test.@test _frontier_throws_message(
+        () -> select_operating_points(PR_OPERATING_POINTS, "not-a-point"),
+        "unknown MYCELIA_RPC_POINTS")
+    Test.@test _frontier_throws_message(
+        () -> select_operating_points(PR_OPERATING_POINTS, "noskip,"),
+        "empty point name")
+    Test.@test _frontier_throws_message(
+        () -> select_operating_points(NamedTuple[], ""),
+        "no precision-recall operating points")
 end
 
 Test.@testset "assess_frontier_dominance" begin
@@ -96,12 +127,15 @@ Test.@testset "assess_frontier_dominance" begin
     ])
     Test.@test !assess_frontier_dominance(df_crash; err = 0.10).dominates
 
-    # --- NaN candidate metrics are excluded (never a false positive)
+    # --- NaN candidate metrics make the requested sweep explicitly incomplete
     df_nan = _frontier([
         (0.10, "noskip+nogate", 0.90, 0.70, 0.030),
         (0.10, "calibrated-gap-1.0", NaN, NaN, NaN)
     ])
-    Test.@test !assess_frontier_dominance(df_nan; err = 0.10).dominates
+    nan_candidate = assess_frontier_dominance(df_nan; err = 0.10)
+    Test.@test !nan_candidate.dominates
+    Test.@test occursin("incomplete candidate sweep", nan_candidate.reason)
+    Test.@test occursin("non-finite metrics", nan_candidate.reason)
 
     # --- NaN BASELINE ⇒ non-dominating with an explicit reason (not a false pass)
     df_nanbase = _frontier([
@@ -190,4 +224,101 @@ Test.@testset "assess_frontier_dominance" begin
         candidate_prefix = "calibrated-prob-")
     Test.@test !partial_baseline.dominates
     Test.@test occursin("failed or partial", partial_baseline.reason)
+
+    # --- no requested family is not a valid negative result
+    df_empty_family = _frontier([
+        (0.10, "noskip+nogate", 0.90, 0.70, 0.030),
+        (0.10, "scalable", 0.40, 1.00, 0.000)
+    ])
+    empty_family = assess_frontier_dominance(
+        df_empty_family; err = 0.10, candidate_prefix = "calibrated-prob-")
+    Test.@test !empty_family.dominates
+    Test.@test occursin("no calibrated-prob-", empty_family.reason)
+
+    # --- all-invalid and mixed valid+invalid sweeps both fail closed
+    df_all_invalid = _frontier([
+        (0.10, "noskip+nogate", 0.90, 0.70, 0.030),
+        (0.10, "calibrated-prob-0.5", NaN, NaN, NaN),
+        (0.10, "calibrated-prob-0.8", 0.89, 0.81, 0.009, false, 100, 100)
+    ])
+    all_invalid = assess_frontier_dominance(
+        df_all_invalid; err = 0.10, candidate_prefix = "calibrated-prob-")
+    Test.@test !all_invalid.dominates
+    Test.@test occursin("incomplete candidate sweep", all_invalid.reason)
+    Test.@test occursin("calibrated-prob-0.5", all_invalid.reason)
+    Test.@test occursin("calibrated-prob-0.8", all_invalid.reason)
+
+    df_mixed = _frontier([
+        (0.10, "noskip+nogate", 0.90, 0.70, 0.030),
+        (0.10, "calibrated-prob-0.8", 0.89, 0.81, 0.009),
+        (0.10, "calibrated-prob-0.9", NaN, NaN, NaN)
+    ])
+    mixed = assess_frontier_dominance(
+        df_mixed; err = 0.10, candidate_prefix = "calibrated-prob-")
+    Test.@test !mixed.dominates
+    Test.@test isnothing(mixed.best)
+    Test.@test occursin("calibrated-prob-0.9", mixed.reason)
+
+    # --- zero-read rows cannot establish either a baseline or candidate verdict
+    df_zero_baseline = _frontier([
+        (0.10, "noskip+nogate", 0.90, 0.70, 0.030, true, 0, 0),
+        (0.10, "calibrated-prob-0.8", 0.89, 0.81, 0.009)
+    ])
+    zero_baseline = assess_frontier_dominance(
+        df_zero_baseline; err = 0.10, candidate_prefix = "calibrated-prob-")
+    Test.@test !zero_baseline.dominates
+    Test.@test occursin("failed or partial", zero_baseline.reason)
+
+    df_zero_candidate = _frontier([
+        (0.10, "noskip+nogate", 0.90, 0.70, 0.030),
+        (0.10, "calibrated-prob-0.8", 0.89, 0.81, 0.009, true, 0, 0)
+    ])
+    zero_candidate = assess_frontier_dominance(
+        df_zero_candidate; err = 0.10, candidate_prefix = "calibrated-prob-")
+    Test.@test !zero_candidate.dominates
+    Test.@test occursin("incomplete candidate sweep", zero_candidate.reason)
+
+    # --- internally complete candidates must still match the baseline cohort
+    df_smaller_cohort = _frontier([
+        (0.10, "noskip+nogate", 0.90, 0.70, 0.030, true, 200, 200, 1_000),
+        (0.10, "calibrated-prob-0.8", 0.89, 0.81, 0.009, true, 20, 20, 100)
+    ])
+    smaller_cohort = assess_frontier_dominance(
+        df_smaller_cohort; err = 0.10, candidate_prefix = "calibrated-prob-")
+    Test.@test !smaller_cohort.dominates
+    Test.@test occursin("cohort-size mismatch", smaller_cohort.reason)
+
+    df_injected_mismatch = _frontier([
+        (0.10, "noskip+nogate", 0.90, 0.70, 0.030, true, 100, 100, 1_000),
+        (0.10, "calibrated-prob-0.8", 0.89, 0.81, 0.009, true, 100, 100, 999)
+    ])
+    injected_mismatch = assess_frontier_dominance(
+        df_injected_mismatch; err = 0.10, candidate_prefix = "calibrated-prob-")
+    Test.@test !injected_mismatch.dominates
+    Test.@test occursin("injected-error mismatch", injected_mismatch.reason)
+
+    # --- configured-but-inactive gates and contract skips fail closed
+    df_inactive = _frontier([
+        (0.10, "noskip+nogate", 0.90, 0.70, 0.030),
+        (0.10, "calibrated-prob-0.8", 0.89, 0.81, 0.009)
+    ])
+    df_inactive.candidate_evaluations[2] = 0
+    df_inactive.gate_executed[2] = false
+    inactive = assess_frontier_dominance(
+        df_inactive; err = 0.10, candidate_prefix = "calibrated-prob-")
+    Test.@test !inactive.dominates
+    Test.@test occursin("zero candidates", inactive.reason)
+
+    df_skips = _frontier([
+        (0.10, "noskip+nogate", 0.90, 0.70, 0.030),
+        (0.10, "calibrated-prob-0.8", 0.89, 0.81, 0.009)
+    ])
+    df_skips.feature_contract_skips[2] = 1
+    strict_skips = assess_frontier_dominance(
+        df_skips; err = 0.10, candidate_prefix = "calibrated-prob-")
+    Test.@test !strict_skips.dominates
+    Test.@test occursin("exceed bound 0", strict_skips.reason)
+    Test.@test assess_frontier_dominance(
+        df_skips; err = 0.10, candidate_prefix = "calibrated-prob-",
+        max_contract_skips = 1).dominates
 end

--- a/test/4_assembly/frontier_dominance_test.jl
+++ b/test/4_assembly/frontier_dominance_test.jl
@@ -53,6 +53,16 @@ Test.@testset "calibrated probability operating points" begin
             calibrated_probability_points()
         end,
         "must be in [0, 1]")
+
+    model = Mycelia.CorrectionConfidenceModel(
+        1.0, 2.0, 3.0, 4.0, 5.0, 6.0)
+    mktempdir() do dir
+        model_path = persist_runtime_probability_model(model, dir)
+        Test.@test isfile(model_path)
+        lines = readlines(model_path)
+        Test.@test first(lines) == "term,coefficient"
+        Test.@test "collapsed_frontier,6.0" in lines
+    end
 end
 
 Test.@testset "assess_frontier_dominance" begin

--- a/test/4_assembly/gap_calibration_fitters_test.jl
+++ b/test/4_assembly/gap_calibration_fitters_test.jl
@@ -43,6 +43,40 @@ Test.@testset "gap calibration fitters (isotonic / logistic / binned)" begin
     # The decision boundary (P=0.5) lands near the true 2.5 threshold.
     Test.@test isapprox(logistic_gap_for_probability(lm, 0.5), 2.5; atol = 0.3)
 
+    # --- Multi-feature logistic uses samples as rows -----------------------
+    features = hcat(
+        gaps,
+        2.0 .+ 3.0 .* gaps,
+        Float64.(gaps .> 1.5),
+        fill(7.0, length(gaps))
+    )
+    multi_lm = fit_logistic_map(features, labels)
+    multi_p = predict_logistic(multi_lm, features)
+    Test.@test multi_lm.b isa Vector{Float64}
+    Test.@test length(multi_lm.b) == size(features, 2)
+    Test.@test length(multi_p) == size(features, 1)
+    Test.@test all(isfinite, (multi_lm.a, multi_lm.b...))
+    Test.@test all(probability -> 0.0 <= probability <= 1.0, multi_p)
+    Test.@test auroc(multi_p, labels) == 1.0
+    # The final column is constant, so it must remain inert rather than
+    # generating a huge unfolded coefficient from a near-zero scale.
+    Test.@test multi_lm.b[4] == 0.0
+
+    # Returned coefficients are in raw feature space, not standardized space.
+    manual_p = [1.0 /
+                (1.0 + exp(-(multi_lm.a + sum(multi_lm.b .* Float64.(features[i, :])))))
+                for i in axes(features, 1)]
+    Test.@test multi_p ≈ manual_p
+
+    # A one-column matrix preserves the scalar fitter's numerical contract,
+    # while returning its slope as a length-one vector.
+    one_feature_lm = fit_logistic_map(reshape(gaps, :, 1), labels)
+    Test.@test lm.b isa Float64
+    Test.@test one_feature_lm.a ≈ lm.a
+    Test.@test only(one_feature_lm.b) ≈ lm.b
+    Test.@test predict_logistic(one_feature_lm, reshape(gaps, :, 1)) ≈
+               predict_logistic(lm, gaps)
+
     # --- Tied scores share one isotonic probability (PAVA tie-pooling) -------
     # Repeated Viterbi gaps tie; all observations at an identical score must map
     # to their shared empirical probability, not to a duplicate-threshold artifact.
@@ -68,6 +102,16 @@ Test.@testset "gap calibration fitters (isotonic / logistic / binned)" begin
     end
     Test.@test throws_msg(() -> fit_isotonic_map([0.1, Inf], [false, true]), "finite")
     Test.@test throws_msg(() -> fit_logistic_map(Float64[], Bool[]), "non-empty")
+    Test.@test throws_msg(
+        () -> fit_logistic_map(zeros(2, 2), [true]), "equal length")
+    Test.@test throws_msg(
+        () -> fit_logistic_map(zeros(2, 0), [false, true]), "at least one column")
+    Test.@test throws_msg(
+        () -> fit_logistic_map([0.0 NaN; 1.0 2.0], [false, true]), "finite")
+    Test.@test throws_msg(
+        () -> predict_logistic(multi_lm, zeros(2, 3)), "match model")
+    Test.@test throws_msg(
+        () -> predict_logistic(multi_lm, [0.0 Inf 0.0 7.0]), "finite")
     Test.@test throws_msg(() -> fit_binned_map([0.1, 0.2], [true]), "equal length")
     Test.@test throws_msg(() -> logistic_gap_for_probability(lm, 1.0), "open interval")
 

--- a/test/4_assembly/gap_calibration_fitters_test.jl
+++ b/test/4_assembly/gap_calibration_fitters_test.jl
@@ -52,6 +52,7 @@ Test.@testset "gap calibration fitters (isotonic / logistic / binned)" begin
     )
     multi_lm = fit_logistic_map(features, labels)
     multi_p = predict_logistic(multi_lm, features)
+    Test.@test keys(multi_lm) == (:a, :b)
     Test.@test multi_lm.b isa Vector{Float64}
     Test.@test length(multi_lm.b) == size(features, 2)
     Test.@test length(multi_p) == size(features, 1)
@@ -61,6 +62,19 @@ Test.@testset "gap calibration fitters (isotonic / logistic / binned)" begin
     # The final column is constant, so it must remain inert rather than
     # generating a huge unfolded coefficient from a near-zero scale.
     Test.@test multi_lm.b[4] == 0.0
+
+    diagnostic_lm = fit_logistic_map(
+        features, labels; l2 = 0.01, return_diagnostics = true)
+    Test.@test keys(diagnostic_lm) == (:a, :b, :diagnostics)
+    Test.@test diagnostic_lm.diagnostics.iterations >= 1
+    Test.@test diagnostic_lm.diagnostics.l2 == 0.01
+    Test.@test isfinite(diagnostic_lm.diagnostics.final_loss)
+    Test.@test isfinite(diagnostic_lm.diagnostics.gradient_norm)
+
+    converged_lm = fit_logistic_map(
+        features, labels; iters = 10_000, l2 = 0.01,
+        gradient_tolerance = 1.0e-6, return_diagnostics = true)
+    Test.@test converged_lm.diagnostics.converged
 
     # Returned coefficients are in raw feature space, not standardized space.
     manual_p = [1.0 /
@@ -76,6 +90,10 @@ Test.@testset "gap calibration fitters (isotonic / logistic / binned)" begin
     Test.@test only(one_feature_lm.b) ≈ lm.b
     Test.@test predict_logistic(one_feature_lm, reshape(gaps, :, 1)) ≈
                predict_logistic(lm, gaps)
+
+    # Stable sigmoid branches remain finite for large but finite logits.
+    Test.@test predict_logistic((a = 1_000.0, b = 0.0), [0.0]) == [1.0]
+    Test.@test only(predict_logistic((a = -1_000.0, b = 0.0), [0.0])) >= 0.0
 
     # --- Tied scores share one isotonic probability (PAVA tie-pooling) -------
     # Repeated Viterbi gaps tie; all observations at an identical score must map
@@ -112,6 +130,17 @@ Test.@testset "gap calibration fitters (isotonic / logistic / binned)" begin
         () -> predict_logistic(multi_lm, zeros(2, 3)), "match model")
     Test.@test throws_msg(
         () -> predict_logistic(multi_lm, [0.0 Inf 0.0 7.0]), "finite")
+    Test.@test throws_msg(
+        () -> predict_logistic((a = Inf, b = 1.0), [0.0]), "coefficients")
+    Test.@test throws_msg(
+        () -> predict_logistic((a = 1.0e308, b = 1.0e308), [2.0]),
+        "linear predictor")
+    Test.@test throws_msg(
+        () -> expected_calibration_error([0.2, NaN], [false, true]), "finite")
+    Test.@test throws_msg(
+        () -> reliability_bins([0.2, 1.1], [false, true]), "[0, 1]")
+    Test.@test throws_msg(
+        () -> fit_logistic_map(gaps, labels; l2 = -0.1), "l2")
     Test.@test throws_msg(() -> fit_binned_map([0.1, 0.2], [true]), "equal length")
     Test.@test throws_msg(() -> logistic_gap_for_probability(lm, 1.0), "open interval")
 

--- a/test/4_assembly/viterbi_gap_calibration_test.jl
+++ b/test/4_assembly/viterbi_gap_calibration_test.jl
@@ -56,20 +56,26 @@ Test.@testset "Grouped held-out correction-confidence calibration" begin
         :raw_gap,
         :min_kmer_support,
         :all_stage0_solid,
-        :competing_branch_support_ratio
+        :competing_branch_support_ratio,
+        :collapsed_frontier
     )
-    Test.@test length(artifact.multifeature_model.b) == 4
-    Test.@test artifact.gap_model.b isa Float64
+    Test.@test length(artifact.multifeature_model.b) == 5
+    Test.@test artifact.gap_model.b isa Vector{Float64}
+    Test.@test length(artifact.gap_model.b) == 2
     Test.@test artifact.metrics_path ==
                joinpath(dirname(artifact.model_path), "rhizomorph_gap_calibration.csv")
     Test.@test artifact.manifest_path == joinpath(
         dirname(artifact.model_path), "rhizomorph_gap_calibration_manifest.csv")
     Test.@test artifact.training.n > 0
     Test.@test artifact.heldout.n > 0
-    Test.@test size(artifact.training.features) == (artifact.training.n, 4)
-    Test.@test size(artifact.heldout.features) == (artifact.heldout.n, 4)
+    Test.@test size(artifact.training.features) == (artifact.training.n, 5)
+    Test.@test size(artifact.heldout.features) == (artifact.heldout.n, 5)
+    Test.@test size(artifact.training.gap_features) == (artifact.training.n, 2)
+    Test.@test size(artifact.heldout.gap_features) == (artifact.heldout.n, 2)
     Test.@test all(row.candidate_edit for row in artifact.training.rows)
     Test.@test all(row.candidate_edit for row in artifact.heldout.rows)
+    Test.@test any(artifact.training.collapsed_frontier)
+    Test.@test any(artifact.heldout.collapsed_frontier)
     Test.@test artifact.serving_config == (
         max_k = 13,
         skip_solid = false,
@@ -96,6 +102,11 @@ Test.@testset "Grouped held-out correction-confidence calibration" begin
                    artifact.contract_read_passes[error_rate] <=
                    artifact.max_contract_skip_fraction
     end
+    Test.@test sum(values(artifact.contract_skips)) > 0
+    Test.@test _contract_skip_fraction(1, 4, 0.25) == 0.25
+    test_throws_message(ArgumentError, "exceeds configured bound") do
+        _contract_skip_fraction(1, 4, 0.2)
+    end
 
     metric_scopes = Set((row.scope, row.error_rate) for row in artifact.rows)
     Test.@test ("pooled", nothing) in metric_scopes
@@ -108,6 +119,7 @@ Test.@testset "Grouped held-out correction-confidence calibration" begin
                    Set(["multifeature-logistic", "gap-only-logistic"])
         for row in scope_rows
             Test.@test row.n > 0
+            Test.@test isfinite(row.auroc) && 0.0 <= row.auroc <= 1.0
             Test.@test isfinite(row.ece) && 0.0 <= row.ece <= 1.0
             Test.@test isfinite(row.brier) && 0.0 <= row.brier <= 1.0
             Test.@test all(bin.count > 0 for bin in row.reliability)
@@ -115,10 +127,24 @@ Test.@testset "Grouped held-out correction-confidence calibration" begin
     end
     pooled = filter(row -> row.scope == "pooled", artifact.rows)
     Test.@test all(!isnan(row.auroc) for row in pooled)
-    Test.@test only(filter(row -> row.model == "gap-only-logistic", pooled)).auroc > 0.5
+    Test.@test Set(row.model for row in pooled) ==
+               Set(["multifeature-logistic", "gap-only-logistic"])
 
     test_throws_message(ArgumentError, "max_contract_skip_fraction") do
         run_gap_calibration(max_contract_skip_fraction = 1.1)
+    end
+    test_throws_message(ArgumentError, "needs both correctness classes") do
+        _heldout_metric_rows(
+            (a = 0.0, b = zeros(5)),
+            (a = 0.0, b = zeros(2)),
+            (
+                labels = [true],
+                rows = [(error_rate = 0.10,)],
+                collapsed_frontier = [false],
+                features = zeros(1, 5),
+                gap_features = zeros(1, 2),
+                scores = [0.0]
+            ); nbins = 2)
     end
 end
 
@@ -158,11 +184,12 @@ Test.@testset "Per-base correction-confidence feature alignment" begin
         Test.@test length(gt.positions) == n_rows
         Test.@test length(gt.candidate_edits) == n_rows
         Test.@test length(gt.feature_rows) == n_rows
-        Test.@test size(gt.features) == (n_rows, 4)
+        Test.@test size(gt.features) == (n_rows, 5)
         Test.@test all(isfinite, gt.features)
         Test.@test all(gt.features[:, 2] .>= 1.0)
         Test.@test all(value -> value == 0.0 || value == 1.0, gt.features[:, 3])
         Test.@test all(value -> 0.0 <= value <= 1.0, gt.features[:, 4])
+        Test.@test all(value -> value == 0.0 || value == 1.0, gt.features[:, 5])
 
         path = only(gt.result.paths).path
         Test.@test path !== nothing
@@ -180,6 +207,8 @@ Test.@testset "Per-base correction-confidence feature alignment" begin
                        expected_features.all_stage0_solid
             Test.@test gt.feature_rows[row_index].competing_branch_support_ratio ==
                        expected_features.competing_branch_support_ratio
+            Test.@test gt.feature_rows[row_index].collapsed_frontier ==
+                       (gt.scores[row_index] == Inf)
             Test.@test gt.candidate_edits[row_index] ==
                        (corrected_sequence[gt.positions[row_index]] !=
                         observed[gt.positions[row_index]])

--- a/test/4_assembly/viterbi_gap_calibration_test.jl
+++ b/test/4_assembly/viterbi_gap_calibration_test.jl
@@ -39,17 +39,54 @@ Test.@testset "Grouped held-out correction-confidence calibration" begin
             results_dir = dir,
             return_artifact = true
         )
-        csv_path = joinpath(dir, "rhizomorph_gap_calibration.csv")
-        model_path = joinpath(dir, "rhizomorph_gap_calibration_model.csv")
-        manifest_path = joinpath(dir, "rhizomorph_gap_calibration_manifest.csv")
+        csv_path = result.metrics_path
+        model_path = result.model_path
+        audit_path = result.replicate_audit_path
+        manifest_path = result.manifest_path
+        Test.@test dirname(result.bundle_path) == dir
+        Test.@test startswith(
+            basename(result.bundle_path), "rhizomorph_gap_calibration_")
         Test.@test isfile(csv_path)
         Test.@test isfile(model_path)
+        Test.@test isfile(audit_path)
         Test.@test isfile(manifest_path)
         Test.@test startswith(readline(csv_path),
             "scope,error_rate,model,n,positive_frac,auroc,ece,brier")
         Test.@test readline(model_path) == "model,term,coefficient"
+        Test.@test startswith(readline(audit_path),
+            "error_rate,replicate,contract_skips,read_passes")
         Test.@test readline(manifest_path) == "key,value"
-        Test.@test "assigned_q,21" in readlines(manifest_path)
+        manifest_lines = readlines(manifest_path)
+        Test.@test "artifact_status,publishable" in manifest_lines
+        Test.@test "assigned_q,21" in manifest_lines
+        Test.@test "evaluation_scope,within_cohort_read_grouped_holdout" in
+                   manifest_lines
+        Test.@test "whole_graph_holdout,false" in manifest_lines
+        Test.@test "error_generator_distribution,bernoulli_per_base" in
+                   manifest_lines
+        Test.@test "frontier_simulator_parity_claimed,false" in manifest_lines
+        Test.@test "feature_schema_version,td-21eg-v1" in manifest_lines
+        Test.@test any(line -> startswith(line, "dataset_sha256,"), manifest_lines)
+        Test.@test any(line -> startswith(line, "model_sha256,"), manifest_lines)
+        Test.@test any(line -> startswith(line, "source_sha,"), manifest_lines)
+        Test.@test any(
+            line -> startswith(
+                line, "optimizer_multifeature_logistic_final_loss,"),
+            manifest_lines)
+        Test.@test "logistic_l2,0.01" in manifest_lines
+
+        # Publishing the same coherent contents again must create a distinct
+        # bundle rather than overwrite or mix with the first run.
+        second = _publish_calibration_bundle(
+            dir, result.rows, result.multifeature_model, result.gap_model,
+            result.replicate_audit, ["test_bundle" => "true"])
+        Test.@test second.bundle_path != result.bundle_path
+        Test.@test all(isfile, (
+            second.metrics_path,
+            second.model_path,
+            second.replicate_audit_path,
+            second.manifest_path
+        ))
         result
     end
 
@@ -68,6 +105,17 @@ Test.@testset "Grouped held-out correction-confidence calibration" begin
                joinpath(dirname(artifact.model_path), "rhizomorph_gap_calibration.csv")
     Test.@test artifact.manifest_path == joinpath(
         dirname(artifact.model_path), "rhizomorph_gap_calibration_manifest.csv")
+    Test.@test artifact.replicate_audit_path == joinpath(
+        dirname(artifact.model_path),
+        "rhizomorph_gap_calibration_replicate_audit.csv")
+    Test.@test artifact.bundle_path == dirname(artifact.model_path)
+    Test.@test !isempty(artifact.run_id)
+    Test.@test length(artifact.dataset_sha256) == 64
+    Test.@test length(artifact.model_sha256) == 64
+    Test.@test artifact.feature_schema_version == "td-21eg-v1"
+    Test.@test artifact.evaluation_scope == :within_cohort_read_grouped_holdout
+    Test.@test artifact.multifeature_model.diagnostics.converged
+    Test.@test artifact.gap_model.diagnostics.converged
     Test.@test artifact.training.n > 0
     Test.@test artifact.heldout.n > 0
     Test.@test size(artifact.training.features) == (artifact.training.n, 5)
@@ -92,6 +140,7 @@ Test.@testset "Grouped held-out correction-confidence calibration" begin
     )
     Test.@test artifact.assigned_q == 21
     Test.@test length(artifact.dataset) >= artifact.training.n + artifact.heldout.n
+    Test.@test all(row.replicate == 1 for row in artifact.dataset)
     Test.@test all(row.k >= 1 for row in artifact.dataset)
     Test.@test isempty(intersect(
         Set(artifact.training.groups), Set(artifact.heldout.groups)))
@@ -105,10 +154,35 @@ Test.@testset "Grouped held-out correction-confidence calibration" begin
                    artifact.contract_read_passes[error_rate] <=
                    artifact.max_contract_skip_fraction
     end
-    Test.@test sum(values(artifact.contract_skips)) > 0
+    Test.@test length(artifact.replicate_audit) == 2
+    Test.@test all(row -> row.read_passes > 0, artifact.replicate_audit)
+    Test.@test all(row -> row.candidate_events > 0, artifact.replicate_audit)
+    Test.@test all(row -> row.candidate_bearing_reads > 0,
+        artifact.replicate_audit)
     Test.@test _contract_skip_fraction(1, 4, 0.25) == 0.25
     test_throws_message(ArgumentError, "exceeds configured bound") do
         _contract_skip_fraction(1, 4, 0.2)
+    end
+    test_throws_message(ArgumentError, "zero usable candidate events") do
+        _validate_replicate_audit([(
+            error_rate = 0.10,
+            replicate = 2,
+            contract_skips = 0,
+            read_passes = 10,
+            candidate_events = 0,
+            candidate_bearing_reads = 0
+        )])
+    end
+    test_throws_message(ArgumentError, "did not converge") do
+        _require_converged_logistic((
+                a = 0.0,
+                b = [0.0],
+                diagnostics = (
+                    converged = false,
+                    iterations = 1,
+                    gradient_norm = 1.0
+                )
+            ), "test")
     end
 
     metric_scopes = Set((row.scope, row.error_rate) for row in artifact.rows)
@@ -139,6 +213,11 @@ Test.@testset "Grouped held-out correction-confidence calibration" begin
     Test.@test _uniform_phred_quality_string(3, 0) == "!!!"
     Test.@test _uniform_phred_quality_string(3, 20) == "555"
     Test.@test _uniform_phred_quality_string(3, 93) == "~~~"
+    assigned_record = _calibration_fastq_record("assigned-q", "ACGT", 21)
+    assigned_quality = _uniform_phred_quality_string(4, 21)
+    Test.@test String(FASTX.quality(assigned_record)) == assigned_quality
+    Test.@test all(character -> Int(character) - 33 == 21,
+        FASTX.quality(assigned_record))
     test_throws_message(ArgumentError, "supported Phred range 0:93") do
         run_gap_calibration(assigned_q = -1)
     end
@@ -156,6 +235,24 @@ Test.@testset "Grouped held-out correction-confidence calibration" begin
                 features = zeros(1, 5),
                 gap_features = zeros(1, 2),
                 scores = [0.0]
+            ); nbins = 2)
+    end
+    test_throws_message(ArgumentError, "error-rate scope") do
+        _heldout_metric_rows(
+            (a = 0.0, b = zeros(5)),
+            (a = 0.0, b = zeros(2)),
+            (
+                labels = [true, false, true, true],
+                rows = [
+                    (error_rate = 0.05,),
+                    (error_rate = 0.05,),
+                    (error_rate = 0.10,),
+                    (error_rate = 0.10,)
+                ],
+                collapsed_frontier = falses(4),
+                features = zeros(4, 5),
+                gap_features = zeros(4, 2),
+                scores = zeros(4)
             ); nbins = 2)
     end
 end
@@ -180,6 +277,7 @@ Test.@testset "Per-base correction-confidence feature alignment" begin
         record_position_gaps = true, error_rate = 0.08,
         strand_mode = :doublestrand)
     any_finite = false
+    checked_boundary_windows = false
     for (record, clean) in zip(reads, truths)
         observed = FASTX.sequence(String, record)
         gt = try
@@ -207,18 +305,26 @@ Test.@testset "Per-base correction-confidence feature alignment" begin
         Test.@test path !== nothing
         corrected_sequence = String(Mycelia.Rhizomorph.path_to_sequence(path, fixture.graph))
         gaps = only(gt.result.paths).diagnostics[:position_gaps]
+        checked_boundary_windows |= n_rows >= 3
         for row_index in eachindex(gt.positions)
             gap_index = gt.positions[row_index] - k
-            expected_features = Mycelia.correction_confidence_features(
-                fixture.graph, path, gap_index, k, solid_kmers,
-                Float64(gaps[gap_index]))
+            first_step = gap_index + 1
+            last_step = min(gap_index + k, length(path.steps))
+            overlapping_labels = [path.steps[index].vertex_label
+                                  for index in first_step:last_step]
+            expected_min_support = minimum(
+                Float64(Mycelia._vertex_coverage(fixture.graph[label]))
+                for label in overlapping_labels)
+            expected_all_solid = all(label -> label in solid_kmers,
+                overlapping_labels)
+            expected_branch_ratio = Float64(path.steps[first_step].probability)
             Test.@test gt.feature_rows[row_index].raw_gap == gt.scores[row_index]
             Test.@test gt.feature_rows[row_index].min_kmer_support ==
-                       expected_features.min_kmer_support
+                       expected_min_support
             Test.@test gt.feature_rows[row_index].all_stage0_solid ==
-                       expected_features.all_stage0_solid
+                       expected_all_solid
             Test.@test gt.feature_rows[row_index].competing_branch_support_ratio ==
-                       expected_features.competing_branch_support_ratio
+                       expected_branch_ratio
             Test.@test gt.feature_rows[row_index].collapsed_frontier ==
                        (gt.scores[row_index] == Inf)
             Test.@test gt.candidate_edits[row_index] ==
@@ -231,4 +337,5 @@ Test.@testset "Per-base correction-confidence feature alignment" begin
         any_finite |= any(isfinite, gt.scores)
     end
     Test.@test any_finite
+    Test.@test checked_boundary_windows
 end

--- a/test/4_assembly/viterbi_gap_calibration_test.jl
+++ b/test/4_assembly/viterbi_gap_calibration_test.jl
@@ -33,6 +33,7 @@ Test.@testset "Grouped held-out correction-confidence calibration" begin
             readlen = 80,
             coverage = 15,
             error_rates = [0.08, 0.10],
+            assigned_q = 21,
             seed = 1,
             replicates = 1,
             results_dir = dir,
@@ -48,6 +49,7 @@ Test.@testset "Grouped held-out correction-confidence calibration" begin
             "scope,error_rate,model,n,positive_frac,auroc,ece,brier")
         Test.@test readline(model_path) == "model,term,coefficient"
         Test.@test readline(manifest_path) == "key,value"
+        Test.@test "assigned_q,21" in readlines(manifest_path)
         result
     end
 
@@ -86,8 +88,9 @@ Test.@testset "Grouped held-out correction-confidence calibration" begin
         soft_em = true,
         cheap_correct = true,
         beam_width = nothing,
-        assigned_q = 20
+        assigned_q = 21
     )
+    Test.@test artifact.assigned_q == 21
     Test.@test length(artifact.dataset) >= artifact.training.n + artifact.heldout.n
     Test.@test all(row.k >= 1 for row in artifact.dataset)
     Test.@test isempty(intersect(
@@ -132,6 +135,15 @@ Test.@testset "Grouped held-out correction-confidence calibration" begin
 
     test_throws_message(ArgumentError, "max_contract_skip_fraction") do
         run_gap_calibration(max_contract_skip_fraction = 1.1)
+    end
+    Test.@test _uniform_phred_quality_string(3, 0) == "!!!"
+    Test.@test _uniform_phred_quality_string(3, 20) == "555"
+    Test.@test _uniform_phred_quality_string(3, 93) == "~~~"
+    test_throws_message(ArgumentError, "supported Phred range 0:93") do
+        run_gap_calibration(assigned_q = -1)
+    end
+    test_throws_message(ArgumentError, "supported Phred range 0:93") do
+        run_gap_calibration(assigned_q = 94)
     end
     test_throws_message(ArgumentError, "needs both correctness classes") do
         _heldout_metric_rows(
@@ -216,7 +228,7 @@ Test.@testset "Per-base correction-confidence feature alignment" begin
                        (corrected_sequence[gt.positions[row_index]] ==
                         clean[gt.positions[row_index]])
         end
-        any_finite |= n_rows > 0
+        any_finite |= any(isfinite, gt.scores)
     end
     Test.@test any_finite
 end

--- a/test/4_assembly/viterbi_gap_calibration_test.jl
+++ b/test/4_assembly/viterbi_gap_calibration_test.jl
@@ -1,77 +1,193 @@
-# Stage 2 gap calibration signal check (td-4osf): the per-position Viterbi gap
-# must DISCRIMINATE a correct decoded base from a wrong one (AUROC > 0.5), and the
-# gap<->path alignment contract must hold on real decodes.
+# Multi-feature per-base correction-confidence calibration (td-21eg).
 #
-# The finite-gap signal only exists on a BRANCHING graph — a read-coverage k-mer
-# graph carries the error/repeat-induced competition the decoder navigates,
-# whereas a truth-only (linear) graph has a single surviving state per depth and
-# every gap is Inf. So this drives the coverage-graph harness in
-# benchmarking/viterbi_gap_calibration.jl (not swept by Pkg.test()) at small scale.
-#
-# Run:
-#   julia --project=. test/4_assembly/viterbi_gap_calibration_test.jl
+# The finite-gap signal only exists on a branching graph. This focused test
+# drives the coverage-graph harness at small scale, verifies feature alignment,
+# and enforces read-grouped train/holdout isolation.
 
 import Test
 import Mycelia
 import FASTX
 
 include(joinpath(@__DIR__, "..", "..", "benchmarking", "viterbi_gap_calibration.jl"))
+if !isdefined(Main, :test_throws_message)
+    include(joinpath(dirname(@__DIR__), "test_helpers.jl"))
+end
 
-Test.@testset "Tier-2 gap calibration signal (AUROC > 0.5)" begin
-    # Small, deterministic coverage-graph run at err=0.08/0.10; aggregate finite
-    # gaps + truth labels and fit all three calibration models.
-    rows = mktempdir() do dir
-        run_gap_calibration(; k = 11, genome_length = 500, readlen = 120, coverage = 25,
-            error_rates = [0.08, 0.10], seed = 1, results_dir = dir)
+Test.@testset "Grouped held-out correction-confidence calibration" begin
+    synthetic_rows = [(error_rate = er, read_id = "r$(read_id)")
+                      for er in (0.05, 0.10) for read_id in 1:10 for _ in 1:2]
+    split_a = grouped_read_split(synthetic_rows; holdout_fraction = 0.2, seed = 9)
+    split_b = grouped_read_split(synthetic_rows; holdout_fraction = 0.2, seed = 9)
+    Test.@test split_a.training_indices == split_b.training_indices
+    Test.@test split_a.heldout_indices == split_b.heldout_indices
+    Test.@test isempty(intersect(split_a.training_groups, split_a.heldout_groups))
+    Test.@test length(split_a.heldout_groups) == 4
+    test_throws_message(ArgumentError, "holdout_fraction must be") do
+        grouped_read_split(synthetic_rows; holdout_fraction = 1.0)
     end
 
-    Test.@test !isempty(rows)                       # class balance sufficient to fit
-    # BOTH requested error rates must yield results — otherwise a silently-skipped
-    # rate (insufficient class balance / regression) would pass unnoticed.
-    Test.@test Set(r.error_rate for r in rows) == Set([0.08, 0.10])
+    artifact = mktempdir() do dir
+        result = run_gap_calibration(;
+            k = 9,
+            genome_length = 300,
+            readlen = 80,
+            coverage = 15,
+            error_rates = [0.08, 0.10],
+            seed = 1,
+            replicates = 1,
+            results_dir = dir,
+            return_artifact = true
+        )
+        csv_path = joinpath(dir, "rhizomorph_gap_calibration.csv")
+        model_path = joinpath(dir, "rhizomorph_gap_calibration_model.csv")
+        manifest_path = joinpath(dir, "rhizomorph_gap_calibration_manifest.csv")
+        Test.@test isfile(csv_path)
+        Test.@test isfile(model_path)
+        Test.@test isfile(manifest_path)
+        Test.@test startswith(readline(csv_path),
+            "scope,error_rate,model,n,positive_frac,auroc,ece,brier")
+        Test.@test readline(model_path) == "model,term,coefficient"
+        Test.@test readline(manifest_path) == "key,value"
+        result
+    end
 
-    # AUROC is shared across models per error rate (property of the raw gap ranking).
-    for er in unique(r.error_rate for r in rows)
-        er_rows = filter(r -> r.error_rate == er, rows)
-        aurocs = unique(r.auroc for r in er_rows)
-        Test.@test length(aurocs) == 1
-        au = only(aurocs)
-        Test.@test !isnan(au)
-        Test.@test au > 0.55                        # the gap is a usable signal (>> chance)
-        # All three models present with finite calibration metrics.
-        Test.@test Set(r.model for r in er_rows) == Set(["isotonic", "logistic", "binned"])
-        for r in er_rows
-            Test.@test isfinite(r.ece) && 0.0 <= r.ece <= 1.0
-            Test.@test isfinite(r.brier) && 0.0 <= r.brier <= 1.0
+    Test.@test artifact.feature_names == CORRECTION_CONFIDENCE_FEATURES
+    Test.@test artifact.feature_names == (
+        :raw_gap,
+        :min_kmer_support,
+        :all_stage0_solid,
+        :competing_branch_support_ratio
+    )
+    Test.@test length(artifact.multifeature_model.b) == 4
+    Test.@test artifact.gap_model.b isa Float64
+    Test.@test artifact.metrics_path ==
+               joinpath(dirname(artifact.model_path), "rhizomorph_gap_calibration.csv")
+    Test.@test artifact.manifest_path == joinpath(
+        dirname(artifact.model_path), "rhizomorph_gap_calibration_manifest.csv")
+    Test.@test artifact.training.n > 0
+    Test.@test artifact.heldout.n > 0
+    Test.@test size(artifact.training.features) == (artifact.training.n, 4)
+    Test.@test size(artifact.heldout.features) == (artifact.heldout.n, 4)
+    Test.@test all(row.candidate_edit for row in artifact.training.rows)
+    Test.@test all(row.candidate_edit for row in artifact.heldout.rows)
+    Test.@test artifact.serving_config == (
+        max_k = 13,
+        skip_solid = false,
+        graph_mode = :doublestrand,
+        n_k_rungs = 3,
+        max_iterations_per_k = 2,
+        hard_window = false,
+        soft_em = true,
+        cheap_correct = true,
+        beam_width = nothing,
+        assigned_q = 20
+    )
+    Test.@test length(artifact.dataset) >= artifact.training.n + artifact.heldout.n
+    Test.@test all(row.k >= 1 for row in artifact.dataset)
+    Test.@test isempty(intersect(
+        Set(artifact.training.groups), Set(artifact.heldout.groups)))
+    for error_rate in (0.08, 0.10)
+        Test.@test any(group -> group[1] == error_rate,
+            artifact.split.training_groups)
+        Test.@test any(group -> group[1] == error_rate,
+            artifact.split.heldout_groups)
+        Test.@test artifact.contract_read_passes[error_rate] > 0
+        Test.@test artifact.contract_skips[error_rate] /
+                   artifact.contract_read_passes[error_rate] <=
+                   artifact.max_contract_skip_fraction
+    end
+
+    metric_scopes = Set((row.scope, row.error_rate) for row in artifact.rows)
+    Test.@test ("pooled", nothing) in metric_scopes
+    Test.@test ("error-rate", 0.08) in metric_scopes
+    Test.@test ("error-rate", 0.10) in metric_scopes
+    for scope in metric_scopes
+        scope_rows = filter(
+            row -> (row.scope, row.error_rate) == scope, artifact.rows)
+        Test.@test Set(row.model for row in scope_rows) ==
+                   Set(["multifeature-logistic", "gap-only-logistic"])
+        for row in scope_rows
+            Test.@test row.n > 0
+            Test.@test isfinite(row.ece) && 0.0 <= row.ece <= 1.0
+            Test.@test isfinite(row.brier) && 0.0 <= row.brier <= 1.0
+            Test.@test all(bin.count > 0 for bin in row.reliability)
         end
     end
+    pooled = filter(row -> row.scope == "pooled", artifact.rows)
+    Test.@test all(!isnan(row.auroc) for row in pooled)
+    Test.@test only(filter(row -> row.model == "gap-only-logistic", pooled)).auroc > 0.5
 
-    # --- Alignment contract + finite gaps on a real coverage-graph decode -------
+    test_throws_message(ArgumentError, "max_contract_skip_fraction") do
+        run_gap_calibration(max_contract_skip_fraction = 1.1)
+    end
+end
+
+Test.@testset "Per-base correction-confidence feature alignment" begin
     rng = Random.MersenneTwister(3)
     genome = String(rand(rng, ['A', 'C', 'G', 'T'], 500))
     k = 11
     reads = FASTX.FASTQ.Record[]
     truths = String[]
     for i in 1:40
-        st = rand(rng, 1:(500 - 120 + 1))
-        clean = genome[st:(st + 119)]
-        obs = _inject_substitutions(clean, 0.08, rng)
-        push!(reads, FASTX.FASTQ.Record("r$i", obs, String(fill('I', 120))))
+        start = rand(rng, 1:(500 - 120 + 1))
+        clean = genome[start:(start + 119)]
+        observed = _inject_substitutions(clean, 0.08, rng)
+        push!(reads, FASTX.FASTQ.Record(
+            "r$(i)", observed, String(fill('I', 120))))
         push!(truths, clean)
     end
-    cov = build_coverage_fixture(reads, k)
-    cfg = Mycelia.ViterbiCorrectionConfig(record_position_gaps = true, error_rate = 0.08)
+    fixture = build_coverage_fixture(reads, k)
+    solid_kmers = Mycelia._solid_kmer_set(fixture.graph)
+    config = Mycelia.ViterbiCorrectionConfig(
+        record_position_gaps = true, error_rate = 0.08,
+        strand_mode = :doublestrand)
     any_finite = false
-    for (rec, clean) in zip(reads, truths)
+    for (record, clean) in zip(reads, truths)
+        observed = FASTX.sequence(String, record)
         gt = try
-            collect_gap_truth(cov, FASTX.sequence(String, rec), clean; config = cfg)
-        catch
-            continue
+            collect_gap_truth(fixture, observed, clean;
+                config = config, solid_kmers = solid_kmers)
+        catch error
+            if error isa ArgumentError && occursin("decode produced no path", error.msg)
+                continue
+            end
+            rethrow()
         end
-        Test.@test length(gt.scores) == length(gt.labels)
-        Test.@test all(isfinite, gt.scores)         # Inf sentinels already filtered
-        Test.@test all(p -> p >= 1, gt.positions)
-        any_finite |= !isempty(gt.scores)
+        n_rows = length(gt.scores)
+        Test.@test length(gt.labels) == n_rows
+        Test.@test length(gt.positions) == n_rows
+        Test.@test length(gt.candidate_edits) == n_rows
+        Test.@test length(gt.feature_rows) == n_rows
+        Test.@test size(gt.features) == (n_rows, 4)
+        Test.@test all(isfinite, gt.features)
+        Test.@test all(gt.features[:, 2] .>= 1.0)
+        Test.@test all(value -> value == 0.0 || value == 1.0, gt.features[:, 3])
+        Test.@test all(value -> 0.0 <= value <= 1.0, gt.features[:, 4])
+
+        path = only(gt.result.paths).path
+        Test.@test path !== nothing
+        corrected_sequence = String(Mycelia.Rhizomorph.path_to_sequence(path, fixture.graph))
+        gaps = only(gt.result.paths).diagnostics[:position_gaps]
+        for row_index in eachindex(gt.positions)
+            gap_index = gt.positions[row_index] - k
+            expected_features = Mycelia.correction_confidence_features(
+                fixture.graph, path, gap_index, k, solid_kmers,
+                Float64(gaps[gap_index]))
+            Test.@test gt.feature_rows[row_index].raw_gap == gt.scores[row_index]
+            Test.@test gt.feature_rows[row_index].min_kmer_support ==
+                       expected_features.min_kmer_support
+            Test.@test gt.feature_rows[row_index].all_stage0_solid ==
+                       expected_features.all_stage0_solid
+            Test.@test gt.feature_rows[row_index].competing_branch_support_ratio ==
+                       expected_features.competing_branch_support_ratio
+            Test.@test gt.candidate_edits[row_index] ==
+                       (corrected_sequence[gt.positions[row_index]] !=
+                        observed[gt.positions[row_index]])
+            Test.@test gt.labels[row_index] ==
+                       (corrected_sequence[gt.positions[row_index]] ==
+                        clean[gt.positions[row_index]])
+        end
+        any_finite |= n_rows > 0
     end
-    Test.@test any_finite                            # the coverage graph yields finite gaps
+    Test.@test any_finite
 end


### PR DESCRIPTION
## Summary

- emit one runtime-serving feature vector for each proposed substitution: raw Viterbi gap, minimum overlapping k-mer support, Stage-0 solidity, normalized competing-branch support, and an explicit collapsed-frontier indicator
- fit multi-feature and gap-only logistic probability maps on deterministic, read-grouped train/holdout partitions; require L2-regularized optimizer convergence before publishing or serving either model
- add an opt-in, substitution-only `P(correct | features) >= tau` gate and a calibrated-probability operating-point family
- make frontier dominance fail closed for failed, partial, unaudited, or cohort-mismatched sweeps
- preserve gate-OFF byte identity and disable the gate/sink when `indel_params !== nothing`

## Calibration evidence and limits

The calibration harness uses the doublestrand qualmer / Stage-0 / three-rung / two-iteration / soft-EM / auto-beam serving path. Bases from the same read cannot cross the deterministic train/holdout boundary. The manifest now explicitly records that this is a **within-cohort read-grouped holdout**, not an independent whole-graph holdout, and records feature order, simulator configuration, optimizer diagnostics, source lineage, dataset/model digests, and per-replicate contract audits.

A prior exploratory, pre-convergence-hardening run produced these point estimates. They are retained only to motivate the next evaluation; they are **not** a current-head coefficient artifact or evidence of independent graph-regime generalization:

| Scope | Model | AUROC | ECE | Brier |
|---|---:|---:|---:|---:|
| pooled | multi-feature | 0.579 | 0.0962 | 0.1012 |
| pooled | gap-only | 0.507 | 0.0857 | 0.1052 |
| err=0.05 | multi-feature | 0.808 | 0.0767 | 0.0882 |
| err=0.05 | gap-only | 0.793 | 0.0705 | 0.0990 |
| err=0.10 | multi-feature | 0.462 | 0.1057 | 0.1075 |
| err=0.10 | gap-only | 0.360 | 0.1017 | 0.1082 |

The multi-feature model had a higher AUROC and lower Brier point estimate than the gap-only encoding in that run, but pooled discrimination remained weak, err=0.10 was below chance, and ECE was slightly worse. Current code refuses to publish or serve an unconverged fit. A confirmatory evaluation across independently generated coverage graphs and graph regimes is tracked in `td-pw7p.2`.

## Frontier verdict

**Blocked / inconclusive; this PR does not claim strict dominance or a publishable negative result.** The prior smoke `noskip+nogate` baseline scored only 5/200 reads at err=0.10 and 61/200 at err=0.05 because the pre-existing substitution decoder emitted truncated or length-divergent reconstructions. The probability threshold also changed the surviving read subset. `assess_frontier_dominance` now rejects failed or partial rows, mismatched read or injected-error cohorts, inactive gates, contract skips above the configured bound, and non-finite metrics.

The serving-path reconstruction fix is intentionally out of scope because changing ungated substitution behavior here would violate this lane's gate-OFF byte-identity requirement. Follow-up: `td-pw7p.1`. Until that is fixed, neither a dominance claim nor a valid negative result is available.

## Verification

Current focused evidence:

- `gap_calibration_fitters_test.jl`: 60/60
- `viterbi_gap_calibration_test.jl`: 134/134 grouped calibration + 30,962/30,962 feature alignment
- `correction_feature_sink_test.jl`: 929/929
- `calibrated_gap_gate_identity_test.jl`: 66/66
- `calibrated_probability_gate_identity_test.jl`: 30/30
- `calibrated_gate_indel_failopen_test.jl`: 26/26
- `frontier_dominance_test.jl`: 15/15 operating-point/provenance + 48/48 dominance
- `rhizomorph_calibrated_gate_frontier_test.jl`: 11/11
- `import Mycelia`: pass
- `git diff --check`: pass

The gate remains OFF by default, metadata is unchanged when not requested, and indel-mode requests are provenance-only and do not execute.

## Review state

- draft because scientific acceptance remains blocked by `td-pw7p.1`
- current head: `d21f3b7c`
- branch merge-base: `99c741b7`; live `origin/master` advanced to `548dc984` after PR #416, so the head is 1 behind / 6 ahead. The draft was intentionally not rebased while scientific acceptance remains blocked; rebase and rerun CI before any merge.
- six-lens comprehensive local review plus post-fix integration re-review: pass; no open Critical or Important findings
- CodeRabbit current-head incremental review completed with no new actionable findings; all prior inline feedback is addressed, replied to, and resolved
- all current-head CI checks green, including LTS tests (39m19s), docs, lint, CodeQL, and GitGuardian
- remote Codex review unavailable because the repository connector is not configured
- no admin merge requested
