### PR TITLE
add: stage indel decode by vertex budget (blocked null)

### DIFF
--- a/scratchpad/measure_indel_decode_vertex_budget.jl
+++ b/scratchpad/measure_indel_decode_vertex_budget.jl
@@ -1,0 +1,162 @@
+# td-2rxh runtime-only calibration for `_INDEL_DECODE_MAX_VERTICES`.
+#
+# Run from the Mycelia repository root:
+#   LD_LIBRARY_PATH='' julia --project=. \
+#     scratchpad/measure_indel_decode_vertex_budget.jl
+#
+# This fixes the graph-size ceiling from a 200 ms/read compute budget. It does
+# not measure or consume correction accuracy.
+
+import BioSequences
+import FASTX
+import Graphs
+import Mycelia
+import Random
+import Statistics
+
+const K = 13
+const BUDGET_MS = 200.0
+const CONFIRMATION_MEDIANS_MS = Dict(
+    1_996 => [165.643, 153.788],
+    3_610 => [263.639, 279.200],
+    4_972 => [475.403, 326.281],
+    6_068 => [451.029, 383.677],
+)
+
+function make_reads()::Vector{FASTX.FASTQ.Record}
+    Random.seed!(20260712)
+    reference = Mycelia.random_fasta_record(
+        moltype = :DNA, seed = 20260712, L = 3_000)
+    reference_sequence = FASTX.sequence(BioSequences.LongDNA{4}, reference)
+    read_length = 1_000
+    n_reads = 90
+    reads = FASTX.FASTQ.Record[]
+    for read_index in 1:n_reads
+        start = 1 + mod((read_index - 1) * 37, length(reference_sequence) - read_length + 1)
+        template = reference_sequence[start:(start + read_length - 1)]
+        observed, qualities = Mycelia.observe(
+            template; error_rate = 0.05, tech = :nanopore)
+        quality = String([Char(score + 33) for score in qualities])
+        push!(reads, FASTX.FASTQ.Record("read_$(read_index)", string(observed), quality))
+    end
+    return reads
+end
+
+function probe_record(read::FASTX.FASTQ.Record)::FASTX.FASTQ.Record
+    sequence = FASTX.sequence(String, read)
+    quality = String(FASTX.quality(read))
+    probe_length = min(200, length(sequence))
+    return FASTX.FASTQ.Record(
+        "probe", sequence[1:probe_length], quality[1:probe_length])
+end
+
+function quality_observations(
+        read::FASTX.FASTQ.Record
+)::Vector{Mycelia.QualityObservation}
+    sequence_string = FASTX.sequence(String, read)
+    alphabet = Mycelia.detect_alphabet(sequence_string)
+    sequence_type = Mycelia.alphabet_to_biosequence_type(alphabet)
+    sequence = Mycelia.extract_typed_sequence(read, sequence_type)
+    kmers = collect(Mycelia._record_kmer_iterator(sequence_type, K, sequence))
+    quality_scores = collect(FASTX.quality_scores(read))
+    observations = Vector{Mycelia.QualityObservation}(undef, length(kmers))
+    for (index, kmer) in enumerate(kmers)
+        lo = clamp(index, 1, length(quality_scores))
+        hi = clamp(index + K - 1, 1, length(quality_scores))
+        observations[index] = Mycelia.QualityObservation(
+            kmer, UInt8.(@view quality_scores[lo:hi]))
+    end
+    return observations
+end
+
+function indel_config(n_observations::Int, n_vertices::Int)::Mycelia.ViterbiCorrectionConfig
+    profile = Mycelia.indel_error_profile(:nanopore)
+    knobs = Mycelia.Rhizomorph._corrector_strategy_knobs(:scalable)
+    beam_width = Mycelia._auto_beam_width(n_observations, n_vertices)
+    beam_is_exact = beam_width == typemax(Int)
+    return Mycelia.ViterbiCorrectionConfig(
+        alphabet = :DNA,
+        strand_mode = :doublestrand,
+        max_steps = n_observations - 1,
+        beam_width = beam_width,
+        max_successors_per_state = beam_is_exact ? typemax(Int) :
+                                   Mycelia._AUTO_SUCCESSOR_BOUND,
+        beam_score_margin = beam_is_exact ? Inf : Mycelia._AUTO_BEAM_SCORE_MARGIN,
+        error_rate = profile.base_error_rate,
+        indel_moves = true,
+        insertion_fraction = profile.insertion_fraction,
+        deletion_fraction = profile.deletion_fraction,
+        insertion_extend_probability = profile.insertion_extend_probability,
+        deletion_extend_probability = profile.deletion_extend_probability,
+        deletion_max_run = knobs.deletion_max_run,
+        max_insertion_run = knobs.max_insertion_run,
+        band_width = knobs.band_width)
+end
+
+function measure_graph(
+        graph::Graphs.AbstractGraph,
+        observations::Vector{Mycelia.QualityObservation}
+)::NamedTuple
+    n_vertices = Graphs.nv(graph)
+    config = indel_config(length(observations), n_vertices)
+    weighted_graph = Mycelia.build_correction_weighted_graph(graph; config = config)
+    warm = Mycelia.correct_observations(
+        graph, [observations]; config = config, weighted_graph = weighted_graph)
+    warm_path = only(warm.paths)
+    algorithm = get(warm_path.diagnostics, :algorithm, :missing)
+    valid = algorithm == :viterbi_indel_pair_hmm && warm_path.path !== nothing
+    timings_ms = Float64[]
+    if valid
+        for _ in 1:5
+            elapsed = @elapsed Mycelia.correct_observations(
+                graph, [observations]; config = config, weighted_graph = weighted_graph)
+            push!(timings_ms, elapsed * 1_000)
+        end
+    end
+    return (
+        n_vertices = n_vertices,
+        median_ms = isempty(timings_ms) ? Inf : Statistics.median(timings_ms),
+        timings_ms = timings_ms,
+        beam_width = config.beam_width,
+        valid = valid,
+        algorithm = algorithm)
+end
+
+function main()::Nothing
+    reads = make_reads()
+    probe = probe_record(first(reads))
+    observations = quality_observations(probe)
+    prefix_sizes = [1, 2, 3, 4]
+    measurements = NamedTuple[]
+    println("budget_ms=$(BUDGET_MS),k=$(K),probe_bases=$(length(FASTX.sequence(probe)))")
+    for prefix_size in prefix_sizes
+        graph = Mycelia.Rhizomorph.build_qualmer_graph(
+            reads[1:prefix_size], K; mode = :doublestrand)
+        measurement = measure_graph(graph, observations)
+        push!(measurements, (; prefix_size = prefix_size, measurement...))
+        println("prefix=$(prefix_size),nv=$(measurement.n_vertices)," *
+                "median_ms=$(round(measurement.median_ms, digits = 3))," *
+                "timings_ms=$(round.(measurement.timings_ms, digits = 3))," *
+                "beam=$(measurement.beam_width),valid=$(measurement.valid)," *
+                "algorithm=$(measurement.algorithm)")
+    end
+
+    # The ceiling is fixed from two independent fresh-process confirmations,
+    # not from whichever transient load this reproduction run happens to see.
+    # A vertex count is admitted only when every confirmation median met the
+    # budget; this conservative all-runs rule selects 1,996, rounded to 2,000.
+    confirmed = sort(collect(CONFIRMATION_MEDIANS_MS); by = first)
+    ceiling = nothing
+    for (n_vertices, medians_ms) in confirmed
+        if all(<=(BUDGET_MS), medians_ms)
+            ceiling = n_vertices
+        end
+    end
+    println("confirmation_medians_ms=$(CONFIRMATION_MEDIANS_MS)")
+    println("selected_ceiling=$(ceiling),selection=largest_nv_with_all_" *
+            "independent_run_medians_under_$(Int(BUDGET_MS))ms")
+    println("rounded_package_ceiling=$(Mycelia._INDEL_DECODE_MAX_VERTICES)")
+    return nothing
+end
+
+main()

--- a/scratchpad/step5_toy_proof.jl
+++ b/scratchpad/step5_toy_proof.jl
@@ -1,0 +1,290 @@
+# td-2rxh Step 5 toy proof: staged indel correction on the same long-read fixture.
+#
+# Run from the Mycelia repository root:
+#   LD_LIBRARY_PATH='' julia --project=. scratchpad/step5_toy_proof.jl
+#
+# The fixture and seeds are fixed before observing any accuracy result. Both arms
+# receive byte-identical indel-rich nanopore reads; only the correction profile
+# differs. The vertex ceiling remains the package constant derived from the
+# independent decode-time calibration and is never tuned here.
+
+import BioSequences
+import FASTX
+import Mycelia
+import Random
+
+const GENOME_LENGTH = 2_000
+const SOURCE_READ_LENGTH = 1_200
+const COVERAGE = 8
+const ERROR_RATE = 0.05
+const FIXTURE_SEED = 42
+const CORRECTOR_SEED = 1_042
+const MAX_K = 31
+const MAX_NANOPORE_WALL_SECONDS = 120.0
+const DECODE_BUDGET_MS = 200.0
+const DECODE_VERTEX_CALIBRATION = [
+    (n_vertices = 1_996, confirmation_medians_ms = (165.643, 153.788)),
+    (n_vertices = 3_610, confirmation_medians_ms = (263.639, 279.200)),
+    (n_vertices = 4_972, confirmation_medians_ms = (475.403, 326.281)),
+    (n_vertices = 6_068, confirmation_medians_ms = (451.029, 383.677)),
+]
+
+function make_fixture()::Tuple{
+        Vector{FASTX.FASTQ.Record}, BioSequences.LongDNA{4}}
+    reference_record = Mycelia.random_fasta_record(
+        moltype = :DNA,
+        seed = FIXTURE_SEED,
+        L = GENOME_LENGTH,
+    )
+    reference = FASTX.sequence(BioSequences.LongDNA{4}, reference_record)
+    rng = Random.MersenneTwister(FIXTURE_SEED)
+    Random.seed!(FIXTURE_SEED)
+
+    n_reads = ceil(Int, COVERAGE * GENOME_LENGTH / SOURCE_READ_LENGTH)
+    reads = FASTX.FASTQ.Record[]
+    for read_index in 1:n_reads
+        start_position = rand(
+            rng,
+            1:(GENOME_LENGTH - SOURCE_READ_LENGTH + 1),
+        )
+        fragment = reference[
+            start_position:(start_position + SOURCE_READ_LENGTH - 1)]
+        if rand(rng, Bool)
+            fragment = BioSequences.reverse_complement(fragment)
+        end
+        observed, qualities = Mycelia.observe(
+            fragment;
+            error_rate = ERROR_RATE,
+            tech = :nanopore,
+        )
+        isempty(observed) && continue
+        quality_string = String([Char(quality + 33) for quality in qualities])
+        push!(
+            reads,
+            FASTX.FASTQ.Record(
+                "nanopore_read_$(read_index)",
+                string(observed),
+                quality_string,
+            ),
+        )
+    end
+    return reads, reference
+end
+
+function calculate_n50(contigs::Vector{String})::Int
+    isempty(contigs) && return 0
+    lengths = sort(length.(contigs); rev = true)
+    target = cld(sum(lengths), 2)
+    cumulative = 0
+    for contig_length in lengths
+        cumulative += contig_length
+        cumulative >= target && return contig_length
+    end
+    return 0
+end
+
+function best_reference_alignment(
+        contigs::Vector{String},
+        reference::BioSequences.LongDNA{4},
+)::NamedTuple
+    reference_forward = string(reference)
+    reference_reverse = string(BioSequences.reverse_complement(reference))
+    best = (
+        identity = 0.0,
+        edit_distance = typemax(Int),
+        matches = 0,
+        aligned_bases = 0,
+        contig_length = 0,
+        orientation = :none,
+    )
+
+    for contig in contigs
+        for (orientation, target) in (
+                (:forward, reference_forward),
+                (:reverse, reference_reverse),
+        )
+            alignment = Mycelia.assess_alignment(contig, target)
+            aligned_bases = alignment.total_matches + alignment.total_edits
+            identity = aligned_bases == 0 ?
+                       0.0 : alignment.total_matches / aligned_bases
+            candidate = (
+                identity = identity,
+                edit_distance = alignment.total_edits,
+                matches = alignment.total_matches,
+                aligned_bases = aligned_bases,
+                contig_length = length(contig),
+                orientation = orientation,
+            )
+            if candidate.identity > best.identity ||
+               (candidate.identity == best.identity &&
+                candidate.matches > best.matches) ||
+               (candidate.identity == best.identity &&
+                candidate.matches == best.matches &&
+                candidate.edit_distance < best.edit_distance)
+                best = candidate
+            end
+        end
+    end
+    return best
+end
+
+function run_arm(
+        reads::Vector{FASTX.FASTQ.Record},
+        reference::BioSequences.LongDNA{4},
+        sequencing_tech::Symbol,
+)::NamedTuple
+    # Reset the corrector RNG so repeated script runs are deterministic and both
+    # correction profiles begin from the same random state.
+    Random.seed!(CORRECTOR_SEED)
+    local assembly::Mycelia.Rhizomorph.AssemblyResult
+    wall_seconds = @elapsed begin
+        assembly = Mycelia.Rhizomorph.assemble_genome(
+            deepcopy(reads);
+            k = MAX_K,
+            corrector = :iterative,
+            strategy = :scalable,
+            sequencing_tech = sequencing_tech,
+        )
+    end
+
+    alignment = best_reference_alignment(assembly.contigs, reference)
+    stats = assembly.assembly_stats
+    return (
+        sequencing_tech = sequencing_tech,
+        wall_seconds = wall_seconds,
+        identity = alignment.identity,
+        edit_distance = alignment.edit_distance,
+        matches = alignment.matches,
+        aligned_bases = alignment.aligned_bases,
+        best_contig_length = alignment.contig_length,
+        best_orientation = alignment.orientation,
+        n_contigs = length(assembly.contigs),
+        total_assembled_bases = sum(length, assembly.contigs; init = 0),
+        largest_contig = isempty(assembly.contigs) ? 0 : maximum(length, assembly.contigs),
+        n50 = calculate_n50(assembly.contigs),
+        k_progression = get(stats, "k_progression", Int[]),
+        rung_vertex_counts = get(
+            stats,
+            "rung_vertex_counts",
+            Dict{Int, Vector{Int}}(),
+        ),
+        staged_indel_rungs = get(stats, "staged_indel_rungs", NamedTuple[]),
+        indel_moves = get(stats, "indel_moves", false),
+        indel_decodes = get(stats, "indel_decodes", 0),
+        truncated_decodes = get(stats, "truncated_decodes", 0),
+        trace_contract_errors = get(stats, "trace_contract_errors", 0),
+        window_divergences = get(stats, "window_divergences", 0),
+        reassembly_k = get(stats, "reassembly_k", nothing),
+        reassembly_k_ceiling = get(stats, "reassembly_k_ceiling", nothing),
+    )
+end
+
+function rung_k(rung::Any)::Union{Int, Nothing}
+    if rung isa NamedTuple
+        return get(rung, :k, nothing)
+    elseif rung isa Pair && first(rung) isa Int
+        return first(rung)
+    end
+    return nothing
+end
+
+function rung_vertices(rung::Any)::Union{Int, Nothing}
+    if rung isa NamedTuple
+        return get(rung, :n_vertices, get(rung, :nv, nothing))
+    elseif rung isa Pair && last(rung) isa Int
+        return last(rung)
+    end
+    return nothing
+end
+
+function print_arm(result::NamedTuple)::Nothing
+    println("\n$(result.sequencing_tech) correction arm")
+    println("  wall_seconds:          $(round(result.wall_seconds; digits = 3))")
+    println("  identity:              $(round(result.identity; digits = 6))")
+    println("  edit_distance:         $(result.edit_distance)")
+    println("  matches/aligned:       $(result.matches)/$(result.aligned_bases)")
+    println("  best_contig_length:    $(result.best_contig_length)")
+    println("  best_orientation:      $(result.best_orientation)")
+    println("  contigs/total/largest: $(result.n_contigs)/" *
+            "$(result.total_assembled_bases)/$(result.largest_contig)")
+    println("  N50:                   $(result.n50)")
+    println("  k_progression:         $(result.k_progression)")
+    println("  graph vertices/pass:   $(result.rung_vertex_counts)")
+    println("  reassembly k/ceiling:  $(result.reassembly_k)/" *
+            "$(result.reassembly_k_ceiling)")
+    println("  indel_moves:           $(result.indel_moves)")
+    println("  indel_decodes:         $(result.indel_decodes)")
+    println("  truncated_decodes:     $(result.truncated_decodes)")
+    println("  trace_contract_errors: $(result.trace_contract_errors)")
+    println("  window_divergences:    $(result.window_divergences)")
+    println("  staged indel rungs (actual k/nv):")
+    if isempty(result.staged_indel_rungs)
+        println("    none")
+    else
+        for rung in result.staged_indel_rungs
+            println("    k=$(rung_k(rung)), nv=$(rung_vertices(rung))")
+        end
+    end
+    return nothing
+end
+
+function main()::Nothing
+    reads, reference = make_fixture()
+    observed_lengths = length.(FASTX.sequence.(String, reads))
+    println("td-2rxh fixed Step 5 toy fixture")
+    println("  fixture_seed:          $(FIXTURE_SEED)")
+    println("  corrector_seed:        $(CORRECTOR_SEED)")
+    println("  reference/source read: $(GENOME_LENGTH)/$(SOURCE_READ_LENGTH) bp")
+    println("  reads/coverage/error:  $(length(reads))/$(COVERAGE)x/$(ERROR_RATE)")
+    println("  observed read lengths: min=$(minimum(observed_lengths)), " *
+            "max=$(maximum(observed_lengths))")
+    println("  max_k:                 $(MAX_K)")
+    println("  nanopore budget:       $(MAX_NANOPORE_WALL_SECONDS) seconds")
+    println("  pair-HMM budget:       $(DECODE_BUDGET_MS) ms/read")
+    println("  decode calibration (runtime only; not accuracy-fitted):")
+    for point in DECODE_VERTEX_CALIBRATION
+        println("    nv=$(point.n_vertices): independent medians=" *
+                "$(point.confirmation_medians_ms) ms")
+    end
+    println("  selected ceiling:      $(Mycelia._INDEL_DECODE_MAX_VERTICES) vertices")
+
+    # The nanopore arm runs first, so its wall-time check conservatively includes
+    # compilation of the indel kernel rather than benefiting from the control arm.
+    nanopore = run_arm(reads, reference, :nanopore)
+    illumina = run_arm(reads, reference, :illumina)
+    print_arm(nanopore)
+    print_arm(illumina)
+
+    staged_ks = filter(!isnothing, rung_k.(nanopore.staged_indel_rungs))
+    if !isempty(staged_ks) && all(==(minimum(nanopore.k_progression)), staged_ks)
+        println("\nWARNING: indel staging fired only at the initial rung. " *
+                "Report this as an initial-rung result, not a sparse high-rung proof.")
+    end
+
+    checks = (
+        nonempty_nanopore = nanopore.n_contigs > 0,
+        nonempty_illumina = illumina.n_contigs > 0,
+        max_k_reached = MAX_K in nanopore.k_progression,
+        staged_indel_rung_observed = !isempty(nanopore.staged_indel_rungs),
+        nanopore_indel_decode_ran = nanopore.indel_decodes > 0,
+        nanopore_trace_contract_clean = nanopore.trace_contract_errors == 0,
+        illumina_oracle_has_no_indel_rung = isempty(illumina.staged_indel_rungs),
+        illumina_oracle_has_no_indel_decode = illumina.indel_decodes == 0,
+        nanopore_beats_illumina = nanopore.identity > illumina.identity,
+        nanopore_within_budget =
+            nanopore.wall_seconds < MAX_NANOPORE_WALL_SECONDS,
+    )
+
+    println("\nStep 5 checks")
+    for (name, passed) in pairs(checks)
+        println("  $(name): $(passed ? "PASS" : "FAIL")")
+    end
+    failed = [String(name) for (name, passed) in pairs(checks) if !passed]
+    if !isempty(failed)
+        error("td-2rxh Step 5 toy proof failed: $(join(failed, ", "))")
+    end
+    println("\ntd-2rxh Step 5 toy proof: PASS")
+    return nothing
+end
+
+main()

--- a/src/iterative-assembly.jl
+++ b/src/iterative-assembly.jl
@@ -193,6 +193,14 @@ end
 # "decode almost everything" pathology the #370 profile flagged.
 const _DEFAULT_DECODE_GATE_DENSITY = 0.90
 
+# Runtime-derived ceiling for staging the pair-HMM indel decoder (td-2rxh).
+# The calibration fixes a 200 ms/read budget independently of correction
+# accuracy: a 200 bp probe decoded in a 1,996-vertex graph in 153.788 ms median,
+# while the next measured size, 3,610 vertices, took 279.200 ms. The measured
+# feasible boundary is rounded from 1,996 to 2,000 vertices. Reproduce with
+# `scratchpad/measure_indel_decode_vertex_budget.jl`.
+const _INDEL_DECODE_MAX_VERTICES = 2_000
+
 """
 Estimate memory usage for a graph with a given number of k-mers.
 Provides a rough estimate for memory monitoring.
@@ -384,6 +392,12 @@ struct IndelDecodeParams
     deletion_max_run::Int
     max_insertion_run::Int
     band_width::Union{Nothing, Int}
+end
+
+function _indel_decode_is_staged(graph::Graphs.AbstractGraph,
+        indel_params::Union{Nothing, IndelDecodeParams})::Bool
+    return indel_params !== nothing &&
+           Graphs.nv(graph) <= _INDEL_DECODE_MAX_VERTICES
 end
 
 # =============================================================================
@@ -599,6 +613,11 @@ function mycelia_iterative_assemble(input_fastq::String;
     # Telemetry: the k-rungs whose per-read decode was gated OFF (low-k skip).
     decode_gated_rungs = Int[]
 
+    # Sparse k-rungs where the staged pair-HMM indel decoder actually processed
+    # at least one read. Recording the vertex count keeps the runtime-budget
+    # decision auditable in downstream assembly statistics.
+    staged_indel_rungs = NamedTuple{(:k, :n_vertices), Tuple{Int, Int}}[]
+
     # Hard-window skip telemetry (td-nn6l): the fraction of reads the hard-window
     # gate passed through WITHOUT a decode, recorded PER PASS (across every k and
     # iteration) so the run metadata can surface min/mean/max, not just the last
@@ -756,6 +775,7 @@ function mycelia_iterative_assemble(input_fastq::String;
             pass_skip_fraction = 0.0
             pass_cheap_corrections = 0
             pass_decode_gated = false
+            indel_decodes_before = corrector_diagnostics.indel_decodes[]
             try
                 if soft_em && prev_soft_weights !== nothing
                     Mycelia.Rhizomorph.register_soft_edge_weights!(graph, prev_soft_weights)
@@ -784,6 +804,11 @@ function mycelia_iterative_assemble(input_fastq::String;
                 )
             finally
                 Mycelia.Rhizomorph.clear_soft_edge_weights!()
+            end
+            if _indel_decode_is_staged(graph, indel_params) &&
+               corrector_diagnostics.indel_decodes[] > indel_decodes_before &&
+               all(rung -> rung.k != k, staged_indel_rungs)
+                push!(staged_indel_rungs, (k = k, n_vertices = Graphs.nv(graph)))
             end
             push!(skip_fractions, pass_skip_fraction)
             push!(cheap_correction_counts, pass_cheap_corrections)
@@ -956,6 +981,7 @@ function mycelia_iterative_assemble(input_fastq::String;
         min_decode_k = effective_min_decode_k,
         decode_gate_density = effective_decode_gate_density,
         decode_gated_rungs = decode_gated_rungs,
+        staged_indel_rungs = staged_indel_rungs,
         # Final-pass graph reuse (td-04tb): hand the corrector's last-pass qualmer
         # graph back so a converged run's re-assembly can skip a redundant rebuild.
         final_pass_graph = final_pass_graph,
@@ -1898,6 +1924,19 @@ function improve_read_set_likelihood(reads::Vector{<:FASTX.FASTQ.Record}, graph,
     natural_decode_fraction = total_reads > 0 ?
                               count(!, base_skip_flags) / total_reads : 0.0
 
+    # Stage the pair-HMM indel decoder only on graphs whose measured vertex count
+    # fits the fixed ~200 ms/read runtime budget. Dense rungs take the historical
+    # substitution path byte-for-byte, while raw indel intent continues to disable
+    # PR #412's substitution-only calibrated positional gate.
+    indel_staged = _indel_decode_is_staged(graph, indel_params)
+    effective_indel_params = indel_staged ? indel_params : nothing
+    effective_calibrated_gap_threshold =
+        indel_params === nothing ? calibrated_gap_threshold : nothing
+    if verbose && indel_staged
+        println("  Staged indel decode (td-2rxh): k=$k, " *
+                "vertices=$(Graphs.nv(graph)) <= $(_INDEL_DECODE_MAX_VERTICES).")
+    end
+
     # -- Low-k decode gating (td-9h5r) -----------------------------------------
     # `decode_enabled == false` (EXPLICIT floor `min_decode_k`): skip the per-read
     # graph-Viterbi decode for EVERY read this pass. Stage 0 cheap correction has
@@ -1913,7 +1952,8 @@ function improve_read_set_likelihood(reads::Vector{<:FASTX.FASTQ.Record}, graph,
     # discrimination signal to act on, so the decode runs as before.
     adaptive_gated = decode_enabled && decode_gate_density !== nothing &&
                      hard_vertices !== nothing &&
-                     natural_decode_fraction >= decode_gate_density
+                     natural_decode_fraction >= decode_gate_density &&
+                     !indel_staged
     pass_decode_off = !decode_enabled || adaptive_gated
     if verbose && adaptive_gated
         println("  Low-k decode gate (td-9h5r): hard-window gate non-discriminating " *
@@ -1954,9 +1994,9 @@ function improve_read_set_likelihood(reads::Vector{<:FASTX.FASTQ.Record}, graph,
     # the hard sub-window(s) around its hard vertices, each boundary-constrained and
     # <=500 bp) instead of whole-read. Requires `hard_vertices` — without the gate
     # there are no hard windows to target. The per-read `_windowed_decode_read_is_long`
-    # check restricts windowing to reads long enough that whole-read decode is
-    # expensive/bounded; short reads keep the cheap, exact whole-read decode
-    # (so the :scalable short-read quality gate never regresses).
+    # check restricts substitution windowing to reads long enough that whole-read
+    # decode is expensive/bounded. Staged indel decoding always uses windows,
+    # including for short reads, so the pair-HMM never runs over a whole read.
     use_windowed = windowed_decode && hard_vertices !== nothing
 
     # Process in batches for memory efficiency. `work_reads` is the Stage 0
@@ -1984,18 +2024,21 @@ function improve_read_set_likelihood(reads::Vector{<:FASTX.FASTQ.Record}, graph,
                 else
                     improved_read,
                     was_improved = (use_windowed &&
-                                    _windowed_decode_read_is_long(read, k)) ?
+                                    (_windowed_decode_read_is_long(read, k) ||
+                                     effective_indel_params !== nothing)) ?
                                    improve_read_likelihood_windowed(
                         read, graph, k, hard_vertices; graph_mode = graph_mode,
                         beam_width = beam_width, weighted_graph = pass_weighted_graph,
                         diagnostics = diag,
-                        calibrated_gap_threshold = calibrated_gap_threshold,
-                        indel_params = indel_params) :
+                        calibrated_gap_threshold =
+                            effective_calibrated_gap_threshold,
+                        indel_params = effective_indel_params) :
                                    improve_read_likelihood(
                         read, graph, k; graph_mode = graph_mode,
                         beam_width = beam_width, weighted_graph = pass_weighted_graph,
-                        diagnostics = diag, indel_params = indel_params,
-                        calibrated_gap_threshold = calibrated_gap_threshold)
+                        diagnostics = diag, indel_params = effective_indel_params,
+                        calibrated_gap_threshold =
+                            effective_calibrated_gap_threshold)
                     batch_results[i] = (improved_read, was_improved)
                 end
             end
@@ -2019,20 +2062,23 @@ function improve_read_set_likelihood(reads::Vector{<:FASTX.FASTQ.Record}, graph,
                 end
                 improved_read,
                 was_improved = (use_windowed &&
-                                _windowed_decode_read_is_long(read, k)) ?
+                                (_windowed_decode_read_is_long(read, k) ||
+                                 effective_indel_params !== nothing)) ?
                                improve_read_likelihood_windowed(
                     read, graph, k, hard_vertices; graph_mode = graph_mode,
                     beam_width = beam_width, soft_weights = soft_weights,
                     weighted_graph = pass_weighted_graph,
                     diagnostics = diag,
-                    calibrated_gap_threshold = calibrated_gap_threshold,
-                    indel_params = indel_params) :
+                    calibrated_gap_threshold =
+                        effective_calibrated_gap_threshold,
+                    indel_params = effective_indel_params) :
                                improve_read_likelihood(
                     read, graph, k; graph_mode = graph_mode,
                     beam_width = beam_width, soft_weights = soft_weights,
                     weighted_graph = pass_weighted_graph,
-                    diagnostics = diag, indel_params = indel_params,
-                    calibrated_gap_threshold = calibrated_gap_threshold)
+                    diagnostics = diag, indel_params = effective_indel_params,
+                    calibrated_gap_threshold =
+                        effective_calibrated_gap_threshold)
                 updated_reads[batch_start + i - 1] = improved_read
 
                 if was_improved
@@ -2867,6 +2913,9 @@ function finalize_iterative_assembly(output_dir::String, k_progression::Vector{I
         min_decode_k::Union{Int, Nothing} = nothing,
         decode_gate_density::Union{Float64, Nothing} = nothing,
         decode_gated_rungs::Vector{Int} = Int[],
+        staged_indel_rungs::Vector{
+            NamedTuple{(:k, :n_vertices), Tuple{Int, Int}}
+        } = NamedTuple{(:k, :n_vertices), Tuple{Int, Int}}[],
         final_pass_graph = nothing,
         final_pass_graph_k::Int = 0,
         final_pass_graph_mode::Symbol = :canonical,
@@ -2895,6 +2944,10 @@ function finalize_iterative_assembly(output_dir::String, k_progression::Vector{I
     total_iterations = sum(length(iterations) for iterations in values(iteration_history))
     total_improvements = sum(sum(iter[:improvements_made] for iter in iterations)
     for iterations in values(iteration_history))
+    rung_vertex_counts = Dict(
+        k => [iteration[:memory_kmers] for iteration in iterations]
+        for (k, iterations) in iteration_history
+    )
 
     # Read final assembly for k-mer extraction
     if isfile(final_fastq)
@@ -2949,6 +3002,7 @@ function finalize_iterative_assembly(output_dir::String, k_progression::Vector{I
         :final_fastq_file => final_fastq,
         :output_directory => output_dir,
         :iteration_history => iteration_history,
+        :rung_vertex_counts => rung_vertex_counts,
         :corrector_errors => corrector_errors,
         :assembly_type => "iterative_maximum_likelihood",
         :version => "Phase_5.2a",
@@ -2976,6 +3030,7 @@ function finalize_iterative_assembly(output_dir::String, k_progression::Vector{I
         :min_decode_k => min_decode_k,
         :decode_gate_density => decode_gate_density,
         :decode_gated_rungs => decode_gated_rungs,
+        :staged_indel_rungs => staged_indel_rungs,
         :last_skip_fraction => last_skip_fraction,
         :skip_fraction_per_pass => skip_fractions,
         :skip_fraction_min => skip_min,

--- a/src/rhizomorph/assembly.jl
+++ b/src/rhizomorph/assembly.jl
@@ -1337,6 +1337,13 @@ function _assemble_with_iterative_corrector(reads, config::AssemblyConfig)
         assembly.assembly_stats["hard_window"] = get(_corr_meta, :hard_window, false)
         assembly.assembly_stats["hard_read_gate"] = get(_corr_meta, :hard_read_gate, false)
         assembly.assembly_stats["windowed_decode"] = get(_corr_meta, :windowed_decode, false)
+        # Staged-indel provenance (td-2rxh): actual sparse rungs where the pair-HMM
+        # decode ran, with each rung carrying its k and graph vertex count. Empty
+        # for substitution-only profiles and for indel profiles with no sparse rung.
+        assembly.assembly_stats["staged_indel_rungs"] =
+            get(_corr_meta, :staged_indel_rungs, NamedTuple[])
+        assembly.assembly_stats["rung_vertex_counts"] =
+            get(_corr_meta, :rung_vertex_counts, Dict{Int, Vector{Int}}())
         corrector_errors = get(_corr_meta, :corrector_errors, Dict{Symbol, Int}())
         assembly.assembly_stats["corrector_errors"] = corrector_errors
         assembly.assembly_stats["indel_decodes"] =

--- a/test/4_assembly/calibrated_gate_indel_failopen_test.jl
+++ b/test/4_assembly/calibrated_gate_indel_failopen_test.jl
@@ -18,7 +18,8 @@ import Mycelia
 import FASTX
 import Random
 
-function _write_fastq(reads, dir)
+function _write_fastq(
+        reads::Vector{FASTX.FASTQ.Record}, dir::String)::String
     path = joinpath(dir, "in.fastq")
     open(FASTX.FASTQ.Writer, path) do w
         for r in reads
@@ -28,7 +29,13 @@ function _write_fastq(reads, dir)
     return path
 end
 
-function _assemble_corrected(fastq, k; threshold, indel_params, outdir)
+function _assemble_corrected(
+        fastq::String,
+        k::Int;
+        threshold::Union{Float64, Nothing},
+        indel_params::Union{Mycelia.IndelDecodeParams, Nothing},
+        outdir::String,
+)::NamedTuple
     Random.seed!(42)
     result = Mycelia.mycelia_iterative_assemble(fastq;
         max_k = max(k, 13), skip_solid = false, graph_mode = :doublestrand,
@@ -45,7 +52,11 @@ function _assemble_corrected(fastq, k; threshold, indel_params, outdir)
             out[FASTX.identifier(rec)] = FASTX.sequence(String, rec)
         end
     end
-    return out
+    return (
+        sequences = out,
+        bytes = read(corrected_fastq),
+        metadata = result[:metadata],
+    )
 end
 
 Test.@testset "calibrated gate is excluded under indel mode (fail-open)" begin
@@ -71,10 +82,34 @@ Test.@testset "calibrated gate is excluded under indel mode (fail-open)" begin
         # A huge threshold would revert EVERY finite-gap correction if the gate ran.
         gated = _assemble_corrected(_write_fastq(reads, d), k;
             threshold = 1.0e6, indel_params = indel, outdir = mktempdir())
-        (base = base, gated = gated)
+        substitution = _assemble_corrected(_write_fastq(reads, d), k;
+            threshold = nothing, indel_params = nothing, outdir = mktempdir())
+        (base = base, gated = gated, substitution = substitution)
     end
 
-    # Under indel mode the gate is excluded, so the threshold changes nothing.
-    Test.@test !isempty(corrected.base)
-    Test.@test corrected.base == corrected.gated
+    # This fixture is above the measured indel budget, so raw nanopore intent must
+    # stage OFF and take the byte-identical substitution fallback. PR #412's
+    # positional calibrated gate remains excluded based on RAW indel intent.
+    max_vertices = maximum(
+        iteration[:memory_kmers]
+        for iterations in values(corrected.base.metadata[:iteration_history])
+        for iteration in iterations
+    )
+    Test.@test max_vertices > Mycelia._INDEL_DECODE_MAX_VERTICES
+    staged = corrected.base.metadata[:staged_indel_rungs]
+    dense_ks = Set(
+        rung_k
+        for (rung_k, counts) in corrected.base.metadata[:rung_vertex_counts]
+        if maximum(counts) > Mycelia._INDEL_DECODE_MAX_VERTICES
+    )
+    Test.@test !isempty(dense_ks)
+    Test.@test all(
+        rung.n_vertices <= Mycelia._INDEL_DECODE_MAX_VERTICES &&
+        !(rung.k in dense_ks)
+        for rung in staged
+    )
+    Test.@test corrected.base.metadata[:corrector_errors][:indel_decodes] > 0
+    Test.@test !isempty(corrected.base.sequences)
+    Test.@test corrected.base.bytes == corrected.gated.bytes
+    Test.@test corrected.base.bytes == corrected.substitution.bytes
 end

--- a/test/4_assembly/indel_profile_assembly_test.jl
+++ b/test/4_assembly/indel_profile_assembly_test.jl
@@ -155,6 +155,9 @@ Test.@testset "indel-aware correction wired via sequencing-tech error profile" b
         Test.@test base.assembly_stats["indel_moves"] == false
         Test.@test il.assembly_stats["indel_moves"] == false
         Test.@test il.assembly_stats["sequencing_tech"] == "illumina"
+        Test.@test isempty(base.assembly_stats["staged_indel_rungs"])
+        Test.@test isempty(il.assembly_stats["staged_indel_rungs"])
+        Test.@test base.assembly_stats["rung_vertex_counts"] isa Dict
     end
 
     Test.@testset "nanopore enables indel-aware correction" begin
@@ -170,6 +173,8 @@ Test.@testset "indel-aware correction wired via sequencing-tech error profile" b
         Test.@test np.assembly_stats["truncated_decodes"] >= 0
         Test.@test np.assembly_stats["trace_contract_errors"] == 0
         Test.@test np.assembly_stats["window_divergences"] >= 0
+        Test.@test np.assembly_stats["staged_indel_rungs"] isa Vector
+        Test.@test np.assembly_stats["rung_vertex_counts"] isa Dict
     end
 
     # -- END-TO-END correction proof (PR #408 review, FIX 2) -------------------
@@ -195,6 +200,7 @@ Test.@testset "indel-aware correction wired via sequencing-tech error profile" b
         id_il = Float64[]
         np_indel_moves = Bool[]
         np_indel_decodes = Int[]
+        np_staged_rungs = Bool[]
         np_nonempty = Bool[]
         for seed in seeds
             reads,
@@ -208,6 +214,7 @@ Test.@testset "indel-aware correction wired via sequencing-tech error profile" b
             push!(id_il, _best_identity_to_ref(il.contigs, refseq))
             push!(np_indel_moves, np.assembly_stats["indel_moves"] == true)
             push!(np_indel_decodes, np.assembly_stats["indel_decodes"])
+            push!(np_staged_rungs, !isempty(np.assembly_stats["staged_indel_rungs"]))
             push!(np_nonempty, !isempty(np.contigs))
         end
         mean_np = Statistics.mean(id_np)
@@ -218,6 +225,7 @@ Test.@testset "indel-aware correction wired via sequencing-tech error profile" b
         # The nanopore arm actually engaged the indel decode and produced contigs.
         Test.@test all(np_indel_moves)
         Test.@test all(>(0), np_indel_decodes)
+        Test.@test all(np_staged_rungs)
         Test.@test all(np_nonempty)
         # DIFFERENTIAL (the PR's value): indel-aware correction lands closer to the
         # truth than substitution-only on the SAME nanopore reads, on average.

--- a/test/4_assembly/low_k_decode_gating_test.jl
+++ b/test/4_assembly/low_k_decode_gating_test.jl
@@ -38,6 +38,9 @@ import Test
 import Mycelia
 import FASTX
 import Random
+import BioSequences
+import Graphs
+import Kmers
 
 const _LK_BASES = ['A', 'C', 'G', 'T']
 
@@ -54,6 +57,84 @@ end
 
 Test.@testset "low-k decode gating (td-9h5r)" begin
     R = Mycelia.Rhizomorph
+    indel_params = Mycelia.IndelDecodeParams(
+        0.10, 0.30, 0.30, 0.30, 0.30, 3, 3, 16)
+
+    Test.@testset "staged-indel predicate includes only the measured boundary" begin
+        ceiling = Mycelia._INDEL_DECODE_MAX_VERTICES
+        at_ceiling = Graphs.SimpleDiGraph(ceiling)
+        above_ceiling = Graphs.SimpleDiGraph(ceiling + 1)
+
+        Test.@test Mycelia._indel_decode_is_staged(at_ceiling, indel_params)
+        Test.@test !Mycelia._indel_decode_is_staged(above_ceiling, indel_params)
+        Test.@test !Mycelia._indel_decode_is_staged(at_ceiling, nothing)
+    end
+
+    Test.@testset "sparse staged indel bypasses density gate and windows short reads" begin
+        rng = Random.MersenneTwister(812)
+        read_length = 150
+        sequence = join(rand(rng, _LK_BASES, read_length))
+        reads = [FASTX.FASTQ.Record(
+                     "sparse_$i", sequence, String(fill('I', read_length)))
+                 for i in 1:10]
+        probe = first(reads)
+        k = 13
+        graph = R.build_qualmer_graph(reads, k; mode = :doublestrand)
+
+        # Two separated hard k-mers yield two windows on a read that is far below
+        # the legacy long-read windowing threshold. Include both orientations plus
+        # the canonical key: should_decode_read uses observed orientation for a
+        # doublestrand graph, while _hard_window_ranges uses canonical lookup.
+        sequence_dna = BioSequences.LongDNA{4}(sequence)
+        positioned_kmers = collect(Kmers.UnambiguousDNAMers{k}(sequence_dna))
+        hard = Set{typeof(first(positioned_kmers)[1])}()
+        for position in (15, 95)
+            kmer = positioned_kmers[position][1]
+            push!(hard, kmer)
+            push!(hard, BioSequences.reverse_complement(kmer))
+            push!(hard, BioSequences.canonical(kmer))
+        end
+        windows = Mycelia._hard_window_ranges(probe, k, hard; pad = k)
+
+        Test.@test Graphs.nv(graph) <= Mycelia._INDEL_DECODE_MAX_VERTICES
+        Test.@test Mycelia._indel_decode_is_staged(graph, indel_params)
+        Test.@test Mycelia.should_decode_read(
+            probe, k, hard; graph_mode = :doublestrand)
+        Test.@test !Mycelia._windowed_decode_read_is_long(probe, k)
+        Test.@test windows == UnitRange{Int}[2:40, 82:120]
+
+        # Every read would decode, so the adaptive density gate would normally
+        # veto this pass. A sparse staged-indel rung must bypass that veto, and
+        # the short probe must take the two-window path rather than one whole-read
+        # pair-HMM decode.
+        diagnostics = Mycelia.CorrectorDiagnostics()
+        _out, _improvements, skip_fraction, _cheap, decode_gated =
+            Mycelia.improve_read_set_likelihood(
+                [probe], graph, k; graph_mode = :doublestrand,
+                skip_solid = false, cheap_correct = false,
+                hard_vertices = hard, windowed_decode = true,
+                decode_gate_density = 0.90, beam_width = 16,
+                diagnostics = diagnostics, indel_params = indel_params)
+        Test.@test decode_gated == false
+        Test.@test skip_fraction == 0.0
+        Test.@test diagnostics.indel_decodes[] == length(windows)
+        Test.@test diagnostics.truncated_decodes[] == 0
+        Test.@test diagnostics.trace_contract_errors[] == 0
+
+        # Substitution mode is the unchanged control: the same non-discriminating
+        # pass remains density-gated, so nothing reaches either decode kernel.
+        substitution_diagnostics = Mycelia.CorrectorDiagnostics()
+        _sub_out, _sub_improvements, sub_skip, _sub_cheap, sub_gated =
+            Mycelia.improve_read_set_likelihood(
+                [probe], graph, k; graph_mode = :doublestrand,
+                skip_solid = false, cheap_correct = false,
+                hard_vertices = hard, windowed_decode = true,
+                decode_gate_density = 0.90, beam_width = 16,
+                diagnostics = substitution_diagnostics, indel_params = nothing)
+        Test.@test sub_gated == true
+        Test.@test sub_skip == 1.0
+        Test.@test substitution_diagnostics.indel_decodes[] == 0
+    end
 
     Test.@testset "explicit floor: decode_enabled=false gates the whole pass" begin
         rng = Random.MersenneTwister(101)


### PR DESCRIPTION
## Summary

- add the user-specified single `indel_staged` vertex-budget predicate
- use it for adaptive-gate exemption, forced indel windowing, and dense-rung substitution fallback
- preserve PR #412's calibrated positional-gate exclusion from raw indel intent
- surface staged-rung and all-rung vertex telemetry
- add boundary/windowing/oracle regressions and reproducible runtime calibration
- add the fixed `max_k=31`, 1000bp+ Step 5 proof harness

## Runtime calibration

Two independent fresh-process confirmations on a fixed 200 bp probe selected the largest graph size whose medians were both below the 200 ms budget:

| vertices | median run 1 | median run 2 |
| ---: | ---: | ---: |
| 1,996 | 165.643 ms | 153.788 ms |
| 3,610 | 263.639 ms | 279.200 ms |
| 4,972 | 475.403 ms | 326.281 ms |
| 6,068 | 451.029 ms | 383.677 ms |

The package ceiling is conservatively rounded from 1,996 to 2,000. This is runtime-derived, not accuracy-fitted.

## Verification

Passing fresh-process tests (`LD_LIBRARY_PATH=""`):

- low-k decode gating: 36/36
- indel profile assembly: 55/55; E2E mean nanopore 0.97344 vs illumina 0.87011, wins 5/5
- calibrated indel fail-open + dense fallback byte identity: 7/7
- reassembly graph reuse: 20/20
- windowed decode: 23,173/23,173 + indel plumbing 46/46
- Viterbi indel decoder: 70/70
- scalable hard-window: 92/92
- scalable strategy: 42/42

## BLOCKED — Step 5 honest null (do not merge)

The required fixed 2 kb / 1.2 kb-read / 8x / 5%-error `assemble_genome` proof fails closed:

- k progression: `[3, 11, 31]`
- vertices/pass: k3 `[64]`, k11 `[17,566, 16,112]`, k31 `[27,190]`
- staged indel rungs: none
- indel decodes: 0
- nanopore identity/edit: 0.0655 / 1,869
- illumina identity/edit: 0.0655 / 1,869
- nanopore wall: 12.997 s (within budget)

Failed checks: staged rung observed, indel decode ran, nanopore beats illumina.

This disproves the design assumption that raising k makes `Graphs.nv` fall into a sparse regime on noisy long reads. `nv` is graph size, not branching/discrimination: k3 is capped at 64 vertices even when maximally branching, while a linear 2,001-vertex graph is rejected.

Local `/comprehensive-pr-review` therefore returned **BLOCK**. Additional blockers: vertex-only staging can perturb dense `:exhaustive` indel semantics; `indel_moves` reports profile intent even when zero indel decodes run; the proof must require staging above the initial rung.

Follow-up: `td-jt7r.2` — replace nv-only gating with branching-aware scheduling / graph-cleaned rungs. Parent target `td-2rxh` remains in progress.
