### PR TITLE
fix: make library figure display opt-in (stop test window pop-ups)

### DIFF
--- a/src/clustering.jl
+++ b/src/clustering.jl
@@ -156,13 +156,15 @@ function mmseqs_easy_cluster(;
         cmd = Mycelia.command_string(
             `$(Mycelia.CONDA_RUNNER) run --live-stream -n mmseqs2 mmseqs easy-cluster $(fasta) $(output) $(tmp) --min-seq-id $(min_seq_id) -c $(coverage) --cov-mode $(coverage_mode)`
         )
-        script = join([
-            "set -euo pipefail",
-            "if [ ! -f \"$(outfile)\" ]; then",
-            "  $(cmd)",
-            "fi",
-            "rm -rf \"$(tmp)\""
-        ], "\n")
+        script = join(
+            [
+                "set -euo pipefail",
+                "if [ ! -f \"$(outfile)\" ]; then",
+                "  $(cmd)",
+                "fi",
+                "rm -rf \"$(tmp)\""
+            ],
+            "\n")
         job = Mycelia.build_execution_job(
             cmd = script,
             job_name = job_name,
@@ -595,10 +597,7 @@ function identify_optimal_number_of_clusters(
         error("Unknown plot_backend: $(plot_backend). Choose :cairomakie or :statsplots.")
     end
 
-    is_ci = get(ENV, "CI", "") == "true" || get(ENV, "GITHUB_ACTIONS", "") == "true"
-    if display_plot && !is_ci
-        display(fig)
-    end
+    present_figure(fig; name = "silhouette_scores", display_plot = display_plot)
 
     return (
         hcl = hcl,

--- a/src/kmer-analysis.jl
+++ b/src/kmer-analysis.jl
@@ -442,9 +442,7 @@ function analyze_kmer_spectra(; out_directory, forward_reads = "", reverse_reads
     peak_index = Int(round(Statistics.median(peak_indices)))
 
     p = StatsPlots.vline!([X[peak_index]], label = "inferred sample coverage)")
-    if isinteractive()
-        display(p)
-    end
+    present_figure(p; name = "kmer_spectra_peak")
     StatsPlots.savefig(p, "$out_directory/peak-detected.png")
     StatsPlots.savefig(p, "$out_directory/peak-detected.svg")
 
@@ -868,7 +866,7 @@ function assess_dnamer_saturation(fastxs::AbstractVector{<:AbstractString}; powe
             if k != first(ks)
                 StatsPlots.plot!(p, legend = false)
             end
-            display(p)
+            present_figure(p; name = "dnamer_saturation_k$(k)")
             if !ismissing(outdir)
                 # StatsPlots.savefig(p, joinpath(outdir, "$k.png"))
                 StatsPlots.savefig(p, joinpath(outdir, "$k.svg"))

--- a/src/plotting-and-visualization.jl
+++ b/src/plotting-and-visualization.jl
@@ -1042,7 +1042,7 @@ function visualize_xam_classifications(; xam, sample_id, accession_to_taxid_tabl
     StatsPlots.savefig(p, xam * ".$(sample_id).sankey.png")
     StatsPlots.savefig(p, xam * ".$(sample_id).sankey.svg")
     StatsPlots.savefig(p, xam * ".$(sample_id).sankey.pdf")
-    display(p)
+    present_figure(p; name = "xam_$(sample_id)_sankey")
 
     for taxa_level in ["domain", "family", "genus", "species"]
         taxa_counts = sort(
@@ -1056,14 +1056,14 @@ function visualize_xam_classifications(; xam, sample_id, accession_to_taxid_tabl
         CairoMakie.save(xam * ".$(sample_id).$(taxa_level).counts.png", fig)
         CairoMakie.save(xam * ".$(sample_id).$(taxa_level).counts.svg", fig)
         CairoMakie.save(xam * ".$(sample_id).$(taxa_level).counts.pdf", fig)
-        display(fig)
+        present_figure(fig; name = "xam_$(sample_id)_$(taxa_level)_counts")
 
         fig = Mycelia.visualize_single_sample_taxa_count_pair_proportions(taxa_count_pairs,
             title = "Distribution of Relative Abundance by Taxa:$(taxa_level) - sample_id:$(sample_id)")
         CairoMakie.save(xam * ".$(sample_id).$(taxa_level).proportion.png", fig)
         CairoMakie.save(xam * ".$(sample_id).$(taxa_level).proportion.svg", fig)
         CairoMakie.save(xam * ".$(sample_id).$(taxa_level).proportion.pdf", fig)
-        display(fig)
+        present_figure(fig; name = "xam_$(sample_id)_$(taxa_level)_proportion")
     end
 end
 
@@ -1312,10 +1312,7 @@ function plot_kmer_rarefaction(
             marker = marker, markersize = markersize)
     end
 
-    if display_plot
-        Base.@info "Displaying rarefaction plot..."
-        Makie.display(fig)
-    end
+    present_figure(fig; name = "kmer_rarefaction", display_plot = display_plot)
 
     output_path_png = Base.Filesystem.joinpath(output_dir, output_basename * ".png")
     output_path_pdf = Base.Filesystem.joinpath(output_dir, output_basename * ".pdf")
@@ -3129,9 +3126,9 @@ function plot_optimal_cluster_assessment_results(clustering_results)
         legend = false
     )
     StatsPlots.vline!(p2, [optimal_number_of_clusters])
-    display(p2)
+    present_figure(p2; name = "cluster_assessment_silhouette")
     StatsPlots.savefig(p1, "$DIR/wcss.svg")
-    display(p1)
+    present_figure(p1; name = "cluster_assessment_wcss")
     StatsPlots.savefig(p2, "$DIR/silhouette.svg")
 end
 
@@ -6267,4 +6264,49 @@ function plot_alpha_diversity_violins(alpha_df::DataFrames.DataFrame;
     end
 
     return fig
+end
+
+"""
+    should_display_plots() -> Bool
+
+Whether library plotting functions should open figures interactively. Off by
+default so tests, scripts, batch pipelines, and CI never pop windows on the
+user's machine; enable interactive display with `ENV["MYCELIA_SHOW_PLOTS"] =
+"true"`. Always `false` under CI (`CI` / `GITHUB_ACTIONS`).
+"""
+function should_display_plots()
+    (get(ENV, "CI", "") == "true" || get(ENV, "GITHUB_ACTIONS", "") == "true") &&
+        return false
+    return lowercase(get(ENV, "MYCELIA_SHOW_PLOTS", "false")) == "true"
+end
+
+"""
+    present_figure(figure; name=nothing, display_plot=true) -> figure
+
+Central policy for a library-generated figure. Saves it to the artifact
+directory `ENV["MYCELIA_PLOT_ARTIFACTS"]` when that is set and a `name` is given
+(as `<dir>/<name>.png` + `.svg` via [`save_plot`](@ref) — so CI can collect
+figures as build artifacts), and displays it interactively only when
+`display_plot` and [`should_display_plots`](@ref) both hold. Returns `figure`
+unchanged so callers can still capture and save it themselves. This replaces
+unconditional `display(...)` calls in plotting functions, which otherwise open
+windows during tests and non-interactive runs.
+"""
+function present_figure(
+        figure;
+        name::Union{AbstractString, Nothing} = nothing,
+        display_plot::Bool = true
+)
+    dir = get(ENV, "MYCELIA_PLOT_ARTIFACTS", "")
+    if !isempty(dir) && name !== nothing
+        try
+            save_plot(figure, joinpath(dir, String(name)))
+        catch e
+            @warn "failed to save plot artifact" name exception = e
+        end
+    end
+    if display_plot && should_display_plots()
+        display(figure)
+    end
+    return figure
 end

--- a/src/plotting-and-visualization.jl
+++ b/src/plotting-and-visualization.jl
@@ -6285,8 +6285,9 @@ end
 
 Central policy for a library-generated figure. Saves it to the artifact
 directory `ENV["MYCELIA_PLOT_ARTIFACTS"]` when that is set and a `name` is given
-(as `<dir>/<name>.png` + `.svg` via [`save_plot`](@ref) — so CI can collect
-figures as build artifacts), and displays it interactively only when
+(as `<dir>/<name>.png` + `.svg` via [`save_plot`](@ref), so a CI job that sets the
+variable and uploads the directory can collect figures as build artifacts — no
+workflow wires this yet), and displays it interactively only when
 `display_plot` and [`should_display_plots`](@ref) both hold. Returns `figure`
 unchanged so callers can still capture and save it themselves. This replaces
 unconditional `display(...)` calls in plotting functions, which otherwise open
@@ -6302,6 +6303,10 @@ function present_figure(
         try
             save_plot(figure, joinpath(dir, String(name)))
         catch e
+            # Best-effort artifact save: a diagnostic figure is never worth
+            # crashing a pipeline. But do not swallow an interrupt (Ctrl-C during
+            # a batch) — re-raise it so the user stays in control.
+            e isa InterruptException && rethrow()
             @warn "failed to save plot artifact" name exception = e
         end
     end

--- a/test/2_preprocessing_qc/figure_display_policy_test.jl
+++ b/test/2_preprocessing_qc/figure_display_policy_test.jl
@@ -1,0 +1,61 @@
+import Test
+import Mycelia
+import CairoMakie
+
+# Locks the figure-display policy that keeps the suite headless: library plotting
+# functions must not open windows unless the user opts in, and must never open
+# them under CI. All ENV mutations are scoped with `withenv` (`=> nothing` unsets)
+# so this test cannot leak display-on into the rest of the suite.
+Test.@testset "figure display policy" begin
+    Test.@testset "should_display_plots" begin
+        # Off by default (no env set).
+        withenv("MYCELIA_SHOW_PLOTS" => nothing, "CI" => nothing,
+            "GITHUB_ACTIONS" => nothing) do
+            Test.@test Mycelia.should_display_plots() == false
+        end
+        # Opt-in on.
+        withenv("MYCELIA_SHOW_PLOTS" => "true", "CI" => nothing,
+            "GITHUB_ACTIONS" => nothing) do
+            Test.@test Mycelia.should_display_plots() == true
+        end
+        # CI forces off even with opt-in (both CI and GITHUB_ACTIONS signals).
+        withenv("MYCELIA_SHOW_PLOTS" => "true", "CI" => "true") do
+            Test.@test Mycelia.should_display_plots() == false
+        end
+        withenv("MYCELIA_SHOW_PLOTS" => "true", "GITHUB_ACTIONS" => "true",
+            "CI" => nothing) do
+            Test.@test Mycelia.should_display_plots() == false
+        end
+        # Any non-"true" value is off.
+        withenv("MYCELIA_SHOW_PLOTS" => "false", "CI" => nothing,
+            "GITHUB_ACTIONS" => nothing) do
+            Test.@test Mycelia.should_display_plots() == false
+        end
+    end
+
+    Test.@testset "present_figure" begin
+        fig = CairoMakie.Figure()
+        ax = CairoMakie.Axis(fig[1, 1])
+        CairoMakie.lines!(ax, [0.0, 1.0], [0.0, 1.0])
+
+        # No-op (no display, no save) + returns the figure when nothing configured.
+        withenv("MYCELIA_PLOT_ARTIFACTS" => nothing, "MYCELIA_SHOW_PLOTS" => nothing) do
+            Test.@test Mycelia.present_figure(fig; name = "x") === fig
+        end
+
+        # Saves png + svg when an artifacts dir AND a name are given.
+        dir = mktempdir()
+        withenv("MYCELIA_PLOT_ARTIFACTS" => dir, "MYCELIA_SHOW_PLOTS" => nothing) do
+            Mycelia.present_figure(fig; name = "unit_smoke")
+        end
+        Test.@test isfile(joinpath(dir, "unit_smoke.png"))
+        Test.@test isfile(joinpath(dir, "unit_smoke.svg"))
+
+        # No artifact written when the dir is set but no name is given.
+        dir2 = mktempdir()
+        withenv("MYCELIA_PLOT_ARTIFACTS" => dir2, "MYCELIA_SHOW_PLOTS" => nothing) do
+            Mycelia.present_figure(fig)
+        end
+        Test.@test isempty(readdir(dir2))
+    end
+end

--- a/test/2_preprocessing_qc/figure_display_policy_test.jl
+++ b/test/2_preprocessing_qc/figure_display_policy_test.jl
@@ -1,6 +1,7 @@
 import Test
 import Mycelia
 import CairoMakie
+import StatsPlots
 
 # Locks the figure-display policy that keeps the suite headless: library plotting
 # functions must not open windows unless the user opts in, and must never open
@@ -31,6 +32,11 @@ Test.@testset "figure display policy" begin
             "GITHUB_ACTIONS" => nothing) do
             Test.@test Mycelia.should_display_plots() == false
         end
+        # Opt-in is case-insensitive (locks the lowercase() normalization).
+        withenv("MYCELIA_SHOW_PLOTS" => "TRUE", "CI" => nothing,
+            "GITHUB_ACTIONS" => nothing) do
+            Test.@test Mycelia.should_display_plots() == true
+        end
     end
 
     Test.@testset "present_figure" begin
@@ -50,6 +56,22 @@ Test.@testset "figure display policy" begin
         end
         Test.@test isfile(joinpath(dir, "unit_smoke.png"))
         Test.@test isfile(joinpath(dir, "unit_smoke.svg"))
+
+        # Also exercise the StatsPlots branch of save_plot — most routed sites
+        # (assess_dnamer_saturation, analyze_kmer_spectra, sankey, cluster
+        # assessment) emit StatsPlots plots, and save_plot handles them on a
+        # separate path. Assert non-empty to defeat a doubly-swallowed save
+        # failure (save_plot @warns internally; present_figure @warns on top).
+        sp = StatsPlots.plot([1, 2, 3], [3, 1, 2])
+        dir_sp = mktempdir()
+        withenv("MYCELIA_PLOT_ARTIFACTS" => dir_sp, "MYCELIA_SHOW_PLOTS" => nothing) do
+            Mycelia.present_figure(sp; name = "statsplots_smoke")
+        end
+        for ext in ("png", "svg")
+            path = joinpath(dir_sp, "statsplots_smoke.$(ext)")
+            Test.@test isfile(path)
+            Test.@test filesize(path) > 0
+        end
 
         # No artifact written when the dir is set but no name is given.
         dir2 = mktempdir()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -27,12 +27,23 @@ const MYCELIA_RUN_EXTERNAL = MYCELIA_RUN_ALL ||
 const MYCELIA_SHOW_PLOTS = lowercase(get(ENV, "MYCELIA_SHOW_PLOTS", "false")) == "true"
 const PROJECT_ROOT = dirname(@__DIR__)
 
-# Suppress plot display during tests by default.
-# Set MYCELIA_SHOW_PLOTS=true to enable interactive plot display.
+# Suppress interactive plot display during tests by default; set
+# MYCELIA_SHOW_PLOTS=true for interactive display. The primary guard is at the
+# library level (Mycelia.present_figure / should_display_plots, which also honors
+# CI); this env block is defense-in-depth for any backend path not routed through
+# present_figure. NOTE: GR reads `GKSwstype` (no underscore) — the previous
+# `GKS_WSTYPE` spelling was ignored, so GR could still open windows.
 if !MYCELIA_SHOW_PLOTS
-    ENV["GKS_WSTYPE"] = "100"       # GR backend: render to memory (no windows)
+    ENV["GKSwstype"] = "100"        # GR backend: render to file, no window (canonical name)
+    ENV["GKS_WSTYPE"] = "100"       # legacy spelling kept for safety
     ENV["DISPLAY"] = ""              # Prevent X11/Wayland window creation
     ENV["MPLBACKEND"] = "Agg"       # Matplotlib non-interactive backend (if used)
+end
+
+# When MYCELIA_PLOT_ARTIFACTS is set (e.g. by CI), library plotting functions
+# save figures there via Mycelia.present_figure for upload as build artifacts.
+if haskey(ENV, "MYCELIA_PLOT_ARTIFACTS") && !isempty(ENV["MYCELIA_PLOT_ARTIFACTS"])
+    mkpath(ENV["MYCELIA_PLOT_ARTIFACTS"])
 end
 
 const TEST_ARTIFACT_DIRS = [

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -40,8 +40,9 @@ if !MYCELIA_SHOW_PLOTS
     ENV["MPLBACKEND"] = "Agg"       # Matplotlib non-interactive backend (if used)
 end
 
-# When MYCELIA_PLOT_ARTIFACTS is set (e.g. by CI), library plotting functions
-# save figures there via Mycelia.present_figure for upload as build artifacts.
+# When MYCELIA_PLOT_ARTIFACTS is set, library plotting functions save figures
+# there via Mycelia.present_figure. A future CI job can set the variable and
+# upload the directory to collect figures as build artifacts (not yet wired).
 if haskey(ENV, "MYCELIA_PLOT_ARTIFACTS") && !isempty(ENV["MYCELIA_PLOT_ARTIFACTS"])
     mkpath(ENV["MYCELIA_PLOT_ARTIFACTS"])
 end


### PR DESCRIPTION
## Summary

Running the test suite opened figure windows on the developer's machine. Nine plotting call sites called `display(...)` / `Makie.display(...)` / `Plots.display(...)` **unconditionally** (or with inconsistent guards — `isinteractive()`, `display_plot && !is_ci`, or none), so the suite's `MYCELIA_SHOW_PLOTS` guard was bypassed whenever a test merely *called* a plotting function.

- Add **`present_figure(fig; name, display_plot)`** + **`should_display_plots()`** — one central policy: display only when `MYCELIA_SHOW_PLOTS=true` and **never under CI** (`CI`/`GITHUB_ACTIONS`); when `MYCELIA_PLOT_ARTIFACTS` is set, save `<name>.png` + `.svg` via the existing `save_plot` so **CI can collect figures as build artifacts**.
- Route all 9 sites through `present_figure` (`analyze_kmer_spectra`, `assess_dnamer_saturation`, `visualize_xam_classifications` ×3, `plot_kmer_rarefaction`, `plot_optimal_cluster_assessment_results` ×2, `identify_optimal_number_of_clusters`).
- `runtests.jl`: GR reads **`GKSwstype`**, not `GKS_WSTYPE` — the old spelling was silently ignored, so GR could still open windows; fixed and wired the artifacts dir (defense-in-depth; the primary guard is now at the library level).

## Behavior change

Library plotting functions no longer auto-display in interactive use unless `MYCELIA_SHOW_PLOTS=true`. They still **return** the figure, so callers can display/save it themselves. This is the intended "make figures optional" behavior.

## Test Plan

- [x] Previously-leaking `test/3_feature_extraction_kmer/kmer_analysis_additional_coverage_test.jl` (exercises `assess_dnamer_saturation`) — **251/251 headless, no windows**.
- [x] Gating + artifact smoke test: display off by default; forced off under CI even with `MYCELIA_SHOW_PLOTS=true`; opt-in enables; `MYCELIA_PLOT_ARTIFACTS` produces PNG+SVG; `present_figure` returns the figure.
- [ ] Full Core suite locally (GitHub Actions is billing-blocked on this account, so the local suite is the gate).

## Follow-up (not in this PR)

Wiring a Documenter.jl docs build to render these figures as documentation artifacts (the third option discussed) — larger, and blocked on GitHub Actions billing before the CI upload can run.