### PR TITLE
[td-ck03] codex dispatch (medium risk)

### DIFF
--- a/src/rhizomorph/core/graph-construction.jl
+++ b/src/rhizomorph/core/graph-construction.jl
@@ -408,6 +408,7 @@ alongside k-mer observations.
 - `dataset_id::String="dataset_01"`: Dataset identifier for evidence tracking
 - `type_hint::Union{Nothing,Symbol}=nothing`: Optional alphabet hint (:DNA, :RNA, :AA)
 - `ambiguous_action::Symbol=:dna`: Resolution for ambiguous alphabets (:dna, :rna, :aa, :error)
+- `min_count::Int=1`: Minimum global k-mer observation count to retain
 
 # Returns
 - `MetaGraphsNext.MetaGraph`: Strand-specific qualmer graph with quality-aware evidence
@@ -417,11 +418,13 @@ function build_qualmer_graph_singlestrand(
         k::Int;
         dataset_id::String = "dataset_01",
         type_hint::Union{Nothing, Symbol} = nothing,
-        ambiguous_action::Symbol = :dna
+        ambiguous_action::Symbol = :dna,
+        min_count::Int = 1
 )
     if isempty(records)
         throw(ArgumentError("Cannot build graph from empty record set"))
     end
+    min_count >= 1 || throw(ArgumentError("min_count must be at least 1, got $min_count"))
 
     sequence_alphabet = _infer_sequence_alphabet(
         records;
@@ -439,11 +442,14 @@ function build_qualmer_graph_singlestrand(
 
     # Dispatch to type-stable core function
     if sequence_alphabet == :DNA
-        return _build_qualmer_graph_core(records, Val(k), Kmers.DNAKmer{k}, dataset_id)
+        return _build_qualmer_graph_core(
+            records, Val(k), Kmers.DNAKmer{k}, dataset_id; min_count = min_count)
     elseif sequence_alphabet == :RNA
-        return _build_qualmer_graph_core(records, Val(k), Kmers.RNAKmer{k}, dataset_id)
+        return _build_qualmer_graph_core(
+            records, Val(k), Kmers.RNAKmer{k}, dataset_id; min_count = min_count)
     elseif sequence_alphabet == :AA
-        return _build_qualmer_graph_core(records, Val(k), Kmers.AAKmer{k}, dataset_id)
+        return _build_qualmer_graph_core(
+            records, Val(k), Kmers.AAKmer{k}, dataset_id; min_count = min_count)
     else
         error("Unsupported sequence type for qualmer graph: $sequence_alphabet")
     end
@@ -459,8 +465,10 @@ function _build_qualmer_graph_core(
         records::Vector{FASTX.FASTQ.Record},
         ::Val{K},
         ::Type{KmerType},
-        dataset_id::String
+        dataset_id::String;
+        min_count::Int = 1
 ) where {K, KmerType <: Kmers.Kmer}
+    min_count >= 1 || throw(ArgumentError("min_count must be at least 1, got $min_count"))
     # Determine sequence type and iterator
     if KmerType <: Kmers.DNAKmer
         SeqType = BioSequences.LongDNA{4}
@@ -497,6 +505,20 @@ function _build_qualmer_graph_core(
     end
     ActualKmerType = actual_kmer_type === nothing ? KmerType : actual_kmer_type
 
+    kmer_counts = if min_count == 1
+        nothing
+    else
+        counts = Dict{ActualKmerType, Int}()
+        for record in records
+            sequence = FASTX.sequence(SeqType, record)
+            for value in KmerIterator(sequence)
+                kmer = is_aa ? value : value[1]
+                counts[kmer] = get(counts, kmer, 0) + 1
+            end
+        end
+        counts
+    end
+
     # Create empty directed graph with actual kmer type as vertex labels
     # ALWAYS use directed graphs - MetaGraph with DiGraph backend
     graph = MetaGraphsNext.MetaGraph(
@@ -521,6 +543,9 @@ function _build_qualmer_graph_core(
         else
             # UnambiguousDNAMers/RNAMers return (kmer, position) tuples
             collect(KmerIterator(sequence))
+        end
+        if kmer_counts !== nothing
+            filter!(item -> get(kmer_counts, item[1], 0) >= min_count, kmers_with_positions)
         end
 
         # Add vertices and evidence
@@ -589,7 +614,8 @@ function build_qualmer_graph_doublestrand(
         k::Int;
         dataset_id::String = "dataset_01",
         type_hint::Union{Nothing, Symbol} = nothing,
-        ambiguous_action::Symbol = :dna
+        ambiguous_action::Symbol = :dna,
+        min_count::Int = 1
 )
     if isempty(records)
         throw(ArgumentError("Cannot build graph from empty record set"))
@@ -601,7 +627,8 @@ function build_qualmer_graph_doublestrand(
         k;
         dataset_id = dataset_id,
         type_hint = type_hint,
-        ambiguous_action = ambiguous_action
+        ambiguous_action = ambiguous_action,
+        min_count = min_count
     )
 
     # Convert to doublestrand representation (replicate vertices/edges)
@@ -865,7 +892,8 @@ function build_qualmer_graph_canonical(
         k::Int;
         dataset_id::String = "dataset_01",
         type_hint::Union{Nothing, Symbol} = nothing,
-        ambiguous_action::Symbol = :dna
+        ambiguous_action::Symbol = :dna,
+        min_count::Int = 1
 )
     if isempty(records)
         throw(ArgumentError("Cannot build graph from empty record set"))
@@ -877,7 +905,8 @@ function build_qualmer_graph_canonical(
         k;
         dataset_id = dataset_id,
         type_hint = type_hint,
-        ambiguous_action = ambiguous_action
+        ambiguous_action = ambiguous_action,
+        min_count = min_count
     )
 
     # Convert to canonical representation

--- a/src/rhizomorph/fixed-length/qualmer-graphs.jl
+++ b/src/rhizomorph/fixed-length/qualmer-graphs.jl
@@ -20,7 +20,7 @@
 
 """
     build_qualmer_graph(records, k; dataset_id="dataset_01", mode=:singlestrand,
-                        type_hint=nothing, ambiguous_action=:dna)
+                        type_hint=nothing, ambiguous_action=:dna, min_count=1)
 
 Build a quality-aware k-mer de Bruijn graph from FASTQ records.
 
@@ -34,6 +34,7 @@ Preserves per-base quality scores for quality-aware assembly algorithms.
 - `mode::Symbol=:singlestrand`: Graph mode (:singlestrand, :doublestrand, or :canonical)
 - `type_hint::Union{Nothing,Symbol}=nothing`: Optional alphabet hint (:DNA, :RNA, :AA)
 - `ambiguous_action::Symbol=:dna`: Resolution for ambiguous alphabets (:dna, :rna, :aa, :error)
+- `min_count::Int=1`: Minimum global k-mer observation count to retain
 
 # Returns
 - `MetaGraphsNext.MetaGraph`: Quality-aware k-mer de Bruijn graph with Phred scores
@@ -89,8 +90,14 @@ function build_qualmer_graph(
         mode::Symbol = :singlestrand,
         type_hint::Union{Nothing, Symbol} = nothing,
         ambiguous_action::Symbol = :dna,
-        memory_profile::Symbol = :full
+        memory_profile::Symbol = :full,
+        min_count::Int = 1
 )
+    min_count >= 1 || throw(ArgumentError("min_count must be at least 1, got $min_count"))
+    if memory_profile != :full && min_count != 1
+        throw(ArgumentError("min_count is only supported with memory_profile=:full"))
+    end
+
     # Reduced quality profiles route through build_kmer_graph
     if memory_profile == :ultralight_quality
         return build_kmer_graph_singlestrand_ultralight_quality(
@@ -116,7 +123,8 @@ function build_qualmer_graph(
             k;
             dataset_id = dataset_id,
             type_hint = type_hint,
-            ambiguous_action = ambiguous_action
+            ambiguous_action = ambiguous_action,
+            min_count = min_count
         )
     elseif mode == :doublestrand
         return build_qualmer_graph_doublestrand(
@@ -124,7 +132,8 @@ function build_qualmer_graph(
             k;
             dataset_id = dataset_id,
             type_hint = type_hint,
-            ambiguous_action = ambiguous_action
+            ambiguous_action = ambiguous_action,
+            min_count = min_count
         )
     elseif mode == :canonical
         return build_qualmer_graph_canonical(
@@ -132,7 +141,8 @@ function build_qualmer_graph(
             k;
             dataset_id = dataset_id,
             type_hint = type_hint,
-            ambiguous_action = ambiguous_action
+            ambiguous_action = ambiguous_action,
+            min_count = min_count
         )
     else
         error("Invalid mode: $mode. Must be :singlestrand, :doublestrand, or :canonical")

--- a/test/4_assembly/qualmer_min_count_prefilter_test.jl
+++ b/test/4_assembly/qualmer_min_count_prefilter_test.jl
@@ -1,0 +1,52 @@
+import Test
+import FASTX
+import Kmers
+import Mycelia
+
+Test.@testset "Qualmer minimum-count prefilter" begin
+    records = [
+        FASTX.FASTQ.Record("shared_1", "AAAC", "IIII"),
+        FASTX.FASTQ.Record("shared_2", "AAAG", "IIII"),
+    ]
+
+    Test.@testset "default preserves all observations" begin
+        default_graph = Mycelia.Rhizomorph.build_qualmer_graph(records, 3)
+        explicit_graph = Mycelia.Rhizomorph.build_qualmer_graph(records, 3; min_count = 1)
+
+        Test.@test Set(Mycelia.Rhizomorph.labels(default_graph)) ==
+                   Set(Mycelia.Rhizomorph.labels(explicit_graph))
+        Test.@test Mycelia.Rhizomorph.vertex_count(default_graph) == 3
+        Test.@test Mycelia.Rhizomorph.edge_count(default_graph) == 2
+    end
+
+    Test.@testset "filters singleton vertices and incident edges before allocation" begin
+        graph = Mycelia.Rhizomorph.build_qualmer_graph(records, 3; min_count = 2)
+        shared = Kmers.DNAKmer{3}("AAA")
+
+        Test.@test Mycelia.Rhizomorph.vertex_count(graph) == 1
+        Test.@test Mycelia.Rhizomorph.edge_count(graph) == 0
+        Test.@test Mycelia.Rhizomorph.has_vertex(graph, shared)
+        Test.@test Mycelia.Rhizomorph.get_vertex_observation_count(graph, shared) == 2
+    end
+
+    Test.@testset "applies before strand conversion" begin
+        expected_vertex_counts = Dict(:doublestrand => 2, :canonical => 1)
+        for mode in keys(expected_vertex_counts)
+            graph = Mycelia.Rhizomorph.build_qualmer_graph(
+                records, 3; mode = mode, min_count = 2)
+            Test.@test Mycelia.Rhizomorph.vertex_count(graph) == expected_vertex_counts[mode]
+            Test.@test Mycelia.Rhizomorph.edge_count(graph) == 0
+        end
+    end
+
+    Test.@testset "rejects invalid thresholds" begin
+        error = try
+            Mycelia.Rhizomorph.build_qualmer_graph(records, 3; min_count = 0)
+            nothing
+        catch exception
+            exception
+        end
+        Test.@test error isa ArgumentError
+        Test.@test occursin("min_count must be at least 1", sprint(showerror, error))
+    end
+end


### PR DESCRIPTION
## Agent Dispatch Review

- **Bead:** td-ck03
- **Tool:** codex
- **Risk:** medium
- **Quality:** 4/5
- **Supervisor Verdict:** ACCEPT

## Summary
Clean min_count prefilter addition to qualmer graph construction. Two-pass counting when min_count>1, zero-overhead default. Properly propagated through all three strand modes with input validation and tests. Sandbox blocked commit/test execution but code is sound.

## Concerns
- Tests could not run due to sandbox Julia package instantiation failure — verify locally before merge
- Commit failed due to index.lock permission — changes are uncommitted in worktree
- Duplicate min_count validation in both public and internal functions is redundant but harmless

---
Auto-generated by agent-supervisor.sh