### PR TITLE
add: precision_recall_curve_summary for operating-point sweeps

### DIFF
--- a/src/quality-control-and-benchmarking.jl
+++ b/src/quality-control-and-benchmarking.jl
@@ -508,6 +508,112 @@ function evaluate_taxonomy_presence_metrics(reference_table::DataFrames.DataFram
 end
 
 """
+    precision_recall_curve_summary(precisions, recalls) -> NamedTuple
+
+Summarize a set of classifier operating points into a precision-recall curve and
+its area. A threshold GRID (e.g. sweeping breadth/depth/count cutoffs) yields an
+unordered cloud of `(precision, recall)` points rather than a single monotone
+ROC; this reduces that cloud defensibly:
+
+  - `frontier_precision` / `frontier_recall` / `frontier_indices`: the Pareto-
+    optimal operating points (no other point has both `>=` precision and `>=`
+    recall, with at least one strict), sorted by recall ascending — the
+    achievable precision/recall tradeoff. `frontier_indices` are positions in the
+    input vectors.
+  - `average_precision`: area under the all-points-interpolated precision step
+    function over recall `[0, max_recall]`, where interpolated precision at
+    recall `r` is `max{ precision_i : recall_i >= r }` (PASCAL-VOC all-points
+    interpolation). Robust to non-monotone and to dominated points.
+  - `auc_trapezoid`: trapezoidal area under the recall-sorted Pareto frontier,
+    reported alongside `average_precision` for transparency; `NaN` for fewer than
+    two frontier points (a single operating point has no defined trapezoid).
+  - `max_f1`, `best_index`, `best_precision`, `best_recall`: the operating point
+    maximizing F1 (`best_index` is a position in the input vectors).
+
+`precisions` and `recalls` must have equal length. Points with a NaN/missing
+precision or recall are dropped first. Empty (or all-dropped) input yields NaN
+metrics, an empty frontier, and `best_index == 0`. This is the general,
+task-agnostic counterpart to the variant-caller-specific ROC summary in
+`calculate_evaluation_summary`.
+"""
+function precision_recall_curve_summary(
+        precisions::AbstractVector, recalls::AbstractVector)
+    length(precisions) == length(recalls) ||
+        error("precisions and recalls must have equal length: " *
+              "$(length(precisions)) vs $(length(recalls))")
+
+    # Drop NaN/missing points, remembering each retained point's input position.
+    ps = Float64[]
+    rs = Float64[]
+    orig = Int[]
+    for i in eachindex(precisions)
+        p = precisions[i]
+        r = recalls[i]
+        (p === missing || r === missing) && continue
+        (isnan(p) || isnan(r)) && continue
+        push!(ps, Float64(p))
+        push!(rs, Float64(r))
+        push!(orig, i)
+    end
+
+    n = length(ps)
+    if n == 0
+        return (n_points = 0,
+            frontier_precision = Float64[], frontier_recall = Float64[],
+            frontier_indices = Int[],
+            average_precision = NaN, auc_trapezoid = NaN,
+            max_f1 = NaN, best_index = 0, best_precision = NaN, best_recall = NaN)
+    end
+
+    # F1 per retained point; the max-F1 point is the single best operating point.
+    f1s = [(ps[i] + rs[i]) == 0 ? 0.0 : 2 * ps[i] * rs[i] / (ps[i] + rs[i])
+           for i in 1:n]
+    bi = argmax(f1s)
+
+    # Pareto frontier: point i survives unless some j dominates it on both axes.
+    frontier = Int[]
+    for i in 1:n
+        dominated = false
+        for j in 1:n
+            i == j && continue
+            if ps[j] >= ps[i] && rs[j] >= rs[i] && (ps[j] > ps[i] || rs[j] > rs[i])
+                dominated = true
+                break
+            end
+        end
+        dominated || push!(frontier, i)
+    end
+    sort!(frontier; by = i -> (rs[i], -ps[i]))
+    fr = [rs[i] for i in frontier]
+    fp = [ps[i] for i in frontier]
+
+    # All-points-interpolated average precision over ALL retained points.
+    ap = 0.0
+    prev = 0.0
+    for r in sort(unique(rs))
+        pinterp = maximum(ps[k] for k in 1:n if rs[k] >= r)
+        ap += (r - prev) * pinterp
+        prev = r
+    end
+
+    # Trapezoid under the recall-sorted frontier (needs >= 2 frontier points).
+    auc = NaN
+    if length(frontier) >= 2
+        auc = 0.0
+        for k in 2:length(frontier)
+            auc += (fr[k] - fr[k - 1]) * (fp[k] + fp[k - 1]) / 2
+        end
+    end
+
+    return (n_points = n,
+        frontier_precision = fp, frontier_recall = fr,
+        frontier_indices = [orig[i] for i in frontier],
+        average_precision = ap, auc_trapezoid = auc,
+        max_f1 = f1s[bi], best_index = orig[bi],
+        best_precision = ps[bi], best_recall = rs[bi])
+end
+
+"""
     accuracy(true_labels, pred_labels)
 
 Returns the overall accuracy.

--- a/src/quality-control-and-benchmarking.jl
+++ b/src/quality-control-and-benchmarking.jl
@@ -519,14 +519,18 @@ ROC; this reduces that cloud defensibly:
     optimal operating points (no other point has both `>=` precision and `>=`
     recall, with at least one strict), sorted by recall ascending — the
     achievable precision/recall tradeoff. `frontier_indices` are positions in the
-    input vectors.
+    input vectors. Exact-duplicate operating points do not dominate each other,
+    so each is retained (the frontier may contain repeated entries).
   - `average_precision`: area under the all-points-interpolated precision step
     function over recall `[0, max_recall]`, where interpolated precision at
     recall `r` is `max{ precision_i : recall_i >= r }` (PASCAL-VOC all-points
     interpolation). Robust to non-monotone and to dominated points.
   - `auc_trapezoid`: trapezoidal area under the recall-sorted Pareto frontier,
     reported alongside `average_precision` for transparency; `NaN` for fewer than
-    two frontier points (a single operating point has no defined trapezoid).
+    two frontier points (a single operating point has no defined trapezoid). Note
+    it integrates only over `[min_recall, max_recall]` (the frontier's span),
+    whereas `average_precision` integrates from recall 0 — so the two areas are
+    not directly comparable.
   - `max_f1`, `best_index`, `best_precision`, `best_recall`: the operating point
     maximizing F1 (`best_index` is a position in the input vectors).
 

--- a/test/5_validation/pr_curve_test.jl
+++ b/test/5_validation/pr_curve_test.jl
@@ -3,7 +3,7 @@ import Mycelia
 
 # Summarize a set of classifier operating points (a threshold GRID, i.e. an
 # unordered cloud of (precision, recall) pairs) into a precision-recall curve and
-# its area. Expected values below are hand-computed; see the doctstring of
+# its area. Expected values below are hand-computed; see the docstring of
 # Mycelia.precision_recall_curve_summary for the all-points-interpolation AP.
 Test.@testset "precision_recall_curve_summary" begin
     # Three non-dominated points: higher precision at lower recall.
@@ -40,12 +40,46 @@ Test.@testset "precision_recall_curve_summary" begin
     Test.@test sd.frontier_recall == [0.2, 0.5, 0.8]   # dominated point dropped
     Test.@test sd.n_points == 4
 
-    # NaN points are dropped before any computation.
+    # NaN points are dropped before any computation. The dropped point shifts
+    # later input positions, so frontier_indices / best_index must remap back to
+    # ORIGINAL positions (retained orig = [1,3,4]); a frontier-local-index bug
+    # would return [1,2,3] and pass every other assertion.
     Pn = [0.9, NaN, 0.6, 0.3]
     Rn = [0.2, 0.4, 0.5, 0.8]
     sn = Mycelia.precision_recall_curve_summary(Pn, Rn)
     Test.@test sn.n_points == 3
     Test.@test isapprox(sn.average_precision, 0.45; atol = 1e-9)
+    Test.@test sn.frontier_indices == [1, 3, 4]   # original positions, not [1,2,3]
+    Test.@test sn.best_index == 3                  # B=(0.6,0.5) is input position 3
+
+    # `missing` (not just NaN) is dropped too, via a distinct branch that must be
+    # checked before isnan (isnan(missing) === missing would throw). Same cloud.
+    Pm = [0.9, missing, 0.6, 0.3]
+    Rm = [0.2, 0.4, 0.5, 0.8]
+    sm = Mycelia.precision_recall_curve_summary(Pm, Rm)
+    Test.@test sm.n_points == 3
+    Test.@test isapprox(sm.average_precision, 0.45; atol = 1e-9)
+
+    # All-points interpolation LIFTING: a higher-recall point with higher precision
+    # raises interpolated precision at lower recall. This is the defining VOC
+    # behavior; without it AP would be 0.2*0.3 + 0.6*0.9 = 0.60 instead of 0.72.
+    #   uniq recall {0.2,0.8}: (0.2-0)*max(0.3,0.9) + (0.8-0.2)*0.9 = 0.18 + 0.54.
+    sl = Mycelia.precision_recall_curve_summary([0.3, 0.9], [0.2, 0.8])
+    Test.@test isapprox(sl.average_precision, 0.72; atol = 1e-9)
+    Test.@test sl.frontier_recall == [0.8]         # (0.3,0.2) is dominated
+    Test.@test isnan(sl.auc_trapezoid)             # single frontier point
+
+    # All-identical recalls collapse the frontier to the max-precision point
+    # (others dominated) -> trapezoid NaN; AP = max_recall * max_precision.
+    si = Mycelia.precision_recall_curve_summary([0.4, 0.6, 0.5], [0.5, 0.5, 0.5])
+    Test.@test si.frontier_recall == [0.5]
+    Test.@test isapprox(si.average_precision, 0.30; atol = 1e-9)
+    Test.@test isnan(si.auc_trapezoid)
+
+    # F1 divide-by-zero guard: a (0,0) operating point must not throw.
+    sz = Mycelia.precision_recall_curve_summary([0.5, 0.0], [0.5, 0.0])
+    Test.@test isapprox(sz.max_f1, 0.5; atol = 1e-9)
+    Test.@test sz.best_index == 1
 
     # Single point: AP = area of the interpolated step from recall 0 to r at p;
     # trapezoid is undefined (<2 frontier points) -> NaN.

--- a/test/5_validation/pr_curve_test.jl
+++ b/test/5_validation/pr_curve_test.jl
@@ -1,0 +1,66 @@
+import Test
+import Mycelia
+
+# Summarize a set of classifier operating points (a threshold GRID, i.e. an
+# unordered cloud of (precision, recall) pairs) into a precision-recall curve and
+# its area. Expected values below are hand-computed; see the doctstring of
+# Mycelia.precision_recall_curve_summary for the all-points-interpolation AP.
+Test.@testset "precision_recall_curve_summary" begin
+    # Three non-dominated points: higher precision at lower recall.
+    P = [0.9, 0.6, 0.3]
+    R = [0.2, 0.5, 0.8]
+
+    s = Mycelia.precision_recall_curve_summary(P, R)
+
+    # Pareto frontier = all three, sorted by recall ascending.
+    Test.@test s.frontier_recall == [0.2, 0.5, 0.8]
+    Test.@test s.frontier_precision == [0.9, 0.6, 0.3]
+
+    # All-points-interpolated average precision:
+    #   (0.2-0)*0.9 + (0.5-0.2)*0.6 + (0.8-0.5)*0.3 = 0.18 + 0.18 + 0.09 = 0.45
+    Test.@test isapprox(s.average_precision, 0.45; atol = 1e-9)
+
+    # Trapezoid under the recall-sorted frontier:
+    #   (0.5-0.2)*(0.9+0.6)/2 + (0.8-0.5)*(0.6+0.3)/2 = 0.225 + 0.135 = 0.36
+    Test.@test isapprox(s.auc_trapezoid, 0.36; atol = 1e-9)
+
+    # max F1 is at B=(0.6,0.5): F1 = 2*0.6*0.5/1.1 = 0.5454...
+    Test.@test isapprox(s.max_f1, 2 * 0.6 * 0.5 / 1.1; atol = 1e-9)
+    Test.@test s.best_index == 2
+    Test.@test isapprox(s.best_precision, 0.6; atol = 1e-9)
+    Test.@test isapprox(s.best_recall, 0.5; atol = 1e-9)
+    Test.@test s.n_points == 3
+
+    # A dominated point must not change AP (a worse point never raises the running
+    # max precision), and must be excluded from the Pareto frontier.
+    Pd = [0.9, 0.6, 0.3, 0.4]
+    Rd = [0.2, 0.5, 0.8, 0.3]   # (0.4,0.3) is dominated by (0.6,0.5)
+    sd = Mycelia.precision_recall_curve_summary(Pd, Rd)
+    Test.@test isapprox(sd.average_precision, 0.45; atol = 1e-9)
+    Test.@test sd.frontier_recall == [0.2, 0.5, 0.8]   # dominated point dropped
+    Test.@test sd.n_points == 4
+
+    # NaN points are dropped before any computation.
+    Pn = [0.9, NaN, 0.6, 0.3]
+    Rn = [0.2, 0.4, 0.5, 0.8]
+    sn = Mycelia.precision_recall_curve_summary(Pn, Rn)
+    Test.@test sn.n_points == 3
+    Test.@test isapprox(sn.average_precision, 0.45; atol = 1e-9)
+
+    # Single point: AP = area of the interpolated step from recall 0 to r at p;
+    # trapezoid is undefined (<2 frontier points) -> NaN.
+    s1 = Mycelia.precision_recall_curve_summary([0.8], [0.5])
+    Test.@test isapprox(s1.average_precision, 0.5 * 0.8; atol = 1e-9)
+    Test.@test isnan(s1.auc_trapezoid)
+    Test.@test s1.best_index == 1
+
+    # Empty (all dropped) -> NaN metrics, empty frontier, best_index 0.
+    s0 = Mycelia.precision_recall_curve_summary(Float64[], Float64[])
+    Test.@test s0.n_points == 0
+    Test.@test isnan(s0.average_precision)
+    Test.@test isempty(s0.frontier_recall)
+    Test.@test s0.best_index == 0
+
+    # Length mismatch is an error.
+    Test.@test_throws Exception Mycelia.precision_recall_curve_summary([0.5, 0.6], [0.5])
+end


### PR DESCRIPTION
## Summary

- Adds `Mycelia.precision_recall_curve_summary(precisions, recalls)` — a general, task-agnostic aggregator that reduces a *grid* of classifier operating points (an unordered cloud of (precision, recall) pairs, e.g. from sweeping detection thresholds) into a Pareto frontier, all-points-interpolated **average precision** (PASCAL-VOC), a frontier trapezoid AUC, and the **max-F1** operating point.
- This is the reusable counterpart to the variant-caller-specific ROC summary in `calculate_evaluation_summary`; it is the aggregator the CAMI concordance+coverage operating-point sweep (Stanford-Virome) needs to report AUPRC over its grid.
- Pure Julia, namespaced (no new deps, no exports), lives in the Core test tier.

## Design notes

- A threshold *grid* is not a monotone ROC — it is a cloud. Average precision uses all-points interpolation (interpolated precision at recall `r` = `max{precision : recall ≥ r}`), which is robust to non-monotone and dominated points. The frontier trapezoid is reported alongside for transparency (it can differ substantially when the frontier is sparse).

## Test Plan

- [x] `test/5_validation/pr_curve_test.jl` — 22 assertions pinned against hand-computed values (3-point curve AP=0.45 / trapezoid=0.36, dominated-point invariance, NaN dropping, single-point, empty, length-mismatch error). Passes standalone (22/22).
- [ ] Full Core suite (`Pkg.test()`) incl. Aqua + ExplicitImports — running locally (GitHub Actions is billing-blocked on this account; local suite is the gate).

Related: Stanford-Virome CAMI concordance-filter validation (td-dlxc).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a utility for summarizing precision–recall curves, including average precision, trapezoidal AUC, F1-based best operating point, and Pareto frontier details.
  * Supports filtering invalid values and reports original input positions for retained points.
  * Handles empty, single-point, duplicate-recall, and mismatched-input cases with defined results.

* **Tests**
  * Added coverage for curve metrics, frontier selection, interpolation, invalid inputs, edge cases, and input validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->