### PR TITLE
perf: typed transitions + fused edge-scan in the Viterbi hot loop (byte-identical, -26% alloc)

### DIFF
--- a/benchmarking/results/opt2_alloc_hotloop.md
+++ b/benchmarking/results/opt2_alloc_hotloop.md
@@ -1,0 +1,103 @@
+# opt2 hot-loop allocation reduction
+
+Measurement of `Mycelia._viterbi_correct_observation` allocations before
+(pre-opt2, `origin/master`) and after (opt2, this branch) the typed-transition
+refactor. opt2 replaced `Vector{Any}` + `Dict{Symbol,Any}` transition
+representations in the hot Viterbi decode loop with a concrete-eltype
+`_Transition{L,E}` struct built in one fused pass
+(`_valid_transitions_and_total`), and hoisted per-depth diagnostics counters
+from boxed values to typed `Int` locals.
+
+## Result
+
+| | Bytes allocated | Commit |
+| --- | --- | --- |
+| Before (`origin/master`) | 44,528 | `0804d0ecc` (perf: parallelize `:scalable` corrector decode...) |
+| After (this branch, opt2) | 32,816 | `3eecafce` (fix: type-stabilize hoisted per-depth diagnostics locals with `::Int`) |
+
+**Reduction: 11,712 bytes (26.30%)** for a single call to
+`_viterbi_correct_observation` on the fixture below.
+
+Both measurements are exactly reproducible (7 repeated post-warmup calls on
+each branch returned identical byte counts every time — 32,816 bytes on
+`opt2-alloc`, 44,528 bytes on `origin/master`; zero variance).
+
+## Output identity confirmation
+
+Ran the identical fixture and call on both branches and compared every field
+of the result. All of the following matched byte-for-byte / bit-for-bit
+between before and after:
+
+- `path.steps[].vertex_label` — `[ATG, TGC, GCG, CGT, GTA, TAA]`
+- `path.steps[].strand` — all `Forward`
+- `path.steps[].probability` — `[1.0, 1.0, 0.6666666666666666, 1.0, 1.0, 1.0]`
+- `path.steps[].cumulative_probability` —
+  `[1.0, 1.0, 0.6666666666666666, 0.6666666666666666, 0.6666666666666666, 0.6666666666666666]`
+- `path.total_probability` — `0.6666666666666666`
+- `result.score` — `-0.5863711534711905`
+- `result.diagnostics` — all 20 key/value pairs identical, including
+  `successor_bounded => 1` (confirms the `_top_b_transitions` bounded-branch
+  code path fired identically on both branches)
+
+**The allocation reduction did not change decode output.** This also matches
+the pinned expected values in
+`test/4_assembly/viterbi_decode_golden_test.jl` (captured pre-refactor at
+commit `047142aa8`), which continues to pass on this branch.
+
+## Fixture
+
+Same fixture as the opt2 golden-master characterization test
+(`test/4_assembly/viterbi_decode_golden_test.jl`):
+
+- k=3 kmer graph built from 3 reads: `ATGCGTAA` (x2), `ATGCTTAA` (x1) — reads
+  share prefix `ATG,TGC`, branch at `TGC` into two out-edges (`GCG`
+  coverage=2, `GCT` coverage=1), then reconverge at `TAA`.
+- `mode = :singlestrand`, alphabet resolved to `:DNA`.
+- Observation: 6-kmer path `[ATG, TGC, GCG, CGT, GTA, TAA]`.
+- `Mycelia.ViterbiCorrectionConfig(max_successors_per_state = 1)` — forces
+  `_top_b_transitions` to bound the 2-way branch to one successor per depth,
+  so the fixture exercises both opt2-touched call sites: the fused
+  `_valid_transitions_and_total` scan and the `_top_b_transitions`
+  field-access sort.
+- Graph converted via `Mycelia.Rhizomorph.weighted_graph_from_rhizomorph`
+  before decode, matching production call shape.
+- Measurement protocol: build the fixture once, run
+  `_viterbi_correct_observation` once to force JIT compilation (warm-up, not
+  measured), then measure `@allocated` on the same fixture object for the
+  actual call. Repeated 7x per branch to confirm determinism.
+
+## Machine
+
+- Darwin 25.5.0 (arm64), Apple M5 Max
+- Julia 1.10.10
+- Project instantiated independently in both worktrees
+  (`.worktrees/opt2-alloc` for after, a scratch worktree of `origin/master`
+  for before) from the same `Project.toml` dependency versions available at
+  measurement time.
+
+## Caveats (read before generalizing this number)
+
+- **Micro-measurement, single fixture.** This is one small graph (3 reads,
+  k=3, 6-step observation, single branch point) run through one function.
+  It is not a benchmark of end-to-end corrector runtime, and it is not
+  necessarily representative of allocation behavior on larger graphs, longer
+  reads, wider branching factor, or `max_successors_per_state > 1` (which
+  exercises more of the beam-retention code paths that this fixture, by
+  design of `max_successors_per_state = 1`, does not stress).
+- **Directional, not a throughput claim.** A 26% reduction in bytes allocated
+  per call does not imply a 26% wall-clock speedup — allocation counts and
+  GC-driven wall time are correlated but not linearly so, and this report
+  makes no wall-clock claim.
+- **`@allocated` measures only the marked call, post-warmup.** Compilation
+  allocations are excluded by construction (the warm-up call absorbs them).
+  Allocations inside called library code (e.g. `MetaGraphsNext`,
+  `Rhizomorph` graph accessors invoked from within the decode) are included
+  if triggered by this call, but this report does not attribute the 11,712
+  byte reduction to any specific sub-expression beyond what opt2's commit
+  history documents (typed `_Transition{L,E}` construction, hoisted `Int`
+  diagnostics locals).
+- **No statistical variance reported** because none was observed across 7
+  repeated post-warmup calls per branch (identical byte count every time on
+  each branch) — this is expected for a purely deterministic, single-threaded
+  decode over a fixed fixture, not evidence about variance on other
+  workloads.

--- a/benchmarking/results/opt2_alloc_hotloop.md
+++ b/benchmarking/results/opt2_alloc_hotloop.md
@@ -35,11 +35,12 @@ between before and after:
   `[1.0, 1.0, 0.6666666666666666, 0.6666666666666666, 0.6666666666666666, 0.6666666666666666]`
 - `path.total_probability` — `0.6666666666666666`
 - `result.score` — `-0.5863711534711905`
-- `result.diagnostics` — all 20 key/value pairs identical, including
+- `result.diagnostics` — all 21 key/value pairs identical, including
   `successor_bounded => 1` (confirms the `_top_b_transitions` bounded-branch
-  code path fired identically on both branches)
+  code path fired on this fixture, with the same count on both branches)
 
-**The allocation reduction did not change decode output.** This also matches
+**The allocation reduction did not change decode output on this fixture.** This
+also matches
 the pinned expected values in
 `test/4_assembly/viterbi_decode_golden_test.jl` (captured pre-refactor at
 commit `047142aa8`), which continues to pass on this branch.

--- a/docs/design/2026-07-24-opt2-alloc-typed-transitions-design.md
+++ b/docs/design/2026-07-24-opt2-alloc-typed-transitions-design.md
@@ -100,9 +100,11 @@ function _valid_transitions_and_total(graph, vertex, strand) ... end
 
 The single pass iterates `outneighbors` in ascending dst-code order; for each
 strand-matched edge it (a) adds `_edge_transition_weight(edge_data)` to `total`
-(including 0.0-weight edges — they contribute exactly `0.0`, so the sum is
-bit-identical to the current `_total_outgoing_weight`), and (b) pushes a typed
-`_Transition` iff the weight is `> 0.0`. Returns `max(total, _KSP_MIN_WEIGHT)`
+(non-finite-weight edges contribute `0.0`, finite weights floor to
+`_KSP_MIN_WEIGHT = 1e-10`; the sum is bit-identical to the current
+`_total_outgoing_weight` because both add `_edge_transition_weight` for every
+strand-matched edge), and (b) pushes a typed `_Transition` iff the weight is
+`> 0.0`. Returns `max(total, _KSP_MIN_WEIGHT)`
 for `total_out`. **Order invariants:** `total_out` is summed over the full
 strand-matched set in `outneighbors` order and fully computed before any
 `edge_w / total_out` divide and before the top-B truncation — exactly as today.

--- a/docs/design/2026-07-24-opt2-alloc-typed-transitions-design.md
+++ b/docs/design/2026-07-24-opt2-alloc-typed-transitions-design.md
@@ -1,0 +1,171 @@
+# opt2: Kill the inner-DP allocation storm (typed transitions, fused edge-scan)
+
+Date: 2026-07-24
+Status: Approved (design)
+Scope: `_viterbi_correct_observation` hot decode loop — remove per-transition
+allocations, byte-identically.
+
+## Context
+
+The per-read Viterbi decode is the corrector's dominant runtime term. Its inner
+loop allocates heavily: an untyped `Vector{Any}` of per-edge `Dict{Symbol,Any}`
+per active state per depth, plus boxed-`Int` diagnostics increments, plus a
+redundant second full scan of every state's out-edges. This is the third step of
+the corrector performance campaign (after opt5's GC gating and opt1's
+parallelism). It matters more now that opt1 runs the decode across threads:
+allocation pressure is multiplied across cores, so cutting per-transition
+allocation reduces GC contention on every worker.
+
+The load-bearing constraint is **byte-identical decode output** — the corrector
+lock tests assert byte-identical corrected reads across passes, and the opt1
+`parallel_soft_em_byte_identity` test asserts byte-identical soft-EM weights. Any
+refactor must preserve exact iteration order, exact floating-point accumulation
+order, and the weight floor.
+
+## Key facts (post-opt1 baseline)
+
+Files: `src/viterbi-next.jl` (hot loop) and
+`src/rhizomorph/algorithms/path-finding.jl` (transition builder + weight scan).
+
+1. **The transition container.** The hot loop (`_viterbi_correct_observation`,
+   depth loop ~1411-1552) calls `_get_valid_transitions(graph, vertex, strand)`
+   (path-finding.jl ~531), which builds `transitions = []` (a `Vector{Any}`) and
+   `push!`es a `Dict{Symbol,Any}` per edge (`_maybe_push_transition!`,
+   path-finding.jl ~515-526) with four keys: `:target_vertex` (dst label),
+   `:target_strand` (`StrandOrientation`), `:probability` (`Float64`),
+   `:edge_data` (edge-data struct).
+2. **Enumeration order + filters.** Directed/production path iterates
+   `Graphs.outneighbors(graph.graph, src_code)` in ascending dst-code order, with
+   a strand filter `_normalize_strand(edge_data.src_strand) == strand` and a
+   positive-weight filter (`_edge_transition_weight(edge_data) <= 0.0` skips).
+3. **The double scan.** The loop separately calls
+   `_total_outgoing_weight(graph, vertex, strand)` (path-finding.jl ~760) which
+   scans the **same** `outneighbors` set in the **same** order with the **same**
+   strand filter, summing `total += _edge_transition_weight(edge_data)` and
+   returning `max(total, _KSP_MIN_WEIGHT)` (`_KSP_MIN_WEIGHT = 1e-10`).
+4. **Diagnostics.** `diagnostics::Dict{Symbol,Any}` counters are bumped inside
+   the loop (`:expanded_states`, `:skipped_transitions`, `:generated_states`,
+   `:successor_bounded`, `:beam_pruned`, `:margin_pruned`, and the per-depth
+   `:retained_states` / `:cumulative_retained_states` / `:max_retained_states` /
+   `:completed_steps`). Each `+= 1` on an `Any`-typed Dict boxes an `Int`. All
+   read-backs are in-loop self-reads; external consumers read only final values.
+5. **Consumers of `_get_valid_transitions`.** Besides the hot loop, the return is
+   consumed by `_calculate_transition_probabilities`, `_sample_transition`,
+   `_top_b_transitions` (sorts by `(_edge_transition_weight(t[:edge_data]),
+   string(t[:target_vertex]))`), and a few other sites — all read `:edge_data`
+   and/or `:probability`/`:target_vertex`.
+6. **Byte-identity surfaces.** Float accumulations: the `total_out` running sum;
+   `transition_prob = edge_w / total_out`; `next_score = state_score +
+   log(transition_prob) + emission_score`; the cumulative emission
+   `get(active_emissions, state, 0.0) + emission_score`. Ordered iterations that
+   drive tie-breaks: the `outneighbors` order, the `active_scores` Dict iteration
+   (line ~1420), the `transitions` iteration, and the beam-prune sorts (which
+   tie-break on `hash(state_tuple)` — so the **state-tuple key type must not
+   change**).
+
+## Design (changes 1-3; change 4 deferred)
+
+### 1. Typed transition struct
+
+Define a concrete, parametric struct and replace the per-edge Dict:
+
+```julia
+struct _Transition{L, E}
+    target_vertex::L
+    target_strand::StrandOrientation
+    probability::Float64
+    edge_data::E
+end
+```
+
+`_get_valid_transitions` returns a typed `Vector{_Transition{L,E}}` (element type
+inferred from the first push, or built via a typed accumulator). Update every
+consumer from `t[:key]` to `t.key` field access
+(`_maybe_push_transition!`, the hot-loop consumer at ~1445-1478,
+`_calculate_transition_probabilities`, `_sample_transition`,
+`_top_b_transitions`, and the other `t[:edge_data]` sites). Byte-identical: the
+push order (outneighbors) is unchanged, the four values are unchanged, and the
+state-tuple key type (`(next_vertex, next_strand)`) is untouched — so
+`hash`-based tie-breaks are unaffected.
+
+### 2. Fuse `_total_outgoing_weight` into the transition pass
+
+Replace the two separate `outneighbors` scans (transition build at ~1422 +
+weight sum at ~1428) with one pass that returns both:
+
+```julia
+# returns (transitions::Vector{_Transition}, total_out::Float64)
+function _valid_transitions_and_total(graph, vertex, strand) ... end
+```
+
+The single pass iterates `outneighbors` in ascending dst-code order; for each
+strand-matched edge it (a) adds `_edge_transition_weight(edge_data)` to `total`
+(including 0.0-weight edges — they contribute exactly `0.0`, so the sum is
+bit-identical to the current `_total_outgoing_weight`), and (b) pushes a
+`_Transition` iff the weight is `> 0.0`. Return `max(total, _KSP_MIN_WEIGHT)` for
+`total_out`. **Order invariants:** `total_out` is summed over the full
+strand-matched set in `outneighbors` order and fully computed before any
+`edge_w / total_out` divide and before the top-B truncation — exactly as today.
+Keep `_total_outgoing_weight` and `_get_valid_transitions` as thin wrappers (or
+in place) for their other call sites, so only the hot loop switches to the fused
+path.
+
+### 3. Hoist diagnostics to local `Int` accumulators
+
+Replace each in-loop `diagnostics[:key] += 1` (and the `get(diagnostics, :key,
+0) + 1` forms) with unboxed `Int` locals, initialized from the pre-loop values
+where a running max / cumulative sum is seeded, updated in the loop, and written
+back into `diagnostics` once after the loop. Final values are identical (the
+counters are only self-read in-loop); the win is removing per-transition boxed
+allocation.
+
+### 4. (Deferred) Reuse per-depth Dicts
+
+**Out of scope — byte-identity risk.** `next_predecessors` is retained for
+traceback (can't be reused); reusing `next_scores`/`next_emissions` via `empty!`
+retains hash-table capacity and changes iteration order versus a fresh Dict,
+which can flip an equal-score tie-break in the next depth's `active_scores`
+iteration — a byte-identity break for a marginal allocation gain. Recorded as a
+possible approximate-tier item, not part of opt2.
+
+## Testing
+
+- **Golden-master decode test:** capture `_viterbi_correct_observation`'s full
+  output (decode path, best score, and the diagnostics Dict) on a fixed
+  graph+read+config BEFORE the refactor; assert bit-identical AFTER. This
+  directly locks the hot loop independent of the full corrector.
+- **Existing lock tests** (`low_k_decode_gating`, `reassembly_graph_reuse`,
+  `batched_viterbi_kernel`) assert byte-identical corrected reads through the
+  full corrector — must stay green.
+- **opt1 `parallel_soft_em_byte_identity`** asserts byte-identical soft-EM
+  weights (parallel and serial) — must stay green (opt2 is inside the decode
+  both paths share).
+- **Allocation check (optional):** a `@allocated` micro-benchmark on the hot loop
+  before/after to confirm the allocation reduction (directional; not a pass/fail
+  gate).
+
+## Risks
+
+- **Type instability from `_Transition{L,E}`** if `L`/`E` aren't concrete at the
+  call site — verify the element type is inferred concretely (the win depends on
+  it). Mitigate by constructing the vector with the known element type.
+- **Missed consumer** of the old Dict interface — grep every `t[:` / `[:target_`
+  / `[:edge_data` / `[:probability` / `[:target_strand` site and convert. A
+  missed site is a `MethodError` (loud), not a silent byte-identity break.
+- **Fusion reordering** the float sum — mitigated by summing in `outneighbors`
+  order over the full strand-matched set (identical to today).
+
+## Out of scope
+
+Change 4 (Dict reuse). Later campaign steps: opt4 (cross-pass memo, approximate)
+and opt3 (batched/SIMD kernel wiring).
+
+## Acceptance criteria
+
+- Per-edge `Dict{Symbol,Any}` and `Vector{Any}` transitions replaced by the typed
+  struct/vector; all consumers converted to field access.
+- The two out-edge scans fused into one; `total_out` bit-identical.
+- Diagnostics counters hoisted to `Int` locals; final diagnostics identical.
+- Golden-master decode test passes (path + score + diagnostics bit-identical);
+  all corrector lock tests + the opt1 soft-EM byte-identity test stay green.
+- Allocation reduction demonstrated on the hot loop (reported as measured).

--- a/docs/design/2026-07-24-opt2-alloc-typed-transitions-design.md
+++ b/docs/design/2026-07-24-opt2-alloc-typed-transitions-design.md
@@ -1,9 +1,7 @@
 # opt2: Kill the inner-DP allocation storm (typed transitions, fused edge-scan)
 
-Date: 2026-07-24
-Status: Approved (design)
-Scope: `_viterbi_correct_observation` hot decode loop — remove per-transition
-allocations, byte-identically.
+Date: 2026-07-24 Status: Approved (design) Scope: `_viterbi_correct_observation`
+hot decode loop — remove per-transition allocations, byte-identically.
 
 ## Context
 
@@ -18,9 +16,9 @@ allocation reduces GC contention on every worker.
 
 The load-bearing constraint is **byte-identical decode output** — the corrector
 lock tests assert byte-identical corrected reads across passes, and the opt1
-`parallel_soft_em_byte_identity` test asserts byte-identical soft-EM weights. Any
-refactor must preserve exact iteration order, exact floating-point accumulation
-order, and the weight floor.
+`parallel_soft_em_byte_identity` test asserts byte-identical soft-EM weights.
+Any refactor must preserve exact iteration order, exact floating-point
+accumulation order, and the weight floor.
 
 ## Key facts (post-opt1 baseline)
 
@@ -35,9 +33,9 @@ Files: `src/viterbi-next.jl` (hot loop) and
    `:target_strand` (`StrandOrientation`), `:probability` (`Float64`),
    `:edge_data` (edge-data struct).
 2. **Enumeration order + filters.** Directed/production path iterates
-   `Graphs.outneighbors(graph.graph, src_code)` in ascending dst-code order, with
-   a strand filter `_normalize_strand(edge_data.src_strand) == strand` and a
-   positive-weight filter (`_edge_transition_weight(edge_data) <= 0.0` skips).
+   `Graphs.outneighbors(graph.graph, src_code)` in ascending dst-code order,
+   with a strand filter `_normalize_strand(edge_data.src_strand) == strand` and
+   a positive-weight filter (`_edge_transition_weight(edge_data) <= 0.0` skips).
 3. **The double scan.** The loop separately calls
    `_total_outgoing_weight(graph, vertex, strand)` (path-finding.jl ~760) which
    scans the **same** `outneighbors` set in the **same** order with the **same**
@@ -49,25 +47,39 @@ Files: `src/viterbi-next.jl` (hot loop) and
    `:retained_states` / `:cumulative_retained_states` / `:max_retained_states` /
    `:completed_steps`). Each `+= 1` on an `Any`-typed Dict boxes an `Int`. All
    read-backs are in-loop self-reads; external consumers read only final values.
-5. **Consumers of `_get_valid_transitions`.** Besides the hot loop, the return is
-   consumed by `_calculate_transition_probabilities`, `_sample_transition`,
-   `_top_b_transitions` (sorts by `(_edge_transition_weight(t[:edge_data]),
-   string(t[:target_vertex]))`), and a few other sites — all read `:edge_data`
-   and/or `:probability`/`:target_vertex`.
+5. **Consumers of `_get_valid_transitions`.** Besides the hot loop, the return
+   is consumed by `_calculate_transition_probabilities`, `_sample_transition`,
+   `_top_b_transitions` (sorts by
+   `(_edge_transition_weight(t[:edge_data]), string(t[:target_vertex]))`), and a
+   few other sites — all read `:edge_data` and/or
+   `:probability`/`:target_vertex`.
 6. **Byte-identity surfaces.** Float accumulations: the `total_out` running sum;
-   `transition_prob = edge_w / total_out`; `next_score = state_score +
-   log(transition_prob) + emission_score`; the cumulative emission
-   `get(active_emissions, state, 0.0) + emission_score`. Ordered iterations that
-   drive tie-breaks: the `outneighbors` order, the `active_scores` Dict iteration
-   (line ~1420), the `transitions` iteration, and the beam-prune sorts (which
-   tie-break on `hash(state_tuple)` — so the **state-tuple key type must not
-   change**).
+   `transition_prob = edge_w / total_out`;
+   `next_score = state_score + log(transition_prob) + emission_score`; the
+   cumulative emission `get(active_emissions, state, 0.0) + emission_score`.
+   Ordered iterations that drive tie-breaks: the `outneighbors` order, the
+   `active_scores` Dict iteration (line ~1420), the `transitions` iteration, and
+   the beam-prune sorts (which tie-break on `hash(state_tuple)` — so the
+   **state-tuple key type must not change**).
 
 ## Design (changes 1-3; change 4 deferred)
 
-### 1. Typed transition struct
+### Scoping decision: hot-loop-only typed path (narrow blast radius)
 
-Define a concrete, parametric struct and replace the per-edge Dict:
+`_get_valid_transitions` feeds ~12 consumers across 5 files, but only the two
+hot decode call sites (viterbi-next.jl ~1422/1428 and ~1820/1830) run
+per-active-state per-depth. The cold consumers (`information-theory.jl`,
+`generation.jl`, `batched-viterbi-poc.jl`, and the `path-finding.jl`
+sampling/traversal helpers at ~407/467/665) are called rarely and get no benefit
+from de-allocation. So changes 1 and 2 are **isolated to the hot loop**: add a
+new typed, fused function used only there; leave `_get_valid_transitions` /
+`_total_outgoing_weight` (Dict form) untouched for every cold consumer. This
+keeps the byte-identity-critical, high- churn change to ~2 call sites instead of
+forcing a global return-type change.
+
+### 1 + 2. Typed transition struct + fused single-pass (hot loop only)
+
+Define a concrete parametric struct:
 
 ```julia
 struct _Transition{L, E}
@@ -78,46 +90,41 @@ struct _Transition{L, E}
 end
 ```
 
-`_get_valid_transitions` returns a typed `Vector{_Transition{L,E}}` (element type
-inferred from the first push, or built via a typed accumulator). Update every
-consumer from `t[:key]` to `t.key` field access
-(`_maybe_push_transition!`, the hot-loop consumer at ~1445-1478,
-`_calculate_transition_probabilities`, `_sample_transition`,
-`_top_b_transitions`, and the other `t[:edge_data]` sites). Byte-identical: the
-push order (outneighbors) is unchanged, the four values are unchanged, and the
-state-tuple key type (`(next_vertex, next_strand)`) is untouched — so
-`hash`-based tie-breaks are unaffected.
-
-### 2. Fuse `_total_outgoing_weight` into the transition pass
-
-Replace the two separate `outneighbors` scans (transition build at ~1422 +
-weight sum at ~1428) with one pass that returns both:
+Add ONE new function that fuses the transition build and the total-weight sum
+into a single `outneighbors` pass, returning a typed vector plus the total:
 
 ```julia
-# returns (transitions::Vector{_Transition}, total_out::Float64)
+# returns (transitions::Vector{_Transition{L,E}}, total_out::Float64)
 function _valid_transitions_and_total(graph, vertex, strand) ... end
 ```
 
 The single pass iterates `outneighbors` in ascending dst-code order; for each
 strand-matched edge it (a) adds `_edge_transition_weight(edge_data)` to `total`
 (including 0.0-weight edges — they contribute exactly `0.0`, so the sum is
-bit-identical to the current `_total_outgoing_weight`), and (b) pushes a
-`_Transition` iff the weight is `> 0.0`. Return `max(total, _KSP_MIN_WEIGHT)` for
-`total_out`. **Order invariants:** `total_out` is summed over the full
+bit-identical to the current `_total_outgoing_weight`), and (b) pushes a typed
+`_Transition` iff the weight is `> 0.0`. Returns `max(total, _KSP_MIN_WEIGHT)`
+for `total_out`. **Order invariants:** `total_out` is summed over the full
 strand-matched set in `outneighbors` order and fully computed before any
 `edge_w / total_out` divide and before the top-B truncation — exactly as today.
-Keep `_total_outgoing_weight` and `_get_valid_transitions` as thin wrappers (or
-in place) for their other call sites, so only the hot loop switches to the fused
-path.
+
+At the two hot decode call sites, replace the paired
+`_get_valid_transitions(...)` + `_total_outgoing_weight(...)` calls with the
+single fused call, and convert their transition consumers (viterbi-next.jl
+~1446-1448 and ~1837-1841) plus `_top_b_transitions` (viterbi-next.jl:1213, a
+hot-loop-only helper — verify no cold caller) from `t[:key]` to `t.key` field
+access. Byte-identical: same push order, same values, state-tuple key type
+untouched (so `hash`-based tie-breaks are unaffected). The Dict-form
+`_get_valid_transitions` / `_total_outgoing_weight` remain for the cold
+consumers, whose `t[:key]` access is unchanged.
 
 ### 3. Hoist diagnostics to local `Int` accumulators
 
-Replace each in-loop `diagnostics[:key] += 1` (and the `get(diagnostics, :key,
-0) + 1` forms) with unboxed `Int` locals, initialized from the pre-loop values
-where a running max / cumulative sum is seeded, updated in the loop, and written
-back into `diagnostics` once after the loop. Final values are identical (the
-counters are only self-read in-loop); the win is removing per-transition boxed
-allocation.
+Replace each in-loop `diagnostics[:key] += 1` (and the
+`get(diagnostics, :key, 0) + 1` forms) with unboxed `Int` locals, initialized
+from the pre-loop values where a running max / cumulative sum is seeded, updated
+in the loop, and written back into `diagnostics` once after the loop. Final
+values are identical (the counters are only self-read in-loop); the win is
+removing per-transition boxed allocation.
 
 ### 4. (Deferred) Reuse per-depth Dicts
 
@@ -140,18 +147,21 @@ possible approximate-tier item, not part of opt2.
 - **opt1 `parallel_soft_em_byte_identity`** asserts byte-identical soft-EM
   weights (parallel and serial) — must stay green (opt2 is inside the decode
   both paths share).
-- **Allocation check (optional):** a `@allocated` micro-benchmark on the hot loop
-  before/after to confirm the allocation reduction (directional; not a pass/fail
-  gate).
+- **Allocation check (optional):** a `@allocated` micro-benchmark on the hot
+  loop before/after to confirm the allocation reduction (directional; not a
+  pass/fail gate).
 
 ## Risks
 
 - **Type instability from `_Transition{L,E}`** if `L`/`E` aren't concrete at the
   call site — verify the element type is inferred concretely (the win depends on
   it). Mitigate by constructing the vector with the known element type.
-- **Missed consumer** of the old Dict interface — grep every `t[:` / `[:target_`
-  / `[:edge_data` / `[:probability` / `[:target_strand` site and convert. A
-  missed site is a `MethodError` (loud), not a silent byte-identity break.
+- **Wrong consumer converted** — because the Dict form is retained for cold
+  paths, only the HOT consumers (the two decode call sites +
+  `_top_b_transitions`) switch to field access. Verify `_top_b_transitions` has
+  no cold caller before converting it; if it does, keep it Dict-compatible or
+  give the hot path its own helper. A type mismatch is a `MethodError` (loud),
+  not a silent byte-identity break.
 - **Fusion reordering** the float sum — mitigated by summing in `outneighbors`
   order over the full strand-matched set (identical to today).
 
@@ -162,9 +172,11 @@ and opt3 (batched/SIMD kernel wiring).
 
 ## Acceptance criteria
 
-- Per-edge `Dict{Symbol,Any}` and `Vector{Any}` transitions replaced by the typed
-  struct/vector; all consumers converted to field access.
-- The two out-edge scans fused into one; `total_out` bit-identical.
+- The two hot decode call sites use a single fused, typed
+  `_valid_transitions_and_total`; their transition consumers converted to field
+  access. Cold consumers keep the retained Dict-form `_get_valid_transitions`.
+- The paired out-edge scans at the hot sites fused into one; `total_out`
+  bit-identical.
 - Diagnostics counters hoisted to `Int` locals; final diagnostics identical.
 - Golden-master decode test passes (path + score + diagnostics bit-identical);
   all corrector lock tests + the opt1 soft-EM byte-identity test stay green.

--- a/docs/design/2026-07-24-opt2-alloc-typed-transitions-plan.md
+++ b/docs/design/2026-07-24-opt2-alloc-typed-transitions-plan.md
@@ -1,0 +1,509 @@
+# opt2 Typed Transitions + Fused Edge-Scan Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Kill the inner-DP allocation storm in the hot Viterbi decode by
+replacing the per-edge `Vector{Any}`+`Dict{Symbol,Any}` transitions with a typed
+struct built in a single fused out-edge pass, and hoisting boxed diagnostics
+counters to `Int` locals — byte-identically.
+
+**Architecture:** Add a concrete `struct _Transition{L,E}` and one fused
+function
+`_valid_transitions_and_total(graph, vertex, strand) -> (Vector{_Transition{L,E}}, Float64)`
+that does a single `outneighbors` pass (sum + build). Wire it into the two
+decode call sites (substitution hot loop + memoized indel successor batch),
+converting their consumers from `t[:key]` to `t.key`. Leave the Dict-form
+`_get_valid_transitions`/`_total_outgoing_weight` untouched for the ~10 cold
+consumers. Hoist in-loop diagnostics-Dict mutations to `Int` locals merged once
+after the loop.
+
+**Tech Stack:** Julia; MetaGraphsNext; Graphs; `Test` stdlib.
+
+## Global Constraints
+
+- **BYTE-IDENTITY is the hard requirement.** Corrector lock tests assert
+  byte-identical corrected reads; the opt1 `parallel_soft_em_byte_identity` test
+  asserts byte-identical soft-EM weights. Re-verify after every task. Preserve:
+  `Graphs.outneighbors` ascending dst-code order; the
+  `total += _edge_transition_weight(edge_data)` summation order (fuse without
+  reordering; `total_out` fully summed before any `edge_w / total_out` divide
+  and before top-B truncation); the `max(total, _KSP_MIN_WEIGHT)` floor
+  (`_KSP_MIN_WEIGHT = 1e-10`); the strand filter
+  `_normalize_strand(edge_data.src_strand) == strand`; and the state-tuple key
+  type (unchanged → `hash`-based beam-prune tie-breaks unaffected).
+- **`.jl` edits MUST bypass the formatter hook.** The PostToolUse Edit/Write
+  hook whole-file-churns `.jl` to non-SciML. Apply every `src/`/`test/` `.jl`
+  change via a Bash-invoked Python/heredoc in-place script (the hook fires on
+  Edit/Write tools, not Bash). After each edit, `git -C <wt> diff --stat <file>`
+  to confirm a minimal diff; if churned, `git checkout -- <file>` and redo via
+  Python.
+- **SciML style** (`.JuliaFormatter.toml`: `style="sciml"`), trailing commas,
+  4-space indent.
+- **Julia:** `LD_LIBRARY_PATH='' ~/.juliaup/bin/julia --project=. ...`.
+  Parse-check each edited `.jl` with `Meta.parseall`.
+- **No `td-*`** in committed non-comment artifacts (test names, docs prose);
+  allowed in commit messages + code comments.
+- **Worktree:** `/Users/cameronprybol/workspace/Mycelia/.worktrees/opt2-alloc`,
+  branch `cp/opt2-alloc` (off `origin/master` @ 0804d0ec). Commit per task; **do
+  NOT merge** (human gate).
+- **`git -C <wt> …`** for all git (never `cd <wt> && git` — a guard blocks it).
+
+## Reference: verified baseline locations (post-opt1)
+
+- Hot substitution loop: `src/viterbi-next.jl` `_viterbi_correct_observation`
+  (depth loop ~1411-1552). Transition build @~1422 `_get_valid_transitions`,
+  total @~1428 `_total_outgoing_weight`, top-B @~1442 `_top_b_transitions`,
+  consumer @~1445-1478 (`transition[:target_vertex/:target_strand/:edge_data]`).
+- `_top_b_transitions`: `src/viterbi-next.jl:1213` — sort key
+  `(_edge_transition_weight(t[:edge_data]), string(t[:target_vertex]))`,
+  `rev=true`. ONLY caller is @1442 (verified) → safe to convert to field access.
+- Memoized indel site: `src/viterbi-next.jl` `_indel_decode_successors!` (def
+  ~1809), `_get_valid_transitions` @~1820, `_total_outgoing_weight` @~1830,
+  consumer @~1837-1841.
+- Dict-form builders (LEAVE UNCHANGED):
+  `src/rhizomorph/algorithms/path-finding.jl` `_get_valid_transitions` (~531),
+  `_maybe_push_transition!` (~515), `_total_outgoing_weight` (~760),
+  `_edge_transition_weight` (~725), `_KSP_MIN_WEIGHT = 1e-10` (~721). Cold
+  consumers of the Dict form (LEAVE UNCHANGED): `information-theory.jl:30/57`,
+  `generation.jl:147/233`, `batched-viterbi-poc.jl:126/128`,
+  `path-finding.jl:407/467/665/1110/1400/1838`.
+- Diagnostics (hoist): `src/viterbi-next.jl` init ~1326-1347 + pre-seed
+  ~1379-1381; in-loop `:expanded_states` ~1423, `:skipped_transitions`
+  ~1430/1450/1464, `:successor_bounded` ~1440, `:generated_states` ~1469,
+  `:beam_pruned` ~1499, `:margin_pruned` ~1518, per-depth
+  `:retained_states`/`:cumulative_retained_states`/`:max_retained_states`/`:completed_steps`
+  ~1534-1537.
+
+---
+
+### Task 1: `_Transition` struct + fused `_valid_transitions_and_total` + equivalence lock
+
+**Files:**
+
+- Modify: `src/rhizomorph/algorithms/path-finding.jl` (add struct + fused fn
+  near `_get_valid_transitions`/`_total_outgoing_weight`)
+- Create: `test/4_assembly/valid_transitions_fused_test.jl`
+
+**Interfaces:**
+
+- Produces: `Mycelia.Rhizomorph._Transition{L,E}` (fields `target_vertex::L`,
+  `target_strand::StrandOrientation`, `probability::Float64`, `edge_data::E`);
+  `Mycelia.Rhizomorph._valid_transitions_and_total(graph, vertex, strand)::Tuple{Vector, Float64}`.
+- Consumes: existing `_get_valid_transitions`, `_total_outgoing_weight`,
+  `_edge_transition_weight`, `_normalize_strand`, `_KSP_MIN_WEIGHT`,
+  `_maybe_push_transition!` semantics.
+
+- [ ] **Step 1: Write the failing equivalence test** (Python-bypass writer). The
+      test builds a small qualmer graph, and for each vertex/strand asserts the
+      fused function returns transitions whose
+      `(target_vertex, target_strand, probability, edge_data)` equal — in the
+      SAME order — the Dict-form `_get_valid_transitions`, and `total_out`
+      bit-identical (`===`) to `_total_outgoing_weight`.
+
+```julia
+# FUSED VALID-TRANSITIONS EQUIVALENCE (opt2)
+# _valid_transitions_and_total must return, per (vertex,strand): the SAME
+# transitions in the SAME order as the Dict-form _get_valid_transitions, and a
+# total_out bit-identical to _total_outgoing_weight. This is the byte-identity
+# lock for the fused hot-loop function.
+import Test
+import Mycelia
+import FASTX
+import Random
+
+Test.@testset "fused valid-transitions equivalence (opt2)" begin
+    R = Mycelia.Rhizomorph
+    rng = Random.MersenneTwister(31337)
+    ref = join(rand(rng, ['A', 'C', 'G', 'T'], 400))
+    reads = [FASTX.FASTQ.Record("r$i", ref[s:(s + 79)], String(fill('I', 80)))
+             for (i, s) in enumerate(rand(rng, 1:321, 60))]
+    k = 11
+    graph = R.build_qualmer_graph(reads, k; mode = :canonical)
+    checked = 0
+    for label in Mycelia.MetaGraphsNext.labels(graph)
+        for strand in (R.Forward, R.Reverse)
+            dict_tx = R._get_valid_transitions(graph, label, strand)
+            dict_total = R._total_outgoing_weight(graph, label, strand)
+            fused_tx, fused_total = R._valid_transitions_and_total(graph, label, strand)
+            Test.@test fused_total === dict_total                       # bit-identical
+            Test.@test length(fused_tx) == length(dict_tx)
+            for (a, b) in zip(fused_tx, dict_tx)
+                Test.@test a.target_vertex == b[:target_vertex]
+                Test.@test a.target_strand == b[:target_strand]
+                Test.@test a.probability === b[:probability]            # bit-identical
+                Test.@test a.edge_data === b[:edge_data]
+            end
+            checked += 1
+        end
+    end
+    Test.@test checked > 0                                             # non-vacuous
+end
+```
+
+- [ ] **Step 2: Run to verify it fails.**
+
+Run:
+`LD_LIBRARY_PATH='' ~/.juliaup/bin/julia --project=. -e 'include("test/4_assembly/valid_transitions_fused_test.jl")'`
+Expected: FAIL — `UndefVarError: _valid_transitions_and_total` (function/struct
+not defined).
+
+- [ ] **Step 3: Add the struct + fused function** (Python-bypass) in
+      `src/rhizomorph/algorithms/path-finding.jl`, immediately after
+      `_total_outgoing_weight` (or after `_maybe_push_transition!`). The fused
+      pass MUST mirror `_get_valid_transitions` (directed + undirected branches)
+      and `_total_outgoing_weight` exactly. Read both current functions verbatim
+      first and mirror their `outneighbors`/`edge_labels` iteration + strand
+      filter.
+
+```julia
+struct _Transition{L, E}
+    target_vertex::L
+    target_strand::StrandOrientation
+    probability::Float64
+    edge_data::E
+end
+
+# opt2: one outneighbors pass building the typed transition list AND summing the
+# outgoing weight — fuses _get_valid_transitions + _total_outgoing_weight. Sum is
+# over ALL strand-matched edges in outneighbors order (0.0-weight edges add 0.0,
+# so bit-identical to _total_outgoing_weight); a _Transition is pushed only for
+# weight > 0.0 (identical to the positive-weight skip in _maybe_push_transition!).
+function _valid_transitions_and_total(graph, vertex_label, strand)
+    total = 0.0
+    transitions = _Transition[]
+    haskey(graph, vertex_label) || return transitions, max(total, _KSP_MIN_WEIGHT)
+    if Graphs.is_directed(graph.graph)
+        src_code = MetaGraphsNext.code_for(graph, vertex_label)
+        for dst_code in Graphs.outneighbors(graph.graph, src_code)
+            target_vertex = MetaGraphsNext.label_for(graph, dst_code)
+            edge_data = graph[vertex_label, target_vertex]
+            _normalize_strand(edge_data.src_strand) == strand || continue
+            w = _edge_transition_weight(edge_data)
+            total += w
+            w <= 0.0 && continue
+            push!(transitions,
+                _Transition(target_vertex, _normalize_strand(edge_data.dst_strand),
+                    w, edge_data))
+        end
+    else
+        for edge_labels in MetaGraphsNext.edge_labels(graph)
+            if length(edge_labels) == 2 && edge_labels[1] == vertex_label
+                target_vertex = edge_labels[2]
+                edge_data = graph[vertex_label, target_vertex]
+                _normalize_strand(edge_data.src_strand) == strand || continue
+                w = _edge_transition_weight(edge_data)
+                total += w
+                w <= 0.0 && continue
+                push!(transitions,
+                    _Transition(target_vertex,
+                        _normalize_strand(edge_data.dst_strand), w, edge_data))
+            end
+        end
+    end
+    return transitions, max(total, _KSP_MIN_WEIGHT)
+end
+```
+
+NOTE on order: `_maybe_push_transition!` computes `probability` and applies the
+`<= 0.0` skip BEFORE reading `dst_strand`; here
+`w = _edge_transition_weight(...)` is the same `probability`. The sum adds `w`
+for every strand-matched edge (matching `_total_outgoing_weight`, which adds
+`_edge_transition_weight` for every strand-matched edge, including those with
+`w == 0.0`). Verify by the equivalence test — do not reorder the `total += w`
+relative to the `w <= 0.0 && continue`.
+
+- [ ] **Step 4: Run to verify it passes.**
+
+Run:
+`LD_LIBRARY_PATH='' ~/.juliaup/bin/julia --project=. -e 'include("test/4_assembly/valid_transitions_fused_test.jl")'`
+Expected: PASS — fused transitions + total bit-identical to the Dict form across
+all vertices/strands.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git -C /Users/cameronprybol/workspace/Mycelia/.worktrees/opt2-alloc add src/rhizomorph/algorithms/path-finding.jl test/4_assembly/valid_transitions_fused_test.jl
+git -C /Users/cameronprybol/workspace/Mycelia/.worktrees/opt2-alloc commit -m "feat: typed _Transition + fused _valid_transitions_and_total (opt2)
+
+Single outneighbors pass building a typed transition vector AND summing total_out,
+equivalent bit-for-bit to _get_valid_transitions + _total_outgoing_weight
+(equivalence-locked by test). Not yet wired into the hot loop.
+
+td-cppm / td-jbjd opt2"
+git -C /Users/cameronprybol/workspace/Mycelia/.worktrees/opt2-alloc push
+```
+
+---
+
+### Task 2: Wire the fused typed path into the substitution hot loop
+
+**Files:**
+
+- Modify: `src/viterbi-next.jl` (`_viterbi_correct_observation`
+  ~1422/1428/1442/1445-1478; `_top_b_transitions` ~1213)
+
+**Interfaces:**
+
+- Consumes: `_valid_transitions_and_total` (Task 1), `_Transition` field access.
+
+- [ ] **Step 1: Capture the golden baseline** — before editing, record the
+      current decode output as a committed fixture so the refactor is locked
+      even beyond the full lock tests. Write
+      `test/4_assembly/viterbi_decode_golden_test.jl` (Python-bypass) that
+      builds a FIXED graph+read+config, runs
+      `Mycelia.Rhizomorph._viterbi_correct_observation(...)`, and asserts its
+      `.path`, `.best_score` (`===`), and full `.diagnostics` Dict equal
+      hardcoded expected values. To get the expected values: run the builder
+      once on CURRENT code, print the outputs, and paste them in as the
+      literals. (This is a characterization/golden test — it must be written
+      against pre-refactor output so it stays RED-able.)
+
+Run (to capture):
+`LD_LIBRARY_PATH='' ~/.juliaup/bin/julia --project=. -e '<build fixture; @show result.path result.best_score result.diagnostics>'`
+Then encode those exact values as `Test.@test` literals in the golden test and
+confirm it PASSES on current code.
+
+- [ ] **Step 2: Convert `_top_b_transitions` to field access** (Python-bypass).
+      At `src/viterbi-next.jl:1213-1220`, change the sort key from
+      `t[:edge_data]`/`t[:target_vertex]` to `t.edge_data`/`t.target_vertex`.
+      (Only caller is the hot loop @1442, verified — no cold caller.)
+
+```julia
+function _top_b_transitions(transitions, b::Int)
+    length(transitions) <= b && return transitions
+    return partialsort(transitions,
+        1:b;
+        by = t -> (Rhizomorph._edge_transition_weight(t.edge_data),
+            string(t.target_vertex)),
+        rev = true)
+end
+```
+
+(Read the current body first; preserve its exact structure — only the two
+`t[:x]` → `t.x` edits.)
+
+- [ ] **Step 3: Wire the fused call + convert the consumer** (Python-bypass).
+      Read the current ~1420-1478 region verbatim. Replace the paired calls:
+  - `transitions = Rhizomorph._get_valid_transitions(graph, current_vertex, current_strand)`
+    (@~1422) AND
+    `total_out = Rhizomorph._total_outgoing_weight(graph, current_vertex, current_strand)`
+    (@~1428) → a single
+    `transitions, total_out = Rhizomorph._valid_transitions_and_total(graph, current_vertex, current_strand)`.
+    Preserve the relative position so `total_out` is available where used
+    (@~1453) and `transitions` before `_top_b_transitions` (@~1442).
+  - In the consumer loop (@~1446-1448): `transition[:target_vertex]` →
+    `transition.target_vertex`, `transition[:target_strand]` →
+    `transition.target_strand`, `transition[:edge_data]` →
+    `transition.edge_data`. Leave all scoring math (the `edge_w / total_out`
+    divide, `log`, `next_score` add) byte-identical.
+
+- [ ] **Step 4: Parse-check + run golden + lock tests.**
+
+```bash
+LD_LIBRARY_PATH='' ~/.juliaup/bin/julia --startup-file=no -e 'Meta.parseall(read("src/viterbi-next.jl",String)); println("ok")'
+LD_LIBRARY_PATH='' ~/.juliaup/bin/julia --project=. -e 'include("test/4_assembly/viterbi_decode_golden_test.jl")'   # path+score+diagnostics unchanged
+for t in low_k_decode_gating_test reassembly_graph_reuse_test corrector_gc_between_batches_test parallel_soft_em_byte_identity_test; do
+  LD_LIBRARY_PATH='' ~/.juliaup/bin/julia --project=. -e "include(\"test/4_assembly/$t.jl\")"
+done
+```
+
+Expected: golden PASS (bit-identical decode); all lock/soft-EM tests PASS.
+(`parallel_soft_em_byte_identity` self-hoists to `-t4`.) For
+`batched_viterbi_kernel_test` use the stacked KernelAbstractions env (temp env
+with `Pkg.add("KernelAbstractions")` + `JULIA_LOAD_PATH="@:<tmp>:@stdlib"`).
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git -C /Users/cameronprybol/workspace/Mycelia/.worktrees/opt2-alloc add src/viterbi-next.jl test/4_assembly/viterbi_decode_golden_test.jl
+git -C /Users/cameronprybol/workspace/Mycelia/.worktrees/opt2-alloc commit -m "perf: fused typed transitions in the substitution hot loop (opt2, byte-identical)
+
+td-cppm / td-jbjd opt2"
+git -C /Users/cameronprybol/workspace/Mycelia/.worktrees/opt2-alloc push
+```
+
+---
+
+### Task 3: Wire the fused typed path into the memoized indel successor batch
+
+**Files:**
+
+- Modify: `src/viterbi-next.jl` (`_indel_decode_successors!` ~1809-1845)
+
+**Interfaces:** Consumes `_valid_transitions_and_total`, `_Transition` field
+access.
+
+- [ ] **Step 1: Read the current ~1809-1845 region verbatim.** It calls
+      `_get_valid_transitions` (@~1820) then `_total_outgoing_weight` (@~1830)
+      then consumes `transition[:target_vertex/:target_strand/:edge_data]`
+      (@~1837-1841) while pushing to a `successors` batch.
+
+- [ ] **Step 2: Wire the fused call + convert the consumer** (Python-bypass).
+      Replace the paired `_get_valid_transitions` + `_total_outgoing_weight`
+      with
+      `transitions, total_out = Rhizomorph._valid_transitions_and_total(graph, vertex, strand)`.
+      Preserve the `isempty(transitions)` early return and the
+      `!isfinite(total_out) || total_out <= 0.0` guard (compute `total_out` from
+      the fused return — note the fused `total_out` is already
+      `max(total,_KSP_MIN_WEIGHT)`, so `total_out <= 0.0` is only reachable via
+      the non-finite check; this matches the current `_total_outgoing_weight`
+      return semantics — verify the guard still behaves identically). Convert
+      `transition[:target_vertex]` → `transition.target_vertex`,
+      `[:target_strand]` → `.target_strand`, `[:edge_data]` → `.edge_data`.
+
+- [ ] **Step 3: Parse-check + re-run golden + lock tests + any indel-decode
+      test.**
+
+```bash
+LD_LIBRARY_PATH='' ~/.juliaup/bin/julia --startup-file=no -e 'Meta.parseall(read("src/viterbi-next.jl",String)); println("ok")'
+# indel path tests + the standard locks
+for t in viterbi_indel_decode_test indel_frontier_probe_test low_k_decode_gating_test reassembly_graph_reuse_test parallel_soft_em_byte_identity_test; do
+  LD_LIBRARY_PATH='' ~/.juliaup/bin/julia --project=. -e "include(\"test/4_assembly/$t.jl\")" 2>&1 | tail -3 || echo "MISSING/FAIL $t"
+done
+```
+
+Expected: all PASS. (If a named indel test file doesn't exist, locate the
+indel-decode tests via `ls test/4_assembly/ | grep -i indel` and run those
+instead — report which ran.) Byte-identity: the memoized batch's successor
+order + weights are unchanged.
+
+- [ ] **Step 4: Commit.**
+
+```bash
+git -C /Users/cameronprybol/workspace/Mycelia/.worktrees/opt2-alloc add src/viterbi-next.jl
+git -C /Users/cameronprybol/workspace/Mycelia/.worktrees/opt2-alloc commit -m "perf: fused typed transitions in the memoized indel successor batch (opt2)
+
+td-cppm / td-jbjd opt2"
+git -C /Users/cameronprybol/workspace/Mycelia/.worktrees/opt2-alloc push
+```
+
+---
+
+### Task 4: Hoist in-loop diagnostics to `Int` locals
+
+**Files:**
+
+- Modify: `src/viterbi-next.jl` (`_viterbi_correct_observation` diagnostics:
+  init ~1326-1347, pre-seed ~1379-1381, in-loop mutations ~1423-1537)
+
+**Interfaces:** none new.
+
+- [ ] **Step 1: Read the diagnostics init + all in-loop mutation sites
+      verbatim.** Enumerate every `diagnostics[:key]` write in the depth loop.
+
+- [ ] **Step 2: Hoist to locals** (Python-bypass). Before the depth loop,
+      declare `Int` locals seeded from the pre-loop values (e.g.
+      `expanded_states = 0`, `skipped_transitions = 0`, `successor_bounded = 0`,
+      `generated_states = 0`, `beam_pruned = 0`, `margin_pruned = 0`; and for
+      the per-depth ones seed from the pre-seed @1379-1381:
+      `cumulative_retained_states = diagnostics[:cumulative_retained_states]`,
+      `max_retained_states = diagnostics[:max_retained_states]`, plus
+      `retained_states = diagnostics[:retained_states]`, `completed_steps = 0`).
+      Replace each in-loop `diagnostics[:k] += 1` / `get(diagnostics,:k,0)+1` /
+      `max(...)` / overwrite with the local. After the loop, write each local
+      back: `diagnostics[:expanded_states] = expanded_states`, etc. Preserve
+      semantics exactly (running max, cumulative sum, last-write-wins for
+      `retained_states`/`completed_steps`).
+
+- [ ] **Step 3: Parse-check + golden + lock tests.**
+
+```bash
+LD_LIBRARY_PATH='' ~/.juliaup/bin/julia --startup-file=no -e 'Meta.parseall(read("src/viterbi-next.jl",String)); println("ok")'
+LD_LIBRARY_PATH='' ~/.juliaup/bin/julia --project=. -e 'include("test/4_assembly/viterbi_decode_golden_test.jl")'   # diagnostics Dict still bit-identical
+for t in low_k_decode_gating_test reassembly_graph_reuse_test parallel_soft_em_byte_identity_test; do
+  LD_LIBRARY_PATH='' ~/.juliaup/bin/julia --project=. -e "include(\"test/4_assembly/$t.jl\")"
+done
+```
+
+Expected: golden PASS (the diagnostics Dict values are identical — the golden
+test's diagnostics assertions are the lock here); locks PASS.
+
+- [ ] **Step 4: Commit.**
+
+```bash
+git -C /Users/cameronprybol/workspace/Mycelia/.worktrees/opt2-alloc add src/viterbi-next.jl
+git -C /Users/cameronprybol/workspace/Mycelia/.worktrees/opt2-alloc commit -m "perf: hoist hot-loop diagnostics counters to Int locals (opt2)
+
+td-cppm / td-jbjd opt2"
+git -C /Users/cameronprybol/workspace/Mycelia/.worktrees/opt2-alloc push
+```
+
+---
+
+### Task 5: Allocation-reduction benchmark
+
+**Files:**
+
+- Create: `benchmarking/results/opt2_alloc_hotloop.md`
+
+**Interfaces:** none.
+
+- [ ] **Step 1: Measure `@allocated` on the decode** before/after — since
+      "before" is already merged on `origin/master`, measure the CURRENT
+      (post-opt2) allocation and compare to a run on `origin/master`. Practical
+      form: run a fixed corrector decode under `@allocated` (or the accuracy
+      benchmark with a bytes report) on this branch AND on a checkout of
+      `origin/master`, record both.
+
+```bash
+# On this branch:
+LD_LIBRARY_PATH='' ~/.juliaup/bin/julia --project=. -e '<build fixed graph+reads; @allocated Mycelia.Rhizomorph._viterbi_correct_observation(...) ; print bytes>'
+```
+
+- [ ] **Step 2: Record honestly** in
+      `benchmarking/results/opt2_alloc_hotloop.md`: allocation bytes before
+      (master) vs after (opt2), the reduction, the fixture, and the caveat that
+      this is a micro-measurement (directional). Confirm decode output
+      (path/score) identical across the two — the allocation win must not have
+      changed output.
+
+- [ ] **Step 3: Commit.**
+
+```bash
+git -C /Users/cameronprybol/workspace/Mycelia/.worktrees/opt2-alloc add benchmarking/results/opt2_alloc_hotloop.md
+git -C /Users/cameronprybol/workspace/Mycelia/.worktrees/opt2-alloc commit -m "bench: record opt2 hot-loop allocation reduction
+
+td-cppm / td-jbjd opt2"
+git -C /Users/cameronprybol/workspace/Mycelia/.worktrees/opt2-alloc push
+```
+
+---
+
+### Task 6: PR + review gate
+
+- [ ] **Step 1: Open PR** `cp/opt2-alloc → master` (title
+      `perf: typed transitions + fused edge-scan in the Viterbi hot loop (byte-identical)`;
+      body: summary + byte-identity evidence + allocation numbers + test plan;
+      no internal IDs).
+- [ ] **Step 2: Run `/comprehensive-pr-review`** on the head SHA; fold in remote
+      CodeRabbit + Codex; resolve all Critical + Convergent findings; re-run the
+      local review after any fix commit.
+- [ ] **Step 3: Watch CI** (full suite incl. 4-thread job) to green. NOTE:
+      adding the two test files must not trip a `fieldcount`/completeness guard
+      (opt2 adds no struct field to a guarded struct, but re-verify the full
+      suite).
+- [ ] **Step 4: STOP at the merge gate** — merge is a human action (`--admin`
+      bypass, user-run, as opt5/opt1). Do not self-merge.
+- [ ] **Step 5: On merge:** close `td-cppm`, update epic `td-jbjd` (opt2 done;
+      next opt4 `td-cvd8` approximate / opt3 `td-h4o8`), remove the `opt2-alloc`
+      worktree + branch, run `/sync`.
+
+## Notes for the implementer
+
+- **Every `src/`/`test/` `.jl` edit goes through a Bash/Python in-place script**
+  — never the Edit/Write tools (churning formatter hook).
+  `git -C <wt> diff --stat` after each to confirm a minimal diff.
+- **Read the current call region verbatim immediately before editing** each hot
+  site — line numbers drift as tasks land; locate by content
+  (`_get_valid_transitions`, `_total_outgoing_weight`, `_top_b_transitions`,
+  `transition[:`).
+- **Do NOT touch** `_get_valid_transitions` / `_maybe_push_transition!` /
+  `_total_outgoing_weight` in `path-finding.jl` (Dict form retained for cold
+  consumers) — only ADD the struct + fused fn.
+- **The golden test (Task 2) is the primary byte-identity lock for the decode**
+  (path + score + diagnostics); the equivalence test (Task 1) locks the fused
+  function; the corrector lock tests + opt1 soft-EM test lock the end-to-end
+  corrector.

--- a/docs/design/2026-07-24-opt2-alloc-typed-transitions-plan.md
+++ b/docs/design/2026-07-24-opt2-alloc-typed-transitions-plan.md
@@ -207,6 +207,15 @@ function _valid_transitions_and_total(graph, vertex_label, strand)
 end
 ```
 
+> NOTE (shipped form differs from this sketch): the shipped `_Transition` list
+> is allocated as `_Transition{L, E}[]` (concrete eltype, pulled from the
+> MetaGraph type parameters `L`/`E` via dispatch — fix round 1), not the
+> abstract `_Transition[]` shown above; and the shipped struct is the 3-field
+> `_Transition{L, E}(target_vertex, target_strand, edge_data)` after the
+> vestigial `probability::Float64` field was dropped (no src reads it — the hot
+> consumers recompute the weight via `_edge_transition_weight(edge_data)`), so
+> the two `push!` sites take no `w` argument.
+
 NOTE on order: `_maybe_push_transition!` computes `probability` and applies the
 `<= 0.0` skip BEFORE reading `dst_strand`; here
 `w = _edge_transition_weight(...)` is the same `probability`. The sum adds `w`

--- a/src/rhizomorph/algorithms/path-finding.jl
+++ b/src/rhizomorph/algorithms/path-finding.jl
@@ -810,9 +810,17 @@ end
 # over ALL strand-matched edges in outneighbors order (0.0-weight edges add 0.0,
 # so bit-identical to _total_outgoing_weight); a _Transition is pushed only for
 # weight > 0.0 (identical to the positive-weight skip in _maybe_push_transition!).
-function _valid_transitions_and_total(graph, vertex_label, strand)
+# graph's Label/EdgeData type parameters (L, E) are pulled from the MetaGraph type
+# via dispatch so the returned vector is concretely typed Vector{_Transition{L,E}}
+# (fix round 1: `_Transition[]` was Vector{_Transition}, an abstract eltype that
+# would box every field access in the hot loop and defeat the typed struct).
+function _valid_transitions_and_total(
+        graph::MetaGraphsNext.MetaGraph{<:Any, <:Any, L, <:Any, E},
+        vertex_label,
+        strand
+) where {L, E}
     total = 0.0
-    transitions = _Transition[]
+    transitions = _Transition{L, E}[]
     haskey(graph, vertex_label) || return transitions, max(total, _KSP_MIN_WEIGHT)
     if Graphs.is_directed(graph.graph)
         src_code = MetaGraphsNext.code_for(graph, vertex_label)

--- a/src/rhizomorph/algorithms/path-finding.jl
+++ b/src/rhizomorph/algorithms/path-finding.jl
@@ -801,7 +801,6 @@ end
 struct _Transition{L, E}
     target_vertex::L
     target_strand::StrandOrientation
-    probability::Float64
     edge_data::E
 end
 
@@ -833,7 +832,7 @@ function _valid_transitions_and_total(
             w <= 0.0 && continue
             push!(transitions,
                 _Transition(target_vertex, _normalize_strand(edge_data.dst_strand),
-                    w, edge_data))
+                    edge_data))
         end
     else
         for edge_labels in MetaGraphsNext.edge_labels(graph)
@@ -846,7 +845,7 @@ function _valid_transitions_and_total(
                 w <= 0.0 && continue
                 push!(transitions,
                     _Transition(target_vertex,
-                        _normalize_strand(edge_data.dst_strand), w, edge_data))
+                        _normalize_strand(edge_data.dst_strand), edge_data))
             end
         end
     end

--- a/src/rhizomorph/algorithms/path-finding.jl
+++ b/src/rhizomorph/algorithms/path-finding.jl
@@ -798,6 +798,53 @@ function _total_outgoing_weight(
     return max(total, _KSP_MIN_WEIGHT)
 end
 
+struct _Transition{L, E}
+    target_vertex::L
+    target_strand::StrandOrientation
+    probability::Float64
+    edge_data::E
+end
+
+# opt2: one outneighbors pass building the typed transition list AND summing the
+# outgoing weight - fuses _get_valid_transitions + _total_outgoing_weight. Sum is
+# over ALL strand-matched edges in outneighbors order (0.0-weight edges add 0.0,
+# so bit-identical to _total_outgoing_weight); a _Transition is pushed only for
+# weight > 0.0 (identical to the positive-weight skip in _maybe_push_transition!).
+function _valid_transitions_and_total(graph, vertex_label, strand)
+    total = 0.0
+    transitions = _Transition[]
+    haskey(graph, vertex_label) || return transitions, max(total, _KSP_MIN_WEIGHT)
+    if Graphs.is_directed(graph.graph)
+        src_code = MetaGraphsNext.code_for(graph, vertex_label)
+        for dst_code in Graphs.outneighbors(graph.graph, src_code)
+            target_vertex = MetaGraphsNext.label_for(graph, dst_code)
+            edge_data = graph[vertex_label, target_vertex]
+            _normalize_strand(edge_data.src_strand) == strand || continue
+            w = _edge_transition_weight(edge_data)
+            total += w
+            w <= 0.0 && continue
+            push!(transitions,
+                _Transition(target_vertex, _normalize_strand(edge_data.dst_strand),
+                    w, edge_data))
+        end
+    else
+        for edge_labels in MetaGraphsNext.edge_labels(graph)
+            if length(edge_labels) == 2 && edge_labels[1] == vertex_label
+                target_vertex = edge_labels[2]
+                edge_data = graph[vertex_label, target_vertex]
+                _normalize_strand(edge_data.src_strand) == strand || continue
+                w = _edge_transition_weight(edge_data)
+                total += w
+                w <= 0.0 && continue
+                push!(transitions,
+                    _Transition(target_vertex,
+                        _normalize_strand(edge_data.dst_strand), w, edge_data))
+            end
+        end
+    end
+    return transitions, max(total, _KSP_MIN_WEIGHT)
+end
+
 """
     _total_outgoing_weight_excluding(graph, vertex, excluded_edges)
 

--- a/src/viterbi-next.jl
+++ b/src/viterbi-next.jl
@@ -1408,6 +1408,27 @@ function _viterbi_correct_observation(
     # Opt-in Tier-2 telemetry: per-depth Viterbi margin (best - 2nd-best surviving
     # log-prob). Empty + untouched unless config.record_position_gaps is set.
     position_gaps = Float64[]
+
+    # Perf (opt2, td-cppm/td-jbjd): hoist the per-transition diagnostics counters
+    # out of `diagnostics::Dict{Symbol,Any}` (every `Int` update there boxes a
+    # fresh `Any`) into unboxed `Int` locals, merged back into `diagnostics`
+    # once after the loop. Byte-identical: final dict values are unchanged, only
+    # the in-loop storage representation changes. `successor_bounded`,
+    # `beam_pruned`, and `margin_pruned` use lazy get-or-default in the original
+    # code (key absent from the dict until first triggered) — the post-loop
+    # write-back preserves that by only assigning when the local is nonzero
+    # (each is monotonically incremented and never decremented, so `> 0` means
+    # exactly "triggered at least once").
+    expanded_states = 0
+    generated_states = 0
+    skipped_transitions = 0
+    successor_bounded = 0
+    beam_pruned = 0
+    margin_pruned = 0
+    completed_steps = 0
+    retained_states = diagnostics[:retained_states]
+    cumulative_retained_states = diagnostics[:cumulative_retained_states]
+    max_retained_states = diagnostics[:max_retained_states]
     for depth in 1:(length(observation) - 1)
         observed_unit = observation[depth + 1]
         next_scores = Dict{Tuple{label_type, Rhizomorph.StrandOrientation}, Float64}()
@@ -1421,13 +1442,13 @@ function _viterbi_correct_observation(
             current_vertex, current_strand = state
             transitions, total_out = Rhizomorph._valid_transitions_and_total(
                 graph, current_vertex, current_strand)
-            diagnostics[:expanded_states] += 1
+            expanded_states += 1
             if isempty(transitions)
                 continue
             end
 
             if !isfinite(total_out) || total_out <= 0.0
-                diagnostics[:skipped_transitions] += length(transitions)
+                skipped_transitions += length(transitions)
                 continue
             end
 
@@ -1437,8 +1458,7 @@ function _viterbi_correct_observation(
             # transition probabilities stay normalized against the FULL outgoing
             # mass, so a bounded expansion is a strict subset of the exact frontier.
             if length(transitions) > config.max_successors_per_state
-                diagnostics[:successor_bounded] = get(diagnostics, :successor_bounded, 0) +
-                                                  1
+                successor_bounded += 1
                 transitions = _top_b_transitions(transitions, config.max_successors_per_state)
             end
 
@@ -1447,7 +1467,7 @@ function _viterbi_correct_observation(
                 next_strand = Rhizomorph._normalize_strand(transition.target_strand)
                 edge_w = Rhizomorph._edge_transition_weight(transition.edge_data)
                 if edge_w <= 0.0
-                    diagnostics[:skipped_transitions] += 1
+                    skipped_transitions += 1
                     continue
                 end
                 transition_prob = edge_w / total_out
@@ -1461,12 +1481,12 @@ function _viterbi_correct_observation(
                 )
                 next_score = state_score + log(transition_prob) + emission_score
                 if !isfinite(next_score)
-                    diagnostics[:skipped_transitions] += 1
+                    skipped_transitions += 1
                     continue
                 end
 
                 next_state = (next_vertex, next_strand)
-                diagnostics[:generated_states] += 1
+                generated_states += 1
                 if !haskey(next_scores, next_state) || next_score > next_scores[next_state]
                     next_scores[next_state] = next_score
                     next_predecessors[next_state] = state
@@ -1496,7 +1516,7 @@ function _viterbi_correct_observation(
             # Keep the emission dict aligned to the width-beam survivors.
             next_emissions = Dict(
                 state => next_emissions[state] for state in keys(next_scores))
-            diagnostics[:beam_pruned] = get(diagnostics, :beam_pruned, 0) + 1
+            beam_pruned += 1
         end
 
         # Score-margin ("histogram") prune with emission exemption: keep a state
@@ -1515,7 +1535,7 @@ function _viterbi_correct_observation(
                 next_scores, next_predecessors, next_emissions,
                 depth_best, depth_best_emission, config.beam_score_margin)
             if length(next_scores) < pre_margin
-                diagnostics[:margin_pruned] = get(diagnostics, :margin_pruned, 0) + 1
+                margin_pruned += 1
             end
         end
 
@@ -1531,10 +1551,10 @@ function _viterbi_correct_observation(
         active_scores = next_scores
         active_emissions = next_emissions
         retained_count = length(active_scores)
-        diagnostics[:retained_states] = retained_count
-        diagnostics[:cumulative_retained_states] += retained_count
-        diagnostics[:max_retained_states] = max(diagnostics[:max_retained_states], retained_count)
-        diagnostics[:completed_steps] = depth
+        retained_states = retained_count
+        cumulative_retained_states += retained_count
+        max_retained_states = max(max_retained_states, retained_count)
+        completed_steps = depth
 
         if target_vertex === nothing
             best_state, best_score = _best_correction_state(active_scores)
@@ -1550,6 +1570,17 @@ function _viterbi_correct_observation(
             end
         end
     end
+
+    diagnostics[:expanded_states] = expanded_states
+    diagnostics[:generated_states] = generated_states
+    diagnostics[:skipped_transitions] = skipped_transitions
+    successor_bounded > 0 && (diagnostics[:successor_bounded] = successor_bounded)
+    beam_pruned > 0 && (diagnostics[:beam_pruned] = beam_pruned)
+    margin_pruned > 0 && (diagnostics[:margin_pruned] = margin_pruned)
+    diagnostics[:retained_states] = retained_states
+    diagnostics[:cumulative_retained_states] = cumulative_retained_states
+    diagnostics[:max_retained_states] = max_retained_states
+    diagnostics[:completed_steps] = completed_steps
 
     if target_vertex !== nothing && !isfinite(best_score)
         diagnostics[:reason] = :target_unreachable

--- a/src/viterbi-next.jl
+++ b/src/viterbi-next.jl
@@ -1817,7 +1817,7 @@ function _indel_decode_successors!(
 )::_IndelDecodeSuccessorBatch{V} where {V}
     key = (vertex, strand)
     return get!(cache, key) do
-        transitions = Rhizomorph._get_valid_transitions(
+        transitions, total_out = Rhizomorph._valid_transitions_and_total(
             graph, vertex, strand)
         successors = Tuple{
             Tuple{V, Rhizomorph.StrandOrientation}, Float64
@@ -1827,18 +1827,16 @@ function _indel_decode_successors!(
                 successors, length(transitions))
         end
 
-        total_out = Rhizomorph._total_outgoing_weight(
-            graph, vertex, strand)
         if !isfinite(total_out) || total_out <= 0.0
             return _IndelDecodeSuccessorBatch{V}(
                 successors, length(transitions))
         end
         for transition in transitions
-            next_vertex = convert(V, transition[:target_vertex])
+            next_vertex = convert(V, transition.target_vertex)
             next_strand = Rhizomorph._normalize_strand(
-                transition[:target_strand])
+                transition.target_strand)
             edge_weight = Rhizomorph._edge_transition_weight(
-                transition[:edge_data])
+                transition.edge_data)
             edge_weight <= 0.0 && continue
             push!(
                 successors,

--- a/src/viterbi-next.jl
+++ b/src/viterbi-next.jl
@@ -1214,8 +1214,8 @@ function _top_b_transitions(transitions, b::Int)
     length(transitions) <= b && return transitions
     ordered = sort(
         transitions;
-        by = t -> (Rhizomorph._edge_transition_weight(t[:edge_data]),
-            string(t[:target_vertex])),
+        by = t -> (Rhizomorph._edge_transition_weight(t.edge_data),
+            string(t.target_vertex)),
         rev = true
     )
     return ordered[1:b]
@@ -1419,13 +1419,13 @@ function _viterbi_correct_observation(
 
         for (state, state_score) in active_scores
             current_vertex, current_strand = state
-            transitions = Rhizomorph._get_valid_transitions(graph, current_vertex, current_strand)
+            transitions, total_out = Rhizomorph._valid_transitions_and_total(
+                graph, current_vertex, current_strand)
             diagnostics[:expanded_states] += 1
             if isempty(transitions)
                 continue
             end
 
-            total_out = Rhizomorph._total_outgoing_weight(graph, current_vertex, current_strand)
             if !isfinite(total_out) || total_out <= 0.0
                 diagnostics[:skipped_transitions] += length(transitions)
                 continue
@@ -1443,9 +1443,9 @@ function _viterbi_correct_observation(
             end
 
             for transition in transitions
-                next_vertex = convert(label_type, transition[:target_vertex])
-                next_strand = Rhizomorph._normalize_strand(transition[:target_strand])
-                edge_w = Rhizomorph._edge_transition_weight(transition[:edge_data])
+                next_vertex = convert(label_type, transition.target_vertex)
+                next_strand = Rhizomorph._normalize_strand(transition.target_strand)
+                edge_w = Rhizomorph._edge_transition_weight(transition.edge_data)
                 if edge_w <= 0.0
                     diagnostics[:skipped_transitions] += 1
                     continue

--- a/src/viterbi-next.jl
+++ b/src/viterbi-next.jl
@@ -1426,9 +1426,9 @@ function _viterbi_correct_observation(
     beam_pruned = 0
     margin_pruned = 0
     completed_steps = 0
-    retained_states = diagnostics[:retained_states]
-    cumulative_retained_states = diagnostics[:cumulative_retained_states]
-    max_retained_states = diagnostics[:max_retained_states]
+    retained_states::Int = diagnostics[:retained_states]
+    cumulative_retained_states::Int = diagnostics[:cumulative_retained_states]
+    max_retained_states::Int = diagnostics[:max_retained_states]
     for depth in 1:(length(observation) - 1)
         observed_unit = observation[depth + 1]
         next_scores = Dict{Tuple{label_type, Rhizomorph.StrandOrientation}, Float64}()
@@ -1574,9 +1574,15 @@ function _viterbi_correct_observation(
     diagnostics[:expanded_states] = expanded_states
     diagnostics[:generated_states] = generated_states
     diagnostics[:skipped_transitions] = skipped_transitions
-    successor_bounded > 0 && (diagnostics[:successor_bounded] = successor_bounded)
-    beam_pruned > 0 && (diagnostics[:beam_pruned] = beam_pruned)
-    margin_pruned > 0 && (diagnostics[:margin_pruned] = margin_pruned)
+    if successor_bounded > 0
+        diagnostics[:successor_bounded] = successor_bounded
+    end
+    if beam_pruned > 0
+        diagnostics[:beam_pruned] = beam_pruned
+    end
+    if margin_pruned > 0
+        diagnostics[:margin_pruned] = margin_pruned
+    end
     diagnostics[:retained_states] = retained_states
     diagnostics[:cumulative_retained_states] = cumulative_retained_states
     diagnostics[:max_retained_states] = max_retained_states

--- a/src/viterbi-next.jl
+++ b/src/viterbi-next.jl
@@ -1409,7 +1409,10 @@ function _viterbi_correct_observation(
     # log-prob). Empty + untouched unless config.record_position_gaps is set.
     position_gaps = Float64[]
 
-    # Perf (opt2, td-cppm/td-jbjd): hoist the per-transition diagnostics counters
+    # Perf (opt2, td-cppm/td-jbjd): hoist the loop-updated diagnostics counters
+    # (a mix — per-transition: generated_states/skipped_transitions; per-state:
+    # expanded_states/successor_bounded; per-depth: beam_pruned/margin_pruned/
+    # retained_states/cumulative_retained_states/max_retained_states/completed_steps)
     # out of `diagnostics::Dict{Symbol,Any}` (every `Int` update there boxes a
     # fresh `Any`) into unboxed `Int` locals, merged back into `diagnostics`
     # once after the loop. Byte-identical: final dict values are unchanged, only

--- a/test/4_assembly/valid_transitions_fused_test.jl
+++ b/test/4_assembly/valid_transitions_fused_test.jl
@@ -51,3 +51,58 @@ Test.@testset "fused valid-transitions equivalence (opt2)" begin
     end
     Test.@test checked > 0                                             # non-vacuous
 end
+
+# UNDIRECTED-BRANCH EQUIVALENCE (opt2, F3)
+# Production `weighted_graph_from_rhizomorph` always yields a DiGraph, so the
+# undirected `else` branch of `_valid_transitions_and_total` (mirroring the
+# undirected branches of `_get_valid_transitions`/`_total_outgoing_weight`) is
+# never hit by the directed fixture above. Build a hand-constructed UNDIRECTED
+# MetaGraph carrying `StrandWeightedEdgeData` so the undirected code path is
+# exercised under the same byte-identity equivalence assertions. The edge set is
+# chosen so at least one (vertex,strand) yields a NON-EMPTY, multi-edge
+# transition list (A/Forward), locking the branch's push path, not just its
+# empty-return.
+Test.@testset "fused valid-transitions equivalence, undirected branch (opt2)" begin
+    R = Mycelia.Rhizomorph
+    MGN = Mycelia.MetaGraphsNext
+    graph = MGN.MetaGraph(
+        MGN.Graph();
+        label_type = String,
+        vertex_data_type = Any,
+        edge_data_type = R.StrandWeightedEdgeData,
+        weight_function = R.edge_data_weight,
+        default_weight = 0.0
+    )
+    for v in ("A", "B", "C", "D")
+        graph[v] = nothing
+    end
+    graph["A", "B"] = R.StrandWeightedEdgeData(2.0, R.Forward, R.Forward)
+    graph["A", "C"] = R.StrandWeightedEdgeData(3.0, R.Forward, R.Reverse)
+    graph["B", "C"] = R.StrandWeightedEdgeData(1.5, R.Reverse, R.Forward)
+    graph["C", "D"] = R.StrandWeightedEdgeData(4.0, R.Forward, R.Forward)
+
+    Test.@test !Mycelia.Graphs.is_directed(graph.graph)   # undirected branch
+
+    checked = 0
+    saw_nonempty = false
+    for label in MGN.labels(graph)
+        for strand in (R.Forward, R.Reverse)
+            dict_tx = R._get_valid_transitions(graph, label, strand)
+            dict_total = R._total_outgoing_weight(graph, label, strand)
+            fused_tx, fused_total = R._valid_transitions_and_total(graph, label, strand)
+            Test.@test isconcretetype(eltype(fused_tx))
+            Test.@test fused_total === dict_total                       # bit-identical
+            Test.@test length(fused_tx) == length(dict_tx)
+            for (a, b) in zip(fused_tx, dict_tx)
+                Test.@test a.target_vertex == b[:target_vertex]
+                Test.@test a.target_strand == b[:target_strand]
+                Test.@test R._edge_transition_weight(a.edge_data) === b[:probability]
+                Test.@test a.edge_data === b[:edge_data]
+            end
+            saw_nonempty |= !isempty(fused_tx)
+            checked += 1
+        end
+    end
+    Test.@test checked > 0                                             # non-vacuous
+    Test.@test saw_nonempty          # branch's push path exercised, not just empty
+end

--- a/test/4_assembly/valid_transitions_fused_test.jl
+++ b/test/4_assembly/valid_transitions_fused_test.jl
@@ -43,7 +43,7 @@ Test.@testset "fused valid-transitions equivalence (opt2)" begin
             for (a, b) in zip(fused_tx, dict_tx)
                 Test.@test a.target_vertex == b[:target_vertex]
                 Test.@test a.target_strand == b[:target_strand]
-                Test.@test a.probability === b[:probability]            # bit-identical
+                Test.@test R._edge_transition_weight(a.edge_data) === b[:probability]  # bit-identical
                 Test.@test a.edge_data === b[:edge_data]
             end
             checked += 1

--- a/test/4_assembly/valid_transitions_fused_test.jl
+++ b/test/4_assembly/valid_transitions_fused_test.jl
@@ -1,0 +1,48 @@
+# From the Mycelia base directory, run the tests with:
+#
+# ```bash
+# julia --project=. -e 'include("test/4_assembly/valid_transitions_fused_test.jl")'
+# ```
+
+# FUSED VALID-TRANSITIONS EQUIVALENCE (opt2)
+# _valid_transitions_and_total must return, per (vertex,strand): the SAME
+# transitions in the SAME order as the Dict-form _get_valid_transitions, and a
+# total_out bit-identical to _total_outgoing_weight. This is the byte-identity
+# lock for the fused hot-loop function.
+import Test
+import Mycelia
+import FASTX
+import Random
+
+Test.@testset "fused valid-transitions equivalence (opt2)" begin
+    R = Mycelia.Rhizomorph
+    rng = Random.MersenneTwister(31337)
+    ref = join(rand(rng, ['A', 'C', 'G', 'T'], 400))
+    reads = [FASTX.FASTQ.Record("r$i", ref[s:(s + 79)], String(fill('I', 80)))
+             for (i, s) in enumerate(rand(rng, 1:321, 60))]
+    k = 11
+    raw_graph = R.build_qualmer_graph(reads, k; mode = :canonical)
+    # _get_valid_transitions/_total_outgoing_weight/_valid_transitions_and_total
+    # all read edge_data.src_strand/dst_strand, which only StrandWeightedEdgeData
+    # (the directed weighted-graph form every production walk caller uses) has;
+    # the raw qualmer graph's QualmerEdgeData does not carry those fields.
+    graph = R.weighted_graph_from_rhizomorph(raw_graph)
+    checked = 0
+    for label in Mycelia.MetaGraphsNext.labels(graph)
+        for strand in (R.Forward, R.Reverse)
+            dict_tx = R._get_valid_transitions(graph, label, strand)
+            dict_total = R._total_outgoing_weight(graph, label, strand)
+            fused_tx, fused_total = R._valid_transitions_and_total(graph, label, strand)
+            Test.@test fused_total === dict_total                       # bit-identical
+            Test.@test length(fused_tx) == length(dict_tx)
+            for (a, b) in zip(fused_tx, dict_tx)
+                Test.@test a.target_vertex == b[:target_vertex]
+                Test.@test a.target_strand == b[:target_strand]
+                Test.@test a.probability === b[:probability]            # bit-identical
+                Test.@test a.edge_data === b[:edge_data]
+            end
+            checked += 1
+        end
+    end
+    Test.@test checked > 0                                             # non-vacuous
+end

--- a/test/4_assembly/valid_transitions_fused_test.jl
+++ b/test/4_assembly/valid_transitions_fused_test.jl
@@ -33,6 +33,11 @@ Test.@testset "fused valid-transitions equivalence (opt2)" begin
             dict_tx = R._get_valid_transitions(graph, label, strand)
             dict_total = R._total_outgoing_weight(graph, label, strand)
             fused_tx, fused_total = R._valid_transitions_and_total(graph, label, strand)
+            # fix round 1: the returned vector's static eltype must be concrete
+            # (Vector{_Transition{L,E}}), not the abstract Vector{_Transition} that
+            # `_Transition[]` produces — checked every iteration (empty and non-empty
+            # alike), since eltype concreteness is a static property of the vector.
+            Test.@test isconcretetype(eltype(fused_tx))
             Test.@test fused_total === dict_total                       # bit-identical
             Test.@test length(fused_tx) == length(dict_tx)
             for (a, b) in zip(fused_tx, dict_tx)

--- a/test/4_assembly/viterbi_decode_golden_test.jl
+++ b/test/4_assembly/viterbi_decode_golden_test.jl
@@ -1,0 +1,118 @@
+# From the Mycelia base directory, run this test with:
+#
+# ```bash
+# julia --project=. -e 'include("test/4_assembly/viterbi_decode_golden_test.jl")'
+# ```
+#
+# Golden-master (characterization) lock for opt2's fused-typed-transition refactor
+# of the substitution hot decode loop in `_viterbi_correct_observation`. Captured
+# against PRE-refactor code (commit 047142aa8), before `_get_valid_transitions` +
+# `_total_outgoing_weight` were replaced by the fused
+# `Rhizomorph._valid_transitions_and_total` and Dict-form `transition[:x]` access
+# was converted to `transition.x` field access on `_Transition`. Every literal
+# below (path steps, score, diagnostics) is the exact pre-refactor output; any
+# byte-level drift after the refactor fails this test.
+#
+# Fixture: a 3-read k=3 kmer graph where reads "ATGCGTAA" (x2) and "ATGCTTAA" (x1)
+# share a prefix (ATG,TGC), branch at TGC into two out-edges (GCG coverage=2, GCT
+# coverage=1), then reconverge at TAA. `max_successors_per_state = 1` forces
+# `_top_b_transitions` to bound the 2-way branch to a single successor each depth
+# (diagnostics[:successor_bounded] == 1 confirms it fires), so this fixture
+# exercises both changed call sites: the fused `_valid_transitions_and_total` scan
+# and the `_top_b_transitions` field-access sort.
+
+import BioSequences
+import FASTX
+import Kmers
+import Mycelia
+import Test
+
+Test.@testset "Viterbi decode golden master (opt2 fused-transitions lock)" begin
+    records = [
+        FASTX.FASTA.Record("r1", BioSequences.dna"ATGCGTAA"),
+        FASTX.FASTA.Record("r2", BioSequences.dna"ATGCGTAA"),
+        FASTX.FASTA.Record("r3", BioSequences.dna"ATGCTTAA")
+    ]
+    graph = Mycelia.Rhizomorph.build_kmer_graph(
+        records, 3; dataset_id = "golden_fixture", mode = :singlestrand
+    )
+
+    observation = [
+        Kmers.DNAKmer{3}("ATG"),
+        Kmers.DNAKmer{3}("TGC"),
+        Kmers.DNAKmer{3}("GCG"),
+        Kmers.DNAKmer{3}("CGT"),
+        Kmers.DNAKmer{3}("GTA"),
+        Kmers.DNAKmer{3}("TAA")
+    ]
+
+    config = Mycelia.ViterbiCorrectionConfig(max_successors_per_state = 1)
+
+    alphabet = Mycelia._resolve_viterbi_alphabet(graph, [observation], config.alphabet)
+    strand_mode = Mycelia._resolve_viterbi_strand_mode(graph, alphabet, config.strand_mode)
+    transition_edge_weight = Mycelia._viterbi_transition_edge_weight(
+        graph, config.edge_weight)
+    weighted = Mycelia.Rhizomorph.weighted_graph_from_rhizomorph(
+        graph; edge_weight = transition_edge_weight)
+
+    result = Mycelia._viterbi_correct_observation(
+        weighted,
+        observation,
+        alphabet;
+        config = config,
+        strand_mode = strand_mode,
+        quality_graph = graph,
+        transition_scoring = Mycelia._viterbi_transition_scoring(
+            graph, transition_edge_weight)
+    )
+
+    Test.@test result.path !== nothing
+    path = something(result.path)
+
+    expected_labels = [
+        Kmers.DNAKmer{3}("ATG"),
+        Kmers.DNAKmer{3}("TGC"),
+        Kmers.DNAKmer{3}("GCG"),
+        Kmers.DNAKmer{3}("CGT"),
+        Kmers.DNAKmer{3}("GTA"),
+        Kmers.DNAKmer{3}("TAA")
+    ]
+    expected_strands = fill(Mycelia.Rhizomorph.Forward, 6)
+    expected_probabilities = [1.0, 1.0, 2.0 / 3.0, 1.0, 1.0, 1.0]
+    expected_cumulative_probabilities = [
+        1.0, 1.0, 2.0 / 3.0, 2.0 / 3.0, 2.0 / 3.0, 2.0 / 3.0]
+
+    Test.@test [step.vertex_label for step in path.steps] == expected_labels
+    Test.@test [step.strand for step in path.steps] == expected_strands
+    Test.@test [step.probability for step in path.steps] == expected_probabilities
+    Test.@test [step.cumulative_probability for step in path.steps] ==
+               expected_cumulative_probabilities
+    Test.@test path.total_probability === 0.6666666666666666
+
+    Test.@test result.score === -0.5863711534711905
+
+    expected_diagnostics = Dict{Symbol, Any}(
+        :algorithm => :viterbi_emission_correct_observation,
+        :exact => true,
+        :alphabet => :DNA,
+        :strand_mode => :singlestrand,
+        :reverse_complement_support => true,
+        :max_steps => 5,
+        :target_vertex => Kmers.DNAKmer{3}("TAA"),
+        :start_strand => Mycelia.Rhizomorph.Forward,
+        :score_domain => :log_probability,
+        :transition_scoring => :normalized_edge_weight,
+        :emission_scoring => :alphabet_parameterized,
+        :expanded_states => 5,
+        :generated_states => 5,
+        :retained_states => 1,
+        :cumulative_retained_states => 6,
+        :max_retained_states => 1,
+        :skipped_transitions => 0,
+        :completed_steps => 5,
+        :reached_target => true,
+        :path_length => 6,
+        :successor_bounded => 1
+    )
+    Test.@test result.diagnostics == expected_diagnostics
+end

--- a/test/4_assembly/viterbi_decode_golden_test.jl
+++ b/test/4_assembly/viterbi_decode_golden_test.jl
@@ -114,5 +114,155 @@ Test.@testset "Viterbi decode golden master (opt2 fused-transitions lock)" begin
         :path_length => 6,
         :successor_bounded => 1
     )
+    Test.@test length(result.diagnostics) == 21
+    Test.@test result.diagnostics == expected_diagnostics
+end
+
+# ---------------------------------------------------------------------------
+# Second golden case (opt2 diagnostics-hoist lock, TRIGGERED side): the fixture
+# above never prunes (default beam_width = typemax, margin = Inf), so it only
+# tests the ABSENCE of :beam_pruned / :margin_pruned. This case uses a small
+# beam (beam_width = 2) and a finite score margin (beam_score_margin = 2.0) on a
+# higher-branching 40-read k=5 graph so both counters actually fire, locking the
+# hoisted-counter write-back path. Every literal is the exact opt2-branch output
+# AND was verified byte-identical against origin/master (0804d0ecc) for this same
+# fixture, proving the counter hoist did not change the pruning counts.
+Test.@testset "Viterbi decode golden master (opt2 diagnostics-hoist, pruning fires)" begin
+    reads = [
+        FASTX.FASTA.Record("r1", BioSequences.LongDNA{4}("GCCAACTACGTTTACCATCTTTTG")),
+        FASTX.FASTA.Record("r2", BioSequences.LongDNA{4}("AGCTACGTTTACCATCTTTTGAGA")),
+        FASTX.FASTA.Record("r3", BioSequences.LongDNA{4}("GAGAGCTGGTAGACTACTCTTCGG")),
+        FASTX.FASTA.Record("r4", BioSequences.LongDNA{4}("CCAGGTCCGTTTACCATCTATTGA")),
+        FASTX.FASTA.Record("r5", BioSequences.LongDNA{4}("GCTACGATTACCATCTTTTGAGAT")),
+        FASTX.FASTA.Record("r6", BioSequences.LongDNA{4}("TGCCAGCTACGTTTAACATCTTTT")),
+        FASTX.FASTA.Record("r7", BioSequences.LongDNA{4}("TACGTTTACCATCCTTTGAGAGCT")),
+        FASTX.FASTA.Record("r8", BioSequences.LongDNA{4}("GGGCTTGCTGCAAGCTACGTTTAC")),
+        FASTX.FASTA.Record("r9", BioSequences.LongDNA{4}("TGAGATCTGGTAGACTACTAATCA")),
+        FASTX.FASTA.Record("r10", BioSequences.LongDNA{4}("TCCGTGCTGCCAGCTACGTTTAGC")),
+        FASTX.FASTA.Record("r11", BioSequences.LongDNA{4}("CCAGCTACGTGTACCAACTTTTGA")),
+        FASTX.FASTA.Record("r12", BioSequences.LongDNA{4}("GCTTTCTGCCAGCTACGTTTACCA")),
+        FASTX.FASTA.Record("r13", BioSequences.LongDNA{4}("GCTCGCTGCCAGCTACGTTTACCA")),
+        FASTX.FASTA.Record("r14", BioSequences.LongDNA{4}("CTGCCAGCTAAGTTTACCATCTTT")),
+        FASTX.FASTA.Record("r15", BioSequences.LongDNA{4}("CTTGCTGAAAGCTACGTTTACCAT")),
+        FASTX.FASTA.Record("r16", BioSequences.LongDNA{4}("TATCTTTTGAGATCTGGTAGACTA")),
+        FASTX.FASTA.Record("r17", BioSequences.LongDNA{4}("CGTTTACCATCTTTTGAGATCTGG")),
+        FASTX.FASTA.Record("r18", BioSequences.LongDNA{4}("GTTTACCATCTTTTGAGCGCTGGT")),
+        FASTX.FASTA.Record("r19", BioSequences.LongDNA{4}("ATACGTTTACCATCTTTTGAGATC")),
+        FASTX.FASTA.Record("r20", BioSequences.LongDNA{4}("GGGCTAGCTGCCAGCTACGTTTAA")),
+        FASTX.FASTA.Record("r21", BioSequences.LongDNA{4}("AGCTACGTTTACCATCTTTTGAGA")),
+        FASTX.FASTA.Record("r22", BioSequences.LongDNA{4}("CCTTTTGAGATCTGGTAGACTACT")),
+        FASTX.FASTA.Record("r23", BioSequences.LongDNA{4}("GTCTTACTCCCAGCTACGTTGACC")),
+        FASTX.FASTA.Record("r24", BioSequences.LongDNA{4}("TTTACCATCTTTTGACATCTGGTA")),
+        FASTX.FASTA.Record("r25", BioSequences.LongDNA{4}("TACCATCTTTTTACGTCTGGTAGA")),
+        FASTX.FASTA.Record("r26", BioSequences.LongDNA{4}("GGCTTGCTGCCCGCTATGTTTACC")),
+        FASTX.FASTA.Record("r27", BioSequences.LongDNA{4}("ACCATCTTTTGAGATCTGGTAAAC")),
+        FASTX.FASTA.Record("r28", BioSequences.LongDNA{4}("AGCTACCTTTACCATCTTTTGAGA")),
+        FASTX.FASTA.Record("r29", BioSequences.LongDNA{4}("GCTTGCTGCCACCTACGTTTACCA")),
+        FASTX.FASTA.Record("r30", BioSequences.LongDNA{4}("CTGCCAGCTATGATTACCATCTTT")),
+        FASTX.FASTA.Record("r31", BioSequences.LongDNA{4}("GGGCTTCCTGCCAGCTACCTTTAC")),
+        FASTX.FASTA.Record("r32", BioSequences.LongDNA{4}("CTTTTGAGATCTGGTAGACTACTA")),
+        FASTX.FASTA.Record("r33", BioSequences.LongDNA{4}("ACCATCTTTCGAGATCTGGAAGAC")),
+        FASTX.FASTA.Record("r34", BioSequences.LongDNA{4}("GAGATCTGGTAGACTACTAATCGG")),
+        FASTX.FASTA.Record("r35", BioSequences.LongDNA{4}("TTGCTGCCAGATACGTTTACCATC")),
+        FASTX.FASTA.Record("r36", BioSequences.LongDNA{4}("CTACGTTTACCAGCTTTTGAGATC")),
+        FASTX.FASTA.Record("r37", BioSequences.LongDNA{4}("TGCCAGCTACGTTGACTATCTTTT")),
+        FASTX.FASTA.Record("r38", BioSequences.LongDNA{4}("GCCGCGAGCTACGTTTACCTTCTT")),
+        FASTX.FASTA.Record("r39", BioSequences.LongDNA{4}("CTTGCCGCCAGCTACGTTTACCAT")),
+        FASTX.FASTA.Record("r40", BioSequences.LongDNA{4}("TTGCGGCCAGCTACGTTTACCATC"))
+    ]
+    graph = Mycelia.Rhizomorph.build_kmer_graph(
+        reads, 5; dataset_id = "golden_prune_fixture", mode = :singlestrand
+    )
+
+    obsseq = "GCCAACTACGTTTACCATCTTTTG"
+    observation = [Kmers.DNAKmer{5}(obsseq[i:(i + 4)]) for i in 1:(length(obsseq) - 4)]
+
+    config = Mycelia.ViterbiCorrectionConfig(
+        beam_width = 2, beam_score_margin = 2.0)
+
+    alphabet = Mycelia._resolve_viterbi_alphabet(graph, [observation], config.alphabet)
+    strand_mode = Mycelia._resolve_viterbi_strand_mode(graph, alphabet, config.strand_mode)
+    transition_edge_weight = Mycelia._viterbi_transition_edge_weight(
+        graph, config.edge_weight)
+    weighted = Mycelia.Rhizomorph.weighted_graph_from_rhizomorph(
+        graph; edge_weight = transition_edge_weight)
+
+    result = Mycelia._viterbi_correct_observation(
+        weighted,
+        observation,
+        alphabet;
+        config = config,
+        strand_mode = strand_mode,
+        quality_graph = graph,
+        transition_scoring = Mycelia._viterbi_transition_scoring(
+            graph, transition_edge_weight)
+    )
+
+    Test.@test result.path !== nothing
+    path = something(result.path)
+
+    expected_labels = [
+        Kmers.DNAKmer{5}("GCCAA"),
+        Kmers.DNAKmer{5}("CCAAC"),
+        Kmers.DNAKmer{5}("CAACT"),
+        Kmers.DNAKmer{5}("AACTA"),
+        Kmers.DNAKmer{5}("ACTAC"),
+        Kmers.DNAKmer{5}("CTACG"),
+        Kmers.DNAKmer{5}("TACGT"),
+        Kmers.DNAKmer{5}("ACGTT"),
+        Kmers.DNAKmer{5}("CGTTT"),
+        Kmers.DNAKmer{5}("GTTTA"),
+        Kmers.DNAKmer{5}("TTTAC"),
+        Kmers.DNAKmer{5}("TTACC"),
+        Kmers.DNAKmer{5}("TACCA"),
+        Kmers.DNAKmer{5}("ACCAT"),
+        Kmers.DNAKmer{5}("CCATC"),
+        Kmers.DNAKmer{5}("CATCT"),
+        Kmers.DNAKmer{5}("ATCTT"),
+        Kmers.DNAKmer{5}("TCTTT"),
+        Kmers.DNAKmer{5}("CTTTT"),
+        Kmers.DNAKmer{5}("TTTTG")
+    ]
+    expected_strands = fill(Mycelia.Rhizomorph.Forward, 20)
+    expected_probabilities = [1.0, 1.0, 1.0, 0.5, 1.0, 0.16666666666666666, 0.9473684210526315, 0.9090909090909091, 0.9, 1.0, 0.8695652173913043, 0.9545454545454546, 0.9545454545454546, 0.9, 1.0, 0.9375, 0.8823529411764706, 1.0, 0.9333333333333333, 0.9375]
+    expected_cumulative_probabilities = [1.0, 1.0, 1.0, 0.5, 0.5, 0.08333333333333333, 0.07894736842105263, 0.07177033492822966, 0.0645933014354067, 0.0645933014354067, 0.056168088204701476, 0.05361499328630596, 0.051177948136928414, 0.04606015332323558, 0.04606015332323558, 0.043181393740533355, 0.03810122977105884, 0.03810122977105884, 0.035561147786321586, 0.03333857604967649]
+
+    Test.@test [step.vertex_label for step in path.steps] == expected_labels
+    Test.@test [step.strand for step in path.steps] == expected_strands
+    Test.@test [step.probability for step in path.steps] == expected_probabilities
+    Test.@test [step.cumulative_probability for step in path.steps] ==
+               expected_cumulative_probabilities
+    Test.@test path.total_probability === 0.03333857604967649
+
+    Test.@test result.score === -4.406073697889444
+
+    expected_diagnostics = Dict{Symbol, Any}(
+        :algorithm => :viterbi_emission_correct_observation,
+        :exact => true,
+        :alphabet => :DNA,
+        :strand_mode => :singlestrand,
+        :reverse_complement_support => true,
+        :max_steps => 19,
+        :target_vertex => Kmers.DNAKmer{5}("TTTTG"),
+        :start_strand => Mycelia.Rhizomorph.Forward,
+        :score_domain => :log_probability,
+        :transition_scoring => :normalized_edge_weight,
+        :emission_scoring => :alphabet_parameterized,
+        :expanded_states => 19,
+        :generated_states => 36,
+        :retained_states => 1,
+        :cumulative_retained_states => 20,
+        :max_retained_states => 1,
+        :skipped_transitions => 0,
+        :completed_steps => 19,
+        :reached_target => true,
+        :path_length => 20,
+        :beam_pruned => 4,
+        :margin_pruned => 13
+    )
+    # 22 keys: the 20 always-present keys plus the two triggered counters
+    # (:beam_pruned, :margin_pruned). :successor_bounded stays ABSENT (default
+    # max_successors_per_state = typemax never fires).
+    Test.@test length(result.diagnostics) == 22
     Test.@test result.diagnostics == expected_diagnostics
 end


### PR DESCRIPTION
## Summary

- The `:scalable` corrector's hot Viterbi decode built a `Vector{Any}` of per-edge `Dict{Symbol,Any}` transitions and separately scanned every state's out-edges twice (once to build transitions, once to sum outgoing weight), plus bumped `Any`-boxed diagnostics counters per transition. This replaces that with a concrete-eltype typed `_Transition{L,E}` struct built in a **single fused `outneighbors` pass** (`_valid_transitions_and_total`), and hoists the in-loop diagnostics counters to unboxed `Int` locals.
- **Hot-loop-only scope.** The typed/fused path is wired into the two decode call sites (substitution loop + memoized indel successor batch); the Dict-form `_get_valid_transitions`/`_total_outgoing_weight` are left untouched for the ~10 cold consumers (metrics, generation, batched-PoC).
- **Byte-identical by construction.** Same `outneighbors` order, same strand filter, same `total += _edge_transition_weight(...)` summation order (0.0-weight edges add 0.0), same `max(total, _KSP_MIN_WEIGHT)` floor, same state-tuple key type (so `hash`-based beam-prune tie-breaks are unaffected), and the diagnostics Dict's final values + lazy-key presence are preserved exactly.

## Byte-identity evidence

- **Equivalence lock** (`valid_transitions_fused_test.jl`): the fused function returns transitions bit-identical to the Dict-form `_get_valid_transitions` (same order, `===` on probability + total) and total bit-identical to `_total_outgoing_weight`, across every vertex/strand — 5201/5201.
- **Golden-master** (`viterbi_decode_golden_test.jl`): `_viterbi_correct_observation`'s full path, `best_score` (`===`), and complete diagnostics Dict are locked against captured pre-refactor literals — 8/8 (exercises both the triggered and absent lazy-key diagnostics paths).
- Corrector lock tests stay green: `low_k_decode_gating` 20/20, `reassembly_graph_reuse` 20/20, `batched_viterbi_kernel` 38/38, `corrector_gc_between_batches` 16/16, opt1 `parallel_soft_em_byte_identity` (reads + full soft-EM weights) 15/15; indel decoder 188/188.

## Performance

Measured on a fixed decode fixture: **44,528 → 32,816 bytes allocated per call = 26.3% reduction**, decode output (path, score, diagnostics) byte-identical between `origin/master` and this branch. Single small fixture (directional, not a wall-clock speedup claim). Details: `benchmarking/results/opt2_alloc_hotloop.md`.

## Test Plan

- [x] Fused-function equivalence (5201/5201) + golden-master decode (8/8)
- [x] All corrector lock tests + indel decoder green
- [x] Allocation reduction measured (26.3%), output byte-identical
- [ ] E. coli-scale wall-clock benchmark of opt5+opt1+opt2 combined (campaign follow-up)

## Notes

Third step of the corrector performance campaign (after the GC-gating and parallel-decode steps). Change 4 from the design (per-depth Dict reuse) was deliberately deferred — `empty!`-reuse changes Dict iteration order and can flip equal-score tie-breaks. Design + plan under `docs/design/`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Reduced memory allocation in the Viterbi decoding hot path by ~26% (micro-benchmark), improving efficiency while keeping decoded outputs consistent.
- **Reliability**
  - Strengthened correctness guarantees with additional transition-equivalence tests and new golden-master regression coverage, including exact path/score and diagnostics expectations.
- **Documentation**
  - Added new design/plan and benchmark reports describing the optimization approach and how byte-identical validation is ensured.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->