### PR TITLE
fix: use portable gzip -cd instead of BSD zcat for .gz on macOS

### DIFF
--- a/src/fastx.jl
+++ b/src/fastx.jl
@@ -1432,7 +1432,7 @@ $(DocStringExtensions.TYPEDSIGNATURES)
 
 Concatenate FASTQ/FASTA files (gz or plain) into a single output file.
 Maintains input order and works for both single-end and paired-end files (one stream).
-Uses system `cat`/`zcat` (or `gzip -cd`) and optional `pigz`/`gzip` compression when
+Uses system `cat`/`gzip -cd` (with a `zcat` fallback) and optional `pigz`/`gzip` compression when
 the output path ends with `.gz`.
 """
 function concatenate_fastx(

--- a/src/fastx.jl
+++ b/src/fastx.jl
@@ -1460,10 +1460,13 @@ function concatenate_fastx(
         open(tmp_out, "w") do out_io
             for f in inputs
                 cmd = if endswith(f, ".gz")
-                    if zcat_cmd !== nothing
-                        Cmd([zcat_cmd, f])
-                    else
+                    # Prefer portable `gzip -cd`: macOS ships BSD `zcat`, which
+                    # only decompresses `.Z` (it appends `.Z` and errors on a
+                    # `.gz` path), so `Sys.which("zcat")` finding it is a trap.
+                    if gzip_cmd !== nothing
                         Cmd([gzip_cmd, "-cd", f])
+                    else
+                        Cmd([zcat_cmd, f])
                     end
                 else
                     Cmd([cat_cmd, f])
@@ -2129,7 +2132,8 @@ function qc_filter_long_reads_chopper(;
 
         # Handle both compressed and uncompressed input files
         input_cmd = if endswith(in_fastq, ".gz")
-            `zcat $(in_fastq)`
+            # `gzip -cd` is portable; macOS BSD `zcat` errors on `.gz` input.
+            `gzip -cd $(in_fastq)`
         else
             `cat $(in_fastq)`
         end


### PR DESCRIPTION
## Summary

The full test suite aborted on macOS at `fastx_utilities_test.jl` because `concatenate_fastx` invoked **BSD `zcat`** (macOS `/usr/bin/zcat`), which only decompresses `.Z` — it appends `.Z` to the path and errors on a `.gz` input (`zcat: can't stat: b.fna.gz (b.fna.gz.Z)`).

- `concatenate_fastx` already had a `gzip -cd` fallback but preferred `zcat` whenever `Sys.which("zcat")` was non-nothing — which on macOS *finds* the broken binary. **Invert the preference: `gzip -cd` first** (portable on macOS + Linux), `zcat` only if `gzip` is absent.
- Apply the same swap to the chopper-QC input path (`src/fastx.jl` ~2132), which hardcoded `` `zcat` ``.

## Test Plan

- [x] `test/2_preprocessing_qc/fastx_utilities_test.jl` — the `concatenate_fastx handles mixed plain and gz FASTA inputs` case now reaches its post-concatenation hash verification (identical hashes) with **0 errors** (previously errored at the `zcat` call).
- [ ] Full Core suite (was aborting here on macOS) — will confirm it now runs past `2_preprocessing_qc` (GitHub Actions is billing-blocked; local suite is the gate).

Unblocks the full-suite gate for the CAMI PR-curve PR (#426).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved cross-platform handling of compressed FASTX inputs.
  - FASTQ/FASTA concatenation and long-read quality control now prefer streaming decompression via `gzip` when available, with a fallback when not.
  - Avoids platform-specific `zcat` behavior issues (including on macOS), improving consistency and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->