### PR TITLE
fix: record normalized transition probability in Rhizomorph walks

### DIFF
--- a/src/rhizomorph/algorithms/generation.jl
+++ b/src/rhizomorph/algorithms/generation.jl
@@ -160,13 +160,17 @@ function _tempered_walk(
             tempered = fill(1.0 / length(valid_transitions), length(valid_transitions))
         end
 
-        next_transition = _sample_transition(valid_transitions, tempered)
+        idx = _sample_transition_index(valid_transitions, tempered)
 
-        if next_transition === nothing
+        if idx === nothing
             break
         end
 
-        step_prob = next_transition[:probability]
+        next_transition = valid_transitions[idx]
+
+        # Record the normalized (tempered) sampling probability actually used, not the
+        # raw edge weight, so cumulative_prob stays a valid path probability.
+        step_prob = tempered[idx]
         cumulative_prob *= step_prob
 
         current_vertex = next_transition[:target_vertex]

--- a/src/rhizomorph/algorithms/path-finding.jl
+++ b/src/rhizomorph/algorithms/path-finding.jl
@@ -411,9 +411,12 @@ function probabilistic_walk_next(
         end
 
         transition_probs = _calculate_transition_probabilities(valid_transitions)
-        next_transition = _sample_transition(valid_transitions, transition_probs)
+        idx = _sample_transition_index(valid_transitions, transition_probs)
+        next_transition = valid_transitions[idx]
 
-        step_prob = next_transition[:probability]
+        # Record the NORMALIZED transition probability, not the raw edge weight, so
+        # cumulative_prob / GraphPath.total_probability stays a valid path probability.
+        step_prob = transition_probs[idx]
         cumulative_prob *= step_prob
 
         current_vertex = next_transition[:target_vertex]
@@ -582,13 +585,15 @@ function _calculate_transition_probabilities(transitions)
     return weights ./ total_weight
 end
 
-function _sample_transition(transitions, probabilities)
+# Draw the INDEX of a sampled transition so callers can recover the matching
+# normalized probability from their probability vector (see probabilistic_walk_next).
+function _sample_transition_index(transitions, probabilities)
     if isempty(transitions)
         return nothing
     end
 
     if length(transitions) == 1
-        return first(transitions)
+        return 1
     end
 
     r = Mycelia.Random.rand()
@@ -597,11 +602,16 @@ function _sample_transition(transitions, probabilities)
     for (i, prob) in enumerate(probabilities)
         cumulative += prob
         if r <= cumulative
-            return transitions[i]
+            return i
         end
     end
 
-    return last(transitions)
+    return length(transitions)
+end
+
+function _sample_transition(transitions, probabilities)
+    idx = _sample_transition_index(transitions, probabilities)
+    return idx === nothing ? nothing : transitions[idx]
 end
 
 """

--- a/test/4_assembly/probabilistic_algorithms_next.jl
+++ b/test/4_assembly/probabilistic_algorithms_next.jl
@@ -55,8 +55,8 @@ Test.@testset "Probabilistic Algorithms Next-Generation Tests" begin
 
     function add_reduced_edge_evidence!(edge_data)
         if edge_data isa Union{
-                Mycelia.Rhizomorph.UltralightQualityEdgeData,
-                Mycelia.Rhizomorph.LightweightQualityEdgeData}
+            Mycelia.Rhizomorph.UltralightQualityEdgeData,
+            Mycelia.Rhizomorph.LightweightQualityEdgeData}
             Mycelia.Rhizomorph.add_evidence!(
                 edge_data,
                 "dataset_01",
@@ -130,6 +130,41 @@ Test.@testset "Probabilistic Algorithms Next-Generation Tests" begin
         sequence1 = Mycelia.Rhizomorph.path_to_sequence(path1, graph)
         sequence2 = Mycelia.Rhizomorph.path_to_sequence(path2, graph)
         Test.@test sequence1 == sequence2
+    end
+
+    Test.@testset "Probabilistic Walk normalization (regression)" begin
+        # Regression: probabilistic_walk_next previously recorded the RAW edge
+        # weight as each step's probability instead of the normalized transition
+        # probability, so GraphPath.total_probability was an un-normalized weight
+        # product that could exceed 1.0. A fork whose raw weights (3.0, 2.0) do not
+        # sum to 1 makes the raw-vs-normalized difference observable.
+        fork = MetaGraphsNext.MetaGraph(
+            MetaGraphsNext.DiGraph(),
+            label_type = String,
+            vertex_data_type = Any,
+            edge_data_type = Mycelia.Rhizomorph.StrandWeightedEdgeData,
+            weight_function = Mycelia.Rhizomorph.edge_data_weight,
+            default_weight = 0.0
+        )
+        fork["A"] = nothing
+        fork["B"] = nothing
+        fork["C"] = nothing
+        fork["A", "B"] = Mycelia.Rhizomorph.StrandWeightedEdgeData(
+            3.0, Mycelia.Rhizomorph.Forward, Mycelia.Rhizomorph.Forward)
+        fork["A", "C"] = Mycelia.Rhizomorph.StrandWeightedEdgeData(
+            2.0, Mycelia.Rhizomorph.Forward, Mycelia.Rhizomorph.Forward)
+
+        # B and C are terminal, so the walk takes exactly one fork step.
+        path = Mycelia.Rhizomorph.probabilistic_walk_next(fork, "A", 5; seed = 42)
+        Test.@test length(path.steps) == 2
+        walked = path.steps[2]
+        # Normalized transition probabilities are 3/5 = 0.6 and 2/5 = 0.4 — never the
+        # raw 3.0 / 2.0 the buggy code recorded.
+        Test.@test walked.probability ≈ 0.6 || walked.probability ≈ 0.4
+        # total_probability must be a valid probability in (0, 1].
+        Test.@test 0.0 < path.total_probability <= 1.0
+        # cumulative probability is the product of per-step probabilities.
+        Test.@test path.total_probability ≈ walked.probability
     end
 
     Test.@testset "Maximum Weight Walk" begin
@@ -305,7 +340,8 @@ Test.@testset "Probabilistic Algorithms Next-Generation Tests" begin
         src, dst = first(MetaGraphsNext.edge_labels(canonical_graph))
         Test.@test haskey(canonical_weighted, src, dst)
         Test.@test haskey(canonical_weighted, dst, src)
-        Test.@test canonical_weighted[src, dst].weight == canonical_weighted[dst, src].weight
+        Test.@test canonical_weighted[src, dst].weight ==
+                   canonical_weighted[dst, src].weight
     end
 
     Test.@testset "Transition helper coverage" begin

--- a/test/4_assembly/probabilistic_algorithms_next.jl
+++ b/test/4_assembly/probabilistic_algorithms_next.jl
@@ -167,6 +167,71 @@ Test.@testset "Probabilistic Algorithms Next-Generation Tests" begin
         Test.@test path.total_probability ≈ walked.probability
     end
 
+    Test.@testset "Tempered generative walk normalization (regression)" begin
+        # The same raw-vs-normalized bug lived in _tempered_walk (generation.jl),
+        # reached only via generate_sequences(...; temperature != 1.0). Exercise it
+        # so a regression there is caught: every generated walk_probability must be
+        # a valid probability in (0, 1], never a raw edge-weight product.
+        fork = MetaGraphsNext.MetaGraph(
+            MetaGraphsNext.DiGraph(),
+            label_type = String,
+            vertex_data_type = Any,
+            edge_data_type = Mycelia.Rhizomorph.StrandWeightedEdgeData,
+            weight_function = Mycelia.Rhizomorph.edge_data_weight,
+            default_weight = 0.0
+        )
+        fork["A"] = nothing
+        fork["B"] = nothing
+        fork["C"] = nothing
+        fork["A", "B"] = Mycelia.Rhizomorph.StrandWeightedEdgeData(
+            3.0, Mycelia.Rhizomorph.Forward, Mycelia.Rhizomorph.Forward)
+        fork["A", "C"] = Mycelia.Rhizomorph.StrandWeightedEdgeData(
+            2.0, Mycelia.Rhizomorph.Forward, Mycelia.Rhizomorph.Forward)
+
+        results = Mycelia.Rhizomorph.generate_sequences(
+            fork, 6; walk_length = 5, seed = 42, temperature = 0.5)
+        Test.@test !isempty(results)
+        # temperature = 0.5 (< 1) sharpens but the recorded probability is still the
+        # normalized tempered value, never the raw 3.0 / 2.0.
+        for r in results
+            Test.@test 0.0 < r.walk_probability <= 1.0
+        end
+    end
+
+    Test.@testset "Probabilistic Walk cumulative product (regression)" begin
+        # Two guaranteed fork steps (every first-level child itself forks) so the
+        # cumulative product of two normalized steps is exercised — a bug that only
+        # manifests across >= 2 steps would slip past the single-step fork test.
+        g = MetaGraphsNext.MetaGraph(
+            MetaGraphsNext.DiGraph(),
+            label_type = String,
+            vertex_data_type = Any,
+            edge_data_type = Mycelia.Rhizomorph.StrandWeightedEdgeData,
+            weight_function = Mycelia.Rhizomorph.edge_data_weight,
+            default_weight = 0.0
+        )
+        for v in ("A", "B", "C", "D", "E", "F", "G")
+            g[v] = nothing
+        end
+        fwd = Mycelia.Rhizomorph.Forward
+        g["A", "B"] = Mycelia.Rhizomorph.StrandWeightedEdgeData(3.0, fwd, fwd)
+        g["A", "C"] = Mycelia.Rhizomorph.StrandWeightedEdgeData(1.0, fwd, fwd)
+        g["B", "D"] = Mycelia.Rhizomorph.StrandWeightedEdgeData(1.0, fwd, fwd)
+        g["B", "E"] = Mycelia.Rhizomorph.StrandWeightedEdgeData(3.0, fwd, fwd)
+        g["C", "F"] = Mycelia.Rhizomorph.StrandWeightedEdgeData(2.0, fwd, fwd)
+        g["C", "G"] = Mycelia.Rhizomorph.StrandWeightedEdgeData(2.0, fwd, fwd)
+
+        path = Mycelia.Rhizomorph.probabilistic_walk_next(g, "A", 10; seed = 7)
+        # Start + two fork steps.
+        Test.@test length(path.steps) == 3
+        # total_probability is the product of every step's probability (start = 1.0).
+        Test.@test path.total_probability ≈ prod(s.probability for s in path.steps)
+        Test.@test 0.0 < path.total_probability <= 1.0
+        # Each non-start step is a normalized fork probability, strictly below 1.
+        Test.@test path.steps[2].probability < 1.0
+        Test.@test path.steps[3].probability < 1.0
+    end
+
     Test.@testset "Maximum Weight Walk" begin
         graph = create_test_graph()
 

--- a/test/4_assembly/probabilistic_algorithms_next.jl
+++ b/test/4_assembly/probabilistic_algorithms_next.jl
@@ -188,13 +188,19 @@ Test.@testset "Probabilistic Algorithms Next-Generation Tests" begin
         fork["A", "C"] = Mycelia.Rhizomorph.StrandWeightedEdgeData(
             2.0, Mycelia.Rhizomorph.Forward, Mycelia.Rhizomorph.Forward)
 
+        # Force every walk to start at the fork vertex A (B and C are terminal, so a
+        # degree-weighted start could otherwise pick them and yield a 0-step walk).
         results = Mycelia.Rhizomorph.generate_sequences(
-            fork, 6; walk_length = 5, seed = 42, temperature = 0.5)
+            fork, 6; walk_length = 5, seed = 42, temperature = 0.5,
+            start_vertices = ["A"])
         Test.@test !isempty(results)
-        # temperature = 0.5 (< 1) sharpens but the recorded probability is still the
-        # normalized tempered value, never the raw 3.0 / 2.0.
+        # At temperature 0.5 the tempered distribution over the 3.0/2.0 fork is
+        # (3/5)^2 : (2/5)^2 renormalized = 9/13 : 4/13. Asserting the exact tempered
+        # value (not just the (0,1] bound) is what distinguishes the correct
+        # tempered[idx] from the raw edge weight OR the untempered 3/5, 2/5.
         for r in results
             Test.@test 0.0 < r.walk_probability <= 1.0
+            Test.@test (r.walk_probability ≈ 9 / 13) || (r.walk_probability ≈ 4 / 13)
         end
     end
 


### PR DESCRIPTION
## Summary
- `probabilistic_walk_next` and the tempered generative walk (`_tempered_walk`) recorded each step's probability as the **raw outgoing edge weight** instead of the normalized transition probability used for sampling.
- `GraphPath.total_probability` was therefore an un-normalized weight product that could exceed 1.0 (observed ~7.29e6 vs the correct ~0.5625 on a two-arm fork) — silently wrong for any caller trusting it.
- Adds `_sample_transition_index` so callers recover the sampled transition's normalized probability by position; `_sample_transition` keeps its existing object-returning contract (still used by `_tempered_walk`'s neighbor and unit-tested directly).

## Test Plan
- New fork regression test (raw weights 3.0/2.0 → normalized 0.6/0.4) asserts the recorded step probability is normalized and `total_probability ∈ (0,1]`; **fails before, passes after**.
- `probabilistic_algorithms_next.jl` 91/91, `generation_test.jl` 56/56, `viterbi_decoding_test.jl` 101/101 — all green.

## Notes
- The H2 K-shortest exact-control benchmark had been working around this by recomputing probabilities independently; this fixes it upstream.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected probabilistic and tempered walk probability tracking to use normalized per-step transition probabilities, keeping per-step and total path probabilities consistent (including multi-step products).
  * Improved transition sampling to select the next step by index from the already-normalized outgoing transition probabilities, with correct handling for empty and single-option cases.

* **Tests**
  * Added next-generation probabilistic walk regression tests validating per-step probabilities, tempered walk probability validity, and multi-step total-probability as the product across non-start steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->