### PR TITLE
fix: gate env-fragile kmer + flaky timing tests

### DIFF
--- a/test/3_feature_extraction_kmer/kmer_analysis_additional_coverage_test.jl
+++ b/test/3_feature_extraction_kmer/kmer_analysis_additional_coverage_test.jl
@@ -282,18 +282,28 @@ Test.@testset "K-mer Analysis Additional Coverage" begin
                 close(gzip_stream)
             end
 
-            histogram_file = Mycelia.jellyfish_counts_to_kmer_frequency_histogram(jellyfish_counts)
-            Test.@test isfile(histogram_file)
+            # `jellyfish_counts_to_kmer_frequency_histogram` shells out to the
+            # coreutils pipeline gzip|cut|sort|uniq|sed. Skip cleanly when any is
+            # absent (e.g. `sort` ENOENT on a minimal CI image) rather than
+            # aborting the whole `Pkg.test` suite.
+            histogram_tools = ("gzip", "cut", "sort", "uniq", "sed")
+            missing_histogram_tools = filter(t -> Sys.which(t) === nothing, collect(histogram_tools))
+            if !isempty(missing_histogram_tools)
+                Test.@test_skip "Missing external tools for jellyfish histogram: $(join(missing_histogram_tools, ", "))"
+            else
+                histogram_file = Mycelia.jellyfish_counts_to_kmer_frequency_histogram(jellyfish_counts)
+                Test.@test isfile(histogram_file)
 
-            histogram = DelimitedFiles.readdlm(histogram_file, '\t', Int, '\n';
-                skipstart = 1)
-            Test.@test size(histogram, 1) == 3
-            Test.@test vec(histogram[1, :]) == [1, 1]
-            Test.@test vec(histogram[2, :]) == [2, 2]
-            Test.@test vec(histogram[3, :]) == [1, 4]
+                histogram = DelimitedFiles.readdlm(histogram_file, '\t', Int, '\n';
+                    skipstart = 1)
+                Test.@test size(histogram, 1) == 3
+                Test.@test vec(histogram[1, :]) == [1, 1]
+                Test.@test vec(histogram[2, :]) == [2, 2]
+                Test.@test vec(histogram[3, :]) == [1, 4]
 
-            Test.@test Mycelia.jellyfish_counts_to_kmer_frequency_histogram(jellyfish_counts) ==
-                       histogram_file
+                Test.@test Mycelia.jellyfish_counts_to_kmer_frequency_histogram(jellyfish_counts) ==
+                           histogram_file
+            end
         end
 
         Test.@testset "DNA saturation helpers" begin

--- a/test/3_feature_extraction_kmer/kmer_analysis_coverage_expansion_test.jl
+++ b/test/3_feature_extraction_kmer/kmer_analysis_coverage_expansion_test.jl
@@ -82,17 +82,29 @@ Test.@testset "K-mer Analysis Coverage Expansion" begin
                 end
             end
 
-            histogram_path = Mycelia.jellyfish_counts_to_kmer_frequency_histogram(jellyfish_counts_path)
-            Test.@test isfile(histogram_path)
+            # `jellyfish_counts_to_kmer_frequency_histogram` shells out to the
+            # coreutils pipeline gzip|cut|sort|uniq|sed. Gate on their presence
+            # so a minimal CI image lacking one of them (e.g. `sort` ENOENT)
+            # skips the histogram assertions cleanly instead of aborting the
+            # whole `Pkg.test` suite. The pure-Julia `load_jellyfish_counts`
+            # coverage below still runs unconditionally.
+            histogram_tools = ("gzip", "cut", "sort", "uniq", "sed")
+            missing_histogram_tools = filter(t -> Sys.which(t) === nothing, collect(histogram_tools))
+            if !isempty(missing_histogram_tools)
+                Test.@test_skip "Missing external tools for jellyfish histogram: $(join(missing_histogram_tools, ", "))"
+            else
+                histogram_path = Mycelia.jellyfish_counts_to_kmer_frequency_histogram(jellyfish_counts_path)
+                Test.@test isfile(histogram_path)
 
-            histogram_table = CSV.read(histogram_path, DataFrames.DataFrame; delim = '\t')
-            histogram_map = Dict(
-                histogram_table[!, "number of observations"] .=> histogram_table[!, "number of kmers"]
-            )
-            Test.@test histogram_map == Dict(2 => 2, 3 => 1)
+                histogram_table = CSV.read(histogram_path, DataFrames.DataFrame; delim = '\t')
+                histogram_map = Dict(
+                    histogram_table[!, "number of observations"] .=> histogram_table[!, "number of kmers"]
+                )
+                Test.@test histogram_map == Dict(2 => 2, 3 => 1)
 
-            Test.@test Mycelia.jellyfish_counts_to_kmer_frequency_histogram(jellyfish_counts_path) ==
-                       histogram_path
+                Test.@test Mycelia.jellyfish_counts_to_kmer_frequency_histogram(jellyfish_counts_path) ==
+                           histogram_path
+            end
 
             loaded_counts = Mycelia.load_jellyfish_counts(jellyfish_counts_path)
             Test.@test isa(loaded_counts, DataFrames.DataFrame)

--- a/test/4_assembly/find_linear_path_set_membership_test.jl
+++ b/test/4_assembly/find_linear_path_set_membership_test.jl
@@ -237,11 +237,15 @@ Test.@testset "find_linear_path Set-membership (td-kokn)" begin
         println("  Vector (old)   t  : ", round.(t_reference; sigdigits = 3), " s  alpha=", round(a_reference; digits = 2))
 
         # The current (Set) implementation is near-linear and clearly below the
-        # Vector reference's super-linear (~2) slope. Thresholds are loose enough
-        # to tolerate timing noise while still proving the scaling improvement:
-        # the separation between the two slopes is the load-bearing assertion.
+        # Vector reference's super-linear (~2) slope. The load-bearing claim is
+        # the QUALITATIVE ordering -- Set scales strictly better than Vector --
+        # not any exact gap. A fixed near-threshold gap (previously > 0.4) flaps
+        # on timing noise (observed 0.3985 vs 0.4 on a loaded CI runner), so the
+        # separation is asserted as a strict ordering plus a loose tolerance that
+        # stays well clear of the noise floor.
         Test.@test a_current < 1.5
         Test.@test a_reference > 1.6
-        Test.@test a_reference - a_current > 0.4
+        Test.@test a_current < a_reference
+        Test.@test a_reference - a_current > 0.2
     end
 end


### PR DESCRIPTION
## Summary

- Two tests could abort the full `Pkg.test` suite on a minimal CI image (consistent with the `test (lts)` job that hung >1h on a test-only PR while a sibling PR passed).
- `jellyfish_counts_to_kmer_frequency_histogram` shells out to the coreutils pipeline `gzip|cut|sort|uniq|sed`; when any binary is absent (e.g. `sort` ENOENT) the whole suite aborted. Both histogram testsets now gate on `Sys.which` and `@test_skip` with a clear reason; the pure-Julia `load_jellyfish_counts` coverage still runs unconditionally.
- The `find_linear_path` Set-membership scaling test asserted a fixed near-threshold gap (`a_reference - a_current > 0.4`) that flapped on timing noise (observed 0.3985 on a loaded runner). Replaced with the qualitative ordering (`a_current < a_reference`) plus a loose tolerance (`> 0.2`) well clear of the noise floor; the near-linear vs super-linear absolute anchors are unchanged, so behavioral coverage is preserved.

## Test Plan

- [x] `LD_LIBRARY_PATH="" julia --project=. -e 'include("test/3_feature_extraction_kmer/kmer_analysis_coverage_expansion_test.jl")'` — 56/56 pass (tools present, real assertions run)
- [x] `LD_LIBRARY_PATH="" julia --project=. -e 'include("test/3_feature_extraction_kmer/kmer_analysis_additional_coverage_test.jl")'` — 251/251 pass
- [x] `LD_LIBRARY_PATH="" julia --project=. -e 'include("test/4_assembly/find_linear_path_set_membership_test.jl")'` — 9/9 pass, slope gap ~0.92 (alpha 1.07 vs 1.99)
- [x] Missing-tool path simulated (empty PATH): histogram gate yields a Broken/skipped result, no ENOENT abort
- Follows the existing `Sys.which` + `@test_skip` gating pattern already used in `test/8_tool_integration/`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated Jellyfish histogram tests to skip gracefully when required external command-line tools are unavailable.
  - Preserved pure-Julia Jellyfish count validation regardless of system tooling.
  - Improved assembly performance tests with more reliable, noise-tolerant timing thresholds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->