### PR TITLE
fix: benchmarking result integrity — min-contig policy, mixed-definition guard, cross-host merge, seed axis

### DIFF
--- a/benchmarking/e2e_phase_profile.jl
+++ b/benchmarking/e2e_phase_profile.jl
@@ -51,6 +51,12 @@ import Random
 import Printf
 import Dates
 
+# Shared QUAST --min-contig policy (bead td-28o0). Replaces the inline
+# `max(50, <len> ÷ 10)` this file used to carry, which for any reference above
+# ~5 kb raised the threshold ABOVE QUAST's default and, for T4 (168,903 bp),
+# demanded a 16,890 bp contig that a fragmented assembly cannot reach.
+include(joinpath(@__DIR__, "quast_min_contig.jl"))
+
 # ---------------------------------------------------------------------------
 # Config
 # ---------------------------------------------------------------------------
@@ -210,7 +216,7 @@ function profile_cell(glen::Int)
                 String[iter_contigs, naive_contigs];
                 outdir = joinpath(score_dir, "quast"),
                 reference = ref_path,
-                min_contig = max(50, glen ÷ 10))
+                min_contig = quast_min_contig(glen))
         catch e
             @warn "run_quast unavailable / failed — reporting t_quast=0" exception = e
         end

--- a/benchmarking/metric_source_guard.jl
+++ b/benchmarking/metric_source_guard.jl
@@ -1,0 +1,257 @@
+# Metric-definition consistency guard for the benchmarking analysis path.
+# =======================================================================
+#
+# Pure and dependency-free (like `rhizomorph_scale_guard.jl`,
+# `quast_report_parsing.jl` and `quast_min_contig.jl`): no Mycelia, no
+# DataFrames import, no network. It reaches columns through `hasproperty` /
+# `getproperty`, so it works on a `DataFrames.DataFrame`, a `NamedTuple` of
+# vectors, or anything else column-shaped — and its unit test runs in
+# milliseconds.
+#
+# WHY THIS FILE EXISTS (bead td-9p91)
+# -----------------------------------
+# When QUAST fails, the harnesses degrade gracefully to internal size-ratio
+# metrics and record `metric_source="internal:quast-failed"` while still
+# reporting `ok=true`. Keeping the job alive is correct. The hazard is downstream:
+# a single results table can then hold rows whose metrics come from TWO DIFFERENT
+# DEFINITIONS —
+#
+#   * `metric_source="quast"`   — alignment-validated (QUAST aligns contigs to the
+#                                 reference; NGA50 and misassemblies are real)
+#   * `metric_source="internal*"` — a size ratio (`total_length / genome_len`) and a
+#                                 length-sorted N50, BLIND to misassembly and to
+#                                 mis-alignment
+#
+# A naive `groupby` across those rows compares incompatible quantities, and the
+# resulting difference reads as a real effect. Observed concretely on Lawrencium
+# job 24247925: T4 rows may carry internal metrics while Lambda rows carry QUAST
+# metrics.
+#
+# This guard is the DURABLE fix; `quast_min_contig.jl` (td-28o0) is the specific
+# one. Fixing the `--min-contig` floor removes one trigger, but graceful
+# degradation will always be able to produce mixed `metric_source`, so any
+# aggregation must assert consistency rather than assume it.
+#
+# WHAT COUNTS AS "THE METRIC DEFINITION"
+# --------------------------------------
+# `metric_source` is the obvious axis, but it is not the only one. The threshold
+# QUAST was run at is equally part of the definition: two rows both labelled
+# `metric_source="quast"` but scored at `--min-contig` 4,850 vs 5,000 are also not
+# comparable. `METRIC_DEFINITION_COLUMNS` therefore covers both, which is why the
+# RGV sweep records `quast_min_contig` per row — it makes a future change to the
+# threshold policy trip THIS guard instead of passing silently.
+#
+# FAIL-CLOSED ON A MISSING COLUMN
+# -------------------------------
+# If a table carries none of the definition columns, the guard RAISES rather than
+# reporting "consistent". A table with no provenance column is not a table that
+# has been shown to be consistent; it is a table that cannot be checked. Callers
+# with a differently-named provenance column pass it via `columns=`.
+
+"""
+Columns that together define "which metric definition produced this row".
+
+  * `:metric_source`     — `"quast"` (alignment-validated) vs `"internal*"` (size-ratio proxy)
+  * `:quast_min_contig`  — the `--min-contig` threshold QUAST was run at
+
+Both must be constant across an aggregation for the aggregate to mean anything.
+"""
+const METRIC_DEFINITION_COLUMNS = (:metric_source, :quast_min_contig)
+
+"""
+    MixedMetricDefinitionError
+
+Raised when an aggregation would span more than one metric definition. Carries
+the offending column(s), the distinct values observed, and (for the grouped
+check) the group keys at fault, so the message is actionable without re-running
+the analysis.
+"""
+struct MixedMetricDefinitionError <: Exception
+    context::String
+    offenders::Vector{Tuple{Union{Nothing, String}, Symbol, Vector{String}}}
+end
+
+_definition_label(v) = v === missing ? "missing" : string(v)
+
+function _render_offenders(offenders)
+    lines = String[]
+    for (group, col, vals) in offenders
+        prefix = group === nothing ? "  " : "  [group $group] "
+        push!(lines, prefix * "$col: " * join(("\"$v\"" for v in vals), ", "))
+    end
+    return join(lines, "\n")
+end
+
+function Base.showerror(io::IO, e::MixedMetricDefinitionError)
+    print(io,
+        """
+        MixedMetricDefinitionError: refusing to aggregate in $(e.context) — the rows \
+        were scored under more than one metric definition.
+
+        $(_render_offenders(e.offenders))
+
+        Rows labelled metric_source="quast" carry ALIGNMENT-VALIDATED metrics; rows \
+        labelled "internal*" carry size-ratio proxies that are blind to misassembly. \
+        Rows scored at different quast_min_contig thresholds were filtered differently. \
+        Aggregating across either boundary compares incompatible quantities, and the \
+        difference reads as a real effect.
+
+        Fix the upstream cause (see beads td-28o0 / td-9p91), or filter to a single \
+        definition, or pass allow_mixed_src=true to override deliberately (a loud \
+        warning is emitted and the mixed values are named).""")
+    return nothing
+end
+
+"""
+    metric_definition_summary(df; columns=METRIC_DEFINITION_COLUMNS)
+        -> Vector{Pair{Symbol, Vector{String}}}
+
+Distinct values of each present definition column, sorted, with `missing`
+rendered as the literal `"missing"` so an absent provenance value participates in
+the consistency check rather than being skipped.
+
+Columns in `columns` that the table does not carry are omitted from the summary
+(use `assert_single_metric_definition` to fail closed when none are present).
+"""
+function metric_definition_summary(df; columns = METRIC_DEFINITION_COLUMNS)
+    summary = Pair{Symbol, Vector{String}}[]
+    for col in columns
+        hasproperty(df, col) || continue
+        vals = sort(unique(String[_definition_label(v) for v in getproperty(df, col)]))
+        push!(summary, col => vals)
+    end
+    return summary
+end
+
+function _require_definition_columns(df, columns, context)
+    present = Symbol[c for c in columns if hasproperty(df, c)]
+    if isempty(present)
+        throw(ArgumentError(
+            "no metric-definition column present in $context (looked for " *
+            join((":$c" for c in columns), ", ") * "). A table with no provenance " *
+            "column cannot be shown to be consistent — add one, or pass an explicit " *
+            "`columns=` naming this table's provenance column."))
+    end
+    return present
+end
+
+"""
+    assert_single_metric_definition(df; columns, context, allow_mixed_src=false)
+        -> Vector{Pair{Symbol, Vector{String}}}
+
+Assert that every row of `df` was scored under ONE metric definition, i.e. that
+each column in `columns` holds a single distinct value. Returns the definition
+summary on success.
+
+Throws `MixedMetricDefinitionError` when a definition column holds more than one
+value, and `ArgumentError` when the table carries none of `columns` (fail-closed:
+unverifiable is not the same as verified).
+
+Set `allow_mixed_src=true` to proceed anyway; the mix is then reported through a
+loud `@warn` that names every mixed value, so the override is visible in the run
+log rather than implicit.
+
+# Example
+
+```julia
+# One definition: passes, returns the summary.
+assert_single_metric_definition(quast_only_rows; context = "H1 NGA50 aggregate")
+
+# Mixed: raises, naming "internal:quast-failed" and "quast".
+assert_single_metric_definition(all_rows; context = "H1 NGA50 aggregate")
+```
+"""
+function assert_single_metric_definition(df;
+        columns = METRIC_DEFINITION_COLUMNS,
+        context::AbstractString = "aggregation",
+        allow_mixed_src::Bool = false)
+    present = _require_definition_columns(df, columns, context)
+    summary = metric_definition_summary(df; columns = present)
+    offenders = Tuple{Union{Nothing, String}, Symbol, Vector{String}}[(nothing, col, vals)
+                                                                      for (col, vals) in
+                                                                          summary
+                                                                      if length(vals) > 1]
+    isempty(offenders) && return summary
+    if allow_mixed_src
+        @warn "MIXED METRIC DEFINITION accepted via allow_mixed_src=true — the "*
+              "aggregate below compares rows scored under different definitions and "*
+              "is NOT validation-grade." context=String(context) mixed=_render_offenders(offenders)
+        return summary
+    end
+    throw(MixedMetricDefinitionError(String(context), offenders))
+end
+
+"""
+    assert_single_metric_definition_per_group(df, groupcols; columns, context,
+                                             allow_mixed_src=false) -> Int
+
+Grouped form of [`assert_single_metric_definition`](@ref): assert that EACH group
+defined by `groupcols` is internally single-definition. This is the check a
+`groupby`-then-aggregate needs, since each group becomes one aggregate.
+
+Every offending group is collected before raising, so one run reports the full
+extent of the problem instead of the first instance. Returns the number of groups
+checked.
+"""
+function assert_single_metric_definition_per_group(df, groupcols;
+        columns = METRIC_DEFINITION_COLUMNS,
+        context::AbstractString = "grouped aggregation",
+        allow_mixed_src::Bool = false)
+    present = _require_definition_columns(df, columns, context)
+    for col in groupcols
+        hasproperty(df, col) ||
+            throw(ArgumentError("group column :$col not present in $context"))
+    end
+    keyvecs = [getproperty(df, col) for col in groupcols]
+    defvecs = [getproperty(df, col) for col in present]
+    nrows = length(first(defvecs))
+
+    group_order = String[]
+    group_values = Dict{String, Vector{Set{String}}}()
+    for i in 1:nrows
+        key = join((_definition_label(v[i]) for v in keyvecs), " | ")
+        if !haskey(group_values, key)
+            group_values[key] = [Set{String}() for _ in present]
+            push!(group_order, key)
+        end
+        for (j, v) in enumerate(defvecs)
+            push!(group_values[key][j], _definition_label(v[i]))
+        end
+    end
+
+    offenders = Tuple{Union{Nothing, String}, Symbol, Vector{String}}[]
+    for key in group_order
+        for (j, col) in enumerate(present)
+            vals = group_values[key][j]
+            length(vals) > 1 && push!(offenders, (key, col, sort(collect(vals))))
+        end
+    end
+    isempty(offenders) && return length(group_order)
+    if allow_mixed_src
+        @warn "MIXED METRIC DEFINITION accepted via allow_mixed_src=true in "*
+              "$(length(offenders)) group(s) — those aggregates compare rows scored "*
+              "under different definitions and are NOT validation-grade." context=String(context) mixed=_render_offenders(offenders)
+        return length(group_order)
+    end
+    throw(MixedMetricDefinitionError(String(context), offenders))
+end
+
+"""
+    guarded_aggregate(f, df; columns, context, allow_mixed_src=false)
+
+Run `f(df)` only after [`assert_single_metric_definition`](@ref) passes. The
+one-line way to make an analysis step definition-safe:
+
+```julia
+median_nga50 = guarded_aggregate(rows; context = "median NGA50") do d
+    Statistics.median(skipmissing(d.quast_nga50))
+end
+```
+"""
+function guarded_aggregate(f, df;
+        columns = METRIC_DEFINITION_COLUMNS,
+        context::AbstractString = "aggregation",
+        allow_mixed_src::Bool = false)
+    assert_single_metric_definition(df; columns, context, allow_mixed_src)
+    return f(df)
+end

--- a/benchmarking/metric_source_guard.jl
+++ b/benchmarking/metric_source_guard.jl
@@ -23,9 +23,18 @@
 #                                 mis-alignment
 #
 # A naive `groupby` across those rows compares incompatible quantities, and the
-# resulting difference reads as a real effect. Observed concretely on Lawrencium
-# job 24247925: T4 rows may carry internal metrics while Lambda rows carry QUAST
-# metrics.
+# resulting difference reads as a real effect.
+#
+# WHAT WAS ACTUALLY OBSERVED. An earlier version of this comment said the mix was
+# "observed concretely on Lawrencium job 24247925: T4 rows MAY carry internal
+# metrics while Lambda rows carry QUAST metrics" — but observed and "may" cannot
+# both be true, and the T4 and Lambda rows came from different jobs and were never
+# in one table. The real observation is stronger and needs no cross-job inference:
+# the completed Lambda sweep produced a SINGLE 12-row CSV holding 4 rows with
+# `metric_source="quast"` and 8 with `"internal:quast-failed"` (bead td-4e19d.1).
+# And because `run_quast` is invoked PER ARM, the naive and iterative arms of one
+# cell can carry different definitions — a mixed PAIR, which defeats the paired
+# design directly rather than merely biasing a group mean.
 #
 # This guard is the DURABLE fix; `quast_min_contig.jl` (td-28o0) is the specific
 # one. Fixing the `--min-contig` floor removes one trigger, but graceful
@@ -41,12 +50,21 @@
 # RGV sweep records `quast_min_contig` per row — it makes a future change to the
 # threshold policy trip THIS guard instead of passing silently.
 #
-# FAIL-CLOSED ON A MISSING COLUMN
-# -------------------------------
-# If a table carries none of the definition columns, the guard RAISES rather than
-# reporting "consistent". A table with no provenance column is not a table that
-# has been shown to be consistent; it is a table that cannot be checked. Callers
-# with a differently-named provenance column pass it via `columns=`.
+# FAIL-CLOSED ON A MISSING COLUMN — PER AXIS, NOT PER SET
+# -------------------------------------------------------
+# If a table carries none of the definition columns, the guard RAISES: a table
+# with no provenance column is not a table that has been shown to be consistent,
+# it is a table that cannot be checked.
+#
+# The same reasoning applies to each axis INDIVIDUALLY, and an earlier version got
+# this wrong. It raised only when EVERY column was absent, so a table with a
+# uniform `metric_source` and no `quast_min_contig` — the shape of every CSV
+# produced before this policy existed — passed and reported a single consistent
+# definition over an axis it had never examined. A table concatenating runs scored
+# at different thresholds has exactly that shape. Any requested axis that is absent
+# while others are present therefore also raises; pass `require_all_columns=false`
+# to accept the narrower check (a warning then names which axes went unchecked), or
+# pass an explicit `columns=` to record the narrower claim deliberately.
 
 """
 Columns that together define "which metric definition produced this row".
@@ -123,14 +141,38 @@ function metric_definition_summary(df; columns = METRIC_DEFINITION_COLUMNS)
     return summary
 end
 
-function _require_definition_columns(df, columns, context)
+function _require_definition_columns(df, columns, context; require_all::Bool = true)
     present = Symbol[c for c in columns if hasproperty(df, c)]
+    absent = Symbol[c for c in columns if !hasproperty(df, c)]
     if isempty(present)
         throw(ArgumentError(
             "no metric-definition column present in $context (looked for " *
             join((":$c" for c in columns), ", ") * "). A table with no provenance " *
             "column cannot be shown to be consistent — add one, or pass an explicit " *
             "`columns=` naming this table's provenance column."))
+    end
+    # PARTIAL absence is the subtler hole, and it was a real one. The doctrine in
+    # this file's header is per-AXIS ("a table that cannot be checked"), but the
+    # implementation was per-SET: it raised only when EVERY column was missing, and
+    # `metric_definition_summary` silently skipped any individually-absent column.
+    # So a table with a uniform `metric_source` and no `quast_min_contig` — the
+    # shape of every CSV produced before this PR — passed and reported a single
+    # consistent definition, over an axis that was never examined. A table
+    # concatenating runs scored at different thresholds is exactly that shape.
+    if require_all && !isempty(absent)
+        throw(ArgumentError(
+            "metric-definition axis not checkable in $context: " *
+            join(("`$c`" for c in absent), ", ") *
+            " absent while " * join(("`$c`" for c in present), ", ") *
+            " present. Reporting 'consistent' would assert something about an axis " *
+            "this table cannot answer for. Either add the column, or pass an " *
+            "explicit `columns=` limited to the axes this table actually carries " *
+            "(which records the narrower claim), or `require_all_columns=false` to " *
+            "accept the narrower check with a warning."))
+    end
+    if !isempty(absent)
+        @warn "metric-definition axis NOT checked (column absent) — the " *
+              "consistency claim below covers only the axes listed as checked." context=String(context) absent=join(("$c" for c in absent), ", ") checked=join(("$c" for c in present), ", ")
     end
     return present
 end
@@ -164,8 +206,10 @@ assert_single_metric_definition(all_rows; context = "H1 NGA50 aggregate")
 function assert_single_metric_definition(df;
         columns = METRIC_DEFINITION_COLUMNS,
         context::AbstractString = "aggregation",
-        allow_mixed_src::Bool = false)
-    present = _require_definition_columns(df, columns, context)
+        allow_mixed_src::Bool = false,
+        require_all_columns::Bool = true)
+    present = _require_definition_columns(df, columns, context;
+        require_all = require_all_columns)
     summary = metric_definition_summary(df; columns = present)
     offenders = Tuple{Union{Nothing, String}, Symbol, Vector{String}}[(nothing, col, vals)
                                                                       for (col, vals) in
@@ -196,8 +240,10 @@ checked.
 function assert_single_metric_definition_per_group(df, groupcols;
         columns = METRIC_DEFINITION_COLUMNS,
         context::AbstractString = "grouped aggregation",
-        allow_mixed_src::Bool = false)
-    present = _require_definition_columns(df, columns, context)
+        allow_mixed_src::Bool = false,
+        require_all_columns::Bool = true)
+    present = _require_definition_columns(df, columns, context;
+        require_all = require_all_columns)
     for col in groupcols
         hasproperty(df, col) ||
             throw(ArgumentError("group column :$col not present in $context"))
@@ -251,7 +297,9 @@ end
 function guarded_aggregate(f, df;
         columns = METRIC_DEFINITION_COLUMNS,
         context::AbstractString = "aggregation",
-        allow_mixed_src::Bool = false)
-    assert_single_metric_definition(df; columns, context, allow_mixed_src)
+        allow_mixed_src::Bool = false,
+        require_all_columns::Bool = true)
+    assert_single_metric_definition(df; columns, context, allow_mixed_src,
+        require_all_columns)
     return f(df)
 end

--- a/benchmarking/quast_min_contig.jl
+++ b/benchmarking/quast_min_contig.jl
@@ -24,58 +24,85 @@
 #
 # and the harness degrades to internal size-ratio metrics
 # (`metric_source="internal:quast-failed"`) while still reporting `ok=true`.
-# Observed live on Lawrencium job 24247925 (RGV T4 @ 30x).
 #
-# THE FIX: a CEILING, not a different scaling
-# -------------------------------------------
+# SOURCE OF THE 11,622 bp FIGURE: the dispatch note on bead td-28o0, recording
+# Lawrencium job 24247925 (RGV T4 NC_000866 @ 30x). The cluster log is not
+# reachable from a checkout, so that number is REPORTED, not reproduced here. The
+# defect does not rest on it: the threshold arithmetic (168,903 / 10 = 16,890) is
+# checkable in-repo, and `t4_ksweep.jl`'s own committed results contain T4 rows
+# with largest contigs of 174 bp and 5,800 bp — local proof that assemblies of
+# this organism land far below a 16,890 bp floor.
+#
+# THE FIX: clamp at QUAST's own default, which is what the term was for
+# ---------------------------------------------------------------------
 # `quast_min_contig` keeps the down-scaling for tiny references (the original,
-# correct intent) and clamps it from above so the threshold can never exceed a
-# length that a legitimately fragmented assembly is unable to reach.
+# correct intent) and clamps it from above at QUAST's own default:
 #
-#   min_contig = clamp(genome_len ÷ 10, 50, 5_000)
+#   min_contig = clamp(genome_len ÷ 10, 50, 500)
 #
-# WHY 5,000 bp as the ceiling. It is the longest read length on the sweep's own
-# read-regime axis (`MYCELIA_RGV_READLEN` defaults to `150,5000`). A contig
-# shorter than a single read carries no assembly evidence, so "at least as long
-# as the longest read" is the strongest filter that is still a filter. Past that
-# point the threshold stops excluding noise and starts requiring a particular
-# DEGREE of assembly success — which is the quantity under measurement, not a
-# precondition for measuring it.
+# The scaling term exists ONLY to go below 500 for references shorter than QUAST's
+# default assumes. Letting it go above 500 was never the intent, and every value
+# it produced above 500 was a threshold nobody chose.
 #
-# WHY NOT the two rejected alternatives (both weighed explicitly):
+# WHY NOT a 5,000 bp ceiling (this file's first attempt, corrected 2026-07-27)
+# ---------------------------------------------------------------------------
+# The first version clamped at 5,000 bp, anchored to the sweep's longest read
+# length, specifically to hold Lambda at 4,850 and so "preserve comparability with
+# results already committed". Both halves of that rationale were checked against
+# primary sources during review and neither survived:
 #
-#   * Clamp to QUAST's own default of 500 bp. Most principled reading of the
-#     original intent, but it MOVES every reference above 5 kb: Lambda
-#     4,850 -> 500, phi29 1,928 -> 500, SARS-CoV-2 2,990 -> 500. That silently
-#     redefines the metric for genomes that were already working and breaks
-#     comparability with results already committed and with the Lambda jobs in
-#     flight (Lawrencium 24247923 / 24247924). Rejected on comparability grounds,
-#     not on principle.
+#   * THERE ARE NO COMMITTED LAMBDA NUMBERS TO PRESERVE. `git log --all
+#     --diff-filter=A` over `benchmarking/results/rhizomorph_correction_validation_sweep_*.csv`
+#     returns exactly one file (commit 548dc984d): two rows of `synthetic_2000bp`
+#     with no QUAST columns at all, whose threshold is 200 under every candidate
+#     policy. The comparability being defended did not exist.
 #
-#   * Derive the threshold from the observed contig-length distribution
-#     (e.g. `min(glen ÷ 10, largest_observed_contig)`). This makes the metric
-#     definition a function of the assembly being scored: the naive and iterative
-#     arms of the SAME cell would be filtered at different thresholds, so any
-#     naive-vs-iterative delta would confound a real effect with a definition
-#     change. That is precisely the mixed-definition failure `td-9p91` exists to
-#     reject, hidden inside a single cell. Rejected.
+#   * LAMBDA WAS NOT "ALREADY WORKING" AT 4,850. Bead `td-4e19d.1` records the
+#     completed Lovelace Lambda sweep: QUAST failed on 8 of 12 cells
+#     (`metric_source=internal:quast-failed`) because the largest contigs at
+#     err>=0.05 were 163-1,939 bp against a 4,850 bp threshold. Holding Lambda at
+#     4,850 preserved the failure, not the measurement. At 500 the long-read
+#     err=0.05 cells (largest 1,100 and 1,939 bp) become scorable; the short-read
+#     err=0.10 cells (163-277 bp) remain unscored, which is correct — those
+#     assemblies are genuinely below any usable threshold.
+#
+# A third consequence, invisible until the guard and the policy were considered
+# together: a ceiling above 500 leaves `quast_min_contig` VARYING BY REFERENCE
+# (Lambda 4,850 / phi29 1,928 / SARS-CoV-2 2,990 / T4 5,000). The
+# pre-registration pools across organisms, so `metric_source_guard.jl` would
+# refuse the pooled analysis as mixed-definition, and the only escape would be the
+# `allow_mixed_src` override. Clamping at 500 makes the threshold UNIFORM across
+# every reference above 5 kb, so the pooled analysis is legal by construction
+# rather than by override. See beads td-28o0 / td-9p91.
+#
+# WHY NOT derive the threshold from the observed contig-length distribution
+# ------------------------------------------------------------------------
+# (e.g. `min(glen ÷ 10, largest_observed_contig)`). This makes the metric
+# definition a function of the assembly being scored: the naive and iterative arms
+# of the SAME cell would be filtered at different thresholds, so any
+# naive-vs-iterative delta would confound a real effect with a definition change.
+# That is precisely the mixed-definition failure `td-9p91` exists to reject,
+# hidden inside a single cell. Rejected.
 #
 # The chosen policy is deterministic, depends only on the reference, and is
-# identical for every arm of every cell — so arms stay comparable by
-# construction. Callers should also RECORD the value they used (the RGV sweep
-# writes it to the `quast_min_contig` CSV column) so the metric definition
-# travels with the data and any future change to this policy is detectable by
-# `metric_source_guard.jl` instead of silent.
+# identical for every arm of every cell — so arms stay comparable by construction.
+# Callers should also RECORD the value they used (the RGV sweep writes it to the
+# `quast_min_contig` CSV column) so the metric definition travels with the data and
+# any future change to this policy is detectable by `metric_source_guard.jl`
+# instead of silent.
 #
-# PRESERVED VALUES (regression-pinned in the unit test):
+# RESULTING THRESHOLDS (regression-pinned in the unit test):
 #
-#   reference     genome_len   before      after
-#   viroid               300       50         50   unchanged
-#   phi29             19,282    1,928      1,928   unchanged
-#   SARS-CoV-2        29,903    2,990      2,990   unchanged
-#   Lambda            48,502    4,850      4,850   unchanged  <- comparability
-#   T4               168,903   16,890      5,000   was FAILING
-#   E. coli        4,641,652  464,165      5,000   would have failed
+#   reference     genome_len   old inline   now
+#   viroid               300           50    50   unchanged (floor; intent preserved)
+#   phi29             19,282        1,928   500
+#   SARS-CoV-2        29,903        2,990   500
+#   Lambda            48,502        4,850   500   recovers cells 4,850 zeroed out
+#   T4               168,903       16,890   500   was FAILING outright
+#   E. coli        4,641,652      464,165   500   would have failed
+#
+# Every reference above 5 kb now shares one threshold, which is the property the
+# pooled pre-registered analysis needs.
 
 """
 Divisor applied to the reference length: the historical `genome_len ÷ 10`
@@ -91,12 +118,11 @@ references so short that `genome_len ÷ 10` would round toward zero.
 const MIN_CONTIG_FLOOR_BP = 50
 
 """
-Absolute upper bound in bp, anchored to the longest read length on the sweep's
-read-regime axis (`MYCELIA_RGV_READLEN` default `150,5000`). Above this the
-threshold would demand a particular degree of assembly success rather than
-filtering sub-read-length noise. See the file header for the full rationale.
+Absolute upper bound in bp: QUAST's own `--min-contig` default. The scaling term
+exists only to go BELOW this for viroid-scale references; it must never go above
+it. See the file header for why an earlier 5,000 bp ceiling was wrong.
 """
-const MIN_CONTIG_CEILING_BP = 5_000
+const MIN_CONTIG_CEILING_BP = 500
 
 """
     quast_min_contig(genome_len; divisor, floor_bp, ceiling_bp) -> Int
@@ -117,7 +143,7 @@ filtered identically.
 
 - `divisor`: down-scaling divisor (default `MIN_CONTIG_GENOME_DIVISOR` = 10).
 - `floor_bp`: absolute lower bound (default `MIN_CONTIG_FLOOR_BP` = 50).
-- `ceiling_bp`: absolute upper bound (default `MIN_CONTIG_CEILING_BP` = 5,000).
+- `ceiling_bp`: absolute upper bound (default `MIN_CONTIG_CEILING_BP` = 500, QUAST's own default).
 
 # Returns
 
@@ -126,9 +152,9 @@ filtered identically.
 # Example
 
 ```julia
-quast_min_contig(48_502)   # Lambda      -> 4850  (unchanged from `max(50, glen ÷ 10)`)
-quast_min_contig(168_903)  # T4          -> 5000  (was 16890, which made QUAST fail)
-quast_min_contig(300)      # viroid      -> 50    (floor)
+quast_min_contig(48_502)   # Lambda -> 500  (ceiling; was 4850 inline)
+quast_min_contig(168_903)  # T4     -> 500  (ceiling; was 16890, which made QUAST fail)
+quast_min_contig(300)      # viroid -> 50   (floor; the down-scaling term's real purpose)
 ```
 """
 function quast_min_contig(genome_len::Integer;

--- a/benchmarking/quast_min_contig.jl
+++ b/benchmarking/quast_min_contig.jl
@@ -1,0 +1,152 @@
+# QUAST `--min-contig` threshold policy.
+# ======================================
+#
+# Pure, dependency-free (like `rhizomorph_scale_guard.jl` and
+# `quast_report_parsing.jl`): no Mycelia, no network, no external tools. Included
+# by the benchmark harnesses AND by the unit test, so the threshold policy has
+# exactly one definition and a regression test can pin it.
+#
+# WHY THIS FILE EXISTS (bead td-28o0)
+# -----------------------------------
+# The harnesses computed the threshold inline as `max(50, glen ÷ 10)`. That
+# expression was introduced to LOWER QUAST's threshold for viroid-scale
+# references, where QUAST's 500 bp default excludes the entire assembly — the
+# surviving comment at its sibling call sites still reads "Use low min_contig for
+# viroid-scale genomes (246-359 nt)".
+#
+# But `glen ÷ 10` is monotone in genome length, so above 5 kb it does the
+# OPPOSITE of its stated purpose: it RAISES the threshold above QUAST's default.
+# For T4 (`NC_000866`, 168,903 bp) it demands a 16,890 bp contig. The naive arm's
+# largest contig is 11,622 bp, so QUAST exits with
+#
+#   "None of the assembly files contains correct contigs. Please, provide
+#    different files or decrease --min-contig threshold."
+#
+# and the harness degrades to internal size-ratio metrics
+# (`metric_source="internal:quast-failed"`) while still reporting `ok=true`.
+# Observed live on Lawrencium job 24247925 (RGV T4 @ 30x).
+#
+# THE FIX: a CEILING, not a different scaling
+# -------------------------------------------
+# `quast_min_contig` keeps the down-scaling for tiny references (the original,
+# correct intent) and clamps it from above so the threshold can never exceed a
+# length that a legitimately fragmented assembly is unable to reach.
+#
+#   min_contig = clamp(genome_len ÷ 10, 50, 5_000)
+#
+# WHY 5,000 bp as the ceiling. It is the longest read length on the sweep's own
+# read-regime axis (`MYCELIA_RGV_READLEN` defaults to `150,5000`). A contig
+# shorter than a single read carries no assembly evidence, so "at least as long
+# as the longest read" is the strongest filter that is still a filter. Past that
+# point the threshold stops excluding noise and starts requiring a particular
+# DEGREE of assembly success — which is the quantity under measurement, not a
+# precondition for measuring it.
+#
+# WHY NOT the two rejected alternatives (both weighed explicitly):
+#
+#   * Clamp to QUAST's own default of 500 bp. Most principled reading of the
+#     original intent, but it MOVES every reference above 5 kb: Lambda
+#     4,850 -> 500, phi29 1,928 -> 500, SARS-CoV-2 2,990 -> 500. That silently
+#     redefines the metric for genomes that were already working and breaks
+#     comparability with results already committed and with the Lambda jobs in
+#     flight (Lawrencium 24247923 / 24247924). Rejected on comparability grounds,
+#     not on principle.
+#
+#   * Derive the threshold from the observed contig-length distribution
+#     (e.g. `min(glen ÷ 10, largest_observed_contig)`). This makes the metric
+#     definition a function of the assembly being scored: the naive and iterative
+#     arms of the SAME cell would be filtered at different thresholds, so any
+#     naive-vs-iterative delta would confound a real effect with a definition
+#     change. That is precisely the mixed-definition failure `td-9p91` exists to
+#     reject, hidden inside a single cell. Rejected.
+#
+# The chosen policy is deterministic, depends only on the reference, and is
+# identical for every arm of every cell — so arms stay comparable by
+# construction. Callers should also RECORD the value they used (the RGV sweep
+# writes it to the `quast_min_contig` CSV column) so the metric definition
+# travels with the data and any future change to this policy is detectable by
+# `metric_source_guard.jl` instead of silent.
+#
+# PRESERVED VALUES (regression-pinned in the unit test):
+#
+#   reference     genome_len   before      after
+#   viroid               300       50         50   unchanged
+#   phi29             19,282    1,928      1,928   unchanged
+#   SARS-CoV-2        29,903    2,990      2,990   unchanged
+#   Lambda            48,502    4,850      4,850   unchanged  <- comparability
+#   T4               168,903   16,890      5,000   was FAILING
+#   E. coli        4,641,652  464,165      5,000   would have failed
+
+"""
+Divisor applied to the reference length: the historical `genome_len ÷ 10`
+down-scaling that exists to bring the threshold BELOW QUAST's 500 bp default for
+viroid-scale references.
+"""
+const MIN_CONTIG_GENOME_DIVISOR = 10
+
+"""
+Absolute lower bound in bp. Keeps the threshold positive (and QUAST happy) for
+references so short that `genome_len ÷ 10` would round toward zero.
+"""
+const MIN_CONTIG_FLOOR_BP = 50
+
+"""
+Absolute upper bound in bp, anchored to the longest read length on the sweep's
+read-regime axis (`MYCELIA_RGV_READLEN` default `150,5000`). Above this the
+threshold would demand a particular degree of assembly success rather than
+filtering sub-read-length noise. See the file header for the full rationale.
+"""
+const MIN_CONTIG_CEILING_BP = 5_000
+
+"""
+    quast_min_contig(genome_len; divisor, floor_bp, ceiling_bp) -> Int
+
+QUAST `--min-contig` threshold for a reference of `genome_len` bp.
+
+Scales the threshold down for very short references and clamps it into
+`[floor_bp, ceiling_bp]` so it can never exceed a contig length that a
+legitimately fragmented assembly cannot produce. The result depends ONLY on the
+reference, never on the assembly being scored, so every arm of a cell is
+filtered identically.
+
+# Arguments
+
+- `genome_len`: reference length in bp (must be non-negative).
+
+# Keywords
+
+- `divisor`: down-scaling divisor (default `MIN_CONTIG_GENOME_DIVISOR` = 10).
+- `floor_bp`: absolute lower bound (default `MIN_CONTIG_FLOOR_BP` = 50).
+- `ceiling_bp`: absolute upper bound (default `MIN_CONTIG_CEILING_BP` = 5,000).
+
+# Returns
+
+- `Int` threshold in bp, in `[floor_bp, ceiling_bp]`.
+
+# Example
+
+```julia
+quast_min_contig(48_502)   # Lambda      -> 4850  (unchanged from `max(50, glen ÷ 10)`)
+quast_min_contig(168_903)  # T4          -> 5000  (was 16890, which made QUAST fail)
+quast_min_contig(300)      # viroid      -> 50    (floor)
+```
+"""
+function quast_min_contig(genome_len::Integer;
+        divisor::Integer = MIN_CONTIG_GENOME_DIVISOR,
+        floor_bp::Integer = MIN_CONTIG_FLOOR_BP,
+        ceiling_bp::Integer = MIN_CONTIG_CEILING_BP)
+    if genome_len < 0
+        throw(ArgumentError("genome_len must be non-negative, got $genome_len"))
+    end
+    if divisor < 1
+        throw(ArgumentError("divisor must be >= 1, got $divisor"))
+    end
+    if floor_bp < 1
+        throw(ArgumentError("floor_bp must be >= 1, got $floor_bp"))
+    end
+    if ceiling_bp < floor_bp
+        throw(ArgumentError(
+            "ceiling_bp ($ceiling_bp) must be >= floor_bp ($floor_bp)"))
+    end
+    return Int(clamp(genome_len ÷ divisor, floor_bp, ceiling_bp))
+end

--- a/benchmarking/real_genome_benchmark.jl
+++ b/benchmarking/real_genome_benchmark.jl
@@ -18,6 +18,12 @@ import CSV
 import Dates
 import Statistics
 
+# Shared QUAST --min-contig policy (bead td-28o0). Replaces the inline
+# `max(50, <len> ÷ 10)` this file used to carry, which for any reference above
+# ~5 kb raised the threshold ABOVE QUAST's default and, for T4 (168,903 bp),
+# demanded a 16,890 bp contig that a fragmented assembly cannot reach.
+include(joinpath(@__DIR__, "quast_min_contig.jl"))
+
 # === Configuration ===
 
 TIER = let
@@ -256,9 +262,8 @@ if run_quast
             continue
         end
         ref_path = first(subset.ref_path)
-        # Use low min_contig for viroid-scale genomes (246-359 nt)
         ref_size = first(subset.ref_size)
-        mc = max(50, ref_size ÷ 10)
+        mc = quast_min_contig(ref_size)
         contig_files = String[r.contigs_path
                               for r in eachrow(subset) if isfile(r.contigs_path)]
         if isempty(contig_files)

--- a/benchmarking/rgv_paired_wilcoxon.jl
+++ b/benchmarking/rgv_paired_wilcoxon.jl
@@ -1,0 +1,699 @@
+# Pre-registered paired-Wilcoxon analysis of the RGV correction-validation sweep.
+# ==============================================================================
+#
+# This is the analysis the pre-registration commits to
+# (`rhizomorph-paper/planning/PLAN-2026-03-28-rhizomorph-preregistration.md`,
+# hypothesis H1 and the shared analysis rules):
+#
+#   "Apply paired Wilcoxon signed-rank test comparing [treatment] vs [control]
+#    across all organism/coverage/technology combinations"
+#   "Random seeds for subsampling: 42, 123, 456 (pre-specified)"
+#   Decision rule: FDR-adjusted p < 0.05 AND median improvement > 10% => supported;
+#                  p < 0.05 with < 10% => partially supported;
+#                  p >= 0.05 => not supported (report as a null with effect size).
+#
+# It exists for two reasons beyond producing the number.
+#
+# 1. IT IS THE EXECUTABILITY PROOF FOR BEAD td-59o7. The pairing key INCLUDES
+#    `seed`. Run this against a sweep CSV that predates the `seed` column and it
+#    raises with a pointer to `rgv_seed_backfill.jl`; run it against the current
+#    schema and it produces a p-value. "Column added" is not the deliverable —
+#    "the pre-registered test runs" is.
+#
+# 2. IT IS THE ANALYSIS PATH BEAD td-9p91 GUARDS. Before any aggregation it calls
+#    `assert_single_metric_definition`, so a table mixing `metric_source="quast"`
+#    with `"internal:quast-failed"` — or mixing two `quast_min_contig` thresholds —
+#    RAISES instead of quietly comparing an alignment-validated NGA50 against a
+#    size-ratio proxy. Selecting a definition is explicit (`--metric-source quast`)
+#    or the run fails.
+#
+# HOW PAIRS ARE FORMED
+# --------------------
+# One pair per (reference, error_rate, readlen, target_coverage, k, seed) cell:
+# the treatment arm and the control arm ran on the SAME simulated reads, which is
+# what makes the comparison paired. A cell missing either arm, holding a `missing`
+# metric, or carrying duplicate rows for one arm is DROPPED AND REPORTED — never
+# imputed, never silently averaged.
+#
+# STATISTICS
+# ----------
+# Wilcoxon signed-rank, implemented here rather than pulled from a new dependency:
+#   * zero differences dropped (Wilcoxon's original treatment), count reported
+#   * ties in |difference| get average ranks
+#   * EXACT two-sided p from the null rank-sum distribution when there are no ties
+#     and no zeros and n <= 50 (dynamic program over subset sums, not enumeration)
+#   * otherwise the normal approximation with the standard tie correction
+#     sigma^2 = [n(n+1)(2n+1) - sum(t^3 - t)/2] / 24
+# Both branches are cross-validated against scipy.stats.wilcoxon in
+# `test/4_assembly/rgv_paired_wilcoxon_test.jl`.
+# Multiplicity across metrics uses Benjamini-Hochberg, as the pre-registration
+# specifies.
+#
+# USAGE
+# -----
+#   julia --project=. benchmarking/rgv_paired_wilcoxon.jl \
+#       --csv results/rhizomorph_correction_validation_sweep_20260725_*.csv \
+#       --metric-source quast \
+#       --output-dir benchmarking/results/rgv_paired_wilcoxon
+#
+#   Flags:
+#     --csv PATH               (repeatable) sweep CSV; several are concatenated,
+#                              which is the point of having `seed` — shards from
+#                              different seeds merge into one pairable table
+#     --treatment NAME         arm under test (default "iterative")
+#     --control NAME           baseline arm (default "naive")
+#     --metrics A,B            metrics to test (default quast_nga50,quast_num_misassemblies)
+#     --metric-source VALUE    keep only rows with this metric_source (e.g. "quast")
+#     --allow-mixed-src        proceed across mixed metric definitions (loud warning)
+#     --keep-not-ok            keep rows with ok=false (default: drop and report)
+#     --output-dir PATH        write report.md + results.json here
+#
+# The figure is produced separately by `rgv_paired_wilcoxon_figure.jl`, which
+# reads this script's `results.json`, so the analysis stays fast enough to unit-test.
+
+import CSV
+import DataFrames
+import Distributions
+import JSON
+import Dates
+import Statistics
+
+# Pure metric-definition guard (bead td-9p91) — the reason this analysis cannot
+# silently aggregate across two metric definitions.
+include(joinpath(@__DIR__, "metric_source_guard.jl"))
+
+"""
+Columns that identify one sweep CELL: the unit within which the treatment and
+control arms are paired. `seed` is REQUIRED — it is what makes two replicate rows
+distinguishable after shards are merged (bead td-59o7).
+"""
+const RGV_PAIR_KEYS = (:reference, :error_rate, :readlen, :target_coverage, :k, :seed)
+
+"""
+Default metrics, matching the pre-registration's primary metrics for H1: NGA50
+(contiguity) and misassembly count (correctness).
+"""
+const RGV_DEFAULT_METRICS = (:quast_nga50, :quast_num_misassemblies)
+
+"""
+Direction in which each metric IMPROVES. `:higher` means larger is better,
+`:lower` means smaller is better, `:none` means report the difference but make no
+improvement claim (a duplication ratio is best near 1, not extremal).
+"""
+const RGV_METRIC_DIRECTION = Dict(
+    :quast_nga50 => :higher,
+    :quast_genome_fraction => :higher,
+    :quast_num_misassemblies => :lower,
+    :quast_duplication_ratio => :none,
+    :n50 => :higher,
+    :largest_contig => :higher,
+    :genome_fraction => :higher
+)
+
+const RGV_ALPHA = 0.05
+const RGV_IMPROVEMENT_THRESHOLD = 0.10  # pre-reg's "> 10% median improvement"
+
+# === Wilcoxon signed-rank ===================================================
+
+"""
+    average_ranks(x) -> Vector{Float64}
+
+Ranks of `x` with tied values receiving the average of the ranks they span (the
+standard treatment for Wilcoxon when |differences| tie).
+"""
+function average_ranks(x::AbstractVector{<:Real})
+    n = length(x)
+    perm = sortperm(x)
+    ranks = zeros(Float64, n)
+    i = 1
+    while i <= n
+        j = i
+        while j < n && x[perm[j + 1]] == x[perm[i]]
+            j += 1
+        end
+        r = (i + j) / 2
+        for t in i:j
+            ranks[perm[t]] = r
+        end
+        i = j + 1
+    end
+    return ranks
+end
+
+"""
+    exact_signed_rank_pvalue(n, w_plus) -> Float64
+
+Exact two-sided p-value for a signed-rank statistic `w_plus` under H0 with `n`
+non-zero differences and no ties.
+
+Under H0 each rank 1..n carries a `+` or `-` sign with probability 1/2
+independently, so the null distribution of W+ is the distribution of a random
+subset sum of `{1, ..., n}`. A dynamic program over that distribution is exact and
+costs `O(n^3)` — far cheaper than the `2^n` enumeration, and it stays exact well
+past the point enumeration becomes impractical.
+"""
+function exact_signed_rank_pvalue(n::Integer, w_plus::Real)
+    maxw = n * (n + 1) ÷ 2
+    dist = zeros(Float64, maxw + 1)
+    dist[1] = 1.0                      # index w+1 holds P(W+ == w)
+    for r in 1:n
+        nxt = zeros(Float64, maxw + 1)
+        for w in 0:maxw
+            pw = dist[w + 1]
+            pw == 0.0 && continue
+            nxt[w + 1] += 0.5 * pw
+            (w + r) <= maxw && (nxt[w + r + 1] += 0.5 * pw)
+        end
+        dist = nxt
+    end
+    w = Int(round(w_plus))
+    w = clamp(w, 0, maxw)
+    lower = sum(@view dist[1:(w + 1)])
+    upper = sum(@view dist[(w + 1):end])
+    return min(1.0, 2 * min(lower, upper))
+end
+
+"""
+    wilcoxon_signed_rank(diffs; exact_max_n=50) -> NamedTuple
+
+Two-sided Wilcoxon signed-rank test on paired differences `diffs`.
+
+Returns `(; n, n_zero_dropped, w_plus, w_minus, statistic, pvalue, method)` where
+`statistic = min(w_plus, w_minus)` (the conventional reported W) and `method`
+names which branch produced the p-value.
+
+Zero differences are dropped and counted. The exact branch is used only when it is
+valid (no zeros, no ties in |difference|, `n <= exact_max_n`); otherwise the normal
+approximation with the standard tie correction is used. With no non-zero
+differences the test is undefined and `pvalue` is `NaN` — reported, not silently
+treated as a null result.
+"""
+function wilcoxon_signed_rank(diffs::AbstractVector{<:Real}; exact_max_n::Integer = 50)
+    nonzero = Float64[d for d in diffs if d != 0]
+    n_zero = length(diffs) - length(nonzero)
+    n = length(nonzero)
+    if n == 0
+        return (n = 0, n_zero_dropped = n_zero, w_plus = NaN, w_minus = NaN,
+            statistic = NaN, pvalue = NaN,
+            method = "undefined (no non-zero differences)")
+    end
+    absd = abs.(nonzero)
+    ranks = average_ranks(absd)
+    w_plus = sum(Float64[ranks[i] for i in 1:n if nonzero[i] > 0]; init = 0.0)
+    w_minus = sum(Float64[ranks[i] for i in 1:n if nonzero[i] < 0]; init = 0.0)
+    statistic = min(w_plus, w_minus)
+
+    has_ties = length(unique(absd)) < n
+    if !has_ties && n_zero == 0 && n <= exact_max_n
+        return (n = n, n_zero_dropped = n_zero, w_plus = w_plus, w_minus = w_minus,
+            statistic = statistic, pvalue = exact_signed_rank_pvalue(n, w_plus),
+            method = "exact (null rank-sum distribution)")
+    end
+
+    mu = n * (n + 1) / 4
+    tie_term = 0.0
+    for t in values(_value_counts(absd))
+        tie_term += t^3 - t
+    end
+    sigma2 = (n * (n + 1) * (2n + 1) - tie_term / 2) / 24
+    if sigma2 <= 0
+        return (n = n, n_zero_dropped = n_zero, w_plus = w_plus, w_minus = w_minus,
+            statistic = statistic, pvalue = NaN,
+            method = "undefined (zero variance under H0)")
+    end
+    z = (w_plus - mu) / sqrt(sigma2)
+    p = 2 * Distributions.ccdf(Distributions.Normal(), abs(z))
+    return (n = n, n_zero_dropped = n_zero, w_plus = w_plus, w_minus = w_minus,
+        statistic = statistic, pvalue = min(1.0, p),
+        method = "normal approximation with tie correction (z = $(round(z; digits = 4)))")
+end
+
+function _value_counts(x)
+    counts = Dict{Float64, Int}()
+    for v in x
+        counts[Float64(v)] = get(counts, Float64(v), 0) + 1
+    end
+    return counts
+end
+
+"""
+    benjamini_hochberg(pvalues) -> Vector{Float64}
+
+Benjamini-Hochberg FDR-adjusted p-values, in the input order. `NaN` inputs are
+excluded from the adjustment (an undefined test does not consume multiplicity
+budget) and returned as `NaN`.
+"""
+function benjamini_hochberg(pvalues::AbstractVector{<:Real})
+    adj = fill(NaN, length(pvalues))
+    valid = [i for i in eachindex(pvalues) if !isnan(pvalues[i])]
+    isempty(valid) && return adj
+    m = length(valid)
+    order = sort(valid; by = i -> pvalues[i])
+    prev = 1.0
+    for rank in m:-1:1
+        idx = order[rank]
+        val = min(prev, pvalues[idx] * m / rank)
+        adj[idx] = val
+        prev = val
+    end
+    return adj
+end
+
+# === Loading + pairing ======================================================
+
+"""
+    load_sweep_csvs(paths) -> DataFrames.DataFrame
+
+Read and vertically concatenate sweep CSVs. `cols=:union` is used so schema drift
+between files surfaces as `missing` values that the pairing step then rejects,
+rather than as a silent read failure.
+"""
+function load_sweep_csvs(paths::AbstractVector{<:AbstractString})
+    isempty(paths) && error("no CSV supplied")
+    frames = DataFrames.DataFrame[]
+    for p in paths
+        isfile(p) || error("CSV not found: $p")
+        push!(frames, CSV.read(p, DataFrames.DataFrame))
+    end
+    return reduce((a, b) -> vcat(a, b; cols = :union), frames)
+end
+
+"""
+    require_pairing_schema(df)
+
+Assert the table can be paired at all. Missing `seed` is called out specifically
+because that is bead td-59o7's whole point: without it the pre-registered paired
+test is not runnable, and the fix is `rgv_seed_backfill.jl` rather than a silently
+weaker analysis.
+"""
+function require_pairing_schema(df)
+    cols = Set(Symbol.(DataFrames.names(df)))
+    missing_keys = [k for k in RGV_PAIR_KEYS if !(k in cols)]
+    if :seed in missing_keys
+        error("this sweep CSV has no `seed` column, so replicate rows cannot be " *
+              "paired and the pre-registration's paired-Wilcoxon rule over seeds " *
+              "42/123/456 is NOT runnable against it (bead td-59o7). Backfill it " *
+              "first:\n" *
+              "  julia --project=. benchmarking/rgv_seed_backfill.jl --csv <csv> " *
+              "(--seed N | --run-log PATH | --assume-default-seed)")
+    end
+    if !isempty(missing_keys)
+        error("sweep CSV is missing pairing column(s): " *
+              join(("`$k`" for k in missing_keys), ", "))
+    end
+    :arm in cols || error("sweep CSV is missing the `arm` column")
+    return nothing
+end
+
+"""
+    build_pairs(df, metric; treatment, control) -> (pairs, dropped)
+
+Form one paired observation per cell for `metric`.
+
+`pairs` is a vector of `(; key, control_value, treatment_value, difference)` where
+`difference = treatment - control`. `dropped` is a vector of
+`(; key, reason)` for every cell that could not contribute — missing arm,
+duplicate rows for one arm, or a `missing`/non-finite metric on either side. Both
+are returned so the report can state exactly how many cells the test actually used.
+"""
+function build_pairs(df, metric::Symbol; treatment::AbstractString, control::AbstractString)
+    metric in Symbol.(DataFrames.names(df)) ||
+        error("metric column `$metric` not present in the sweep table")
+    keyvals = [getproperty(df, k) for k in RGV_PAIR_KEYS]
+    arms = getproperty(df, :arm)
+    metvals = getproperty(df, metric)
+    nrows = length(arms)
+
+    order = String[]
+    cells = Dict{String, Dict{String, Vector{Any}}}()
+    for i in 1:nrows
+        key = join((string(v[i]) for v in keyvals), " | ")
+        if !haskey(cells, key)
+            cells[key] = Dict{String, Vector{Any}}()
+            push!(order, key)
+        end
+        push!(get!(cells[key], string(arms[i]), Any[]), metvals[i])
+    end
+
+    pairs = Any[]
+    dropped = Any[]
+    for key in order
+        byarm = cells[key]
+        if !haskey(byarm, control) || !haskey(byarm, treatment)
+            missing_arm = !haskey(byarm, control) ? control : treatment
+            push!(dropped, (key = key, reason = "no `$missing_arm` row for this cell"))
+            continue
+        end
+        if length(byarm[control]) != 1 || length(byarm[treatment]) != 1
+            push!(dropped,
+                (key = key,
+                    reason = "duplicate rows for one arm ($(length(byarm[control])) " *
+                             "$control, $(length(byarm[treatment])) $treatment) — the " *
+                             "pairing key does not uniquely identify a cell"))
+            continue
+        end
+        cv, tv = first(byarm[control]), first(byarm[treatment])
+        if cv === missing || tv === missing
+            push!(dropped, (key = key, reason = "`missing` $metric on at least one arm"))
+            continue
+        end
+        cvf, tvf = Float64(cv), Float64(tv)
+        if !isfinite(cvf) || !isfinite(tvf)
+            push!(dropped, (key = key, reason = "non-finite $metric on at least one arm"))
+            continue
+        end
+        push!(pairs,
+            (key = key, control_value = cvf, treatment_value = tvf,
+                difference = tvf - cvf))
+    end
+    return pairs, dropped
+end
+
+"""
+    analyze_metric(df, metric; treatment, control) -> NamedTuple
+
+Pair, test, and size the effect for one metric. Reports the median paired
+difference (the pre-registration's effect size) AND the median per-pair relative
+improvement (what its > 10% decision threshold is stated in), oriented by
+`RGV_METRIC_DIRECTION` so "improvement" is positive for both higher-is-better and
+lower-is-better metrics.
+
+Pairs whose control value is zero are excluded from the RELATIVE improvement only
+(the ratio is undefined) and counted, since dropping them can bias that statistic.
+"""
+function analyze_metric(df, metric::Symbol;
+        treatment::AbstractString, control::AbstractString)
+    pairs, dropped = build_pairs(df, metric; treatment = treatment, control = control)
+    diffs = Float64[p.difference for p in pairs]
+    test = wilcoxon_signed_rank(diffs)
+    direction = get(RGV_METRIC_DIRECTION, metric, :none)
+    sign_factor = direction == :lower ? -1.0 : 1.0
+
+    median_diff = isempty(diffs) ? NaN : Statistics.median(diffs)
+    rel = Float64[]
+    n_zero_control = 0
+    for p in pairs
+        if p.control_value == 0
+            n_zero_control += 1
+            continue
+        end
+        push!(rel, sign_factor * (p.treatment_value - p.control_value) /
+                   abs(p.control_value))
+    end
+    median_rel = isempty(rel) ? NaN : Statistics.median(rel)
+
+    return (metric = metric, direction = direction,
+        n_pairs = length(pairs), n_dropped = length(dropped), dropped = dropped,
+        pairs = pairs,
+        median_paired_difference = median_diff,
+        median_relative_improvement = median_rel,
+        n_zero_control_excluded_from_relative = n_zero_control,
+        test = test)
+end
+
+"""
+    decide(result, adjusted_p) -> String
+
+The pre-registration's decision rule verbatim, applied to one metric.
+
+`:none`-direction metrics get "reported (no directional claim)" rather than a
+verdict — the pre-registration does not define an improvement threshold for them.
+"""
+function decide(result, adjusted_p)
+    if result.direction == :none
+        return "reported (no directional claim pre-registered for this metric)"
+    end
+    if result.n_pairs == 0 || isnan(adjusted_p)
+        return "indeterminate (test undefined — see n_pairs / dropped cells)"
+    end
+    improved = result.median_relative_improvement
+    if adjusted_p < RGV_ALPHA
+        if !isnan(improved) && improved > RGV_IMPROVEMENT_THRESHOLD
+            return "SUPPORTED (FDR-adjusted p < $RGV_ALPHA and median improvement > " *
+                   "$(round(Int, RGV_IMPROVEMENT_THRESHOLD * 100))%)"
+        end
+        return "PARTIALLY SUPPORTED (significant but median improvement <= " *
+               "$(round(Int, RGV_IMPROVEMENT_THRESHOLD * 100))%)"
+    end
+    return "NOT SUPPORTED (FDR-adjusted p >= $RGV_ALPHA — report as a null with effect size)"
+end
+
+"""
+    run_paired_analysis(df; treatment, control, metrics, metric_source=nothing,
+                        allow_mixed_src=false, keep_not_ok=false) -> NamedTuple
+
+Full pre-registered analysis over one already-loaded sweep table.
+
+Order of operations is deliberate: schema check, then row filtering, then the
+metric-definition guard, then pairing and testing. The guard runs on the FILTERED
+rows — the ones that will actually be aggregated — so selecting
+`metric_source="quast"` is what makes the run legal, not a bypass of the check.
+"""
+function run_paired_analysis(df;
+        treatment::AbstractString = "iterative",
+        control::AbstractString = "naive",
+        # Any iterable of Symbol: a Tuple (the default) or a Vector (from --metrics).
+        metrics = RGV_DEFAULT_METRICS,
+        metric_source::Union{Nothing, AbstractString} = nothing,
+        allow_mixed_src::Bool = false,
+        keep_not_ok::Bool = false)
+    require_pairing_schema(df)
+
+    work = df
+    n_input = DataFrames.nrow(work)
+    n_dropped_not_ok = 0
+    if !keep_not_ok && (:ok in Symbol.(DataFrames.names(work)))
+        before = DataFrames.nrow(work)
+        work = work[coalesce.(work.ok, false) .== true, :]
+        n_dropped_not_ok = before - DataFrames.nrow(work)
+    end
+    n_dropped_source = 0
+    if metric_source !== nothing
+        before = DataFrames.nrow(work)
+        work = work[string.(work.metric_source) .== String(metric_source), :]
+        n_dropped_source = before - DataFrames.nrow(work)
+    end
+    DataFrames.nrow(work) == 0 &&
+        error("no rows left after filtering (ok=$(!keep_not_ok ? "true" : "any"), " *
+              "metric_source=$(something(metric_source, "any")))")
+
+    # Bead td-9p91: refuse to aggregate rows scored under two definitions.
+    definition = assert_single_metric_definition(work;
+        context = "RGV paired-Wilcoxon analysis",
+        allow_mixed_src = allow_mixed_src)
+
+    results = [analyze_metric(work, m; treatment = treatment, control = control)
+               for m in metrics]
+    adjusted = benjamini_hochberg(Float64[r.test.pvalue for r in results])
+    verdicts = [decide(results[i], adjusted[i]) for i in eachindex(results)]
+
+    seeds = sort(unique(work.seed))
+    return (results = results, adjusted_p = adjusted, verdicts = verdicts,
+        definition = definition, seeds = seeds,
+        treatment = String(treatment), control = String(control),
+        n_input_rows = n_input, n_rows_analyzed = DataFrames.nrow(work),
+        n_dropped_not_ok = n_dropped_not_ok, n_dropped_metric_source = n_dropped_source,
+        pair_keys = RGV_PAIR_KEYS)
+end
+
+# === Reporting ==============================================================
+
+_pw_fmt(x) = x isa Real ? (isnan(x) ? "n/a" : string(round(x; digits = 6))) : string(x)
+
+"""
+    write_paired_report(path, analysis; csv_paths) -> String
+
+Markdown report: what was analyzed, the metric definition it was analyzed under,
+the per-metric test and effect size, the pre-registration verdict, and every
+dropped cell with its reason.
+"""
+function write_paired_report(path::AbstractString, analysis; csv_paths)
+    open(path, "w") do io
+        println(io, "# RGV paired-Wilcoxon analysis (pre-registered rule)\n")
+        println(io, "Generated: $(Dates.now())\n")
+        println(io,
+            "Pre-registration: `PLAN-2026-03-28-rhizomorph-preregistration.md` " *
+            "(H1 test procedure + shared analysis rules)\n")
+        println(io, "## Inputs\n")
+        for p in csv_paths
+            println(io, "- `$p`")
+        end
+        println(io,
+            "\n- Arms: **$(analysis.treatment)** (treatment) vs " *
+            "**$(analysis.control)** (control)")
+        println(io, "- Pairing key: " *
+                    join(("`$k`" for k in analysis.pair_keys), " x "))
+        println(io, "- Seeds present: $(join(string.(analysis.seeds), ", "))")
+        println(io,
+            "- Rows: $(analysis.n_input_rows) read, " *
+            "$(analysis.n_rows_analyzed) analyzed " *
+            "($(analysis.n_dropped_not_ok) dropped for ok=false, " *
+            "$(analysis.n_dropped_metric_source) dropped by metric_source filter)")
+        println(io, "\n### Metric definition analyzed under\n")
+        for (col, vals) in analysis.definition
+            println(io, "- `$col`: " * join(("`$v`" for v in vals), ", "))
+        end
+        println(io,
+            "\n_A single value per definition column is what makes the aggregate " *
+            "meaningful; `metric_source_guard.jl` (bead td-9p91) enforces it._\n")
+
+        println(io, "## Results\n")
+        println(io,
+            "| metric | better | n pairs | dropped | W | p | FDR p | median paired diff | median % improvement | verdict |")
+        println(io, "| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |")
+        for (i, r) in enumerate(analysis.results)
+            pct = isnan(r.median_relative_improvement) ? "n/a" :
+                  string(round(r.median_relative_improvement * 100; digits = 2)) * "%"
+            println(io,
+                "| `$(r.metric)` | $(r.direction) | $(r.n_pairs) | $(r.n_dropped) | " *
+                "$(_pw_fmt(r.test.statistic)) | $(_pw_fmt(r.test.pvalue)) | " *
+                "$(_pw_fmt(analysis.adjusted_p[i])) | $(_pw_fmt(r.median_paired_difference)) | " *
+                "$pct | $(analysis.verdicts[i]) |")
+        end
+        println(io)
+        for r in analysis.results
+            println(io, "### `$(r.metric)`\n")
+            println(io, "- Test: $(r.test.method)")
+            println(io,
+                "- Non-zero differences used: $(r.test.n) " *
+                "($(r.test.n_zero_dropped) zero difference(s) dropped)")
+            println(io, "- W+ = $(_pw_fmt(r.test.w_plus)), W- = $(_pw_fmt(r.test.w_minus))")
+            if r.n_zero_control_excluded_from_relative > 0
+                println(io,
+                    "- **$(r.n_zero_control_excluded_from_relative) pair(s) " *
+                    "excluded from the % improvement statistic** (control value " *
+                    "is 0, ratio undefined). The absolute median paired " *
+                    "difference uses all pairs.")
+            end
+            if !isempty(r.dropped)
+                println(io, "\n#### Cells dropped ($(length(r.dropped)))\n")
+                for d in r.dropped
+                    println(io, "- `$(d.key)` — $(d.reason)")
+                end
+            end
+            println(io)
+        end
+        println(io, "## Decision rule applied\n")
+        println(io,
+            "- SUPPORTED: FDR-adjusted p < $RGV_ALPHA **and** median improvement " *
+            "> $(round(Int, RGV_IMPROVEMENT_THRESHOLD * 100))%")
+        println(io,
+            "- PARTIALLY SUPPORTED: FDR-adjusted p < $RGV_ALPHA, median " *
+            "improvement <= $(round(Int, RGV_IMPROVEMENT_THRESHOLD * 100))%")
+        println(io,
+            "- NOT SUPPORTED: FDR-adjusted p >= $RGV_ALPHA (report as a null " *
+            "result with effect size)")
+    end
+    return path
+end
+
+"""
+    paired_analysis_json(analysis; csv_paths) -> Dict
+
+Machine-readable form of the analysis, also consumed by
+`rgv_paired_wilcoxon_figure.jl` to draw the paired-difference figure.
+"""
+function paired_analysis_json(analysis; csv_paths)
+    return Dict(
+        "generated_at" => string(Dates.now()),
+        "inputs" => String[String(p) for p in csv_paths],
+        "treatment" => analysis.treatment,
+        "control" => analysis.control,
+        "pair_keys" => String[string(k) for k in analysis.pair_keys],
+        "seeds" => collect(analysis.seeds),
+        "n_input_rows" => analysis.n_input_rows,
+        "n_rows_analyzed" => analysis.n_rows_analyzed,
+        "metric_definition" => Dict(string(col) => vals
+        for (col, vals) in analysis.definition),
+        "alpha" => RGV_ALPHA,
+        "improvement_threshold" => RGV_IMPROVEMENT_THRESHOLD,
+        "metrics" => [Dict(
+                          "metric" => string(r.metric),
+                          "direction" => string(r.direction),
+                          "n_pairs" => r.n_pairs,
+                          "n_dropped" => r.n_dropped,
+                          "n_nonzero_differences" => r.test.n,
+                          "n_zero_differences_dropped" => r.test.n_zero_dropped,
+                          "w_plus" => r.test.w_plus,
+                          "w_minus" => r.test.w_minus,
+                          "statistic" => r.test.statistic,
+                          "pvalue" => r.test.pvalue,
+                          "pvalue_fdr" => analysis.adjusted_p[i],
+                          "method" => r.test.method,
+                          "median_paired_difference" => r.median_paired_difference,
+                          "median_relative_improvement" => r.median_relative_improvement,
+                          "n_zero_control_excluded_from_relative" => r.n_zero_control_excluded_from_relative,
+                          "verdict" => analysis.verdicts[i],
+                          "dropped" => [Dict("key" => d.key, "reason" => d.reason)
+                                        for d in r.dropped],
+                          # Per-pair observations, so rgv_paired_wilcoxon_figure.jl can
+                          # draw the paired differences without re-reading the CSVs.
+                          "pairs" => [Dict("key" => pr.key,
+                                          "control" => pr.control_value,
+                                          "treatment" => pr.treatment_value,
+                                          "difference" => pr.difference)
+                                      for pr in r.pairs]
+                      )
+                      for (i, r) in enumerate(analysis.results)]
+    )
+end
+
+# === CLI ====================================================================
+
+function _pw_args(flag)
+    String[ARGS[i + 1]
+           for i in eachindex(ARGS)
+           if ARGS[i] == flag && i < length(ARGS)]
+end
+
+function _pw_arg(flag)
+    i = findfirst(==(flag), ARGS)
+    return (i !== nothing && i < length(ARGS)) ? ARGS[i + 1] : nothing
+end
+
+function main()
+    csv_paths = _pw_args("--csv")
+    if isempty(csv_paths)
+        println(stderr,
+            "ERROR: at least one --csv PATH is required.\n" *
+            "  julia --project=. benchmarking/rgv_paired_wilcoxon.jl --csv <sweep.csv> " *
+            "[--csv <sweep2.csv>] --metric-source quast")
+        return 2
+    end
+    treatment = something(_pw_arg("--treatment"), "iterative")
+    control = something(_pw_arg("--control"), "naive")
+    metrics = let v = _pw_arg("--metrics")
+        v === nothing ? RGV_DEFAULT_METRICS : Symbol.(strip.(split(v, ",")))
+    end
+    output_dir = something(_pw_arg("--output-dir"),
+        joinpath(@__DIR__, "results", "rgv_paired_wilcoxon"))
+
+    println("=== RGV paired-Wilcoxon (pre-registered rule) ===")
+    df = load_sweep_csvs(csv_paths)
+    analysis = run_paired_analysis(df;
+        treatment = treatment, control = control, metrics = metrics,
+        metric_source = _pw_arg("--metric-source"),
+        allow_mixed_src = "--allow-mixed-src" in ARGS,
+        keep_not_ok = "--keep-not-ok" in ARGS)
+
+    mkpath(output_dir)
+    report = write_paired_report(
+        joinpath(output_dir, "report.md"), analysis; csv_paths = csv_paths)
+    json_path = joinpath(output_dir, "results.json")
+    open(json_path, "w") do io
+        JSON.print(io, paired_analysis_json(analysis; csv_paths = csv_paths), 2)
+    end
+
+    println("Seeds present : $(join(string.(analysis.seeds), ", "))")
+    println("Rows analyzed : $(analysis.n_rows_analyzed) / $(analysis.n_input_rows)")
+    for (i, r) in enumerate(analysis.results)
+        println("  $(r.metric): n=$(r.n_pairs) pairs, p=$(_pw_fmt(r.test.pvalue)) " *
+                "(FDR $(_pw_fmt(analysis.adjusted_p[i]))) -> $(analysis.verdicts[i])")
+    end
+    println("\nWrote:\n  $report\n  $json_path")
+    return 0
+end
+
+if abspath(PROGRAM_FILE) == @__FILE__
+    exit(main())
+end

--- a/benchmarking/rgv_paired_wilcoxon.jl
+++ b/benchmarking/rgv_paired_wilcoxon.jl
@@ -709,19 +709,48 @@ function write_paired_report(path::AbstractString, analysis; csv_paths)
             end
             println(io)
         end
+        # The legend must enumerate EVERY outcome `decide` can emit, or a reader
+        # meets a verdict string the report never defines. It listed three while
+        # the function emitted five.
+        pct = round(Int, RGV_IMPROVEMENT_THRESHOLD * 100)
         println(io, "## Decision rule applied\n")
         println(io,
-            "- SUPPORTED: FDR-adjusted p < $RGV_ALPHA **and** median improvement " *
-            "> $(round(Int, RGV_IMPROVEMENT_THRESHOLD * 100))%")
+            "- **SUPPORTED**: FDR-adjusted p < $RGV_ALPHA, direction positive, " *
+            "median improvement > $pct%")
         println(io,
-            "- PARTIALLY SUPPORTED: FDR-adjusted p < $RGV_ALPHA, median " *
-            "improvement <= $(round(Int, RGV_IMPROVEMENT_THRESHOLD * 100))%")
+            "- **PARTIALLY SUPPORTED**: FDR-adjusted p < $RGV_ALPHA, direction " *
+            "positive, median improvement <= $pct%")
         println(io,
-            "- NOT SUPPORTED: FDR-adjusted p >= $RGV_ALPHA (report as a null " *
+            "- **FALSIFIED**: FDR-adjusted p < $RGV_ALPHA and the direction is " *
+            "NEGATIVE — the treatment is significantly worse. This is the " *
+            "pre-registration's falsification clause: a significant harm is not " *
+            "weak support.")
+        println(io,
+            "- **NOT SUPPORTED**: FDR-adjusted p >= $RGV_ALPHA (report as a null " *
             "result with effect size)")
+        println(io,
+            "- **INDETERMINATE**: the test or the effect size is undefined (no " *
+            "non-zero differences, or every control value is zero so relative " *
+            "improvement cannot be computed) — read the median paired difference " *
+            "instead")
     end
     return path
 end
+
+"""
+    _json_num(x)
+
+Render a number for JSON, mapping non-finite values to `nothing` (`null`).
+
+`NaN` is an ORDINARY outcome here — an undefined test, or an undefined effect
+size when every control value is zero — so it reaches the payload on normal runs.
+JSON has no NaN literal. Julia's JSON.jl happens to emit `null` for it rather
+than raising, but relying on that leaves the intent implicit and version-dependent;
+doing it explicitly keeps the contract with `rgv_paired_wilcoxon_figure.jl`, which
+already treats `null` as missing, visible in this file.
+"""
+_json_num(x::Real) = isfinite(x) ? x : nothing
+_json_num(x) = x
 
 """
     paired_analysis_json(analysis; csv_paths) -> Dict
@@ -742,10 +771,9 @@ function paired_analysis_json(analysis; csv_paths)
         "metric_definition" => Dict(string(col) => vals
         for (col, vals) in analysis.definition),
         "exploratory" => true,
-        "preregistration_status" =>
-            "Applies the pre-registration's statistical rule to a comparison it " *
-            "does not describe (H1 is Viterbi DP vs greedy; this is " *
-            "corrector=:none vs :iterative). Not a confirmatory test.",
+        "preregistration_status" => "Applies the pre-registration's statistical rule to a comparison it " *
+                                    "does not describe (H1 is Viterbi DP vs greedy; this is " *
+                                    "corrector=:none vs :iterative). Not a confirmatory test.",
         "axes_swept" => Dict(string(k) => v for (k, v) in analysis.axes),
         "allow_mixed_src" => analysis.allow_mixed_src,
         "mixed_definition_axes" => analysis.mixed_axes,
@@ -759,14 +787,14 @@ function paired_analysis_json(analysis; csv_paths)
                           "n_dropped" => r.n_dropped,
                           "n_nonzero_differences" => r.test.n,
                           "n_zero_differences_dropped" => r.test.n_zero_dropped,
-                          "w_plus" => r.test.w_plus,
-                          "w_minus" => r.test.w_minus,
-                          "statistic" => r.test.statistic,
-                          "pvalue" => r.test.pvalue,
-                          "pvalue_fdr" => analysis.adjusted_p[i],
+                          "w_plus" => _json_num(r.test.w_plus),
+                          "w_minus" => _json_num(r.test.w_minus),
+                          "statistic" => _json_num(r.test.statistic),
+                          "pvalue" => _json_num(r.test.pvalue),
+                          "pvalue_fdr" => _json_num(analysis.adjusted_p[i]),
                           "method" => r.test.method,
-                          "median_paired_difference" => r.median_paired_difference,
-                          "median_relative_improvement" => r.median_relative_improvement,
+                          "median_paired_difference" => _json_num(r.median_paired_difference),
+                          "median_relative_improvement" => _json_num(r.median_relative_improvement),
                           "n_zero_control_excluded_from_relative" => r.n_zero_control_excluded_from_relative,
                           "verdict" => analysis.verdicts[i],
                           "dropped" => [Dict("key" => d.key, "reason" => d.reason)
@@ -774,9 +802,9 @@ function paired_analysis_json(analysis; csv_paths)
                           # Per-pair observations, so rgv_paired_wilcoxon_figure.jl can
                           # draw the paired differences without re-reading the CSVs.
                           "pairs" => [Dict("key" => pr.key,
-                                          "control" => pr.control_value,
-                                          "treatment" => pr.treatment_value,
-                                          "difference" => pr.difference)
+                                          "control" => _json_num(pr.control_value),
+                                          "treatment" => _json_num(pr.treatment_value),
+                                          "difference" => _json_num(pr.difference))
                                       for pr in r.pairs]
                       )
                       for (i, r) in enumerate(analysis.results)]

--- a/benchmarking/rgv_paired_wilcoxon.jl
+++ b/benchmarking/rgv_paired_wilcoxon.jl
@@ -833,7 +833,9 @@ function main()
     output_dir = something(_pw_arg("--output-dir"),
         joinpath(@__DIR__, "results", "rgv_paired_wilcoxon"))
 
-    println("=== RGV paired-Wilcoxon (pre-registered rule) ===")
+    println("=== RGV correction sweep — paired Wilcoxon (EXPLORATORY) ===")
+    println("    Applies the pre-registration's statistical RULE to a comparison it")
+    println("    does not describe (H1 is Viterbi DP vs greedy). Not confirmatory.")
     df = load_sweep_csvs(csv_paths)
     analysis = run_paired_analysis(df;
         treatment = treatment, control = control, metrics = metrics,

--- a/benchmarking/rgv_paired_wilcoxon.jl
+++ b/benchmarking/rgv_paired_wilcoxon.jl
@@ -1,16 +1,31 @@
 # Pre-registered paired-Wilcoxon analysis of the RGV correction-validation sweep.
 # ==============================================================================
 #
-# This is the analysis the pre-registration commits to
-# (`rhizomorph-paper/planning/PLAN-2026-03-28-rhizomorph-preregistration.md`,
-# hypothesis H1 and the shared analysis rules):
+# WHAT THIS IS, AND WHAT IT IS NOT
+# --------------------------------
+# It applies the pre-registration's STATISTICAL RULE — paired Wilcoxon signed-rank
+# over replicate seeds, Benjamini-Hochberg across metrics, and the
+# supported/partial/falsified/null decision thresholds
+# (`rhizomorph-paper/planning/PLAN-2026-03-28-rhizomorph-preregistration.md`) — to
+# the RGV correction-validation sweep.
 #
-#   "Apply paired Wilcoxon signed-rank test comparing [treatment] vs [control]
-#    across all organism/coverage/technology combinations"
-#   "Random seeds for subsampling: 42, 123, 456 (pre-specified)"
-#   Decision rule: FDR-adjusted p < 0.05 AND median improvement > 10% => supported;
-#                  p < 0.05 with < 10% => partially supported;
-#                  p >= 0.05 => not supported (report as a null with effect size).
+# It is NOT a pre-registered hypothesis test, and must not be reported as one.
+# The pre-registration's H1 is "Full Viterbi DP improves assembly quality over
+# greedy Viterbi" (:344), and its procedure says "comparing Viterbi DP vs. greedy"
+# (:52). This sweep compares `corrector=:none` against `corrector=:iterative`.
+# Grepping the entire pre-registration for `iterativ|corrector|naive` returns ZERO
+# hits: none of H1-H7 covers error correction. An earlier version of this header
+# quoted H1's procedure with the arms elided to "[treatment] vs [control]", which
+# read as though this comparison were pre-registered. It is not.
+#
+# Two further mismatches that must travel with any number this produces:
+#   * The pre-registration's design is 4 coverage levels x 3 replicates per
+#     organism/technology (~360 paired comparisons). The RGV sweep runs ONE
+#     coverage and varies `error_rate`, an axis the pre-registration never names.
+#   * `k` is pooled here; the pre-registration designates k=31 primary with
+#     k=21/51 as sensitivity analyses.
+# `write_paired_report` therefore prints the axes actually swept and the pair
+# count next to every p-value, and labels the analysis exploratory.
 #
 # It exists for two reasons beyond producing the number.
 #
@@ -278,13 +293,25 @@ function load_sweep_csvs(paths::AbstractVector{<:AbstractString})
     return reduce((a, b) -> vcat(a, b; cols = :union), frames)
 end
 
+const RGV_BACKFILL_HINT = "  julia --project=. benchmarking/rgv_seed_backfill.jl --csv <csv> " *
+                          "(--seed N | --run-log PATH | --assume-default-seed) " *
+                          "[--metric-source <src> --quast-min-contig <bp>]"
+
 """
     require_pairing_schema(df)
 
-Assert the table can be paired at all. Missing `seed` is called out specifically
-because that is bead td-59o7's whole point: without it the pre-registered paired
-test is not runnable, and the fix is `rgv_seed_backfill.jl` rather than a silently
-weaker analysis.
+Assert the table can be paired at all: every pairing key must be PRESENT **and
+fully populated**.
+
+Checking presence alone is not enough, and the gap was a real defect. Shards are
+concatenated with `cols = :union`, so a shard predating the `seed` column
+contributes rows whose `seed` is `missing` — the column is then present and a
+presence-only check passes. `build_pairs` stringifies the key, so `missing`
+becomes the literal pseudo-seed `"missing"`, a distinct cell that pairs normally.
+The same physical runs supplied twice then report n = 12 for 6 independent
+replicates and deflate p by ~27x. Pseudo-replication is the single worst failure
+available to this file, because it makes the result look BETTER, so the key
+columns are checked for missing VALUES, not just for existence.
 """
 function require_pairing_schema(df)
     cols = Set(Symbol.(DataFrames.names(df)))
@@ -293,15 +320,37 @@ function require_pairing_schema(df)
         error("this sweep CSV has no `seed` column, so replicate rows cannot be " *
               "paired and the pre-registration's paired-Wilcoxon rule over seeds " *
               "42/123/456 is NOT runnable against it (bead td-59o7). Backfill it " *
-              "first:\n" *
-              "  julia --project=. benchmarking/rgv_seed_backfill.jl --csv <csv> " *
-              "(--seed N | --run-log PATH | --assume-default-seed)")
+              "first:\n" * RGV_BACKFILL_HINT)
     end
     if !isempty(missing_keys)
         error("sweep CSV is missing pairing column(s): " *
               join(("`$k`" for k in missing_keys), ", "))
     end
     :arm in cols || error("sweep CSV is missing the `arm` column")
+
+    # Fully-populated check. A `missing` in any pairing key means some shard did
+    # not carry that column; `cols = :union` filled it in. Refuse rather than let
+    # `missing` become a pseudo-level of that key.
+    for k in RGV_PAIR_KEYS
+        col = getproperty(df, k)
+        n_missing = count(ismissing, col)
+        n_missing == 0 && continue
+        error("$(n_missing) of $(length(col)) rows have a `missing` value in the " *
+              "pairing column `$k`. That happens when shards with different schemas " *
+              "are concatenated (`cols = :union` fills the absent column with " *
+              "`missing`), and it is NOT safe to proceed: `missing` would become a " *
+              "distinct pseudo-level of `$k`, so the same physical runs supplied " *
+              "twice would be counted as independent replicates — inflating n and " *
+              "deflating p. Backfill the incomplete shard before merging it:\n" *
+              RGV_BACKFILL_HINT)
+    end
+
+    # `arm` is not a pairing key but it selects which side of the pair a row is on;
+    # a `missing` arm silently belongs to neither and would be dropped invisibly.
+    n_missing_arm = count(ismissing, getproperty(df, :arm))
+    n_missing_arm == 0 ||
+        error("$(n_missing_arm) row(s) have a `missing` `arm` and cannot be " *
+              "assigned to either side of a pair")
     return nothing
 end
 
@@ -414,10 +463,25 @@ end
 """
     decide(result, adjusted_p) -> String
 
-The pre-registration's decision rule verbatim, applied to one metric.
+The pre-registration's decision rule, applied to one metric.
+
+Four outcomes, not three. The rule's falsification clause is
+`"Falsified if p >= 0.05, THE DIRECTION IS NEGATIVE, or ..."`, so a
+statistically significant result in the WRONG direction is falsification, not
+weak support. An earlier version branched only on
+`improved > RGV_IMPROVEMENT_THRESHOLD`, which made every significant result that
+failed the 10% bar — including outright harm — read as "PARTIALLY SUPPORTED":
+a treatment worse on all 9 pairs, median -45%, FDR p = 0.0039, was reported as
+partial support. That is the one error class this whole PR exists to prevent, so
+the sign is now tested before the magnitude.
 
 `:none`-direction metrics get "reported (no directional claim)" rather than a
-verdict — the pre-registration does not define an improvement threshold for them.
+verdict — the pre-registration defines no improvement threshold for them.
+
+An undefined effect size (`NaN`, e.g. every control value zero so no relative
+improvement is computable) is reported as indeterminate rather than being allowed
+to fall through the `> threshold` comparison, where `NaN > 0.1 === false` would
+have silently rendered it as "<= 10%".
 """
 function decide(result, adjusted_p)
     if result.direction == :none
@@ -427,15 +491,26 @@ function decide(result, adjusted_p)
         return "indeterminate (test undefined — see n_pairs / dropped cells)"
     end
     improved = result.median_relative_improvement
-    if adjusted_p < RGV_ALPHA
-        if !isnan(improved) && improved > RGV_IMPROVEMENT_THRESHOLD
-            return "SUPPORTED (FDR-adjusted p < $RGV_ALPHA and median improvement > " *
-                   "$(round(Int, RGV_IMPROVEMENT_THRESHOLD * 100))%)"
-        end
-        return "PARTIALLY SUPPORTED (significant but median improvement <= " *
-               "$(round(Int, RGV_IMPROVEMENT_THRESHOLD * 100))%)"
+    pct = round(Int, RGV_IMPROVEMENT_THRESHOLD * 100)
+    if adjusted_p >= RGV_ALPHA
+        return "NOT SUPPORTED (FDR-adjusted p >= $RGV_ALPHA — report as a null with effect size)"
     end
-    return "NOT SUPPORTED (FDR-adjusted p >= $RGV_ALPHA — report as a null with effect size)"
+    # Significant. The sign decides between falsified and (partially) supported.
+    if isnan(improved)
+        return "INDETERMINATE (significant, but the effect size is undefined — " *
+               "every control value is zero, so relative improvement cannot be " *
+               "computed; read the median paired difference instead)"
+    end
+    if improved < 0
+        return "FALSIFIED (FDR-adjusted p < $RGV_ALPHA and the direction is " *
+               "NEGATIVE — the treatment is significantly WORSE by " *
+               "$(round(abs(improved) * 100; digits = 1))%)"
+    end
+    if improved > RGV_IMPROVEMENT_THRESHOLD
+        return "SUPPORTED (FDR-adjusted p < $RGV_ALPHA and median improvement > $pct%)"
+    end
+    return "PARTIALLY SUPPORTED (significant, direction positive, but median " *
+           "improvement <= $pct%)"
 end
 
 """
@@ -478,9 +553,17 @@ function run_paired_analysis(df;
               "metric_source=$(something(metric_source, "any")))")
 
     # Bead td-9p91: refuse to aggregate rows scored under two definitions.
+    # The override must leave a trace in the DELIVERABLE, not only in a stderr
+    # @warn that lands in a SLURM .out nobody reads: `report.md` / `results.json`
+    # are what reach a manuscript. Record both whether the override was PASSED and
+    # whether it actually BOUND (i.e. the table really was mixed), because
+    # "override available but unused" and "override load-bearing" are very
+    # different provenance claims.
     definition = assert_single_metric_definition(work;
         context = "RGV paired-Wilcoxon analysis",
         allow_mixed_src = allow_mixed_src)
+    mixed_axes = [String(col) for (col, vals) in definition if length(vals) > 1]
+    override_bound = allow_mixed_src && !isempty(mixed_axes)
 
     results = [analyze_metric(work, m; treatment = treatment, control = control)
                for m in metrics]
@@ -488,8 +571,17 @@ function run_paired_analysis(df;
     verdicts = [decide(results[i], adjusted[i]) for i in eachindex(results)]
 
     seeds = sort(unique(work.seed))
+    # The axes actually swept, so the report can state them next to every p-value
+    # (the pre-registration's thresholds were calibrated for a different design).
+    axes = Dict{Symbol, Vector{Any}}()
+    for col in (:reference, :error_rate, :readlen, :target_coverage, :k)
+        hasproperty(work, col) || continue
+        axes[col] = sort(unique(getproperty(work, col)))
+    end
     return (results = results, adjusted_p = adjusted, verdicts = verdicts,
         definition = definition, seeds = seeds,
+        axes = axes, allow_mixed_src = allow_mixed_src, mixed_axes = mixed_axes,
+        override_bound = override_bound,
         treatment = String(treatment), control = String(control),
         n_input_rows = n_input, n_rows_analyzed = DataFrames.nrow(work),
         n_dropped_not_ok = n_dropped_not_ok, n_dropped_metric_source = n_dropped_source,
@@ -509,11 +601,17 @@ dropped cell with its reason.
 """
 function write_paired_report(path::AbstractString, analysis; csv_paths)
     open(path, "w") do io
-        println(io, "# RGV paired-Wilcoxon analysis (pre-registered rule)\n")
+        println(io, "# RGV correction sweep — paired Wilcoxon (EXPLORATORY)\n")
         println(io, "Generated: $(Dates.now())\n")
         println(io,
-            "Pre-registration: `PLAN-2026-03-28-rhizomorph-preregistration.md` " *
-            "(H1 test procedure + shared analysis rules)\n")
+            "> **Status: exploratory, not a pre-registered test.** This applies the " *
+            "statistical RULE from `PLAN-2026-03-28-rhizomorph-preregistration.md` " *
+            "(paired Wilcoxon signed-rank over seeds, Benjamini-Hochberg across " *
+            "metrics, and its decision thresholds) to a comparison the " *
+            "pre-registration does not describe. Its H1 is *Viterbi DP vs greedy*; " *
+            "this compares `corrector=:none` vs `corrector=:iterative`, and no " *
+            "hypothesis H1-H7 covers error correction. Do not report these as " *
+            "confirmatory results.\n")
         println(io, "## Inputs\n")
         for p in csv_paths
             println(io, "- `$p`")
@@ -524,6 +622,19 @@ function write_paired_report(path::AbstractString, analysis; csv_paths)
         println(io, "- Pairing key: " *
                     join(("`$k`" for k in analysis.pair_keys), " x "))
         println(io, "- Seeds present: $(join(string.(analysis.seeds), ", "))")
+        # The axes ACTUALLY swept, next to the numbers. A p-value read without them
+        # invites the reader to assume the pre-registered design produced it.
+        for (label, col) in (("Error rates", :error_rate), ("Read lengths", :readlen),
+            ("Coverages", :target_coverage), ("k", :k), ("References", :reference))
+            haskey(analysis.axes, col) || continue
+            println(io, "- $label swept: " * join(string.(analysis.axes[col]), ", "))
+        end
+        println(io,
+            "\n_The pre-registration's design is 4 coverage levels x 3 replicates " *
+            "per organism/technology (~360 paired comparisons), varies coverage " *
+            "rather than error rate, and designates k=31 primary (k=21/51 " *
+            "sensitivity). Compare the axes above against that before reading the " *
+            "decision column — the thresholds were calibrated for that design._")
         println(io,
             "- Rows: $(analysis.n_input_rows) read, " *
             "$(analysis.n_rows_analyzed) analyzed " *
@@ -533,9 +644,34 @@ function write_paired_report(path::AbstractString, analysis; csv_paths)
         for (col, vals) in analysis.definition
             println(io, "- `$col`: " * join(("`$v`" for v in vals), ", "))
         end
-        println(io,
-            "\n_A single value per definition column is what makes the aggregate " *
-            "meaningful; `metric_source_guard.jl` (bead td-9p91) enforces it._\n")
+        # The artifact must never assert the guard was enforced when it was
+        # overridden. Previously this line printed unconditionally, so a run with
+        # `--allow-mixed-src` listed two definitions and then, one line later, told
+        # the reader single-definition-ness had been enforced. That is strictly
+        # worse than having no guard: it launders the override into an assurance.
+        if analysis.override_bound
+            println(io,
+                "\n> ## :warning: MIXED METRIC DEFINITIONS — GUARD OVERRIDDEN\n>\n" *
+                "> This analysis was run with `--allow-mixed-src`, and the override " *
+                "was **load-bearing**: the rows really do span more than one " *
+                "definition on " *
+                join(("`$a`" for a in analysis.mixed_axes), ", ") * ".\n>\n" *
+                "> Every number below therefore compares quantities produced under " *
+                "different definitions — for `metric_source`, an alignment-validated " *
+                "QUAST metric against an internal size-ratio proxy that is blind to " *
+                "misassembly. **These results are not validation-grade and must not " *
+                "be reported as a measured effect.**\n")
+        elseif analysis.allow_mixed_src
+            println(io,
+                "\n_`--allow-mixed-src` was passed but did NOT bind: the rows are " *
+                "single-definition on every checked axis, so the aggregate is " *
+                "well-defined._\n")
+        else
+            println(io,
+                "\n_A single value per definition column is what makes the aggregate " *
+                "meaningful; `metric_source_guard.jl` (bead td-9p91) enforced it — " *
+                "no override was used._\n")
+        end
 
         println(io, "## Results\n")
         println(io,
@@ -605,6 +741,15 @@ function paired_analysis_json(analysis; csv_paths)
         "n_rows_analyzed" => analysis.n_rows_analyzed,
         "metric_definition" => Dict(string(col) => vals
         for (col, vals) in analysis.definition),
+        "exploratory" => true,
+        "preregistration_status" =>
+            "Applies the pre-registration's statistical rule to a comparison it " *
+            "does not describe (H1 is Viterbi DP vs greedy; this is " *
+            "corrector=:none vs :iterative). Not a confirmatory test.",
+        "axes_swept" => Dict(string(k) => v for (k, v) in analysis.axes),
+        "allow_mixed_src" => analysis.allow_mixed_src,
+        "mixed_definition_axes" => analysis.mixed_axes,
+        "metric_definition_override_bound" => analysis.override_bound,
         "alpha" => RGV_ALPHA,
         "improvement_threshold" => RGV_IMPROVEMENT_THRESHOLD,
         "metrics" => [Dict(
@@ -641,9 +786,29 @@ end
 # === CLI ====================================================================
 
 function _pw_args(flag)
-    String[ARGS[i + 1]
-           for i in eachindex(ARGS)
-           if ARGS[i] == flag && i < length(ARGS)]
+    # Consume EVERY token after the flag until the next `--flag`, not just one, so
+    # both documented forms work:
+    #   --csv a.csv --csv b.csv       (repeated flag)
+    #   --csv results/sweep_*.csv     (shell glob -> --csv a.csv b.csv c.csv)
+    # Taking only `ARGS[i + 1]` silently used the first value and discarded the
+    # rest. Merging per-shard files is the entire purpose of the `seed` column, so
+    # that failure mode quietly analysed a fraction of the data behind an
+    # invocation this file's own header documents.
+    out = String[]
+    i = 1
+    while i <= length(ARGS)
+        if ARGS[i] == flag
+            j = i + 1
+            while j <= length(ARGS) && !startswith(ARGS[j], "--")
+                push!(out, ARGS[j])
+                j += 1
+            end
+            i = j
+        else
+            i += 1
+        end
+    end
+    return out
 end
 
 function _pw_arg(flag)

--- a/benchmarking/rgv_paired_wilcoxon_figure.jl
+++ b/benchmarking/rgv_paired_wilcoxon_figure.jl
@@ -65,7 +65,7 @@ function draw_paired_figure(payload; output_dir::AbstractString,
             xticklabelrotation = 0.0)
         CairoMakie.xlims!(ax1, 0.7, 2.3)
         if isempty(pairs)
-            CairoMakie.text!(ax1, 1.5, 0.5; text = "no usable pairs",
+            CairoMakie.text!(ax1, 0.5, 0.5; text = "no usable pairs",
                 align = (:center, :center), space = :relative)
         else
             for i in eachindex(ctrl)

--- a/benchmarking/rgv_paired_wilcoxon_figure.jl
+++ b/benchmarking/rgv_paired_wilcoxon_figure.jl
@@ -1,0 +1,149 @@
+# Figure for the pre-registered paired-Wilcoxon analysis.
+# =======================================================
+#
+# Reads `results.json` written by `rgv_paired_wilcoxon.jl` and draws, per metric:
+#
+#   * LEFT  — a paired slope plot: one line per cell from the control arm's value
+#             to the treatment arm's value. A paired test's evidence IS the set of
+#             within-cell lines, so showing them (rather than two group means) is
+#             what makes the figure honest about what was tested.
+#   * RIGHT — the paired differences with the median marked and zero as a reference
+#             line, which is the quantity the Wilcoxon statistic actually ranks.
+#
+# Kept in its own script so the analysis stays free of CairoMakie and fast enough
+# to unit-test. Emits BOTH SVG and PNG (house convention).
+#
+# USAGE
+# -----
+#   julia --project=. benchmarking/rgv_paired_wilcoxon_figure.jl \
+#       --json benchmarking/results/rgv_paired_wilcoxon/results.json
+#
+#   Flags:
+#     --json PATH        (required) results.json from rgv_paired_wilcoxon.jl
+#     --output-dir PATH  where to write the figure (default: alongside the JSON)
+#     --basename NAME    output stem (default "rgv_paired_wilcoxon")
+
+import CairoMakie
+import JSON
+import Statistics
+
+"""
+    draw_paired_figure(payload; output_dir, basename) -> (svg_path, png_path)
+
+Render the paired slope plot and paired-difference panel for every metric in
+`payload` (the parsed `results.json`). Metrics with no usable pairs are still
+given a panel, labelled as such, so an empty result is visible rather than absent.
+"""
+function draw_paired_figure(payload; output_dir::AbstractString,
+        basename::AbstractString = "rgv_paired_wilcoxon")
+    metrics = payload["metrics"]
+    isempty(metrics) && error("results.json contains no metrics")
+    treatment = payload["treatment"]
+    control = payload["control"]
+
+    nrows = length(metrics)
+    fig = CairoMakie.Figure(size = (980, 380 * nrows))
+    for (row, m) in enumerate(metrics)
+        name = m["metric"]
+        pairs = get(m, "pairs", Any[])
+        ctrl = Float64[p["control"] for p in pairs]
+        trt = Float64[p["treatment"] for p in pairs]
+        diffs = Float64[p["difference"] for p in pairs]
+
+        # Only the verdict LABEL goes on the axis; the full pre-registration wording
+        # ("SUPPORTED (FDR-adjusted p < 0.05 and ...)") is long enough to overrun
+        # into the neighbouring panel, and it is already in report.md verbatim.
+        verdict = first(split(m["verdict"], " ("))
+        pf = m["pvalue_fdr"]
+        subtitle = "n=$(m["n_pairs"]) pairs · FDR p=" *
+                   (pf === nothing || (pf isa Real && isnan(pf)) ? "n/a" :
+                    string(round(Float64(pf); digits = 5))) * " · " * verdict
+
+        ax1 = CairoMakie.Axis(fig[row, 1];
+            title = "$name — paired by cell\n$subtitle",
+            ylabel = name, xticks = ([1, 2], [control, treatment]),
+            xticklabelrotation = 0.0)
+        CairoMakie.xlims!(ax1, 0.7, 2.3)
+        if isempty(pairs)
+            CairoMakie.text!(ax1, 1.5, 0.5; text = "no usable pairs",
+                align = (:center, :center), space = :relative)
+        else
+            for i in eachindex(ctrl)
+                # Colour by direction of change so the paired structure is readable
+                # at a glance without implying a group-level claim.
+                improving = m["direction"] == "lower" ? trt[i] < ctrl[i] : trt[i] > ctrl[i]
+                CairoMakie.lines!(ax1, [1, 2], [ctrl[i], trt[i]];
+                    color = improving ? (:steelblue, 0.75) : (:firebrick, 0.75),
+                    linewidth = 1.5)
+            end
+            CairoMakie.scatter!(ax1, fill(1, length(ctrl)), ctrl;
+                color = :black, markersize = 7)
+            CairoMakie.scatter!(ax1, fill(2, length(trt)), trt;
+                color = :black, markersize = 7)
+        end
+
+        ax2 = CairoMakie.Axis(fig[row, 2];
+            title = "paired differences ($treatment − $control)",
+            ylabel = "Δ $name", xticks = ([1], ["pairs"]))
+        CairoMakie.xlims!(ax2, 0.5, 1.5)
+        CairoMakie.hlines!(ax2, [0.0]; color = :grey40, linestyle = :dash)
+        if !isempty(diffs)
+            jitter = range(0.9, 1.1; length = max(length(diffs), 2))
+            CairoMakie.scatter!(ax2, collect(jitter)[1:length(diffs)], diffs;
+                color = :steelblue, markersize = 9)
+            med = Statistics.median(diffs)
+            CairoMakie.hlines!(ax2, [med]; color = :black, linewidth = 2)
+            CairoMakie.text!(ax2, 0.52, med;
+                text = "median $(round(med; digits = 2))",
+                align = (:left, :bottom), fontsize = 11)
+        else
+            CairoMakie.text!(ax2, 0.5, 0.5; text = "no usable pairs",
+                align = (:center, :center), space = :relative)
+        end
+    end
+
+    # The metric definition belongs ON the figure: a paired plot of QUAST NGA50 and
+    # a paired plot of an internal size-ratio proxy look identical, so the caption
+    # is what keeps the reader from conflating them (bead td-9p91).
+    definition = join(
+        [string(k, "=", join(v, "/")) for (k, v) in payload["metric_definition"]], "  ")
+    seeds = join(string.(payload["seeds"]), ", ")
+    CairoMakie.Label(fig[0, 1:2],
+        "RGV correction-validation sweep — pre-registered paired Wilcoxon\n" *
+        "seeds $seeds · definition: $definition";
+        fontsize = 15, padding = (0, 0, 8, 0))
+
+    mkpath(output_dir)
+    svg_path = joinpath(output_dir, basename * ".svg")
+    png_path = joinpath(output_dir, basename * ".png")
+    CairoMakie.save(svg_path, fig)
+    CairoMakie.save(png_path, fig)
+    return svg_path, png_path
+end
+
+function _fig_arg(flag)
+    i = findfirst(==(flag), ARGS)
+    return (i !== nothing && i < length(ARGS)) ? ARGS[i + 1] : nothing
+end
+
+function main()
+    json_path = _fig_arg("--json")
+    if json_path === nothing
+        println(stderr,
+            "ERROR: --json PATH is required (results.json from rgv_paired_wilcoxon.jl).")
+        return 2
+    end
+    isfile(json_path) || (println(stderr, "ERROR: not found: $json_path"); return 1)
+    payload = JSON.parsefile(json_path)
+    out = something(_fig_arg("--output-dir"), dirname(abspath(json_path)))
+    svg,
+    png = draw_paired_figure(payload;
+        output_dir = out,
+        basename = something(_fig_arg("--basename"), "rgv_paired_wilcoxon"))
+    println("Wrote:\n  $svg\n  $png")
+    return 0
+end
+
+if abspath(PROGRAM_FILE) == @__FILE__
+    exit(main())
+end

--- a/benchmarking/rgv_seed_backfill.jl
+++ b/benchmarking/rgv_seed_backfill.jl
@@ -76,8 +76,8 @@ const RGV_DEFAULT_SEED = 42
 #   sbatch export  'export MYCELIA_RGV_SEED="42"'  /  MYCELIA_RGV_SEED=42
 #   harness banner "Seed           : 42"
 const SEED_LOG_PATTERNS = (
-    r"\bSEED=\"?(\d+)\"?"i,
-    r"\bMYCELIA_RGV_SEED=\"?(\d+)\"?",
+    r"\bSEED=\"?([\d,]+)\"?"i,
+    r"\bMYCELIA_RGV_SEED=\"?([\d,]+)\"?",
     r"^\s*Seed\s*:\s*(\d+)\s*$"
 )
 
@@ -98,13 +98,26 @@ function recover_seed_from_log(log_path::AbstractString)
         for pat in SEED_LOG_PATTERNS
             m = match(pat, line)
             m === nothing && continue
-            push!(found, parse(Int, m.captures[1]))
+            # The capture may be a COMMA LIST (`SEED=42,123,456`) since
+            # MYCELIA_RGV_SEED became a list. Taking `parse(Int, ...)` of the whole
+            # match would throw; taking only the first number would silently
+            # attribute one seed to a multi-seed run.
+            for piece in split(m.captures[1], ",")
+                isempty(strip(piece)) && continue
+                push!(found, parse(Int, strip(piece)))
+            end
         end
     end
     isempty(found) && return nothing
     if length(found) > 1
-        error("ambiguous seed in $log_path: found $(join(sort(collect(found)), ", ")). " *
-              "The log appears to cover more than one run — split it or pass --seed explicitly.")
+        error("this run used MORE THAN ONE seed ($(join(sort(collect(found)), ", ")) " *
+              "in $log_path), so a single value cannot be attributed to every row of " *
+              "the CSV. Since MYCELIA_RGV_SEED became a list, this is the normal shape " *
+              "of a replicate run: such a CSV must carry its own per-row `seed` column " *
+              "from the harness. Backfilling one seed here would label every replicate " *
+              "identically and make an unpairable table look pairable — the exact " *
+              "failure this tool exists to prevent (see the pseudo-replication guard " *
+              "in rgv_paired_wilcoxon.jl).")
     end
     return first(found)
 end
@@ -121,7 +134,16 @@ rather than add it.
 """
 function insert_seed_column!(df::DataFrames.DataFrame, seed::Integer)
     if "seed" in DataFrames.names(df)
-        existing = unique(df.seed)
+        # A legacy CSV can carry the HEADER with empty cells, which CSV.jl reads as
+        # `missing`. That is "present but unpopulated", not "present with a
+        # conflicting value" — and it is exactly the historical shape this tool
+        # targets, so treating it as a conflict made the documented workflow
+        # impossible on its intended input. Fill it instead.
+        existing = unique(skipmissing(df.seed))
+        if isempty(existing)
+            df[!, :seed] = fill(Int(seed), DataFrames.nrow(df))
+            return df
+        end
         if length(existing) == 1 && first(existing) == seed
             return df
         end
@@ -150,6 +172,10 @@ function insert_definition_column!(df::DataFrames.DataFrame, name::Symbol, value
     col = String(name)
     if col in DataFrames.names(df)
         existing = unique(skipmissing(getproperty(df, name)))
+        if isempty(existing)          # present but unpopulated — fill, do not refuse
+            df[!, name] = fill(value, DataFrames.nrow(df))
+            return df
+        end
         if length(existing) == 1 && first(existing) == value
             return df
         end

--- a/benchmarking/rgv_seed_backfill.jl
+++ b/benchmarking/rgv_seed_backfill.jl
@@ -1,0 +1,241 @@
+# Backfill the `seed` column into pre-existing RGV sweep CSVs (bead td-59o7).
+# ===========================================================================
+#
+# `rhizomorph_correction_validation_sweep.jl` now writes `seed` as a first-class
+# column. CSVs produced BEFORE that change do not carry it, so their replicate
+# rows are indistinguishable once merged and the pre-registration's
+# paired-Wilcoxon rule over seeds 42/123/456 cannot be run against them.
+#
+# This tool adds the column to an existing CSV, and is deliberately strict about
+# provenance, because a seed value invented for a historical run is worse than a
+# missing one: it makes an unpairable run look pairable.
+#
+#   * The seed must come from an explicit `--seed N`, or be RECOVERED from a run
+#     log via `--run-log`.
+#   * `--assume-default-seed` is the only way to fall back on the harness's
+#     documented default (42), and it records that weaker provenance in the
+#     sidecar rather than pretending the value was observed.
+#   * The original CSV is NEVER modified in place. Output goes to a new path and a
+#     sidecar JSON records the source file, the seed, and exactly how the seed was
+#     determined, so the audit trail survives.
+#
+# WHAT IS RECOVERABLE
+# -------------------
+# `run_rgv_sweep_{lrc,nersc}.sbatch` export `MYCELIA_RGV_SEED` and now echo
+# `SEED=<n>` into the run log; the harness banner now prints `Seed : <n>`. Any of
+# those three forms is recognized. The completed Lovelace sweep predates all
+# three, so its seed is recoverable only as the documented default 42 — which is
+# exactly the case `--assume-default-seed` exists to label honestly.
+#
+# USAGE
+# -----
+#   # seed stated explicitly
+#   julia --project=. benchmarking/rgv_seed_backfill.jl \
+#       --csv benchmarking/results/rhizomorph_correction_validation_sweep_20260711_125013.csv \
+#       --seed 42
+#
+#   # seed recovered from a run log
+#   julia --project=. benchmarking/rgv_seed_backfill.jl \
+#       --csv results/....csv --run-log ~/workspace/slurmlogs/lovelace-jobs/rgv_sweep_*.log
+#
+#   # no log available; accept the documented default, labelled as such
+#   julia --project=. benchmarking/rgv_seed_backfill.jl --csv results/....csv \
+#       --assume-default-seed
+#
+#   Flags:
+#     --csv PATH                 (required) sweep CSV to backfill
+#     --seed N                   seed to write; provenance "explicit"
+#     --run-log PATH             recover the seed from a run log
+#     --assume-default-seed      fall back to 42; provenance "documented-default"
+#     --output PATH              output CSV (default <csv-stem>_seedbackfill.csv)
+#     --force                    overwrite an existing output file
+
+import CSV
+import DataFrames
+import JSON
+import Dates
+
+"""
+The harness default for `MYCELIA_RGV_SEED`, mirrored from
+`rhizomorph_correction_validation_sweep.jl`. Only used when
+`--assume-default-seed` is passed, and always recorded as the weaker
+`"documented-default"` provenance.
+"""
+const RGV_DEFAULT_SEED = 42
+
+# Three forms in which the seed can appear in a run log:
+#   sbatch echo    "    ERR=...  K=21  SEED=42  QUAST=true"
+#   sbatch export  'export MYCELIA_RGV_SEED="42"'  /  MYCELIA_RGV_SEED=42
+#   harness banner "Seed           : 42"
+const SEED_LOG_PATTERNS = (
+    r"\bSEED=\"?(\d+)\"?"i,
+    r"\bMYCELIA_RGV_SEED=\"?(\d+)\"?",
+    r"^\s*Seed\s*:\s*(\d+)\s*$"
+)
+
+"""
+    recover_seed_from_log(log_path) -> Union{Int, Nothing}
+
+Scan a run log for the seed. Returns the seed, or `nothing` if no recognized form
+appears.
+
+Throws an `ErrorException` if the log contains MORE THAN ONE distinct seed value:
+that means the log covers several runs, so attributing one seed to the CSV would
+be a guess.
+"""
+function recover_seed_from_log(log_path::AbstractString)
+    isfile(log_path) || error("run log not found: $log_path")
+    found = Set{Int}()
+    for line in eachline(log_path)
+        for pat in SEED_LOG_PATTERNS
+            m = match(pat, line)
+            m === nothing && continue
+            push!(found, parse(Int, m.captures[1]))
+        end
+    end
+    isempty(found) && return nothing
+    if length(found) > 1
+        error("ambiguous seed in $log_path: found $(join(sort(collect(found)), ", ")). " *
+              "The log appears to cover more than one run — split it or pass --seed explicitly.")
+    end
+    return first(found)
+end
+
+"""
+    insert_seed_column!(df, seed) -> DataFrames.DataFrame
+
+Insert `seed` immediately after `k`, matching the live sweep schema's column
+order. If `k` is absent the column is appended.
+
+Throws if `df` already has a `seed` column holding a value other than `seed` —
+silently rewriting an existing replicate identifier would corrupt provenance
+rather than add it.
+"""
+function insert_seed_column!(df::DataFrames.DataFrame, seed::Integer)
+    if "seed" in DataFrames.names(df)
+        existing = unique(df.seed)
+        if length(existing) == 1 && first(existing) == seed
+            return df
+        end
+        error("CSV already has a `seed` column with value(s) " *
+              "$(join(string.(existing), ", ")); refusing to overwrite it with $seed.")
+    end
+    n = DataFrames.nrow(df)
+    pos = findfirst(==("k"), DataFrames.names(df))
+    idx = pos === nothing ? DataFrames.ncol(df) + 1 : pos + 1
+    DataFrames.insertcols!(df, idx, :seed => fill(Int(seed), n))
+    return df
+end
+
+"""
+    backfill_seed(csv_path; seed, provenance, output_path=nothing, force=false)
+        -> (output_path, sidecar_path, nrows)
+
+Write a copy of `csv_path` with a `seed` column, plus a sidecar
+`<output>.seed_backfill.json` recording the source CSV, the seed, the provenance
+label, and the timestamp. The input file is never modified.
+"""
+function backfill_seed(csv_path::AbstractString;
+        seed::Integer,
+        provenance::AbstractString,
+        output_path::Union{Nothing, AbstractString} = nothing,
+        force::Bool = false)
+    isfile(csv_path) || error("CSV not found: $csv_path")
+    out = output_path === nothing ?
+          replace(csv_path, r"\.csv$" => "") * "_seedbackfill.csv" :
+          String(output_path)
+    if isfile(out) && !force
+        error("output already exists: $out (pass --force to overwrite)")
+    end
+    df = CSV.read(csv_path, DataFrames.DataFrame)
+    insert_seed_column!(df, seed)
+    CSV.write(out, df)
+    sidecar = out * ".seed_backfill.json"
+    open(sidecar, "w") do io
+        JSON.print(io,
+            Dict(
+                "source_csv" => abspath(csv_path),
+                "output_csv" => abspath(out),
+                "seed" => Int(seed),
+                "seed_provenance" => String(provenance),
+                "rows" => DataFrames.nrow(df),
+                "backfilled_at" => string(Dates.now()),
+                "tool" => "benchmarking/rgv_seed_backfill.jl",
+                "bead" => "td-59o7"
+            ), 2)
+    end
+    return out, sidecar, DataFrames.nrow(df)
+end
+
+# === CLI ====================================================================
+
+function _bf_arg(flag)
+    i = findfirst(==(flag), ARGS)
+    return (i !== nothing && i < length(ARGS)) ? ARGS[i + 1] : nothing
+end
+
+function main()
+    csv_path = _bf_arg("--csv")
+    if csv_path === nothing
+        println(stderr,
+            "ERROR: --csv PATH is required.\n" *
+            "  julia --project=. benchmarking/rgv_seed_backfill.jl --csv <sweep.csv> " *
+            "(--seed N | --run-log PATH | --assume-default-seed)")
+        return 2
+    end
+
+    explicit = _bf_arg("--seed")
+    run_log = _bf_arg("--run-log")
+    assume_default = "--assume-default-seed" in ARGS
+
+    seed = nothing
+    provenance = ""
+    if explicit !== nothing
+        seed = parse(Int, explicit)
+        provenance = "explicit (--seed $seed)"
+    elseif run_log !== nothing
+        recovered = recover_seed_from_log(run_log)
+        if recovered === nothing
+            if assume_default
+                seed = RGV_DEFAULT_SEED
+                provenance = "documented-default ($RGV_DEFAULT_SEED); no seed found in " *
+                             "$(abspath(run_log))"
+            else
+                println(stderr,
+                    "ERROR: no seed found in $run_log. That log predates SEED being " *
+                    "echoed. Pass --seed N if you know it, or --assume-default-seed to " *
+                    "record the documented default ($RGV_DEFAULT_SEED) with weaker provenance.")
+                return 1
+            end
+        else
+            seed = recovered
+            provenance = "recovered-from-run-log ($(abspath(run_log)))"
+        end
+    elseif assume_default
+        seed = RGV_DEFAULT_SEED
+        provenance = "documented-default ($RGV_DEFAULT_SEED); no run log supplied"
+    else
+        println(stderr,
+            "ERROR: the seed must be justified. Pass one of --seed N, --run-log PATH, " *
+            "or --assume-default-seed. Inventing a seed would make an unpairable run " *
+            "look pairable.")
+        return 2
+    end
+
+    out, sidecar,
+    n = backfill_seed(csv_path;
+        seed = seed, provenance = provenance,
+        output_path = _bf_arg("--output"), force = "--force" in ARGS)
+    println("=== RGV seed backfill ===")
+    println("Source     : $csv_path")
+    println("Seed       : $seed")
+    println("Provenance : $provenance")
+    println("Rows       : $n")
+    println("Wrote      : $out")
+    println("Sidecar    : $sidecar")
+    return 0
+end
+
+if abspath(PROGRAM_FILE) == @__FILE__
+    exit(main())
+end

--- a/benchmarking/rgv_seed_backfill.jl
+++ b/benchmarking/rgv_seed_backfill.jl
@@ -47,8 +47,16 @@
 #     --seed N                   seed to write; provenance "explicit"
 #     --run-log PATH             recover the seed from a run log
 #     --assume-default-seed      fall back to 42; provenance "documented-default"
+#     --metric-source VALUE      also backfill `metric_source` (e.g. "quast")
+#     --quast-min-contig BP      also backfill `quast_min_contig` (e.g. 500)
 #     --output PATH              output CSV (default <csv-stem>_seedbackfill.csv)
 #     --force                    overwrite an existing output file
+#
+# WHY THE DEFINITION COLUMNS ARE HERE TOO. A `seed`-only backfill DEAD-ENDS: the
+# analysis accepts the seed and then refuses the same file for carrying no
+# metric-definition column, and nothing else could supply one. Both are opt-in and
+# operator-supplied — never inferred — and both are recorded in the sidecar, so a
+# reader can always tell a backfilled definition from an observed one.
 
 import CSV
 import DataFrames
@@ -128,6 +136,33 @@ function insert_seed_column!(df::DataFrames.DataFrame, seed::Integer)
 end
 
 """
+    insert_definition_column!(df, name, value) -> DataFrames.DataFrame
+
+Append a metric-definition column (`:metric_source` / `:quast_min_contig`) with a
+single operator-supplied `value`.
+
+Refuses to overwrite an existing column holding a different value, for the same
+reason `insert_seed_column!` does: asserting a definition a run did not have makes
+an unusable table look usable, and the metric-definition guard would then pass on
+a claim nobody verified.
+"""
+function insert_definition_column!(df::DataFrames.DataFrame, name::Symbol, value)
+    col = String(name)
+    if col in DataFrames.names(df)
+        existing = unique(skipmissing(getproperty(df, name)))
+        if length(existing) == 1 && first(existing) == value
+            return df
+        end
+        error("CSV already has a `$col` column with value(s) " *
+              "$(join(string.(existing), ", ")); refusing to overwrite it with " *
+              "$value.")
+    end
+    DataFrames.insertcols!(df, DataFrames.ncol(df) + 1,
+        name => fill(value, DataFrames.nrow(df)))
+    return df
+end
+
+"""
     backfill_seed(csv_path; seed, provenance, output_path=nothing, force=false)
         -> (output_path, sidecar_path, nrows)
 
@@ -138,6 +173,8 @@ label, and the timestamp. The input file is never modified.
 function backfill_seed(csv_path::AbstractString;
         seed::Integer,
         provenance::AbstractString,
+        metric_source::Union{Nothing, AbstractString} = nothing,
+        quast_min_contig::Union{Nothing, Integer} = nothing,
         output_path::Union{Nothing, AbstractString} = nothing,
         force::Bool = false)
     isfile(csv_path) || error("CSV not found: $csv_path")
@@ -149,6 +186,17 @@ function backfill_seed(csv_path::AbstractString;
     end
     df = CSV.read(csv_path, DataFrames.DataFrame)
     insert_seed_column!(df, seed)
+    # A `seed`-only backfill DEAD-ENDS: the analysis then refuses the same file for
+    # having no metric-definition column, and nothing else could supply one. The
+    # documented backfill -> analyse workflow has to be completable, so the same
+    # provenance discipline is extended to the definition columns — each is opt-in,
+    # explicit, and recorded in the sidecar, never inferred.
+    if metric_source !== nothing
+        insert_definition_column!(df, :metric_source, String(metric_source))
+    end
+    if quast_min_contig !== nothing
+        insert_definition_column!(df, :quast_min_contig, Int(quast_min_contig))
+    end
     CSV.write(out, df)
     sidecar = out * ".seed_backfill.json"
     open(sidecar, "w") do io
@@ -158,6 +206,10 @@ function backfill_seed(csv_path::AbstractString;
                 "output_csv" => abspath(out),
                 "seed" => Int(seed),
                 "seed_provenance" => String(provenance),
+                "metric_source_backfilled" =>
+                    metric_source === nothing ? nothing : String(metric_source),
+                "quast_min_contig_backfilled" =>
+                    quast_min_contig === nothing ? nothing : Int(quast_min_contig),
                 "rows" => DataFrames.nrow(df),
                 "backfilled_at" => string(Dates.now()),
                 "tool" => "benchmarking/rgv_seed_backfill.jl",
@@ -222,14 +274,20 @@ function main()
         return 2
     end
 
+    ms = _bf_arg("--metric-source")
+    qmc = _bf_arg("--quast-min-contig")
     out, sidecar,
     n = backfill_seed(csv_path;
         seed = seed, provenance = provenance,
+        metric_source = ms,
+        quast_min_contig = qmc === nothing ? nothing : parse(Int, qmc),
         output_path = _bf_arg("--output"), force = "--force" in ARGS)
     println("=== RGV seed backfill ===")
     println("Source     : $csv_path")
     println("Seed       : $seed")
     println("Provenance : $provenance")
+    ms === nothing || println("metric_source    : $ms (operator-supplied)")
+    qmc === nothing || println("quast_min_contig : $qmc (operator-supplied)")
     println("Rows       : $n")
     println("Wrote      : $out")
     println("Sidecar    : $sidecar")

--- a/benchmarking/rhizomorph_correction_validation_sweep.jl
+++ b/benchmarking/rhizomorph_correction_validation_sweep.jl
@@ -52,6 +52,23 @@
 #                              into the CSV (metric_source="quast"); degrades
 #                              gracefully to internal size-ratio metrics
 #                              (metric_source="internal") if QUAST is absent
+#
+# CSV columns that exist for RESULT INTEGRITY (not for the science directly):
+#
+#   seed              — the RNG seed this run used (MYCELIA_RGV_SEED). REQUIRED to
+#                       make seed a usable parallelization axis and to run the
+#                       pre-registration's paired-Wilcoxon rule over seeds
+#                       42/123/456: once shards are merged, replicate rows are
+#                       indistinguishable without it, so pairs cannot be formed.
+#                       See bead td-59o7 and `rgv_paired_wilcoxon.jl`.
+#   metric_source     — WHICH metric definition produced this row: "quast"
+#                       (alignment-validated) vs "internal*" (size-ratio proxy).
+#   quast_min_contig  — the --min-contig threshold QUAST was run at. Part of the
+#                       metric definition too: two rows both labelled "quast" but
+#                       filtered at different thresholds are not comparable.
+#                       Recording it makes a future change to the threshold policy
+#                       trip `metric_source_guard.jl` instead of silently moving
+#                       numbers. See beads td-28o0 / td-9p91.
 
 import Pkg
 if isinteractive()
@@ -72,6 +89,11 @@ include(joinpath(@__DIR__, "rhizomorph_scale_guard.jl"))
 # Pure, dependency-free QUAST report.tsv parser + per-arm metric attribution
 # (shared with the unit test and with mode_comparison.jl).
 include(joinpath(@__DIR__, "quast_report_parsing.jl"))
+# Pure, dependency-free QUAST --min-contig threshold policy (bead td-28o0). The
+# inline `max(50, glen ÷ 10)` this replaces demanded a 16,890 bp contig for T4,
+# which the naive arm cannot reach, so QUAST failed and the run degraded to
+# internal metrics. See that file's header for the ceiling rationale.
+include(joinpath(@__DIR__, "quast_min_contig.jl"))
 
 # === Configuration parsing =================================================
 
@@ -245,6 +267,9 @@ function run_sweep()
     println("Read lengths   : $readlens")
     println("Coverage       : $(coverage)x")
     println("k              : $k")
+    # Printed so the seed is recoverable from a run log even for runs whose CSV
+    # predates the `seed` column (see rgv_seed_backfill.jl).
+    println("Seed           : $seed")
     println("Arms           : naive (corrector=:none) vs iterative (corrector=:iterative), both DoubleStrand")
     println("Scale floor    : $(scale_floor) bases")
     println("QUAST          : $(run_external ? "enabled" : "disabled (set MYCELIA_RUN_EXTERNAL=true)")")
@@ -260,6 +285,15 @@ function run_sweep()
     glen = length(refseq)
     println("Reference: $ref_label ($glen bp)")
 
+    # QUAST --min-contig for this reference. Fixed by the reference alone (never by
+    # the assembly being scored), so every arm of every cell is filtered
+    # identically and the arms stay comparable by construction. See
+    # quast_min_contig.jl for why this is clamped from above.
+    min_contig = quast_min_contig(glen)
+    println("QUAST --min-contig: $min_contig bp (genome_len ÷ " *
+            "$(MIN_CONTIG_GENOME_DIVISOR), clamped to " *
+            "[$(MIN_CONTIG_FLOOR_BP), $(MIN_CONTIG_CEILING_BP)])")
+
     # k must not exceed the shortest read; clamp and warn rather than fail.
     min_readlen = minimum(min.(readlens, glen))
     if k > min_readlen
@@ -272,7 +306,12 @@ function run_sweep()
     rows = DataFrames.DataFrame(
         reference = String[], genome_len = Int[], error_rate = Float64[],
         regime = String[], readlen = Int[], tech = String[], target_coverage = Float64[],
-        effective_coverage = Float64[], k = Int[], arm = String[], ok = Bool[],
+        effective_coverage = Float64[], k = Int[],
+        # First-class replicate identifier (bead td-59o7): without it, merged
+        # shards cannot be paired, so the pre-reg's paired-Wilcoxon over seeds
+        # 42/123/456 is not runnable.
+        seed = Int[],
+        arm = String[], ok = Bool[],
         n_contigs = Int[], total_length = Int[], largest_contig = Int[], n50 = Int[],
         genome_fraction = Float64[], runtime_s = Float64[],
         # Alignment-validated QUAST metrics (populated per arm when QUAST ran);
@@ -281,7 +320,11 @@ function run_sweep()
         quast_nga50 = Union{Missing, Float64}[],
         quast_num_misassemblies = Union{Missing, Float64}[],
         quast_duplication_ratio = Union{Missing, Float64}[],
-        metric_source = String[]
+        metric_source = String[],
+        # The --min-contig threshold QUAST was run at: part of the metric
+        # DEFINITION, recorded so a change to the policy is detectable rather
+        # than silent (beads td-28o0 / td-9p91).
+        quast_min_contig = Int[]
     )
 
     # Track the minimum effective coverage across cells for the scale guard: the
@@ -335,7 +378,7 @@ function run_sweep()
                         Mycelia.run_quast(res.contigs_path;
                             outdir = quast_dir,
                             reference = ref_path,
-                            min_contig = max(50, glen ÷ 10))
+                            min_contig = min_contig)
                         ran = true
                     catch e
                         @warn "QUAST external tool unavailable/failed — falling back to internal metrics" arm_name exception = (
@@ -365,6 +408,7 @@ function run_sweep()
                         reference = ref_label, genome_len = glen, error_rate = err,
                         regime = regime, readlen = readlen, tech = String(tech),
                         target_coverage = coverage, effective_coverage = eff_cov, k = k,
+                        seed = seed,
                         arm = arm_name, ok = res.ok, n_contigs = res.n_contigs,
                         total_length = res.total_length, largest_contig = res.largest_contig,
                         n50 = res.n50, genome_fraction = res.genome_fraction,
@@ -373,7 +417,8 @@ function run_sweep()
                         quast_nga50 = quast.quast_nga50,
                         quast_num_misassemblies = quast.quast_num_misassemblies,
                         quast_duplication_ratio = quast.quast_duplication_ratio,
-                        metric_source = quast.metric_source))
+                        metric_source = quast.metric_source,
+                        quast_min_contig = min_contig))
                 println("    $(rpad(arm_name, 9)) -> ok=$(res.ok) contigs=$(res.n_contigs) " *
                         "total=$(res.total_length)bp largest=$(res.largest_contig) " *
                         "n50=$(res.n50) frac=$(res.genome_fraction)% " *

--- a/benchmarking/rhizomorph_correction_validation_sweep.jl
+++ b/benchmarking/rhizomorph_correction_validation_sweep.jl
@@ -44,7 +44,11 @@
 #   MYCELIA_RGV_READLEN        comma-separated read lengths (default 150,5000)
 #   MYCELIA_RGV_COVERAGE       target fold coverage per cell (default 30; smoke default 10)
 #   MYCELIA_RGV_K              assembly k-mer size (default 21)
-#   MYCELIA_RGV_SEED           RNG seed for reproducibility (default 42)
+#   MYCELIA_RGV_SEED           comma-separated RNG seeds; each is an independent
+#                              replicate of the whole (err x readlen) grid and is
+#                              written to the `seed` CSV column (default 42). Use
+#                              "42,123,456" to produce the replicate axis the
+#                              paired-Wilcoxon analysis pairs over.
 #   MYCELIA_RGV_SCALE_FLOOR    override the scale-guard floor in bases
 #   MYCELIA_RUN_EXTERNAL       truthy -> run QUAST per arm and parse its
 #                              alignment-validated metrics (Genome fraction,
@@ -256,7 +260,13 @@ function run_sweep()
     readlens = _parse_int_list(get(ENV, "MYCELIA_RGV_READLEN", ""), [150, 5000])
     coverage = parse(Float64, get(ENV, "MYCELIA_RGV_COVERAGE", smoke ? "10" : "30"))
     k = parse(Int, get(ENV, "MYCELIA_RGV_K", "21"))
-    seed = parse(Int, get(ENV, "MYCELIA_RGV_SEED", "42"))
+    # Seed is a LIST, matching ERR and READLEN. It was a scalar, so no launcher
+    # could produce the replicate axis the paired analysis needs: a pairable
+    # multi-seed table required three separate manual submissions plus a
+    # three-way `--csv` merge, a procedure documented nowhere. The axis was
+    # asserted by the schema and not wired by the harness (bead td-59o7).
+    seeds = _parse_int_list(get(ENV, "MYCELIA_RGV_SEED", ""), [42])
+    seed = first(seeds)   # the reference seed, for the banner and for k clamping
     scale_floor = parse(Float64, get(ENV, "MYCELIA_RGV_SCALE_FLOOR", string(SCALE_FLOOR_BASES)))
     run_external = _truthy(get(ENV, "MYCELIA_RUN_EXTERNAL", "false"))
 
@@ -269,7 +279,7 @@ function run_sweep()
     println("k              : $k")
     # Printed so the seed is recoverable from a run log even for runs whose CSV
     # predates the `seed` column (see rgv_seed_backfill.jl).
-    println("Seed           : $seed")
+    println("Seeds          : $(join(seeds, ", "))")
     println("Arms           : naive (corrector=:none) vs iterative (corrector=:iterative), both DoubleStrand")
     println("Scale floor    : $(scale_floor) bases")
     println("QUAST          : $(run_external ? "enabled" : "disabled (set MYCELIA_RUN_EXTERNAL=true)")")
@@ -301,7 +311,8 @@ function run_sweep()
         k = min_readlen
     end
 
-    rng = Random.MersenneTwister(seed)
+    # One RNG per seed, constructed inside the loop, so each replicate is
+    # reproducible on its own rather than depending on how many cells preceded it.
 
     rows = DataFrames.DataFrame(
         reference = String[], genome_len = Int[], error_rate = Float64[],
@@ -331,13 +342,15 @@ function run_sweep()
     # weakest cell governs whether the whole sweep earns a VERDICT.
     min_effective_coverage = Inf
 
-    println("\n--- Sweeping (error_rate x read-regime) x {naive, iterative} ---")
-    for err in errs
+    println("\n--- Sweeping (seed x error_rate x read-regime) x {naive, iterative} ---")
+    for seed in seeds
+        rng = Random.MersenneTwister(seed)
+        for err in errs
         for readlen in readlens
             regime, tech = regime_for_readlen(readlen)
-            cell_dir = joinpath(workdir, "err$(err)_len$(readlen)")
+            cell_dir = joinpath(workdir, "seed$(seed)_err$(err)_len$(readlen)")
             mkpath(cell_dir)
-            println("\n[cell] err=$err  regime=$regime  readlen=$readlen  tech=$tech")
+            println("\n[cell] seed=$seed  err=$err  regime=$regime  readlen=$readlen  tech=$tech")
 
             reads,
             sampled_bases = simulate_regime_reads(refseq, readlen, coverage, err, tech, rng)
@@ -346,7 +359,7 @@ function run_sweep()
             println("  simulated $(length(reads)) reads, effective coverage $(eff_cov)x")
 
             for corrector in (:none, :iterative)
-                tag = "$(ref_label)_err$(err)_len$(readlen)"
+                tag = "$(ref_label)_seed$(seed)_err$(err)_len$(readlen)"
                 arm_name = corrector == :none ? "naive" : "iterative"
                 res = run_arm(reads, corrector, k, glen, cell_dir, tag)
 
@@ -424,6 +437,7 @@ function run_sweep()
                         "n50=$(res.n50) frac=$(res.genome_fraction)% " *
                         "src=$(quast.metric_source) $(res.runtime_s)s")
             end
+        end
         end
     end
 

--- a/benchmarking/run_rgv_sweep_lrc.sbatch
+++ b/benchmarking/run_rgv_sweep_lrc.sbatch
@@ -58,7 +58,10 @@ export MYCELIA_RGV_ERR="${MYCELIA_RGV_ERR:-0.01,0.05,0.10}"     # low / mid / hi
 export MYCELIA_RGV_READLEN="${MYCELIA_RGV_READLEN:-150,5000}"   # short-Illumina / long-Nanopore
 export MYCELIA_RGV_COVERAGE="${MYCELIA_RGV_COVERAGE:-30}"       # 48.5kb x 30x ~= 1.46 Mbase > scale floor
 export MYCELIA_RGV_K="${MYCELIA_RGV_K:-21}"
-export MYCELIA_RGV_SEED="${MYCELIA_RGV_SEED:-42}"
+# Three pre-registered replicate seeds. The sweep loops over this list, so one
+# submission yields a table the paired analysis can pair over; a single seed
+# would need three manual submissions plus a three-way --csv merge.
+export MYCELIA_RGV_SEED="${MYCELIA_RGV_SEED:-42,123,456}"
 # Enable QUAST (Mycelia auto-provisions it via Conda.jl); harness degrades
 # gracefully to internal metrics if QUAST/Conda is unavailable.
 export MYCELIA_RUN_EXTERNAL="${MYCELIA_RUN_EXTERNAL:-true}"

--- a/benchmarking/run_rgv_sweep_lrc.sbatch
+++ b/benchmarking/run_rgv_sweep_lrc.sbatch
@@ -67,7 +67,7 @@ cd "${HOME}/workspace/Mycelia/benchmarking" || exit 1
 
 echo ""
 echo ">>> RUN rhizomorph_correction_validation_sweep.jl  $(date)"
-echo "    ERR=${MYCELIA_RGV_ERR}  READLEN=${MYCELIA_RGV_READLEN}  COVERAGE=${MYCELIA_RGV_COVERAGE}x  K=${MYCELIA_RGV_K}  QUAST=${MYCELIA_RUN_EXTERNAL}"
+echo "    ERR=${MYCELIA_RGV_ERR}  READLEN=${MYCELIA_RGV_READLEN}  COVERAGE=${MYCELIA_RGV_COVERAGE}x  K=${MYCELIA_RGV_K}  SEED=${MYCELIA_RGV_SEED}  QUAST=${MYCELIA_RUN_EXTERNAL}"
 
 # Capture julia stdout to a runlog while still streaming it to the job .out (tee),
 # so the guard can bind to THIS run's CSV by the path the .jl prints

--- a/benchmarking/run_rgv_sweep_lrc.sbatch
+++ b/benchmarking/run_rgv_sweep_lrc.sbatch
@@ -6,7 +6,14 @@
 #SBATCH --nodes=1
 #SBATCH --ntasks=1
 #SBATCH --cpus-per-task=16
-#SBATCH --time=04:00:00
+# 2 days. The 4h that was here is not merely tight, it is known-insufficient: the
+# 2026-07-25 submissions had to be overridden with --time=2-00:00:00 because 4h
+# was too short for a SINGLE seed. MYCELIA_RGV_SEED now defaults to three seeds,
+# so the sweep iterates the full (err x readlen x arm) matrix three times. A
+# timeout kills the job mid-sweep and the green-but-empty guard below never runs,
+# so the failure would present as a missing CSV rather than as a clear timeout.
+# lr_normal MaxWall is 3 days, so 2 days leaves headroom without hitting the cap.
+#SBATCH --time=2-00:00:00
 #SBATCH --output=rgv_sweep_lrc_%j.out
 #SBATCH --error=rgv_sweep_lrc_%j.err
 

--- a/benchmarking/run_rgv_sweep_nersc.sbatch
+++ b/benchmarking/run_rgv_sweep_nersc.sbatch
@@ -59,7 +59,7 @@ cd "${HOME}/workspace/Mycelia/benchmarking" || exit 1
 
 echo ""
 echo ">>> RUN rhizomorph_correction_validation_sweep.jl  $(date)"
-echo "    ERR=${MYCELIA_RGV_ERR}  READLEN=${MYCELIA_RGV_READLEN}  COVERAGE=${MYCELIA_RGV_COVERAGE}x  K=${MYCELIA_RGV_K}  QUAST=${MYCELIA_RUN_EXTERNAL}"
+echo "    ERR=${MYCELIA_RGV_ERR}  READLEN=${MYCELIA_RGV_READLEN}  COVERAGE=${MYCELIA_RGV_COVERAGE}x  K=${MYCELIA_RGV_K}  SEED=${MYCELIA_RGV_SEED}  QUAST=${MYCELIA_RUN_EXTERNAL}"
 
 # Capture julia stdout to a runlog while still streaming it to the job .out (tee),
 # so the guard can bind to THIS run's CSV by the path the .jl prints

--- a/benchmarking/run_rgv_sweep_nersc.sbatch
+++ b/benchmarking/run_rgv_sweep_nersc.sbatch
@@ -52,7 +52,10 @@ export MYCELIA_RGV_ERR="${MYCELIA_RGV_ERR:-0.01,0.05,0.10}"
 export MYCELIA_RGV_READLEN="${MYCELIA_RGV_READLEN:-150,5000}"
 export MYCELIA_RGV_COVERAGE="${MYCELIA_RGV_COVERAGE:-30}"
 export MYCELIA_RGV_K="${MYCELIA_RGV_K:-21}"
-export MYCELIA_RGV_SEED="${MYCELIA_RGV_SEED:-42}"
+# Three pre-registered replicate seeds. The sweep loops over this list, so one
+# submission yields a table the paired analysis can pair over; a single seed
+# would need three manual submissions plus a three-way --csv merge.
+export MYCELIA_RGV_SEED="${MYCELIA_RGV_SEED:-42,123,456}"
 export MYCELIA_RUN_EXTERNAL="${MYCELIA_RUN_EXTERNAL:-true}"
 
 cd "${HOME}/workspace/Mycelia/benchmarking" || exit 1

--- a/benchmarking/run_rgv_sweep_nersc.sbatch
+++ b/benchmarking/run_rgv_sweep_nersc.sbatch
@@ -6,7 +6,14 @@
 #SBATCH --nodes=1
 #SBATCH --ntasks=1
 #SBATCH --cpus-per-task=16
-#SBATCH --time=04:00:00
+# MYCELIA_RGV_SEED now defaults to three seeds, so this sweep does 3x the work
+# the original 4h assumed — and 4h was already observed to be too short for one
+# seed on Lawrencium. 12h is the documented cap for the `regular` QOS on
+# Perlmutter CPU; VERIFY against current NERSC policy before submitting, and if
+# the three-seed sweep does not fit, shard it by seed
+# (MYCELIA_RGV_SEED=42 / 123 / 456 as three jobs) rather than raising this past
+# the cap — the analysis concatenates per-seed CSVs by design.
+#SBATCH --time=12:00:00
 #SBATCH --output=rgv_sweep_nersc_%j.out
 #SBATCH --error=rgv_sweep_nersc_%j.err
 

--- a/benchmarking/t4_ksweep.jl
+++ b/benchmarking/t4_ksweep.jl
@@ -18,6 +18,12 @@ import CSV
 import Dates
 import Statistics
 
+# Shared QUAST --min-contig policy (bead td-28o0). Replaces the inline
+# `max(50, <len> ÷ 10)` this file used to carry, which for any reference above
+# ~5 kb raised the threshold ABOVE QUAST's default and, for T4 (168,903 bp),
+# demanded a 16,890 bp contig that a fragmented assembly cannot reach.
+include(joinpath(@__DIR__, "quast_min_contig.jl"))
+
 # === Configuration ===
 
 TIER = let
@@ -256,9 +262,8 @@ if run_quast
             continue
         end
         ref_path = first(subset.ref_path)
-        # Use low min_contig for viroid-scale genomes (246-359 nt)
         ref_size = first(subset.ref_size)
-        mc = max(50, ref_size ÷ 10)
+        mc = quast_min_contig(ref_size)
         contig_files = String[r.contigs_path
                               for r in eachrow(subset) if isfile(r.contigs_path)]
         if isempty(contig_files)

--- a/benchmarking/track_a_merge_hosts.jl
+++ b/benchmarking/track_a_merge_hosts.jl
@@ -6,7 +6,10 @@
 #
 #   <results_root>/cells/<cell_id>/cell_result.json
 #
-# Concretely (2026-07-26):
+# Concretely, per the dispatch notes on bead td-bblmi (2026-07-26 — REPORTED job
+# state, not verified from this repository; the cluster logs are not reachable
+# from a checkout, so treat these as the shard LAYOUT the tool was built for
+# rather than as measured facts):
 #   * Lovelace   — Lambda complete (72/72), T4 in progress; phi29 / SARS-CoV-2 untouched
 #   * Lawrencium — the `--organisms phi29,SARS-CoV-2` shard (144 cells)
 #
@@ -21,9 +24,13 @@
 #    bury it. Byte-equivalent duplicates are benign and reported separately from
 #    content collisions, which fail the merge unless `--allow-collisions`.
 #
-# 2. PER-CELL PROVENANCE, BECAUSE THE HOSTS DO NOT MEASURE THE SAME THING
-#    QUAST works on Lawrencium but was failing on Lovelace (conda
-#    `ProcessExited(4)`), where the harness degrades to internal metrics. So the
+# 2. PER-CELL PROVENANCE, BECAUSE THE HOSTS MAY NOT MEASURE THE SAME THING
+#    QUAST was reported working on Lawrencium and failing on Lovelace (conda
+#    `ProcessExited(4)`) in the td-bblmi dispatch notes. That specific per-host
+#    status is NOT verifiable from this repository, and the tool does not depend
+#    on it being true: it classifies every cell from the checkpoint itself and
+#    reports the breakdown, so a matrix that is uniform passes and one that is
+#    mixed is caught, whichever host caused it. Where the harness degrades, the
 #    merged matrix MIXES METRIC SOURCES BY HOST. The merge therefore records which
 #    host produced each cell and classifies whether QUAST actually scored it (see
 #    `quast_evidence` below), and reports the breakdown by host — which is the
@@ -199,18 +206,36 @@ Classify whether QUAST actually scored this cell. See the file header for why th
                                   alignment-validated values
 """
 function quast_evidence(cell::AbstractDict)
-    status = get(cell, "status", "")
+    # A field that is ABSENT or UNREADABLE must never be coerced into a benign
+    # class. An earlier version routed every read failure through `_as_number ->
+    # 0.0`, so a truncated checkpoint or a schema change landed in
+    # "n/a:empty-assembly" (n_contigs unreadable -> 0) or "unknown:quast-unscored"
+    # (largest_contig unreadable -> 0), and the merge exited 0 reporting a clean
+    # matrix. The classifier's signal was inverted: quiet exactly when the data was
+    # broken. Malformed input now gets its own class and is counted as a defect.
+    haskey(cell, "status") || return "malformed:missing-field(status)"
+    status = string(cell["status"])
     status == "error" && return "n/a:cell-error"
-    n_contigs = _as_number(get(cell, "n_contigs", 0))
+    n_contigs = _ta_as_number(cell, "n_contigs")
+    n_contigs === nothing && return "malformed:unreadable(n_contigs)"
     n_contigs <= 0 && return "n/a:empty-assembly"
-    largest = _as_number(get(cell, "largest_contig", 0))
+    largest = _ta_as_number(cell, "largest_contig")
+    largest === nothing && return "malformed:unreadable(largest_contig)"
     return largest > 0 ? "quast:scored" : "unknown:quast-unscored"
 end
 
-_as_number(v::Real) = Float64(v)
-function _as_number(v)
-    parsed = tryparse(Float64, string(v))
-    return parsed === nothing ? 0.0 : parsed
+"""
+    _ta_as_number(cell, key) -> Union{Float64, Nothing}
+
+Numeric value of `cell[key]`, or `nothing` when the key is absent or the value is
+not numeric. Returning `nothing` rather than a default is the point: a default
+would make a read failure indistinguishable from a real zero.
+"""
+function _ta_as_number(cell::AbstractDict, key::AbstractString)
+    haskey(cell, key) || return nothing
+    v = cell[key]
+    v isa Real && return Float64(v)
+    return tryparse(Float64, string(v))
 end
 
 # === Discovery ==============================================================
@@ -300,10 +325,15 @@ function merge_hosts(sources::AbstractVector; expected_ids::AbstractVector{<:Abs
 
     for (label, path) in sources
         root = cells_root(path)
+        # An unreachable source is NOT "a host with zero cells". Treated as zero it
+        # silently shrinks the merge — a mistyped path or an unmounted filesystem
+        # produced a smaller-but-plausible matrix, and (before tables moved behind
+        # the gate) overwrote a larger correct table with it.
+        exists = isdir(root)
         cells, unreadable = discover_cells(root)
         push!(per_host,
-            (host = String(label), root = root, discovered = length(cells),
-                unreadable = unreadable))
+            (host = String(label), root = root, exists = exists,
+                discovered = length(cells), unreadable = unreadable))
         for (cell_id, parsed) in cells
             entry = (String(label), cell_digest(parsed), parsed)
             push!(get!(seen, cell_id, Tuple{String, String, Any}[]), entry)
@@ -348,9 +378,13 @@ function merge_hosts(sources::AbstractVector; expected_ids::AbstractVector{<:Abs
     missing_ids = sort(collect(setdiff(expected, found)))
     unexpected_ids = sort(collect(setdiff(Set{String}(keys(seen)), expected)))
 
+    unreachable = [h.host for h in per_host if !h.exists]
+    malformed = sort([cid for (cid, cell) in merged
+                      if is_malformed_evidence(quast_evidence(cell))])
     return (merged = merged, origin = origin, digests = digests,
         collisions = collisions, duplicates = duplicates,
         missing_ids = missing_ids, unexpected_ids = unexpected_ids,
+        unreachable_sources = unreachable, malformed_cells = malformed,
         per_host = per_host, expected_n = length(expected))
 end
 
@@ -426,7 +460,16 @@ function evidence_by_host(result)
 end
 
 const EVIDENCE_CLASSES = ("quast:scored", "unknown:quast-unscored",
-    "n/a:empty-assembly", "n/a:cell-error")
+    "n/a:empty-assembly", "n/a:cell-error", "malformed")
+
+"""
+    is_malformed_evidence(cls) -> Bool
+
+True for any `quast_evidence` class produced by a checkpoint that could not be
+read (absent or non-numeric field). Kept separate from the benign `n/a:*` classes
+so a schema change or a truncated file can never be counted as "nothing to score".
+"""
+is_malformed_evidence(cls::AbstractString) = startswith(cls, "malformed")
 
 """
     write_merge_report(path, result; sources, output_dir) -> String
@@ -634,6 +677,27 @@ function merge_exit_status(result;
         allow_collisions::Bool = false, allow_incomplete::Bool = false,
         report_hint::AbstractString = "the merge report")
     problems = Any[]
+    # Deliberately NOT waivable by any --allow-* flag. `--allow-incomplete` says
+    # "I know the matrix is partial"; it does not say "I am fine with a source I
+    # asked for having silently contributed nothing", which is an operator error
+    # (wrong path, unmounted filesystem), not an accepted state of the data.
+    if !isempty(result.unreachable_sources)
+        push!(problems,
+            (kind = :unreachable_source, fatal = true,
+                message = "source root does not exist for host(s): " *
+                          join(result.unreachable_sources, ", ") *
+                          ". Refusing to treat an unreachable source as an empty one."))
+    end
+    if !isempty(result.malformed_cells)
+        push!(problems,
+            (kind = :malformed_cells, fatal = true,
+                message = "$(length(result.malformed_cells)) checkpoint(s) could not " *
+                          "be read (absent or non-numeric field): " *
+                          join(first(result.malformed_cells, 5), ", ") *
+                          (length(result.malformed_cells) > 5 ? ", ..." : "") *
+                          ". These are schema drift or truncated files, not empty " *
+                          "assemblies."))
+    end
     if !isempty(result.collisions)
         push!(problems,
             (kind = :collisions, fatal = !allow_collisions,
@@ -653,9 +717,29 @@ end
 # === CLI ====================================================================
 
 function _arg_all(flag)
-    String[ARGS[i + 1]
-           for i in eachindex(ARGS)
-           if ARGS[i] == flag && i < length(ARGS)]
+    # Consume EVERY token after the flag until the next `--flag`, not just one, so
+    # both documented forms work:
+    #   --csv a.csv --csv b.csv       (repeated flag)
+    #   --csv results/sweep_*.csv     (shell glob -> --csv a.csv b.csv c.csv)
+    # Taking only `ARGS[i + 1]` silently used the first value and discarded the
+    # rest. Merging per-shard files is the entire purpose of the `seed` column, so
+    # that failure mode quietly analysed a fraction of the data behind an
+    # invocation this file's own header documents.
+    out = String[]
+    i = 1
+    while i <= length(ARGS)
+        if ARGS[i] == flag
+            j = i + 1
+            while j <= length(ARGS) && !startswith(ARGS[j], "--")
+                push!(out, ARGS[j])
+                j += 1
+            end
+            i = j
+        else
+            i += 1
+        end
+    end
+    return out
 end
 
 function _arg_value(flag)
@@ -677,6 +761,27 @@ function _parse_host_spec(spec::AbstractString)
     isempty(label) && error("--host label is empty in \"$spec\"")
     isempty(path) && error("--host path is empty in \"$spec\"")
     return String(label) => String(path)
+end
+
+"""
+    _atomic_write(f, path)
+
+Write via `f(io)` to a sibling temp file and `mv` it into place, so a reader never
+observes a partially-written table and an interrupted run leaves the previous
+contents intact.
+"""
+function _atomic_write(f, path::AbstractString)
+    dir = dirname(path)
+    mkpath(dir)
+    tmp = joinpath(dir, "." * basename(path) * ".tmp")
+    try
+        open(f, tmp, "w")
+        mv(tmp, path; force = true)
+    catch
+        isfile(tmp) && rm(tmp; force = true)
+        rethrow()
+    end
+    return path
 end
 
 function main()
@@ -730,8 +835,6 @@ function main()
     results_df, provenance_df = merged_tables(result)
     results_path = joinpath(output_dir, "track_a_results.tsv")
     provenance_path = joinpath(output_dir, "track_a_results_provenance.tsv")
-    CSV.write(results_path, results_df; delim = '\t')
-    CSV.write(provenance_path, provenance_df; delim = '\t')
 
     if copy_cells
         copied, skipped, dest_conflicts = copy_merged_cells(result, output_dir)
@@ -744,44 +847,84 @@ function main()
         end
     end
 
+    # The report is a DIAGNOSTIC and is always written — it is how the operator
+    # finds out what went wrong.
     report_path = write_merge_report(
         joinpath(output_dir, "merge_report.md"), result; output_dir = output_dir)
 
-    println("\n--- Summary ---")
-    for h in result.per_host
-        println("  $(h.host): $(h.discovered) checkpoints, $(length(h.unreadable)) not readable")
-    end
-    println("  merged: $(length(result.merged)) / $(length(ids)) expected")
-    println("  identical duplicates: $(length(result.duplicates))")
-    println("  CONTENT COLLISIONS:   $(length(result.collisions))")
-    println("  missing:              $(length(result.missing_ids))")
-    println("  unexpected ids:       $(length(result.unexpected_ids))")
-    println("\nWrote:\n  $results_path\n  $provenance_path\n  $report_path")
-
-    rc,
-    problems = merge_exit_status(result;
+    rc, problems = merge_exit_status(result;
         allow_collisions = allow_collisions, allow_incomplete = allow_incomplete,
         report_hint = report_path)
     for p in problems
         if p.fatal
             println(stderr, "ERROR: $(p.message)")
         else
-            @warn "WAIVED via --allow-$(p.kind == :collisions ? "collisions" : "incomplete"). $(p.message)"
+            @warn "WAIVED via --allow-$(p.kind). $(p.message)"
         end
     end
+
     if assert_single_def
-        try
-            assert_single_metric_definition(provenance_df;
-                columns = (:quast_evidence,),
-                context = "merged Track A matrix")
-            println("\nmetric-definition check: single quast_evidence class — OK")
-        catch e
-            println(stderr, "\nERROR: metric-definition check failed:")
-            showerror(stderr, e)
-            println(stderr)
-            rc = 1
+        # Ask the question the flag is FOR: do the cells that were actually SCORED
+        # share one metric definition? Passing the unfiltered table asked a
+        # different question and answered it uselessly — every realistic 288-cell
+        # matrix contains at least one empty assembly, so `n/a:empty-assembly`
+        # always sat alongside `quast:scored` and the check fired on every clean
+        # run. Malformed cells are excluded here only because they are already a
+        # separate FATAL problem above; they are never silently tolerated.
+        scored = provenance_df[
+            .!startswith.(String.(provenance_df.quast_evidence), "n/a:") .&
+            .!is_malformed_evidence.(String.(provenance_df.quast_evidence)), :]
+        if DataFrames.nrow(scored) == 0
+            println("\nmetric-definition check: no scored cells to compare — skipped")
+        else
+            try
+                assert_single_metric_definition(scored;
+                    columns = (:quast_evidence,),
+                    context = "merged Track A matrix (scored cells only)")
+                println("\nmetric-definition check: single quast_evidence class " *
+                        "across $(DataFrames.nrow(scored)) scored cells — OK")
+            catch e
+                println(stderr, "\nERROR: metric-definition check failed:")
+                showerror(stderr, e)
+                println(stderr)
+                rc = 1
+            end
         end
     end
+
+    # TABLES ARE WRITTEN ONLY BEHIND THE GATE. They are the artifact a downstream
+    # analysis reads, so writing them before the completeness/collision check meant
+    # a failing merge still left a smaller-but-plausible table on disk, overwriting
+    # a correct one. Written atomically (temp + rename) so an interrupted run
+    # cannot leave a half-written table either.
+    if rc == 0
+        _atomic_write(results_path) do io
+            CSV.write(io, results_df; delim = '\t')
+        end
+        _atomic_write(provenance_path) do io
+            CSV.write(io, provenance_df; delim = '\t')
+        end
+    else
+        println(stderr,
+            "\nTables NOT written (merge did not pass its gate). The previous " *
+            "contents of\n  $results_path\n  $provenance_path\nare left intact. " *
+            "See $report_path, fix the cause, and re-run; pass the matching " *
+            "--allow-* flag only if the condition is genuinely acceptable.")
+    end
+
+    println("\n--- Summary ---")
+    for h in result.per_host
+        println("  $(h.host): $(h.exists ? "" : "UNREACHABLE, ")" *
+                "$(h.discovered) checkpoints, $(length(h.unreadable)) not readable")
+    end
+    println("  merged: $(length(result.merged)) / $(length(ids)) expected")
+    println("  identical duplicates: $(length(result.duplicates))")
+    println("  CONTENT COLLISIONS:   $(length(result.collisions))")
+    println("  malformed checkpoints:$(length(result.malformed_cells))")
+    println("  missing:              $(length(result.missing_ids))")
+    println("  unexpected ids:       $(length(result.unexpected_ids))")
+    println("\nWrote:\n  $report_path" *
+            (rc == 0 ? "\n  $results_path\n  $provenance_path" : ""))
     return rc
 end
 

--- a/benchmarking/track_a_merge_hosts.jl
+++ b/benchmarking/track_a_merge_hosts.jl
@@ -1,0 +1,790 @@
+# Track A cross-host checkpoint merge (bead td-bblmi, epic td-yddpr).
+# ===================================================================
+#
+# The Track A baseline 288-cell matrix is computed on MORE THAN ONE HOST at once,
+# and its checkpoints are per-host and per-cell:
+#
+#   <results_root>/cells/<cell_id>/cell_result.json
+#
+# Concretely (2026-07-26):
+#   * Lovelace   — Lambda complete (72/72), T4 in progress; phi29 / SARS-CoV-2 untouched
+#   * Lawrencium — the `--organisms phi29,SARS-CoV-2` shard (144 cells)
+#
+# Those trees live on separate filesystems, so the matrix cannot be analyzed as
+# one until they are merged. This tool does the merge, and it is deliberately
+# PARANOID about the two ways a merge can silently produce a wrong 288-cell table.
+#
+# 1. COLLISION DETECTION, NOT LAST-WRITE-WINS
+#    The shards were supposed to be disjoint. If the same `cell_id` exists on two
+#    hosts with DIFFERENT content, that is a real anomaly — overlapping shards, a
+#    stale checkpoint, or two different Mycelia SHAs — and picking a winner would
+#    bury it. Byte-equivalent duplicates are benign and reported separately from
+#    content collisions, which fail the merge unless `--allow-collisions`.
+#
+# 2. PER-CELL PROVENANCE, BECAUSE THE HOSTS DO NOT MEASURE THE SAME THING
+#    QUAST works on Lawrencium but was failing on Lovelace (conda
+#    `ProcessExited(4)`), where the harness degrades to internal metrics. So the
+#    merged matrix MIXES METRIC SOURCES BY HOST. The merge therefore records which
+#    host produced each cell and classifies whether QUAST actually scored it (see
+#    `quast_evidence` below), and reports the breakdown by host — which is the
+#    input the `metric_source_guard.jl` check (bead td-9p91) needs downstream.
+#
+# WHY `quast_evidence` IS AN INFERENCE, AND WHY IT IS A SOUND ONE
+# --------------------------------------------------------------
+# `track_a_baseline_benchmark.jl`'s row schema has no `metric_source` column: on
+# QUAST failure it substitutes `empty_metrics()` (all five metrics zero) and still
+# writes `status="ok"`. Adding a `metric_source` column to that schema would
+# invalidate every existing checkpoint (`canonical()` would `KeyError`) and break
+# resume for the runs currently in flight, so this tool does NOT touch the
+# harness schema. It infers instead, from one sound signal:
+#
+#   n_contigs > 0 AND largest_contig == 0  =>  QUAST did not score this cell
+#
+# A contig has a length, so a QUAST run that scored a non-empty assembly cannot
+# report `Largest contig = 0`. Only the `empty_metrics()` fallback can. This is an
+# implication, not a heuristic — unlike "all metrics are zero", which a genuinely
+# unalignable assembly could also produce (`genome_fraction = 0` with a real
+# `largest_contig`). A follow-up should add a real `metric_source` column to the
+# harness once the in-flight runs have finished.
+#
+# USAGE
+# -----
+#   julia --project=. benchmarking/track_a_merge_hosts.jl \
+#       --host lovelace=/path/to/lovelace/track_a_baseline \
+#       --host lrc=/path/to/lrc/track_a_baseline \
+#       --output-dir benchmarking/results/track_a_baseline_merged
+#
+#   Flags:
+#     --host LABEL=PATH        source tree (repeatable). PATH may be the results
+#                              root or the `cells/` directory itself.
+#     --output-dir PATH        merge destination (default results/track_a_baseline_merged)
+#     --no-copy-cells          write tables + report only; do not materialize cells/
+#     --allow-collisions       report content collisions but exit 0
+#     --allow-incomplete       report missing cells but exit 0
+#     --assert-single-metric-definition
+#                              additionally require ONE quast_evidence class among
+#                              non-empty assemblies (fails a host-mixed matrix)
+#     --organisms / --technologies / --coverages / --seeds / --arms
+#                              narrow the EXPECTED matrix, mirroring the harness's
+#                              shard flags (comma-separated)
+#
+# IDEMPOTENT AND RE-RUNNABLE: both source runs are checkpointed and resumable, so
+# cells appear on a host after a first merge. Every output is rebuilt from the
+# sources on each run; a cell is copied only when absent or content-identical, and
+# a destination cell that DIFFERS from its source is itself reported as a
+# collision (host label `<merged-output>`) rather than overwritten.
+
+import JSON
+import SHA
+import DataFrames
+import CSV
+import Dates
+
+# Pure, dependency-free metric-definition guard (bead td-9p91). Included at top
+# level, matching how the RGV sweep includes its own pure helpers, so
+# `--assert-single-metric-definition` can reuse the one definition of the check
+# rather than reimplementing it.
+include(joinpath(@__DIR__, "metric_source_guard.jl"))
+
+# === Expected matrix ========================================================
+#
+# MIRRORS `track_a_baseline_benchmark.jl` (which cannot be `include`d — it runs
+# the whole benchmark at include time). `test/4_assembly/track_a_merge_hosts_test.jl`
+# asserts these constants and the cell-id format still match the harness source,
+# so drift fails a test rather than silently mis-computing "missing".
+
+const TRACK_A_ORGANISMS = ("Lambda", "T4", "phi29", "SARS-CoV-2")
+const TRACK_A_TECHNOLOGIES = ("illumina", "pacbio", "ont")
+const TRACK_A_COVERAGES = (10, 30, 50, 100)
+const TRACK_A_SEEDS = (42, 123, 456)
+const TRACK_A_ARMS = ("qualmer", "kmer")
+
+"""
+    track_a_cell_id(organism, technology, coverage, seed, arm) -> String
+
+The harness's per-cell directory name. Must stay byte-identical to
+`track_a_baseline_benchmark.jl`'s
+`cell_id = "\$(org)__\$(tech)__\$(cov)x__seed\$(seed)__\$(arm)"`.
+"""
+function track_a_cell_id(organism, technology, coverage, seed, arm)
+    return "$(organism)__$(technology)__$(coverage)x__seed$(seed)__$(arm)"
+end
+
+"""
+    expected_cell_ids(; organisms, technologies, coverages, seeds, arms) -> Vector{String}
+
+Every cell id in the (possibly narrowed) expected matrix. The full matrix is
+4 organisms x 3 technologies x 4 coverages x 3 seeds x 2 arms = 288 cells.
+"""
+function expected_cell_ids(;
+        organisms = TRACK_A_ORGANISMS,
+        technologies = TRACK_A_TECHNOLOGIES,
+        coverages = TRACK_A_COVERAGES,
+        seeds = TRACK_A_SEEDS,
+        arms = TRACK_A_ARMS)
+    ids = String[]
+    for org in organisms, tech in technologies, cov in coverages, seed in seeds, arm in arms
+        push!(ids, track_a_cell_id(org, tech, cov, seed, arm))
+    end
+    return ids
+end
+
+# === Canonicalization + digest ==============================================
+
+# Normalize numbers so a pure representation difference (2 vs 2.0, which JSON
+# round-tripping can introduce) never reads as a content collision, while any
+# genuine value difference always does.
+_canon_value(v::Integer) = string(v)
+function _canon_value(v::AbstractFloat)
+    if isfinite(v) && isinteger(v) && abs(v) < 2.0^53
+        return string(Integer(v))
+    end
+    return repr(v)
+end
+_canon_value(v::AbstractString) = String(v)
+_canon_value(v::Nothing) = "null"
+_canon_value(v::Missing) = "missing"
+_canon_value(v) = string(v)
+
+"""
+    canonical_cell_string(d) -> String
+
+Stable, key-sorted textual rendering of one parsed `cell_result.json`. Two cells
+with the same canonical string are the same result regardless of key order or
+integer/float formatting.
+"""
+function canonical_cell_string(d::AbstractDict)
+    ks = sort(String[string(k) for k in keys(d)])
+    return join(("$(k)=$(_canon_value(d[k]))" for k in ks), "\n")
+end
+
+"""
+    cell_digest(d) -> String
+
+SHA-256 hex digest of [`canonical_cell_string`](@ref). Used for collision
+detection and recorded per cell in the provenance table.
+"""
+cell_digest(d::AbstractDict) = bytes2hex(SHA.sha256(canonical_cell_string(d)))
+
+"""
+    differing_fields(a, b) -> Vector{String}
+
+Field-level diff of two parsed cells, rendered for the collision report. Keys
+present in only one side are reported as `<absent>` on the other.
+"""
+function differing_fields(a::AbstractDict, b::AbstractDict)
+    ks = sort(collect(union(Set(string.(keys(a))), Set(string.(keys(b))))))
+    diffs = String[]
+    for k in ks
+        va = haskey(a, k) ? _canon_value(a[k]) : "<absent>"
+        vb = haskey(b, k) ? _canon_value(b[k]) : "<absent>"
+        va == vb || push!(diffs, "$k: $va vs $vb")
+    end
+    return diffs
+end
+
+# === Metric provenance inference ============================================
+
+"""
+    quast_evidence(cell) -> String
+
+Classify whether QUAST actually scored this cell. See the file header for why the
+`largest_contig == 0` signal is an implication rather than a heuristic.
+
+  * `"n/a:cell-error"`          — the harness recorded `status="error"`
+  * `"n/a:empty-assembly"`      — no contigs to score
+  * `"quast:scored"`            — QUAST reported a real `Largest contig`
+  * `"unknown:quast-unscored"`  — contigs exist but `largest_contig == 0`, so the
+                                  metrics are the `empty_metrics()` fallback, not
+                                  alignment-validated values
+"""
+function quast_evidence(cell::AbstractDict)
+    status = get(cell, "status", "")
+    status == "error" && return "n/a:cell-error"
+    n_contigs = _as_number(get(cell, "n_contigs", 0))
+    n_contigs <= 0 && return "n/a:empty-assembly"
+    largest = _as_number(get(cell, "largest_contig", 0))
+    return largest > 0 ? "quast:scored" : "unknown:quast-unscored"
+end
+
+_as_number(v::Real) = Float64(v)
+function _as_number(v)
+    parsed = tryparse(Float64, string(v))
+    return parsed === nothing ? 0.0 : parsed
+end
+
+# === Discovery ==============================================================
+
+"""
+    cells_root(path) -> String
+
+Resolve a `--host` path to the directory that holds per-cell subdirectories.
+Accepts either the results root (which contains `cells/`) or `cells/` itself.
+"""
+function cells_root(path::AbstractString)
+    candidate = joinpath(path, "cells")
+    isdir(candidate) && return candidate
+    return String(path)
+end
+
+"""
+    discover_cells(root) -> (cells, unreadable)
+
+Scan `root` for `<cell_id>/cell_result.json`.
+
+Returns `cells::Dict{String, Any}` mapping cell id to the parsed checkpoint, and
+`unreadable::Vector{Tuple{String, String}}` of `(cell_id, reason)` for
+directories whose checkpoint is missing (cell still running) or unparseable.
+Both are reported; neither is silently dropped.
+"""
+function discover_cells(root::AbstractString)
+    cells = Dict{String, Any}()
+    unreadable = Tuple{String, String}[]
+    isdir(root) || return cells, unreadable
+    for entry in sort(readdir(root))
+        cell_dir = joinpath(root, entry)
+        isdir(cell_dir) || continue
+        ckpt = joinpath(cell_dir, "cell_result.json")
+        if !isfile(ckpt)
+            push!(unreadable, (entry, "no cell_result.json (cell in progress?)"))
+            continue
+        end
+        try
+            parsed = JSON.parsefile(ckpt)
+            parsed isa AbstractDict ||
+                error("checkpoint is not a JSON object (got $(typeof(parsed)))")
+            cells[entry] = parsed
+        catch e
+            push!(unreadable, (entry, "unparseable: $(sprint(showerror, e))"))
+        end
+    end
+    return cells, unreadable
+end
+
+# === Merge core =============================================================
+
+"""
+    merge_hosts(sources; expected_ids) -> NamedTuple
+
+Merge per-host cell checkpoints into one matrix.
+
+`sources` is a vector of `(label, root_path)` pairs, where `root_path` is
+anything [`cells_root`](@ref) accepts. `expected_ids` is the matrix the merge is
+checked against.
+
+Returns a NamedTuple with:
+
+  * `merged`     — `Dict{String, Any}`: cell id -> parsed checkpoint (winner-free;
+                   only cells with no content conflict are included)
+  * `origin`     — `Dict{String, String}`: cell id -> producing host label
+  * `digests`    — `Dict{String, String}`: cell id -> canonical digest
+  * `collisions` — `Vector`: one entry per cell id whose content DIFFERS between
+                   hosts, with the per-host digests and the field-level diff
+  * `duplicates` — `Vector`: cell ids present on >1 host with IDENTICAL content
+  * `missing_ids`, `unexpected_ids` — expected-matrix reconciliation
+  * `per_host`   — per-source discovery counts and unreadable entries
+
+A cell involved in a content collision is deliberately EXCLUDED from `merged`:
+there is no defensible winner, so it must not enter the analyzed matrix at all.
+"""
+function merge_hosts(sources::AbstractVector; expected_ids::AbstractVector{<:AbstractString})
+    merged = Dict{String, Any}()
+    origin = Dict{String, String}()
+    digests = Dict{String, String}()
+    collisions = Any[]
+    duplicates = Any[]
+    per_host = Any[]
+
+    # cell id -> Vector of (host, digest, parsed)
+    seen = Dict{String, Vector{Tuple{String, String, Any}}}()
+
+    for (label, path) in sources
+        root = cells_root(path)
+        cells, unreadable = discover_cells(root)
+        push!(per_host,
+            (host = String(label), root = root, discovered = length(cells),
+                unreadable = unreadable))
+        for (cell_id, parsed) in cells
+            entry = (String(label), cell_digest(parsed), parsed)
+            push!(get!(seen, cell_id, Tuple{String, String, Any}[]), entry)
+        end
+    end
+
+    for cell_id in sort(collect(keys(seen)))
+        entries = sort(seen[cell_id]; by = first)
+        unique_digests = unique(e[2] for e in entries)
+        if length(unique_digests) == 1
+            first_host, digest, parsed = entries[1]
+            merged[cell_id] = parsed
+            origin[cell_id] = first_host
+            digests[cell_id] = digest
+            if length(entries) > 1
+                push!(duplicates,
+                    (cell_id = cell_id, hosts = String[e[1] for e in entries],
+                        digest = digest))
+            end
+        else
+            # Real anomaly: the shards were supposed to be disjoint.
+            pairs = Any[]
+            for i in 1:(length(entries) - 1)
+                for j in (i + 1):length(entries)
+                    entries[i][2] == entries[j][2] && continue
+                    push!(pairs,
+                        (a = entries[i][1], b = entries[j][1],
+                            diffs = differing_fields(entries[i][3], entries[j][3])))
+                end
+            end
+            push!(collisions,
+                (cell_id = cell_id,
+                    hosts = String[e[1] for e in entries],
+                    host_digests = [e[1] => e[2] for e in entries],
+                    pairs = pairs))
+        end
+    end
+
+    expected = Set{String}(expected_ids)
+    found = Set{String}(keys(merged))
+    # A colliding cell is NOT merged, so it is genuinely absent from the matrix.
+    missing_ids = sort(collect(setdiff(expected, found)))
+    unexpected_ids = sort(collect(setdiff(Set{String}(keys(seen)), expected)))
+
+    return (merged = merged, origin = origin, digests = digests,
+        collisions = collisions, duplicates = duplicates,
+        missing_ids = missing_ids, unexpected_ids = unexpected_ids,
+        per_host = per_host, expected_n = length(expected))
+end
+
+# === Output tables ==========================================================
+
+# Harness row order, so `track_a_results.tsv` written here is drop-in compatible
+# with `track_a_baseline_benchmark.jl`'s own aggregate.
+const TRACK_A_ROW_KEYS = String[
+"organism", "accession", "technology", "coverage", "seed", "decoder_arm", "k",
+"n_reads", "n_contigs", "NGA50", "misassemblies", "genome_fraction",
+"duplication_ratio", "largest_contig", "wall_seconds", "peak_rss_bytes", "status"
+]
+
+"""
+    merged_tables(result) -> (results_df, provenance_df)
+
+Build the two output tables from a [`merge_hosts`](@ref) result:
+
+  * `results_df`    — harness schema and column order (drop-in for downstream
+                      readers of `track_a_results.tsv`)
+  * `provenance_df` — the same rows plus `host`, `source_digest`, and
+                      `quast_evidence`, which is what the metric-definition guard
+                      consumes
+"""
+function merged_tables(result)
+    ids = sort(collect(keys(result.merged)))
+    rows = Any[]
+    prov_rows = Any[]
+    for cell_id in ids
+        cell = result.merged[cell_id]
+        base = Dict{String, Any}(k => get(cell, k, missing) for k in TRACK_A_ROW_KEYS)
+        push!(rows, NamedTuple{Tuple(Symbol.(TRACK_A_ROW_KEYS))}(
+            Tuple(base[k] for k in TRACK_A_ROW_KEYS)))
+        prov_keys = vcat(["cell_id"], TRACK_A_ROW_KEYS,
+            ["host", "source_digest", "quast_evidence"])
+        prov_vals = Any[cell_id]
+        append!(prov_vals, Any[base[k] for k in TRACK_A_ROW_KEYS])
+        push!(prov_vals, result.origin[cell_id])
+        push!(prov_vals, result.digests[cell_id])
+        push!(prov_vals, quast_evidence(cell))
+        push!(prov_rows,
+            NamedTuple{Tuple(Symbol.(prov_keys))}(Tuple(prov_vals)))
+    end
+    results_df = isempty(rows) ?
+                 DataFrames.DataFrame([Symbol(k) => Any[] for k in TRACK_A_ROW_KEYS]) :
+                 DataFrames.DataFrame(rows)
+    provenance_df = isempty(prov_rows) ?
+                    DataFrames.DataFrame(
+        [Symbol(k) => Any[]
+         for k in vcat(["cell_id"], TRACK_A_ROW_KEYS,
+        ["host", "source_digest", "quast_evidence"])]) :
+                    DataFrames.DataFrame(prov_rows)
+    return results_df, provenance_df
+end
+
+"""
+    evidence_by_host(result) -> Dict{String, Dict{String, Int}}
+
+Counts of each `quast_evidence` class per host — the "does the merged matrix mix
+metric sources by host?" table. QUAST works on Lawrencium but was failing on
+Lovelace, so a non-trivial `unknown:quast-unscored` count on one host and not the
+other is the expected, and dangerous, shape.
+"""
+function evidence_by_host(result)
+    out = Dict{String, Dict{String, Int}}()
+    for (cell_id, cell) in result.merged
+        host = result.origin[cell_id]
+        per = get!(out, host, Dict{String, Int}())
+        cls = quast_evidence(cell)
+        per[cls] = get(per, cls, 0) + 1
+    end
+    return out
+end
+
+const EVIDENCE_CLASSES = ("quast:scored", "unknown:quast-unscored",
+    "n/a:empty-assembly", "n/a:cell-error")
+
+"""
+    write_merge_report(path, result; sources, output_dir) -> String
+
+Human-readable merge report: per-source counts, content collisions with
+field-level diffs, benign duplicates, expected-matrix reconciliation (exactly
+which cells are missing), and the `quast_evidence` x host breakdown.
+"""
+function write_merge_report(path::AbstractString, result; output_dir::AbstractString)
+    open(path, "w") do io
+        println(io, "# Track A cross-host merge report\n")
+        println(io, "Generated: $(Dates.now())")
+        println(io, "Output dir: `$output_dir`\n")
+
+        println(io, "## Sources\n")
+        println(io, "| host | cells root | checkpoints found | not readable |")
+        println(io, "| --- | --- | --- | --- |")
+        for h in result.per_host
+            println(io,
+                "| $(h.host) | `$(h.root)` | $(h.discovered) | $(length(h.unreadable)) |")
+        end
+        println(io)
+        for h in result.per_host
+            isempty(h.unreadable) && continue
+            println(io, "### Not readable on $(h.host)\n")
+            for (cell_id, reason) in h.unreadable
+                println(io, "- `$cell_id` — $reason")
+            end
+            println(io)
+        end
+
+        n_merged = length(result.merged)
+        println(io, "## Merge outcome\n")
+        println(io, "- Expected matrix cells: **$(result.expected_n)**")
+        println(io, "- Unique cells merged: **$n_merged**")
+        println(io, "- Missing from the expected matrix: **$(length(result.missing_ids))**")
+        println(io, "- Identical duplicates across hosts (benign): $(length(result.duplicates))")
+        println(io, "- **CONTENT COLLISIONS: $(length(result.collisions))** (must be 0)")
+        println(io, "- Cell ids outside the expected matrix: $(length(result.unexpected_ids))")
+        complete = length(result.missing_ids) == 0 && isempty(result.collisions)
+        println(io,
+            "\n**Matrix complete and collision-free: $(complete ? "YES" : "NO")**\n")
+
+        if !isempty(result.collisions)
+            println(io, "## Content collisions\n")
+            println(io,
+                "The shards were supposed to be disjoint, so the same cell id with " *
+                "DIFFERENT content on two hosts is a real anomaly (overlapping " *
+                "shards, a stale checkpoint, or two different Mycelia SHAs). These " *
+                "cells are EXCLUDED from the merged matrix — there is no defensible " *
+                "winner to pick.\n")
+            for c in result.collisions
+                println(io, "### `$(c.cell_id)`\n")
+                for (host, digest) in c.host_digests
+                    println(io, "- $host: `$(first(digest, 16))…`")
+                end
+                for p in c.pairs
+                    println(io, "\n$(p.a) vs $(p.b):\n")
+                    if isempty(p.diffs)
+                        println(io,
+                            "- (digests differ but no field-level diff — " *
+                            "check for key-set differences)")
+                    else
+                        for d in p.diffs
+                            println(io, "- $d")
+                        end
+                    end
+                end
+                println(io)
+            end
+        end
+
+        if !isempty(result.duplicates)
+            println(io, "## Identical duplicates across hosts\n")
+            println(io,
+                "Same cell id, byte-equivalent content. Benign (the shard overlapped " *
+                "but agreed); recorded so the overlap is visible.\n")
+            for d in result.duplicates
+                println(io, "- `$(d.cell_id)` on $(join(d.hosts, ", "))")
+            end
+            println(io)
+        end
+
+        if !isempty(result.missing_ids)
+            println(io, "## Missing cells ($(length(result.missing_ids)))\n")
+            by_org = Dict{String, Vector{String}}()
+            for id in result.missing_ids
+                org = first(split(id, "__"))
+                push!(get!(by_org, org, String[]), id)
+            end
+            for org in sort(collect(keys(by_org)))
+                ids = by_org[org]
+                println(io, "### $org ($(length(ids)))\n")
+                for id in ids
+                    println(io, "- `$id`")
+                end
+                println(io)
+            end
+        end
+
+        if !isempty(result.unexpected_ids)
+            println(io, "## Cell ids outside the expected matrix\n")
+            println(io,
+                "Either the expected matrix was narrowed incorrectly, or the " *
+                "harness's cell-id format drifted from this tool's mirror of it.\n")
+            for id in result.unexpected_ids
+                println(io, "- `$id`")
+            end
+            println(io)
+        end
+
+        println(io, "## Metric provenance: quast_evidence x host\n")
+        println(io,
+            "QUAST works on Lawrencium but was failing on Lovelace (conda " *
+            "`ProcessExited(4)`), where the harness degrades to internal metrics. A " *
+            "non-trivial `unknown:quast-unscored` count on one host and not another " *
+            "means the merged matrix MIXES METRIC DEFINITIONS BY HOST — see bead " *
+            "td-9p91 and `metric_source_guard.jl` before aggregating.\n")
+        breakdown = evidence_by_host(result)
+        println(io, "| host | " * join(EVIDENCE_CLASSES, " | ") * " |")
+        println(io, "| --- |" * repeat(" --- |", length(EVIDENCE_CLASSES)))
+        for host in sort(collect(keys(breakdown)))
+            per = breakdown[host]
+            println(io,
+                "| $host | " *
+                join((string(get(per, cls, 0)) for cls in EVIDENCE_CLASSES), " | ") * " |")
+        end
+        println(io)
+        classes_present = unique(vcat(
+            [collect(keys(v)) for v in values(breakdown)]...))
+        scoring = filter(c -> !startswith(c, "n/a:"), classes_present)
+        if length(scoring) > 1
+            println(io,
+                "> **WARNING:** more than one scoring class present " *
+                "($(join(scoring, ", "))). Do not aggregate across them without " *
+                "`assert_single_metric_definition`.\n")
+        end
+    end
+    return path
+end
+
+"""
+    copy_merged_cells(result, output_dir) -> (copied, skipped, conflicts)
+
+Materialize `<output_dir>/cells/<cell_id>/cell_result.json` for every merged cell
+so a single tree can be analyzed (or resumed) as one matrix.
+
+Idempotent: a destination that is already content-identical is skipped. A
+destination that DIFFERS from the source is never overwritten — it is returned as
+a conflict, because the previously merged state disagreeing with the source is
+the same class of anomaly as a cross-host collision.
+"""
+function copy_merged_cells(result, output_dir::AbstractString)
+    dest_root = joinpath(output_dir, "cells")
+    mkpath(dest_root)
+    copied = String[]
+    skipped = String[]
+    conflicts = Any[]
+    for (cell_id, cell) in result.merged
+        cell_dir = joinpath(dest_root, cell_id)
+        dest = joinpath(cell_dir, "cell_result.json")
+        if isfile(dest)
+            existing = try
+                JSON.parsefile(dest)
+            catch
+                nothing
+            end
+            if existing isa AbstractDict && cell_digest(existing) == result.digests[cell_id]
+                push!(skipped, cell_id)
+                continue
+            end
+            push!(conflicts,
+                (cell_id = cell_id, hosts = ["<merged-output>", result.origin[cell_id]],
+                    host_digests = [
+                        "<merged-output>" => (existing isa AbstractDict ?
+                                              cell_digest(existing) : "unparseable"),
+                        result.origin[cell_id] => result.digests[cell_id]],
+                    pairs = existing isa AbstractDict ?
+                            [(a = "<merged-output>", b = result.origin[cell_id],
+                        diffs = differing_fields(existing, cell))] : Any[]))
+            continue
+        end
+        mkpath(cell_dir)
+        open(dest, "w") do io
+            JSON.print(io, cell, 2)
+        end
+        push!(copied, cell_id)
+    end
+    return sort(copied), sort(skipped), conflicts
+end
+
+"""
+    merge_exit_status(result; allow_collisions=false, allow_incomplete=false)
+        -> (code, problems)
+
+The merge's pass/fail decision, factored out of the CLI so it is unit-testable
+(the exit code IS the contract for callers that chain a merge into an analysis).
+
+Returns `code` (0 pass, 1 fail) and `problems`, a vector of
+`(; kind, message, fatal)` describing each condition found. A condition that was
+waived by its `--allow-*` flag still appears, with `fatal = false`, so a waiver is
+never invisible.
+"""
+function merge_exit_status(result;
+        allow_collisions::Bool = false, allow_incomplete::Bool = false,
+        report_hint::AbstractString = "the merge report")
+    problems = Any[]
+    if !isempty(result.collisions)
+        push!(problems,
+            (kind = :collisions, fatal = !allow_collisions,
+                message = "$(length(result.collisions)) content collision(s) — same " *
+                          "cell id, different content across hosts. See $report_hint."))
+    end
+    if !isempty(result.missing_ids)
+        push!(problems,
+            (kind = :incomplete, fatal = !allow_incomplete,
+                message = "matrix incomplete: $(length(result.missing_ids)) of " *
+                          "$(result.expected_n) cells missing. See $report_hint."))
+    end
+    code = any(p -> p.fatal, problems) ? 1 : 0
+    return code, problems
+end
+
+# === CLI ====================================================================
+
+function _arg_all(flag)
+    String[ARGS[i + 1]
+           for i in eachindex(ARGS)
+           if ARGS[i] == flag && i < length(ARGS)]
+end
+
+function _arg_value(flag)
+    i = findfirst(==(flag), ARGS)
+    return (i !== nothing && i < length(ARGS)) ? ARGS[i + 1] : nothing
+end
+
+function _arg_list(flag)
+    v = _arg_value(flag)
+    return v === nothing ? nothing : String.(split(v, ","))
+end
+
+function _parse_host_spec(spec::AbstractString)
+    idx = findfirst('=', spec)
+    idx === nothing && error(
+        "--host expects LABEL=PATH, got \"$spec\" (e.g. --host lrc=/scratch/track_a_baseline)")
+    label = strip(spec[1:(idx - 1)])
+    path = strip(spec[(idx + 1):end])
+    isempty(label) && error("--host label is empty in \"$spec\"")
+    isempty(path) && error("--host path is empty in \"$spec\"")
+    return String(label) => String(path)
+end
+
+function main()
+    specs = _arg_all("--host")
+    if isempty(specs)
+        println(stderr,
+            "ERROR: at least one --host LABEL=PATH is required.\n" *
+            "  julia --project=. benchmarking/track_a_merge_hosts.jl \\\n" *
+            "      --host lovelace=/path/to/track_a_baseline \\\n" *
+            "      --host lrc=/path/to/track_a_baseline \\\n" *
+            "      --output-dir benchmarking/results/track_a_baseline_merged")
+        return 2
+    end
+    sources = [_parse_host_spec(s) for s in specs]
+    labels = String[first(s) for s in sources]
+    if length(unique(labels)) != length(labels)
+        println(stderr, "ERROR: duplicate --host labels: $(join(labels, ", "))")
+        return 2
+    end
+
+    output_dir = something(_arg_value("--output-dir"),
+        joinpath(@__DIR__, "results", "track_a_baseline_merged"))
+    copy_cells = !("--no-copy-cells" in ARGS)
+    allow_collisions = "--allow-collisions" in ARGS
+    allow_incomplete = "--allow-incomplete" in ARGS
+    assert_single_def = "--assert-single-metric-definition" in ARGS
+
+    organisms = something(_arg_list("--organisms"), TRACK_A_ORGANISMS)
+    technologies = something(_arg_list("--technologies"), TRACK_A_TECHNOLOGIES)
+    coverages = let v = _arg_list("--coverages")
+        v === nothing ? TRACK_A_COVERAGES : parse.(Int, v)
+    end
+    seeds = let v = _arg_list("--seeds")
+        v === nothing ? TRACK_A_SEEDS : parse.(Int, v)
+    end
+    arms = something(_arg_list("--arms"), TRACK_A_ARMS)
+
+    ids = expected_cell_ids(; organisms, technologies, coverages, seeds, arms)
+
+    println("=== Track A cross-host merge ===")
+    println("Sources:")
+    for (label, path) in sources
+        println("  $label -> $path")
+    end
+    println("Expected matrix: $(length(ids)) cells")
+    println("Output dir     : $output_dir")
+
+    result = merge_hosts(sources; expected_ids = ids)
+
+    mkpath(output_dir)
+    results_df, provenance_df = merged_tables(result)
+    results_path = joinpath(output_dir, "track_a_results.tsv")
+    provenance_path = joinpath(output_dir, "track_a_results_provenance.tsv")
+    CSV.write(results_path, results_df; delim = '\t')
+    CSV.write(provenance_path, provenance_df; delim = '\t')
+
+    if copy_cells
+        copied, skipped, dest_conflicts = copy_merged_cells(result, output_dir)
+        println("Cells materialized: $(length(copied)) new, $(length(skipped)) already identical")
+        if !isempty(dest_conflicts)
+            append!(result.collisions, dest_conflicts)
+            println(stderr,
+                "WARNING: $(length(dest_conflicts)) previously-merged cell(s) differ " *
+                "from their source and were NOT overwritten.")
+        end
+    end
+
+    report_path = write_merge_report(
+        joinpath(output_dir, "merge_report.md"), result; output_dir = output_dir)
+
+    println("\n--- Summary ---")
+    for h in result.per_host
+        println("  $(h.host): $(h.discovered) checkpoints, $(length(h.unreadable)) not readable")
+    end
+    println("  merged: $(length(result.merged)) / $(length(ids)) expected")
+    println("  identical duplicates: $(length(result.duplicates))")
+    println("  CONTENT COLLISIONS:   $(length(result.collisions))")
+    println("  missing:              $(length(result.missing_ids))")
+    println("  unexpected ids:       $(length(result.unexpected_ids))")
+    println("\nWrote:\n  $results_path\n  $provenance_path\n  $report_path")
+
+    rc,
+    problems = merge_exit_status(result;
+        allow_collisions = allow_collisions, allow_incomplete = allow_incomplete,
+        report_hint = report_path)
+    for p in problems
+        if p.fatal
+            println(stderr, "ERROR: $(p.message)")
+        else
+            @warn "WAIVED via --allow-$(p.kind == :collisions ? "collisions" : "incomplete"). $(p.message)"
+        end
+    end
+    if assert_single_def
+        try
+            assert_single_metric_definition(provenance_df;
+                columns = (:quast_evidence,),
+                context = "merged Track A matrix")
+            println("\nmetric-definition check: single quast_evidence class — OK")
+        catch e
+            println(stderr, "\nERROR: metric-definition check failed:")
+            showerror(stderr, e)
+            println(stderr)
+            rc = 1
+        end
+    end
+    return rc
+end
+
+if abspath(PROGRAM_FILE) == @__FILE__
+    exit(main())
+end

--- a/benchmarking/track_a_merge_hosts.jl
+++ b/benchmarking/track_a_merge_hosts.jl
@@ -151,6 +151,15 @@ end
 _canon_value(v::AbstractString) = String(v)
 _canon_value(v::Nothing) = "null"
 _canon_value(v::Missing) = "missing"
+# Recurse into nested containers. Falling through to `string(v)` would render a
+# nested object via Dict iteration order, which is not guaranteed to match between
+# two hosts holding EQUAL content — a false collision. Keys are sorted here for the
+# same reason they are sorted at the top level.
+function _canon_value(v::AbstractDict)
+    ks = sort(String[string(k) for k in keys(v)])
+    return "{" * join(("$(k):$(_canon_value(v[k]))" for k in ks), ",") * "}"
+end
+_canon_value(v::AbstractVector) = "[" * join((_canon_value(x) for x in v), ",") * "]"
 _canon_value(v) = string(v)
 
 """
@@ -329,7 +338,15 @@ function merge_hosts(sources::AbstractVector; expected_ids::AbstractVector{<:Abs
         # silently shrinks the merge — a mistyped path or an unmounted filesystem
         # produced a smaller-but-plausible matrix, and (before tables moved behind
         # the gate) overwrote a larger correct table with it.
-        exists = isdir(root)
+        # `isdir(root)` alone is not enough: `cells_root` falls back to the given
+        # path when it has no `cells/` subdirectory, so a path that exists but is
+        # not a checkpoint tree at all (a typo landing on some other directory)
+        # would report `exists = true` with zero cells and escape the guard —
+        # exactly the silent-shrink this check exists to stop.
+        looks_like_tree = isdir(joinpath(path, "cells")) ||
+                          (isdir(root) && any(isfile(joinpath(root, e, "cell_result.json"))
+        for e in (isdir(root) ? readdir(root) : String[])))
+        exists = isdir(root) && looks_like_tree
         cells, unreadable = discover_cells(root)
         push!(per_host,
             (host = String(label), root = root, exists = exists,
@@ -589,6 +606,19 @@ function write_merge_report(path::AbstractString, result; output_dir::AbstractSt
             "means the merged matrix MIXES METRIC DEFINITIONS BY HOST — see bead " *
             "td-9p91 and `metric_source_guard.jl` before aggregating.\n")
         breakdown = evidence_by_host(result)
+        # Collapse `malformed:unreadable(n_contigs)` etc. onto the `malformed`
+        # column, otherwise the table's malformed count is permanently 0 because no
+        # observed class ever equals the bare bucket name.
+        _bucket(cls) = is_malformed_evidence(cls) ? "malformed" : cls
+        collapsed = Dict{String, Dict{String, Int}}()
+        for (host, per) in breakdown
+            acc = get!(collapsed, host, Dict{String, Int}())
+            for (cls, n) in per
+                b = _bucket(cls)
+                acc[b] = get(acc, b, 0) + n
+            end
+        end
+        breakdown = collapsed
         println(io, "| host | " * join(EVIDENCE_CLASSES, " | ") * " |")
         println(io, "| --- |" * repeat(" --- |", length(EVIDENCE_CLASSES)))
         for host in sort(collect(keys(breakdown)))
@@ -653,7 +683,10 @@ function copy_merged_cells(result, output_dir::AbstractString)
             continue
         end
         mkpath(cell_dir)
-        open(dest, "w") do io
+        # Atomic, for the same reason the tables are: an interrupted merge must not
+        # leave a half-written checkpoint that a later run would read as corrupt
+        # (and now, correctly, treat as a fatal malformed cell).
+        _atomic_write(dest) do io
             JSON.print(io, cell, 2)
         end
         push!(copied, cell_id)
@@ -684,9 +717,10 @@ function merge_exit_status(result;
     if !isempty(result.unreachable_sources)
         push!(problems,
             (kind = :unreachable_source, fatal = true,
-                message = "source root does not exist for host(s): " *
-                          join(result.unreachable_sources, ", ") *
-                          ". Refusing to treat an unreachable source as an empty one."))
+                message = "source is unreachable or is not a checkpoint tree for " *
+                          "host(s): " * join(result.unreachable_sources, ", ") *
+                          ". Expected <path>/cells/<cell_id>/cell_result.json. " *
+                          "Refusing to treat an unreachable source as an empty one."))
     end
     if !isempty(result.malformed_cells)
         push!(problems,
@@ -718,13 +752,12 @@ end
 
 function _arg_all(flag)
     # Consume EVERY token after the flag until the next `--flag`, not just one, so
-    # both documented forms work:
-    #   --csv a.csv --csv b.csv       (repeated flag)
-    #   --csv results/sweep_*.csv     (shell glob -> --csv a.csv b.csv c.csv)
-    # Taking only `ARGS[i + 1]` silently used the first value and discarded the
-    # rest. Merging per-shard files is the entire purpose of the `seed` column, so
-    # that failure mode quietly analysed a fraction of the data behind an
-    # invocation this file's own header documents.
+    # both forms work:
+    #   --host a=/p1 --host b=/p2     (repeated flag)
+    #   --host a=/p1 b=/p2            (one flag, several values)
+    # Taking only `ARGS[i + 1]` silently used the first value and dropped the rest,
+    # which for `--host` means merging fewer trees than the operator asked for and
+    # reporting the result as complete.
     out = String[]
     i = 1
     while i <= length(ARGS)
@@ -750,6 +783,29 @@ end
 function _arg_list(flag)
     v = _arg_value(flag)
     return v === nothing ? nothing : String.(split(v, ","))
+end
+
+"""
+    _parse_int_flag(flag, default) -> Union{Vector{Int}, Tuple, Nothing}
+
+Parse a comma-separated integer shard flag, or return `default` when absent.
+Returns `nothing` (after printing a usage error) when a value is not an integer,
+so the caller can exit 2 rather than surfacing a stacktrace.
+"""
+function _parse_int_flag(flag::AbstractString, default)
+    v = _arg_list(flag)
+    v === nothing && return default
+    out = Int[]
+    for s in v
+        n = tryparse(Int, strip(s))
+        if n === nothing
+            println(stderr,
+                "ERROR: $flag expects comma-separated integers, got \"$s\"")
+            return nothing
+        end
+        push!(out, n)
+    end
+    return out
 end
 
 function _parse_host_spec(spec::AbstractString)
@@ -811,12 +867,12 @@ function main()
 
     organisms = something(_arg_list("--organisms"), TRACK_A_ORGANISMS)
     technologies = something(_arg_list("--technologies"), TRACK_A_TECHNOLOGIES)
-    coverages = let v = _arg_list("--coverages")
-        v === nothing ? TRACK_A_COVERAGES : parse.(Int, v)
-    end
-    seeds = let v = _arg_list("--seeds")
-        v === nothing ? TRACK_A_SEEDS : parse.(Int, v)
-    end
+    # A typo in a numeric shard flag is operator error, and should read as usage
+    # (exit 2) rather than as an unhandled `ArgumentError` stacktrace.
+    coverages = _parse_int_flag("--coverages", TRACK_A_COVERAGES)
+    coverages === nothing && return 2
+    seeds = _parse_int_flag("--seeds", TRACK_A_SEEDS)
+    seeds === nothing && return 2
     arms = something(_arg_list("--arms"), TRACK_A_ARMS)
 
     ids = expected_cell_ids(; organisms, technologies, coverages, seeds, arms)

--- a/test/4_assembly/metric_source_guard_test.jl
+++ b/test/4_assembly/metric_source_guard_test.jl
@@ -1,0 +1,210 @@
+# Unit test for the metric-definition consistency guard (bead td-9p91).
+#
+# The bead's requirement is specific: "any aggregation spanning more than one src
+# value RAISES rather than silently proceeding. Opt-out must be explicit (e.g.
+# allow_mixed_src=true) and should emit a loud warning naming the src values being
+# mixed."
+#
+# So the central assertion is not "the function exists" — it is that a mixed-src
+# aggregation ACTUALLY RAISES, that the message names the mixed values, and that
+# the documented opt-out warns rather than passing quietly. A guard without a test
+# proving it fires is not a guard.
+#
+# Dependency-free apart from DataFrames (a direct Mycelia dep that loads without
+# importing Mycelia), so the real column type the harness writes is exercised.
+
+import Test
+import DataFrames
+import Logging
+
+include(joinpath(@__DIR__, "..", "..", "benchmarking", "metric_source_guard.jl"))
+
+function _msg_throws_with(f, needles::Vector{String})
+    try
+        f()
+    catch e
+        msg = sprint(showerror, e)
+        for needle in needles
+            Test.@test occursin(needle, msg)
+        end
+        return msg
+    end
+    Test.@test false  # expected a throw, got none
+    return ""
+end
+
+# Capture @warn output so "warns loudly" is asserted, not assumed.
+function _msg_capture_logs(f)
+    logger = Test.TestLogger()
+    result = Logging.with_logger(logger) do
+        f()
+    end
+    return result, logger.logs
+end
+
+# A results table shaped like the RGV sweep's, parameterized by metric definition.
+function _msg_frame(sources, thresholds; nga50 = nothing)
+    n = length(sources)
+    return DataFrames.DataFrame(
+        arm = [iseven(i) ? "naive" : "iterative" for i in 1:n],
+        seed = fill(42, n),
+        quast_nga50 = nga50 === nothing ? collect(1.0:1.0:n) : nga50,
+        metric_source = collect(sources),
+        quast_min_contig = collect(thresholds)
+    )
+end
+
+Test.@testset "metric-definition guard (td-9p91)" begin
+    Test.@testset "single definition passes and reports the summary" begin
+        df = _msg_frame(["quast", "quast", "quast"], [4_850, 4_850, 4_850])
+        summary = assert_single_metric_definition(df; context = "H1 NGA50 aggregate")
+        Test.@test Dict(summary) == Dict(
+            :metric_source => ["quast"], :quast_min_contig => ["4850"])
+    end
+
+    Test.@testset "MIXED metric_source RAISES and names the values" begin
+        # The exact situation observed on Lawrencium job 24247925: T4 rows carry
+        # internal metrics while Lambda rows carry QUAST metrics.
+        df = _msg_frame(
+            ["quast", "internal:quast-failed", "quast"], [4_850, 4_850, 4_850])
+        msg = _msg_throws_with(
+            () -> assert_single_metric_definition(df; context = "H1 NGA50 aggregate"),
+            ["MixedMetricDefinitionError",
+                "H1 NGA50 aggregate",
+                "metric_source",
+                "\"internal:quast-failed\"",   # both mixed values named
+                "\"quast\"",
+                "allow_mixed_src"])            # the opt-out is discoverable
+        # Not a bare type check: the message must carry the actionable content.
+        Test.@test occursin("ALIGNMENT-VALIDATED", msg)
+    end
+
+    Test.@testset "MIXED quast_min_contig RAISES too" begin
+        # Two rows both labelled "quast" are still incomparable if QUAST filtered
+        # them at different thresholds. This is why the sweep records the threshold.
+        df = _msg_frame(["quast", "quast"], [4_850, 5_000])
+        _msg_throws_with(
+            () -> assert_single_metric_definition(df; context = "threshold check"),
+            ["quast_min_contig", "\"4850\"", "\"5000\""])
+    end
+
+    Test.@testset "missing values participate rather than being skipped" begin
+        df = DataFrames.DataFrame(
+            metric_source = ["quast", missing],
+            quast_min_contig = [4_850, 4_850])
+        _msg_throws_with(
+            () -> assert_single_metric_definition(df; context = "missing-source check"),
+            ["\"missing\"", "\"quast\""])
+    end
+
+    Test.@testset "explicit opt-out warns loudly and names the mix" begin
+        df = _msg_frame(["quast", "internal:quast-failed"], [4_850, 4_850])
+        summary,
+        logs = _msg_capture_logs() do
+            assert_single_metric_definition(df;
+                context = "deliberate override", allow_mixed_src = true)
+        end
+        Test.@test Dict(summary)[:metric_source] == ["internal:quast-failed", "quast"]
+        warns = filter(l -> l.level == Logging.Warn, logs)
+        Test.@test length(warns) == 1
+        Test.@test occursin("MIXED METRIC DEFINITION", warns[1].message)
+        Test.@test occursin("allow_mixed_src=true", warns[1].message)
+        Test.@test occursin("NOT validation-grade", warns[1].message)
+        mixed = string(Dict(warns[1].kwargs)[:mixed])
+        Test.@test occursin("internal:quast-failed", mixed)
+        Test.@test occursin("quast", mixed)
+    end
+
+    Test.@testset "fail-closed when no definition column is present" begin
+        # A table with no provenance column has not been shown to be consistent;
+        # it is a table that cannot be checked. Reporting "OK" would be a lie.
+        df = DataFrames.DataFrame(arm = ["naive", "iterative"], quast_nga50 = [1.0, 2.0])
+        _msg_throws_with(
+            () -> assert_single_metric_definition(df; context = "schemaless table"),
+            ["no metric-definition column present", "schemaless table", ":metric_source"])
+    end
+
+    Test.@testset "custom provenance column (the merge tool's quast_evidence)" begin
+        ok = DataFrames.DataFrame(quast_evidence = ["quast:scored", "quast:scored"])
+        Test.@test Dict(assert_single_metric_definition(ok;
+            columns = (:quast_evidence,), context = "merged matrix")) ==
+                   Dict(:quast_evidence => ["quast:scored"])
+        mixed = DataFrames.DataFrame(
+            quast_evidence = ["quast:scored", "unknown:quast-unscored"])
+        _msg_throws_with(
+            () -> assert_single_metric_definition(mixed;
+                columns = (:quast_evidence,), context = "merged matrix"),
+            ["quast_evidence", "\"quast:scored\"", "\"unknown:quast-unscored\""])
+    end
+
+    Test.@testset "grouped check: per-group, and every offender reported" begin
+        # The realistic shape: a groupby by organism where ONE organism's rows are
+        # internally mixed. A whole-table check would flag it too, but the grouped
+        # check names WHICH group, which is what an analyst needs.
+        df = DataFrames.DataFrame(
+            organism = ["Lambda", "Lambda", "T4", "T4", "phi29", "phi29"],
+            metric_source = ["quast", "quast",
+                "quast", "internal:quast-failed",
+                "quast", "internal:quast-failed"],
+            quast_min_contig = fill(5_000, 6))
+        msg = _msg_throws_with(
+            () -> assert_single_metric_definition_per_group(df, (:organism,);
+                context = "per-organism NGA50"),
+            ["[group T4]", "[group phi29]", "metric_source"])
+        # Lambda is clean, so it must NOT be reported as an offender.
+        Test.@test !occursin("[group Lambda]", msg)
+
+        clean = DataFrames.DataFrame(
+            organism = ["Lambda", "Lambda", "T4", "T4"],
+            metric_source = ["quast", "quast", "internal:quast-failed",
+                "internal:quast-failed"],
+            quast_min_contig = fill(5_000, 4))
+        # Each GROUP is internally consistent even though the table as a whole is
+        # not — correct for a groupby, since each group becomes one aggregate.
+        Test.@test assert_single_metric_definition_per_group(clean, (:organism,)) == 2
+        _msg_throws_with(
+            () -> assert_single_metric_definition(clean; context = "whole table"),
+            ["metric_source"])
+    end
+
+    Test.@testset "grouped check validates its group columns" begin
+        df = _msg_frame(["quast"], [5_000])
+        _msg_throws_with(
+            () -> assert_single_metric_definition_per_group(df, (:organism,);
+                context = "bad group col"),
+            ["group column :organism not present"])
+    end
+
+    Test.@testset "guarded_aggregate runs the body only when the guard passes" begin
+        ran = Ref(0)
+        ok = _msg_frame(["quast", "quast"], [5_000, 5_000])
+        value = guarded_aggregate(ok; context = "mean NGA50") do d
+            ran[] += 1
+            sum(d.quast_nga50)
+        end
+        Test.@test value == 3.0
+        Test.@test ran[] == 1
+
+        mixed = _msg_frame(["quast", "internal:quast-failed"], [5_000, 5_000])
+        _msg_throws_with(
+            () -> guarded_aggregate(d -> (ran[] += 1), mixed; context = "mean NGA50"),
+            ["MixedMetricDefinitionError"])
+        Test.@test ran[] == 1  # body never executed on the mixed table
+    end
+
+    Test.@testset "metric_definition_summary omits absent columns" begin
+        df = DataFrames.DataFrame(metric_source = ["quast", "quast"])
+        Test.@test Dict(metric_definition_summary(df)) ==
+                   Dict(:metric_source => ["quast"])
+    end
+
+    Test.@testset "the sweep records both definition columns" begin
+        # The guard is only useful if the harness actually writes what it checks.
+        sweep = read(
+            joinpath(@__DIR__, "..", "..", "benchmarking",
+                "rhizomorph_correction_validation_sweep.jl"), String)
+        for col in METRIC_DEFINITION_COLUMNS
+            Test.@test occursin("$col = ", sweep)
+        end
+    end
+end

--- a/test/4_assembly/metric_source_guard_test.jl
+++ b/test/4_assembly/metric_source_guard_test.jl
@@ -207,4 +207,41 @@ Test.@testset "metric-definition guard (td-9p91)" begin
             Test.@test occursin("$col = ", sweep)
         end
     end
+
+    Test.@testset "C4/I2: a PARTIALLY absent axis fails closed too" begin
+        # The doctrine is per-AXIS. An earlier implementation was per-SET: it raised
+        # only when EVERY definition column was missing, so a table with a uniform
+        # metric_source and no quast_min_contig — the shape of every CSV produced
+        # before this policy — passed and reported a single consistent definition
+        # over an axis it never examined.
+        partial = DataFrames.DataFrame(metric_source = ["quast", "quast"])
+        _msg_throws_with(
+            () -> assert_single_metric_definition(partial; context = "pre-policy CSV"),
+            ["not checkable", "quast_min_contig", "pre-policy CSV"])
+
+        # The narrower check is still available, but it must be asked for, and it
+        # says out loud which axis went unchecked.
+        summary, logs = _msg_capture_logs() do
+            assert_single_metric_definition(partial;
+                context = "pre-policy CSV", require_all_columns = false)
+        end
+        Test.@test Dict(summary) == Dict(:metric_source => ["quast"])
+        warns = filter(l -> l.level == Logging.Warn, logs)
+        Test.@test length(warns) == 1
+        Test.@test occursin("NOT checked", warns[1].message)
+        Test.@test occursin("quast_min_contig", string(Dict(warns[1].kwargs)[:absent]))
+
+        # Naming the axes explicitly records the narrower claim deliberately.
+        Test.@test Dict(assert_single_metric_definition(partial;
+            columns = (:metric_source,), context = "explicit narrow")) ==
+                   Dict(:metric_source => ["quast"])
+
+        # Grouped form fails closed on the same grounds.
+        pg = DataFrames.DataFrame(
+            organism = ["Lambda", "Lambda"], metric_source = ["quast", "quast"])
+        _msg_throws_with(
+            () -> assert_single_metric_definition_per_group(pg, (:organism,);
+                context = "grouped partial"),
+            ["not checkable", "quast_min_contig"])
+    end
 end

--- a/test/4_assembly/quast_min_contig_test.jl
+++ b/test/4_assembly/quast_min_contig_test.jl
@@ -1,0 +1,142 @@
+# Unit test for the QUAST --min-contig threshold policy (bead td-28o0).
+#
+# The load-bearing property is NOT "the new formula equals the old one" — it
+# deliberately does not, for T4. It is:
+#
+#   (a) every reference the old expression already handled keeps its EXACT
+#       threshold, so results already committed and the Lambda runs in flight stay
+#       comparable, and
+#   (b) T4 (and anything larger) now gets a threshold a fragmented assembly can
+#       actually satisfy, so QUAST runs instead of silently degrading to internal
+#       metrics.
+#
+# Both are asserted against the specific documented values, not against a
+# re-implementation of the old expression.
+#
+# Dependency-free: includes only the pure policy helper. No Mycelia, no QUAST.
+
+import Test
+
+include(joinpath(@__DIR__, "..", "..", "benchmarking", "quast_min_contig.jl"))
+
+# The expression this policy replaces, kept ONLY so the test can state exactly
+# which references move and which do not.
+_qmc_legacy(glen) = max(50, glen ÷ 10)
+
+function _qmc_throws_with(f, needle)
+    try
+        f()
+    catch e
+        msg = sprint(showerror, e)
+        Test.@test occursin(needle, msg)
+        return nothing
+    end
+    Test.@test false  # expected a throw, got none
+    return nothing
+end
+
+Test.@testset "QUAST --min-contig policy (td-28o0)" begin
+    lambda_len = 48_502
+    t4_len = 168_903
+    phi29_len = 19_282
+    sars_len = 29_903
+    ecoli_len = 4_641_652
+
+    Test.@testset "preserved thresholds — comparability with committed results" begin
+        # These are the values the harness has ALREADY used. A change here would
+        # silently redefine the metric for genomes that were working, and would
+        # break comparability with Lawrencium jobs 24247923 / 24247924 (Lambda
+        # 50x / 100x) that are in flight.
+        Test.@test quast_min_contig(lambda_len) == 4_850
+        Test.@test quast_min_contig(phi29_len) == 1_928
+        Test.@test quast_min_contig(sars_len) == 2_990
+
+        # Same assertion stated the other way: unchanged relative to the legacy
+        # expression for every reference the legacy expression could serve.
+        for glen in (246, 300, 359, 1_000, 5_000, phi29_len, sars_len, lambda_len)
+            Test.@test quast_min_contig(glen) == _qmc_legacy(glen)
+        end
+    end
+
+    Test.@testset "T4 is fixed — threshold is now reachable" begin
+        # The bug: 168_903 ÷ 10 = 16_890, but the naive arm's largest contig is
+        # 11_622 bp, so QUAST exits "None of the assembly files contains correct
+        # contigs... decrease --min-contig threshold".
+        Test.@test _qmc_legacy(t4_len) == 16_890
+        t4_naive_largest_contig = 11_622
+        Test.@test _qmc_legacy(t4_len) > t4_naive_largest_contig      # the failure
+        Test.@test quast_min_contig(t4_len) == 5_000
+        Test.@test quast_min_contig(t4_len) < t4_naive_largest_contig # the fix
+
+        # And it stays reachable as references grow, rather than getting worse.
+        Test.@test quast_min_contig(ecoli_len) == MIN_CONTIG_CEILING_BP
+        Test.@test quast_min_contig(typemax(Int) ÷ 2) == MIN_CONTIG_CEILING_BP
+    end
+
+    Test.@testset "viroid-scale down-scaling (the original intent) still works" begin
+        # The whole reason the ÷10 term exists: bring the threshold BELOW QUAST's
+        # 500 bp default for references shorter than QUAST's default assumes.
+        for glen in (246, 300, 359)
+            Test.@test quast_min_contig(glen) == MIN_CONTIG_FLOOR_BP
+            Test.@test quast_min_contig(glen) < 500
+        end
+        Test.@test quast_min_contig(0) == MIN_CONTIG_FLOOR_BP
+        # 5_000 bp is where the ÷10 term crosses QUAST's own default.
+        Test.@test quast_min_contig(5_000) == 500
+    end
+
+    Test.@testset "monotone, and bounded on both sides" begin
+        prev = 0
+        for glen in 0:997:2_000_000
+            v = quast_min_contig(glen)
+            Test.@test MIN_CONTIG_FLOOR_BP <= v <= MIN_CONTIG_CEILING_BP
+            Test.@test v >= prev            # non-decreasing in genome length
+            prev = v
+        end
+    end
+
+    Test.@testset "arm independence — the property that keeps arms comparable" begin
+        # The rejected "derive from the observed contig distribution" option would
+        # make the threshold a function of the assembly. This policy takes only
+        # the reference, so both arms of a cell are filtered identically. Asserted
+        # structurally: the function has no way to see an assembly.
+        Test.@test quast_min_contig(t4_len) == quast_min_contig(t4_len)
+        Test.@test length(methods(quast_min_contig)) == 1
+    end
+
+    Test.@testset "keyword overrides" begin
+        Test.@test quast_min_contig(lambda_len; ceiling_bp = 500) == 500
+        Test.@test quast_min_contig(lambda_len; divisor = 100) == 485
+        Test.@test quast_min_contig(100; floor_bp = 1) == 10
+        Test.@test quast_min_contig(1; floor_bp = 1) == 1
+    end
+
+    Test.@testset "argument validation" begin
+        _qmc_throws_with(() -> quast_min_contig(-1), "genome_len must be non-negative")
+        _qmc_throws_with(() -> quast_min_contig(1_000; divisor = 0), "divisor must be >= 1")
+        _qmc_throws_with(() -> quast_min_contig(1_000; floor_bp = 0), "floor_bp must be >= 1")
+        _qmc_throws_with(
+            () -> quast_min_contig(1_000; floor_bp = 900, ceiling_bp = 100),
+            "must be >= floor_bp")
+    end
+
+    Test.@testset "constants are the documented ones" begin
+        Test.@test MIN_CONTIG_GENOME_DIVISOR == 10
+        Test.@test MIN_CONTIG_FLOOR_BP == 50
+        # Anchored to the longest read length on the sweep's read-regime axis
+        # (MYCELIA_RGV_READLEN default "150,5000").
+        Test.@test MIN_CONTIG_CEILING_BP == 5_000
+        # The ceiling must sit at or above Lambda's threshold, or Lambda moves.
+        Test.@test MIN_CONTIG_CEILING_BP >= _qmc_legacy(lambda_len)
+    end
+
+    Test.@testset "the sweep harness uses the policy, not an inline expression" begin
+        sweep = read(
+            joinpath(@__DIR__, "..", "..", "benchmarking",
+                "rhizomorph_correction_validation_sweep.jl"), String)
+        Test.@test occursin("include(joinpath(@__DIR__, \"quast_min_contig.jl\"))", sweep)
+        Test.@test occursin("min_contig = quast_min_contig(glen)", sweep)
+        # The inline expression that caused the T4 failure must be gone.
+        Test.@test !occursin("min_contig = max(50, glen ÷ 10)", sweep)
+    end
+end

--- a/test/4_assembly/quast_min_contig_test.jl
+++ b/test/4_assembly/quast_min_contig_test.jl
@@ -1,17 +1,21 @@
 # Unit test for the QUAST --min-contig threshold policy (bead td-28o0).
 #
-# The load-bearing property is NOT "the new formula equals the old one" — it
-# deliberately does not, for T4. It is:
+# The load-bearing properties are:
 #
-#   (a) every reference the old expression already handled keeps its EXACT
-#       threshold, so results already committed and the Lambda runs in flight stay
-#       comparable, and
-#   (b) T4 (and anything larger) now gets a threshold a fragmented assembly can
-#       actually satisfy, so QUAST runs instead of silently degrading to internal
-#       metrics.
+#   (a) the threshold never exceeds QUAST's own 500 bp default — the scaling term
+#       exists only to go BELOW it for viroid-scale references, and every value it
+#       produced above 500 was a threshold nobody chose;
+#   (b) it is UNIFORM across the viral tier, because the pre-registration pools
+#       across organisms and a per-reference threshold would make that pooled
+#       analysis mixed-definition, which `metric_source_guard.jl` must refuse; and
+#   (c) T4 (and anything larger) gets a threshold a fragmented assembly can
+#       actually satisfy, so QUAST runs instead of silently degrading.
 #
-# Both are asserted against the specific documented values, not against a
-# re-implementation of the old expression.
+# An earlier version of this policy clamped at 5,000 bp to hold Lambda at 4,850
+# "for comparability with committed results". Review established that no such
+# committed results exist (one committed CSV, synthetic, threshold 200 under every
+# candidate policy) and that Lambda was itself failing 8/12 cells at 4,850. The
+# tests below therefore pin the CONTRACT, not the historical values.
 #
 # Dependency-free: includes only the pure policy helper. No Mycelia, no QUAST.
 
@@ -42,20 +46,26 @@ Test.@testset "QUAST --min-contig policy (td-28o0)" begin
     sars_len = 29_903
     ecoli_len = 4_641_652
 
-    Test.@testset "preserved thresholds — comparability with committed results" begin
-        # These are the values the harness has ALREADY used. A change here would
-        # silently redefine the metric for genomes that were working, and would
-        # break comparability with Lawrencium jobs 24247923 / 24247924 (Lambda
-        # 50x / 100x) that are in flight.
-        Test.@test quast_min_contig(lambda_len) == 4_850
-        Test.@test quast_min_contig(phi29_len) == 1_928
-        Test.@test quast_min_contig(sars_len) == 2_990
+    Test.@testset "clamped at QUAST's default; uniform above 5 kb" begin
+        # The ceiling IS QUAST's own default. The scaling term exists only to go
+        # below it for viroid-scale references.
+        Test.@test quast_min_contig(lambda_len) == 500
+        Test.@test quast_min_contig(phi29_len) == 500
+        Test.@test quast_min_contig(sars_len) == 500
+        Test.@test quast_min_contig(t4_len) == 500
 
-        # Same assertion stated the other way: unchanged relative to the legacy
-        # expression for every reference the legacy expression could serve.
-        for glen in (246, 300, 359, 1_000, 5_000, phi29_len, sars_len, lambda_len)
-            Test.@test quast_min_contig(glen) == _qmc_legacy(glen)
-        end
+        # UNIFORMITY IS THE LOAD-BEARING PROPERTY, not any single value: the
+        # pre-registration pools across organisms, so a threshold that varied by
+        # reference would make the pooled analysis mixed-definition and
+        # `metric_source_guard.jl` would refuse it. Every viral-tier reference must
+        # land on one threshold.
+        viral_tier = (lambda_len, t4_len, phi29_len, sars_len)
+        Test.@test length(unique(quast_min_contig.(viral_tier))) == 1
+
+        # An earlier ceiling of 5,000 gave four distinct thresholds — the state
+        # that would have forced `--allow-mixed-src` on the pooled analysis.
+        Test.@test length(unique(
+            quast_min_contig.(viral_tier; ceiling_bp = 5_000))) == 4
     end
 
     Test.@testset "T4 is fixed — threshold is now reachable" begin
@@ -65,7 +75,7 @@ Test.@testset "QUAST --min-contig policy (td-28o0)" begin
         Test.@test _qmc_legacy(t4_len) == 16_890
         t4_naive_largest_contig = 11_622
         Test.@test _qmc_legacy(t4_len) > t4_naive_largest_contig      # the failure
-        Test.@test quast_min_contig(t4_len) == 5_000
+        Test.@test quast_min_contig(t4_len) == 500
         Test.@test quast_min_contig(t4_len) < t4_naive_largest_contig # the fix
 
         # And it stays reachable as references grow, rather than getting worse.
@@ -82,7 +92,7 @@ Test.@testset "QUAST --min-contig policy (td-28o0)" begin
         end
         Test.@test quast_min_contig(0) == MIN_CONTIG_FLOOR_BP
         # 5_000 bp is where the ÷10 term crosses QUAST's own default.
-        Test.@test quast_min_contig(5_000) == 500
+        Test.@test quast_min_contig(5_000) == 500  # where the scaling term meets the ceiling
     end
 
     Test.@testset "monotone, and bounded on both sides" begin
@@ -105,8 +115,8 @@ Test.@testset "QUAST --min-contig policy (td-28o0)" begin
     end
 
     Test.@testset "keyword overrides" begin
-        Test.@test quast_min_contig(lambda_len; ceiling_bp = 500) == 500
-        Test.@test quast_min_contig(lambda_len; divisor = 100) == 485
+        Test.@test quast_min_contig(lambda_len; ceiling_bp = 5_000) == 4_850
+        Test.@test quast_min_contig(lambda_len; divisor = 100, ceiling_bp = 5_000) == 485
         Test.@test quast_min_contig(100; floor_bp = 1) == 10
         Test.@test quast_min_contig(1; floor_bp = 1) == 1
     end
@@ -125,18 +135,35 @@ Test.@testset "QUAST --min-contig policy (td-28o0)" begin
         Test.@test MIN_CONTIG_FLOOR_BP == 50
         # Anchored to the longest read length on the sweep's read-regime axis
         # (MYCELIA_RGV_READLEN default "150,5000").
-        Test.@test MIN_CONTIG_CEILING_BP == 5_000
-        # The ceiling must sit at or above Lambda's threshold, or Lambda moves.
-        Test.@test MIN_CONTIG_CEILING_BP >= _qmc_legacy(lambda_len)
+        Test.@test MIN_CONTIG_CEILING_BP == 500
+        # The ceiling IS QUAST's documented default; the scaling term must only
+        # ever reduce below it, never raise above it.
+        Test.@test all(quast_min_contig(g) <= 500 for g in
+        (300, phi29_len, sars_len, lambda_len, t4_len, ecoli_len))
     end
 
-    Test.@testset "the sweep harness uses the policy, not an inline expression" begin
-        sweep = read(
-            joinpath(@__DIR__, "..", "..", "benchmarking",
-                "rhizomorph_correction_validation_sweep.jl"), String)
-        Test.@test occursin("include(joinpath(@__DIR__, \"quast_min_contig.jl\"))", sweep)
-        Test.@test occursin("min_contig = quast_min_contig(glen)", sweep)
-        # The inline expression that caused the T4 failure must be gone.
-        Test.@test !occursin("min_contig = max(50, glen ÷ 10)", sweep)
+    Test.@testset "every harness uses the shared policy, not an inline formula" begin
+        # C2: claiming "exactly one definition" is only true if every call site
+        # actually uses it. Three harnesses still carried the inline expression
+        # after the first fix, and two of them (t4_ksweep, real_genome_benchmark)
+        # run T4 — so the original bug was still live on the organism it was found
+        # on. Assert the absence of the formula repo-wide rather than in one file.
+        bench = joinpath(@__DIR__, "..", "..", "benchmarking")
+        harnesses = ["rhizomorph_correction_validation_sweep.jl", "t4_ksweep.jl",
+            "real_genome_benchmark.jl", "e2e_phase_profile.jl"]
+        for h in harnesses
+            src = read(joinpath(bench, h), String)
+            Test.@test occursin("include(joinpath(@__DIR__, \"quast_min_contig.jl\"))", src)
+            Test.@test occursin("quast_min_contig(", src)
+        end
+        # No inline `max(50, <something> ÷ 10)` may survive in CODE anywhere under
+        # benchmarking/ (comments describing the old formula are fine).
+        for f in readdir(bench)
+            endswith(f, ".jl") || continue
+            for (i, line) in enumerate(eachline(joinpath(bench, f)))
+                startswith(strip(line), "#") && continue
+                Test.@test !occursin(r"max\(50,[^)]*÷\s*10\)", line)
+            end
+        end
     end
 end

--- a/test/4_assembly/quast_min_contig_test.jl
+++ b/test/4_assembly/quast_min_contig_test.jl
@@ -152,9 +152,12 @@ Test.@testset "QUAST --min-contig policy (td-28o0)" begin
         harnesses = ["rhizomorph_correction_validation_sweep.jl", "t4_ksweep.jl",
             "real_genome_benchmark.jl", "e2e_phase_profile.jl"]
         for h in harnesses
-            src = read(joinpath(bench, h), String)
-            Test.@test occursin("include(joinpath(@__DIR__, \"quast_min_contig.jl\"))", src)
-            Test.@test occursin("quast_min_contig(", src)
+            # Assert on CODE lines only: a comment mentioning the helper would
+            # otherwise satisfy "this harness uses the shared policy".
+            code = join([l for l in eachline(joinpath(bench, h))
+                         if !startswith(strip(l), "#")], "\n")
+            Test.@test occursin("include(joinpath(@__DIR__, \"quast_min_contig.jl\"))", code)
+            Test.@test occursin("quast_min_contig(", code)
         end
         # No inline `max(50, <something> ÷ 10)` may survive in CODE anywhere under
         # benchmarking/ (comments describing the old formula are fine).

--- a/test/4_assembly/rgv_paired_wilcoxon_test.jl
+++ b/test/4_assembly/rgv_paired_wilcoxon_test.jl
@@ -40,7 +40,7 @@ end
 # Build a sweep-shaped table. `with_seed=false` reproduces the pre-td-59o7 schema.
 # `naive`/`iterative` give the per-cell metric values, one entry per (seed, cell).
 function _pwt_frame(cells; with_seed = true, metric_source = "quast",
-        min_contig = 4_850, metric = :quast_nga50, ok = true)
+        min_contig = 500, metric = :quast_nga50, ok = true)
     rows = []
     for c in cells
         for (arm, value) in (("naive", c.naive), ("iterative", c.iterative))
@@ -392,7 +392,7 @@ Test.@testset "RGV paired-Wilcoxon analysis" begin
             report = write_paired_report(joinpath(dir, "report.md"), a;
                 csv_paths = ["fixture.csv"])
             text = read(report, String)
-            Test.@test occursin("paired-Wilcoxon", text)
+            Test.@test occursin("paired Wilcoxon", text)
             Test.@test occursin("42, 123, 456", text)            # seeds used
             Test.@test occursin("`seed`", text)                   # pairing key shown
             Test.@test occursin("quast_nga50", text)
@@ -430,5 +430,153 @@ Test.@testset "RGV paired-Wilcoxon analysis" begin
         df = _pwt_frame([(seed = 42, error_rate = 0.01, naive = 1.0, iterative = 2.0)])
         _pwt_throws_with(() -> run_paired_analysis(df; metrics = (:not_a_column,)),
             ["metric column `not_a_column` not present"])
+    end
+
+    Test.@testset "C16: a shard lacking `seed` must NOT create pseudo-replicates" begin
+        # The worst failure available to this file, because it makes the result look
+        # BETTER. `load_sweep_csvs` concatenates with `cols = :union`, so a shard
+        # predating the `seed` column contributes rows with `seed = missing`. A
+        # presence-only schema check passed, `build_pairs` stringified the key, and
+        # `missing` became a distinct pseudo-seed that paired normally: the same
+        # physical runs supplied twice reported n = 12 for 6 replicates and deflated
+        # p by ~27x.
+        cells = [(seed = 42, error_rate = e, naive = 1000.0 + i, iterative = 1300.0 + i)
+                 for (i, e) in enumerate((0.01, 0.02, 0.03, 0.04, 0.05, 0.06))]
+        withseed = _pwt_frame(cells)
+        noseed = _pwt_frame(cells; with_seed = false)
+
+        # Correct baseline: 6 real cells.
+        a_ok = run_paired_analysis(withseed; metrics = (:quast_nga50,))
+        Test.@test a_ok.results[1].n_pairs == 6
+
+        merged = vcat(withseed, noseed; cols = :union)
+        Test.@test "seed" in DataFrames.names(merged)      # column IS present...
+        Test.@test count(ismissing, merged.seed) == 12     # ...but half is missing
+        msg = _pwt_throws_with(
+            () -> run_paired_analysis(merged; metrics = (:quast_nga50,)),
+            ["missing", "pairing column", "`seed`",
+                "pseudo-level", "inflating n", "deflating p"])
+        Test.@test occursin("rgv_seed_backfill.jl", msg)
+
+        # Every pairing key is checked, not just seed.
+        holed = DataFrames.DataFrame(withseed)
+        holed[!, :error_rate] = Vector{Union{Missing, Float64}}(holed.error_rate)
+        holed[1, :error_rate] = missing
+        _pwt_throws_with(() -> run_paired_analysis(holed; metrics = (:quast_nga50,)),
+            ["`error_rate`"])
+
+        # A `missing` arm belongs to neither side of a pair.
+        badarm = DataFrames.DataFrame(withseed)
+        badarm[!, :arm] = Vector{Union{Missing, String}}(badarm.arm)
+        badarm[1, :arm] = missing
+        _pwt_throws_with(() -> run_paired_analysis(badarm; metrics = (:quast_nga50,)),
+            ["`missing` `arm`"])
+    end
+
+    Test.@testset "C9: a significant HARM is FALSIFIED, not partially supported" begin
+        # The pre-registration's H1 row: "Falsified if p >= 0.05, THE DIRECTION IS
+        # NEGATIVE, or ...". `decide` branched only on magnitude, so a treatment
+        # worse on every pair reported as PARTIALLY SUPPORTED — the exact class of
+        # misreport this PR exists to prevent.
+        harm = _pwt_frame([(seed = s, error_rate = e, naive = 1000.0,
+                               iterative = 1000.0 - d)
+                           for (s, e, d) in [
+            (42, 0.01, 400.0), (42, 0.05, 450.0), (123, 0.01, 500.0),
+            (123, 0.05, 420.0), (456, 0.01, 470.0), (456, 0.05, 430.0),
+            (42, 0.10, 460.0), (123, 0.10, 440.0), (456, 0.10, 480.0)]])
+        a = run_paired_analysis(harm; metrics = (:quast_nga50,))
+        Test.@test a.adjusted_p[1] < RGV_ALPHA                       # significant
+        Test.@test a.results[1].median_relative_improvement < 0      # and WORSE
+        Test.@test occursin("FALSIFIED", a.verdicts[1])
+        Test.@test occursin("direction is", a.verdicts[1])
+        Test.@test !occursin("SUPPORTED (", a.verdicts[1])
+        # A positive-but-small effect is still PARTIALLY SUPPORTED, not falsified.
+        small = _pwt_frame([(seed = s, error_rate = e, naive = 1000.0,
+                                iterative = 1000.0 + d)
+                            for (s, e, d) in [
+            (42, 0.01, 10.0), (42, 0.05, 12.0), (123, 0.01, 11.0),
+            (123, 0.05, 13.0), (456, 0.01, 9.0), (456, 0.05, 14.0)]])
+        Test.@test occursin("PARTIALLY SUPPORTED",
+            run_paired_analysis(small; metrics = (:quast_nga50,)).verdicts[1])
+    end
+
+    Test.@testset "C12: an undefined effect size is not silently '<= 10%'" begin
+        # `NaN > 0.1` is false, so an undefined relative improvement fell through to
+        # the "<= 10%" branch. Routine for misassembly counts, where a clean control
+        # is zero on every pair.
+        zc = _pwt_frame([(seed = s, error_rate = e, naive = 0.0, iterative = 3.0)
+                         for (s, e) in [(42, 0.01), (42, 0.05), (123, 0.01),
+            (123, 0.05), (456, 0.01), (456, 0.05)]])
+        a = run_paired_analysis(zc; metrics = (:quast_nga50,))
+        Test.@test a.adjusted_p[1] < RGV_ALPHA
+        Test.@test isnan(a.results[1].median_relative_improvement)
+        Test.@test a.results[1].n_zero_control_excluded_from_relative == 6
+        Test.@test occursin("INDETERMINATE", a.verdicts[1])
+        Test.@test !occursin("<= 10%", a.verdicts[1])
+    end
+
+    Test.@testset "C5: the mixed-src override is recorded in the deliverable" begin
+        mixed = _pwt_frame([
+            (seed = 42, error_rate = 0.01, naive = 1000.0, iterative = 1500.0,
+                metric_source = "quast"),
+            (seed = 123, error_rate = 0.01, naive = 900.0, iterative = 1400.0,
+                metric_source = "internal:quast-failed"),
+            (seed = 456, error_rate = 0.01, naive = 950.0, iterative = 1450.0,
+                metric_source = "quast")])
+        a = run_paired_analysis(mixed;
+            metrics = (:quast_nga50,), allow_mixed_src = true)
+        Test.@test a.allow_mixed_src
+        Test.@test a.override_bound                       # it actually BOUND
+        Test.@test "metric_source" in a.mixed_axes
+
+        mktempdir() do dir
+            text = read(write_paired_report(joinpath(dir, "r.md"), a;
+                csv_paths = ["f.csv"]), String)
+            # The artifact must say the guard was overridden...
+            Test.@test occursin("GUARD OVERRIDDEN", text)
+            Test.@test occursin("not validation-grade", lowercase(text))
+            # ...and must NOT go on to assert the guard was enforced.
+            Test.@test !occursin("enforced it — no override was used", text)
+            payload = paired_analysis_json(a; csv_paths = ["f.csv"])
+            Test.@test payload["metric_definition_override_bound"] == true
+            Test.@test payload["allow_mixed_src"] == true
+            Test.@test payload["exploratory"] == true
+        end
+
+        # An override that does NOT bind is reported differently — "available but
+        # unused" is a different provenance claim from "load-bearing".
+        clean = _pwt_frame([(seed = s, error_rate = 0.01, naive = 1000.0,
+                                iterative = 1500.0) for s in (42, 123, 456)])
+        b = run_paired_analysis(clean; metrics = (:quast_nga50,), allow_mixed_src = true)
+        Test.@test b.allow_mixed_src
+        Test.@test !b.override_bound
+        mktempdir() do dir
+            text = read(write_paired_report(joinpath(dir, "r.md"), b;
+                csv_paths = ["f.csv"]), String)
+            Test.@test occursin("did NOT bind", text)
+            Test.@test !occursin("GUARD OVERRIDDEN", text)
+        end
+    end
+
+    Test.@testset "C1/I3: the report does not claim to be a pre-registered test" begin
+        df = _pwt_frame([(seed = s, error_rate = e, naive = 1000.0, iterative = 1600.0)
+                         for (s, e) in [(42, 0.01), (42, 0.05), (123, 0.01),
+            (123, 0.05), (456, 0.01), (456, 0.05)]])
+        a = run_paired_analysis(df; metrics = (:quast_nga50,))
+        mktempdir() do dir
+            text = read(write_paired_report(joinpath(dir, "r.md"), a;
+                csv_paths = ["f.csv"]), String)
+            # H1 is Viterbi-DP-vs-greedy; this compares correctors. Attributing it
+            # to H1 would put an unregistered comparison into a manuscript as
+            # confirmatory.
+            Test.@test occursin("EXPLORATORY", text)
+            Test.@test occursin("not a pre-registered test", text)
+            Test.@test occursin("Viterbi DP vs greedy", text)
+            Test.@test !occursin("(H1 test procedure + shared analysis rules)", text)
+            # I3: the axes actually swept must sit next to the numbers.
+            Test.@test occursin("Error rates swept", text)
+            Test.@test occursin("0.01, 0.05", text)
+            Test.@test occursin("~360 paired comparisons", text)
+        end
     end
 end

--- a/test/4_assembly/rgv_paired_wilcoxon_test.jl
+++ b/test/4_assembly/rgv_paired_wilcoxon_test.jl
@@ -1,0 +1,434 @@
+# Unit test for the pre-registered paired-Wilcoxon analysis (beads td-59o7, td-9p91).
+#
+# This test carries the executability claim for td-59o7. The bead says explicitly:
+# "confirm the pre-reg's paired test becomes executable — do not stop at 'column
+# added'." So the central pair of assertions is:
+#
+#   * against a sweep CSV WITHOUT `seed`, the analysis RAISES and points at the
+#     backfill tool (the pre-registered test is genuinely not runnable), and
+#   * against the current schema WITH `seed`, it produces a real p-value, pairs
+#     across seeds 42/123/456, and applies the pre-registration's decision rule.
+#
+# It also pins td-9p91's guard inside this analysis path, and cross-validates the
+# statistics against scipy.stats.wilcoxon (reference values computed with
+# scipy 1.16.3; see the comment at each fixture for the exact call).
+#
+# Dependency-free apart from CSV / DataFrames / Distributions / JSON (direct
+# Mycelia deps). No network, no QUAST, no assembly.
+
+import Test
+import CSV
+import DataFrames
+import JSON
+
+include(joinpath(@__DIR__, "..", "..", "benchmarking", "rgv_paired_wilcoxon.jl"))
+
+function _pwt_throws_with(f, needles::Vector{String})
+    try
+        f()
+    catch e
+        msg = sprint(showerror, e)
+        for needle in needles
+            Test.@test occursin(needle, msg)
+        end
+        return msg
+    end
+    Test.@test false
+    return ""
+end
+
+# Build a sweep-shaped table. `with_seed=false` reproduces the pre-td-59o7 schema.
+# `naive`/`iterative` give the per-cell metric values, one entry per (seed, cell).
+function _pwt_frame(cells; with_seed = true, metric_source = "quast",
+        min_contig = 4_850, metric = :quast_nga50, ok = true)
+    rows = []
+    for c in cells
+        for (arm, value) in (("naive", c.naive), ("iterative", c.iterative))
+            row = Dict{Symbol, Any}(
+                :reference => get(c, :reference, "NC_001416"),
+                :error_rate => get(c, :error_rate, 0.05),
+                :readlen => get(c, :readlen, 150),
+                :target_coverage => get(c, :target_coverage, 30.0),
+                :k => 21,
+                :arm => arm,
+                :ok => get(c, :ok, ok),
+                :metric_source => get(c, :metric_source, metric_source),
+                :quast_min_contig => get(c, :min_contig, min_contig),
+                metric => value
+            )
+            with_seed && (row[:seed] = get(c, :seed, 42))
+            push!(rows, row)
+        end
+    end
+    cols = collect(keys(rows[1]))
+    return DataFrames.DataFrame([c => [r[c] for r in rows] for c in cols])
+end
+
+Test.@testset "RGV paired-Wilcoxon analysis" begin
+    Test.@testset "Wilcoxon signed-rank vs scipy.stats.wilcoxon" begin
+        # scipy: wilcoxon(A, method="exact") -> statistic 4.0, p 0.109375
+        A = [1.5, -2.5, 3.5, 4.5, -0.5, 6.5, 7.5]
+        ra = wilcoxon_signed_rank(A)
+        Test.@test ra.n == 7
+        Test.@test ra.n_zero_dropped == 0
+        Test.@test ra.statistic == 4.0
+        Test.@test occursin("exact", ra.method)
+        Test.@test isapprox(ra.pvalue, 0.109375; atol = 1e-12)
+
+        # scipy: wilcoxon(B, method="approx", correction=False)
+        #        -> statistic 14.5, p 0.18371406577326088   (ties in |d| force approx)
+        B = [1.0, -1.0, 2.0, 2.0, -3.0, 3.0, 4.0, -4.0, 5.0, 5.0]
+        rb = wilcoxon_signed_rank(B)
+        Test.@test rb.n == 10
+        Test.@test rb.statistic == 14.5
+        Test.@test occursin("normal approximation", rb.method)
+        Test.@test occursin("tie correction", rb.method)
+        Test.@test isapprox(rb.pvalue, 0.18371406577326088; atol = 1e-10)
+
+        # scipy: wilcoxon(C, method="approx", zero_method="wilcox", correction=False)
+        #        -> statistic 4.0, p 0.17177277759571152   (zeros dropped, ties present)
+        C = [0.0, 2.0, -3.0, 4.0, 4.0, 0.0, -1.0, 5.0]
+        rc = wilcoxon_signed_rank(C)
+        Test.@test rc.n == 6
+        Test.@test rc.n_zero_dropped == 2
+        Test.@test rc.statistic == 4.0
+        Test.@test isapprox(rc.pvalue, 0.17177277759571152; atol = 1e-10)
+
+        # scipy: wilcoxon(D, method="exact") -> statistic 6.0, p 0.0068359375
+        D = [3.1, -1.2, 4.7, 5.9, -0.3, 7.2, 8.8, 9.4, -2.6, 10.5, 11.1, 12.3]
+        rd = wilcoxon_signed_rank(D)
+        Test.@test rd.statistic == 6.0
+        Test.@test isapprox(rd.pvalue, 0.0068359375; atol = 1e-12)
+
+        # Degenerate inputs are reported as undefined, not as a null result.
+        rz = wilcoxon_signed_rank([0.0, 0.0, 0.0])
+        Test.@test rz.n == 0
+        Test.@test rz.n_zero_dropped == 3
+        Test.@test isnan(rz.pvalue)
+        Test.@test occursin("undefined", rz.method)
+        Test.@test isnan(wilcoxon_signed_rank(Float64[]).pvalue)
+
+        # An all-positive set is the strongest one-directional signal available.
+        rp = wilcoxon_signed_rank([1.0, 2.0, 3.0, 4.0, 5.0, 6.0])
+        Test.@test rp.w_minus == 0.0
+        Test.@test isapprox(rp.pvalue, 2 / 2^6; atol = 1e-12)  # 2*(1/64)
+    end
+
+    Test.@testset "average_ranks handles ties as Wilcoxon requires" begin
+        Test.@test average_ranks([10.0, 20.0, 30.0]) == [1.0, 2.0, 3.0]
+        Test.@test average_ranks([5.0, 5.0, 9.0]) == [1.5, 1.5, 3.0]
+        Test.@test average_ranks([7.0, 7.0, 7.0]) == [2.0, 2.0, 2.0]
+        Test.@test average_ranks([3.0, 1.0, 2.0]) == [3.0, 1.0, 2.0]
+    end
+
+    Test.@testset "exact_signed_rank_pvalue endpoints" begin
+        # n=1: W+ is 0 or 1 with probability 1/2 each, so the smallest attainable
+        # two-sided p is 1.0 — a single pair can never be significant.
+        Test.@test exact_signed_rank_pvalue(1, 1) == 1.0
+        Test.@test exact_signed_rank_pvalue(1, 0) == 1.0
+        # The distribution is symmetric about n(n+1)/4.
+        for n in 2:8
+            maxw = n * (n + 1) ÷ 2
+            for w in 0:maxw
+                Test.@test isapprox(exact_signed_rank_pvalue(n, w),
+                    exact_signed_rank_pvalue(n, maxw - w); atol = 1e-12)
+            end
+        end
+        # Extreme W+ for n=6: 2 * (1/64).
+        Test.@test isapprox(exact_signed_rank_pvalue(6, 21), 2 / 64; atol = 1e-12)
+    end
+
+    Test.@testset "Benjamini-Hochberg matches the standard procedure" begin
+        # Reference (statsmodels multipletests fdr_bh / the standard step-up):
+        # [0.01, 0.04, 0.03, 0.2] -> [0.04, 0.05333333, 0.05333333, 0.2]
+        adj = benjamini_hochberg([0.01, 0.04, 0.03, 0.2])
+        Test.@test isapprox(adj, [0.04, 0.4 / 7.5, 0.4 / 7.5, 0.2]; atol = 1e-8)
+        Test.@test isapprox(adj[2], 0.05333333333; atol = 1e-8)
+        # Monotone and never above 1.
+        Test.@test all(adj .<= 1.0)
+        Test.@test benjamini_hochberg([0.5])[1] == 0.5
+        Test.@test benjamini_hochberg([0.9, 0.95]) == [0.95, 0.95]
+        # NaN (undefined test) does not consume multiplicity budget.
+        adj2 = benjamini_hochberg([0.01, NaN])
+        Test.@test adj2[1] == 0.01      # m == 1, not 2
+        Test.@test isnan(adj2[2])
+        Test.@test all(isnan, benjamini_hochberg([NaN, NaN]))
+    end
+
+    Test.@testset "WITHOUT seed: the pre-registered test is NOT runnable" begin
+        # This is the defect td-59o7 describes. Merged replicate rows are
+        # indistinguishable, so pairs cannot be formed and the pre-registration's
+        # paired-Wilcoxon rule over seeds 42/123/456 cannot be executed at all.
+        df = _pwt_frame(
+            [
+                (naive = 1000.0, iterative = 1500.0),
+                (naive = 1100.0, iterative = 1600.0)
+            ];
+            with_seed = false)
+        Test.@test !("seed" in DataFrames.names(df))
+        msg = _pwt_throws_with(() -> run_paired_analysis(df),
+            ["no `seed` column",
+                "NOT runnable",
+                "42/123/456",
+                "td-59o7",
+                "rgv_seed_backfill.jl"])   # the message names the fix
+        Test.@test occursin("paired", msg)
+        # require_pairing_schema is the gate, and it also catches other key losses.
+        _pwt_throws_with(
+            () -> require_pairing_schema(DataFrames.select(
+                _pwt_frame([(naive = 1.0, iterative = 2.0)]),
+                DataFrames.Not(:reference))),
+            ["missing pairing column", "reference"])
+    end
+
+    Test.@testset "WITH seed: the pre-registered test IS runnable" begin
+        # Three pre-registered seeds x two error rates = 6 pairs, exactly the shape
+        # the pre-registration's rule assumes. Seed is what separates the replicates.
+        cells = []
+        for (i, seed) in enumerate((42, 123, 456))
+            for (j, err) in enumerate((0.01, 0.05))
+                push!(cells,
+                    (seed = seed, error_rate = err,
+                        naive = 1000.0 + 10 * i + j,
+                        iterative = 1400.0 + 13 * i + 2 * j))
+            end
+        end
+        df = _pwt_frame(cells)
+        Test.@test DataFrames.nrow(df) == 12          # 6 cells x 2 arms
+        analysis = run_paired_analysis(df; metrics = (:quast_nga50,))
+
+        # It ran, and it ran on the pre-registered seeds.
+        Test.@test analysis.seeds == [42, 123, 456]
+        r = analysis.results[1]
+        Test.@test r.n_pairs == 6
+        Test.@test r.n_dropped == 0
+        Test.@test !isnan(r.test.pvalue)
+        Test.@test !isnan(analysis.adjusted_p[1])
+        # Every difference is positive here, so the exact two-sided p is 2/2^6.
+        Test.@test isapprox(r.test.pvalue, 2 / 64; atol = 1e-12)
+        Test.@test r.median_paired_difference > 0
+        Test.@test r.median_relative_improvement > RGV_IMPROVEMENT_THRESHOLD
+        Test.@test occursin("SUPPORTED", analysis.verdicts[1])
+        Test.@test !occursin("PARTIALLY", analysis.verdicts[1])
+
+        # The pairing key is what makes this work: drop seed from it and the six
+        # cells collapse into duplicate rows per arm, which is refused.
+        collapsed = DataFrames.select(df, DataFrames.Not(:seed))
+        _pwt_throws_with(() -> run_paired_analysis(collapsed), ["no `seed` column"])
+    end
+
+    Test.@testset "decision rule follows the pre-registration" begin
+        # Significant but small: PARTIALLY SUPPORTED (< 10% median improvement).
+        small = _pwt_frame([(seed = s, error_rate = e,
+                                naive = 1000.0, iterative = 1000.0 + d)
+                            for (s, e, d) in [
+            (42, 0.01, 10.0), (42, 0.05, 12.0), (123, 0.01, 11.0),
+            (123, 0.05, 13.0), (456, 0.01, 9.0), (456, 0.05, 14.0)]])
+        a_small = run_paired_analysis(small; metrics = (:quast_nga50,))
+        Test.@test a_small.adjusted_p[1] < RGV_ALPHA
+        Test.@test a_small.results[1].median_relative_improvement <
+                   RGV_IMPROVEMENT_THRESHOLD
+        Test.@test occursin("PARTIALLY SUPPORTED", a_small.verdicts[1])
+
+        # Not significant: NOT SUPPORTED, reported as a null with effect size.
+        mixed_signs = _pwt_frame([(seed = s, error_rate = e,
+                                      naive = 1000.0, iterative = 1000.0 + d)
+                                  for (s, e, d) in [
+            (42, 0.01, 300.0), (42, 0.05, -280.0), (123, 0.01, 250.0),
+            (123, 0.05, -320.0)]])
+        a_null = run_paired_analysis(mixed_signs; metrics = (:quast_nga50,))
+        Test.@test a_null.adjusted_p[1] >= RGV_ALPHA
+        Test.@test occursin("NOT SUPPORTED", a_null.verdicts[1])
+        Test.@test !isnan(a_null.results[1].median_paired_difference)  # effect size reported
+    end
+
+    Test.@testset "lower-is-better metrics are oriented correctly" begin
+        # Misassemblies: FEWER is an improvement, so a negative paired difference
+        # must yield a POSITIVE relative improvement.
+        df = _pwt_frame(
+            [(seed = s, error_rate = e, naive = 10.0, iterative = 4.0)
+             for (s, e) in [(42, 0.01), (42, 0.05), (123, 0.01),
+                (123, 0.05), (456, 0.01), (456, 0.05)]];
+            metric = :quast_num_misassemblies)
+        a = run_paired_analysis(df; metrics = (:quast_num_misassemblies,))
+        r = a.results[1]
+        Test.@test r.direction == :lower
+        Test.@test r.median_paired_difference == -6.0            # fewer misassemblies
+        Test.@test isapprox(r.median_relative_improvement, 0.6)  # a 60% improvement
+        Test.@test occursin("SUPPORTED", a.verdicts[1])
+    end
+
+    Test.@testset "no directional claim where the pre-registration makes none" begin
+        df = _pwt_frame(
+            [(seed = s, error_rate = 0.01, naive = 1.0, iterative = 1.4)
+             for s in (42, 123, 456)];
+            metric = :quast_duplication_ratio)
+        a = run_paired_analysis(df; metrics = (:quast_duplication_ratio,))
+        Test.@test a.results[1].direction == :none
+        Test.@test occursin("no directional claim", a.verdicts[1])
+    end
+
+    Test.@testset "td-9p91 guard fires inside THIS analysis path" begin
+        # A realistic sweep CSV holds both QUAST-scored and degraded rows. Running
+        # the analysis over them unfiltered must RAISE, not compare an
+        # alignment-validated NGA50 against an internal size-ratio proxy.
+        cells = [
+            (seed = 42, error_rate = 0.01, naive = 1000.0, iterative = 1500.0,
+                metric_source = "quast"),
+            (seed = 123, error_rate = 0.01, naive = 900.0, iterative = 1400.0,
+                metric_source = "internal:quast-failed"),
+            (seed = 456, error_rate = 0.01, naive = 950.0, iterative = 1450.0,
+                metric_source = "quast")
+        ]
+        df = _pwt_frame(cells)
+        _pwt_throws_with(() -> run_paired_analysis(df; metrics = (:quast_nga50,)),
+            ["MixedMetricDefinitionError",
+                "RGV paired-Wilcoxon analysis",
+                "internal:quast-failed", "quast"])
+
+        # Selecting a definition explicitly is what makes the run legal.
+        a = run_paired_analysis(df;
+            metrics = (:quast_nga50,), metric_source = "quast")
+        Test.@test a.results[1].n_pairs == 2
+        Test.@test a.n_dropped_metric_source == 2
+        Test.@test Dict(a.definition)[:metric_source] == ["quast"]
+
+        # Mixed quast_min_contig is rejected on the same grounds: the T4 fix
+        # changes the threshold, so rows either side of it are not comparable.
+        thresholds = _pwt_frame([
+            (seed = 42, error_rate = 0.01, naive = 1000.0, iterative = 1500.0,
+                min_contig = 16_890),
+            (seed = 123, error_rate = 0.01, naive = 900.0, iterative = 1400.0,
+                min_contig = 5_000)
+        ])
+        _pwt_throws_with(
+            () -> run_paired_analysis(thresholds; metrics = (:quast_nga50,)),
+            ["quast_min_contig", "16890", "5000"])
+    end
+
+    Test.@testset "unpairable cells are dropped and reported, never imputed" begin
+        base = [(seed = 42, error_rate = 0.01, naive = 1000.0, iterative = 1500.0),
+            (seed = 123, error_rate = 0.01, naive = 900.0, iterative = 1400.0)]
+        df = _pwt_frame(base)
+
+        # A cell with only one arm cannot be paired.
+        orphan = DataFrames.DataFrame(df[1:1, :])
+        orphan[1, :seed] = 456
+        with_orphan = vcat(df, orphan)
+        a = run_paired_analysis(with_orphan; metrics = (:quast_nga50,))
+        Test.@test a.results[1].n_pairs == 2
+        Test.@test a.results[1].n_dropped == 1
+        Test.@test occursin("no `iterative` row", a.results[1].dropped[1].reason)
+
+        # A `missing` metric on one arm is dropped, not filled in.
+        holey = DataFrames.DataFrame(df)
+        holey[!, :quast_nga50] = Vector{Union{Missing, Float64}}(holey.quast_nga50)
+        holey[2, :quast_nga50] = missing
+        a2 = run_paired_analysis(holey; metrics = (:quast_nga50,))
+        Test.@test a2.results[1].n_pairs == 1
+        Test.@test occursin("`missing`", a2.results[1].dropped[1].reason)
+
+        # Duplicate rows for one arm mean the pairing key is not unique — refused
+        # for that cell rather than silently averaged.
+        dup = vcat(df, DataFrames.DataFrame(df[1:1, :]))
+        a3 = run_paired_analysis(dup; metrics = (:quast_nga50,))
+        Test.@test a3.results[1].n_pairs == 1
+        Test.@test occursin("duplicate rows", a3.results[1].dropped[1].reason)
+
+        # ok=false rows are dropped by default and counted.
+        notok = _pwt_frame(base; ok = false)
+        _pwt_throws_with(() -> run_paired_analysis(notok; metrics = (:quast_nga50,)),
+            ["no rows left after filtering"])
+        a4 = run_paired_analysis(notok; metrics = (:quast_nga50,), keep_not_ok = true)
+        Test.@test a4.results[1].n_pairs == 2
+    end
+
+    Test.@testset "zero-control pairs are excluded from % improvement and counted" begin
+        # A zero baseline makes the RATIO undefined; dropping it silently would bias
+        # the statistic the 10% threshold is applied to.
+        df = _pwt_frame([
+            (seed = 42, error_rate = 0.01, naive = 0.0, iterative = 1500.0),
+            (seed = 123, error_rate = 0.01, naive = 1000.0, iterative = 1500.0),
+            (seed = 456, error_rate = 0.01, naive = 1000.0, iterative = 1600.0)
+        ])
+        a = run_paired_analysis(df; metrics = (:quast_nga50,))
+        r = a.results[1]
+        Test.@test r.n_pairs == 3                                      # all pairs tested
+        Test.@test r.n_zero_control_excluded_from_relative == 1
+        Test.@test !isnan(r.median_relative_improvement)
+        Test.@test r.median_paired_difference == 600.0                 # uses all 3
+    end
+
+    Test.@testset "multiple CSVs concatenate into one pairable table" begin
+        # This is the parallelization payoff of having `seed`: seed-sharded runs
+        # from different hosts merge into one table the paired test can use.
+        mktempdir() do dir
+            paths = String[]
+            for (i, seed) in enumerate((42, 123, 456))
+                df = _pwt_frame([(seed = seed, error_rate = 0.01,
+                    naive = 1000.0 + i, iterative = 1500.0 + 2i)])
+                p = joinpath(dir, "shard_seed$(seed).csv")
+                CSV.write(p, df)
+                push!(paths, p)
+            end
+            combined = load_sweep_csvs(paths)
+            Test.@test DataFrames.nrow(combined) == 6
+            a = run_paired_analysis(combined; metrics = (:quast_nga50,))
+            Test.@test a.seeds == [42, 123, 456]
+            Test.@test a.results[1].n_pairs == 3
+            _pwt_throws_with(() -> load_sweep_csvs([joinpath(dir, "nope.csv")]),
+                ["CSV not found"])
+            _pwt_throws_with(() -> load_sweep_csvs(String[]), ["no CSV supplied"])
+        end
+    end
+
+    Test.@testset "report and JSON record what was actually done" begin
+        mktempdir() do dir
+            df = _pwt_frame([(seed = s, error_rate = e, naive = 1000.0,
+                                 iterative = 1600.0)
+                             for (s, e) in [(42, 0.01), (42, 0.05), (123, 0.01),
+                (123, 0.05), (456, 0.01), (456, 0.05)]])
+            a = run_paired_analysis(df; metrics = (:quast_nga50,))
+            report = write_paired_report(joinpath(dir, "report.md"), a;
+                csv_paths = ["fixture.csv"])
+            text = read(report, String)
+            Test.@test occursin("paired-Wilcoxon", text)
+            Test.@test occursin("42, 123, 456", text)            # seeds used
+            Test.@test occursin("`seed`", text)                   # pairing key shown
+            Test.@test occursin("quast_nga50", text)
+            Test.@test occursin("SUPPORTED", text)
+            Test.@test occursin("metric_source_guard.jl", text)   # definition provenance
+
+            payload = paired_analysis_json(a; csv_paths = ["fixture.csv"])
+            json_path = joinpath(dir, "results.json")
+            open(json_path, "w") do io
+                JSON.print(io, payload, 2)
+            end
+            round = JSON.parsefile(json_path)
+            Test.@test round["seeds"] == [42, 123, 456]
+            Test.@test round["pair_keys"][end] == "seed"
+            Test.@test round["metrics"][1]["metric"] == "quast_nga50"
+            Test.@test round["metrics"][1]["n_pairs"] == 6
+            Test.@test round["alpha"] == RGV_ALPHA
+            Test.@test round["metric_definition"]["metric_source"] == ["quast"]
+        end
+    end
+
+    Test.@testset "pairing key and metrics match the pre-registration" begin
+        # seed must be part of the pairing key, or the pre-registered replicate
+        # design is not represented in the analysis.
+        Test.@test :seed in RGV_PAIR_KEYS
+        # H1's primary metrics: NGA50 and misassembly count.
+        Test.@test RGV_DEFAULT_METRICS == (:quast_nga50, :quast_num_misassemblies)
+        Test.@test RGV_ALPHA == 0.05
+        Test.@test RGV_IMPROVEMENT_THRESHOLD == 0.10
+        Test.@test RGV_METRIC_DIRECTION[:quast_nga50] == :higher
+        Test.@test RGV_METRIC_DIRECTION[:quast_num_misassemblies] == :lower
+    end
+
+    Test.@testset "an unknown metric column raises" begin
+        df = _pwt_frame([(seed = 42, error_rate = 0.01, naive = 1.0, iterative = 2.0)])
+        _pwt_throws_with(() -> run_paired_analysis(df; metrics = (:not_a_column,)),
+            ["metric column `not_a_column` not present"])
+    end
+end

--- a/test/4_assembly/rgv_paired_wilcoxon_test.jl
+++ b/test/4_assembly/rgv_paired_wilcoxon_test.jl
@@ -533,6 +533,26 @@ Test.@testset "RGV paired-Wilcoxon analysis" begin
         Test.@test a.results[1].n_zero_control_excluded_from_relative == 6
         Test.@test occursin("INDETERMINATE", a.verdicts[1])
         Test.@test !occursin("<= 10%", a.verdicts[1])
+
+        # This is the analysis that carries NaN into the payload, so it is the one
+        # that must round-trip through JSON — the all-finite fixture elsewhere
+        # cannot pin `_json_num`. Non-finite values must serialize as `null`
+        # (which the figure script already reads as missing), not as a bare NaN
+        # token that no strict JSON parser accepts.
+        mktempdir() do dir
+            payload = paired_analysis_json(a; csv_paths = ["f.csv"])
+            Test.@test payload["metrics"][1]["median_relative_improvement"] === nothing
+            jp = joinpath(dir, "results.json")
+            open(jp, "w") do io
+                JSON.print(io, payload, 2)
+            end
+            text = read(jp, String)
+            Test.@test !occursin("NaN", text)
+            round = JSON.parsefile(jp)                      # must parse back
+            Test.@test round["metrics"][1]["median_relative_improvement"] === nothing
+            # And the figure can consume it without a NaN blowing up the axes.
+            Test.@test round["metrics"][1]["n_pairs"] == 6
+        end
     end
 
     Test.@testset "C5: the mixed-src override is recorded in the deliverable" begin

--- a/test/4_assembly/rgv_paired_wilcoxon_test.jl
+++ b/test/4_assembly/rgv_paired_wilcoxon_test.jl
@@ -414,6 +414,26 @@ Test.@testset "RGV paired-Wilcoxon analysis" begin
         end
     end
 
+    Test.@testset "C6: multi-value flag parsing (glob and repeated forms)" begin
+        # The fix has to be exercised, or the header's documented glob invocation
+        # can silently regress to reading one shard again.
+        saved = copy(ARGS)
+        try
+            empty!(ARGS)
+            append!(ARGS, ["--csv", "a.csv", "--csv", "b.csv", "--metric-source", "quast"])
+            Test.@test _pw_args("--csv") == ["a.csv", "b.csv"]          # repeated flag
+            empty!(ARGS)
+            append!(ARGS, ["--csv", "a.csv", "b.csv", "c.csv", "--metrics", "n50"])
+            Test.@test _pw_args("--csv") == ["a.csv", "b.csv", "c.csv"] # shell glob
+            Test.@test _pw_arg("--metrics") == "n50"                    # single-value intact
+            empty!(ARGS)
+            append!(ARGS, ["--metric-source", "quast"])
+            Test.@test isempty(_pw_args("--csv"))                       # absent flag
+        finally
+            empty!(ARGS); append!(ARGS, saved)
+        end
+    end
+
     Test.@testset "pairing key and metrics match the pre-registration" begin
         # seed must be part of the pairing key, or the pre-registered replicate
         # design is not represented in the analysis.
@@ -577,6 +597,12 @@ Test.@testset "RGV paired-Wilcoxon analysis" begin
             Test.@test occursin("Error rates swept", text)
             Test.@test occursin("0.01, 0.05", text)
             Test.@test occursin("~360 paired comparisons", text)
+            # Every outcome decide() can emit must be defined in the legend, or a
+            # reader meets a verdict string the report never explains.
+            for outcome in ("SUPPORTED", "PARTIALLY SUPPORTED", "FALSIFIED",
+                "NOT SUPPORTED", "INDETERMINATE")
+                Test.@test occursin("**$outcome**", text)
+            end
         end
     end
 end

--- a/test/4_assembly/rgv_seed_backfill_test.jl
+++ b/test/4_assembly/rgv_seed_backfill_test.jl
@@ -92,12 +92,54 @@ Test.@testset "RGV seed backfill (td-59o7)" begin
         end
     end
 
+    Test.@testset "the log form the launchers NOW emit (a seed LIST)" begin
+        # MYCELIA_RGV_SEED became a comma-list, so the wrappers echo
+        # `SEED=42,123,456`. The old single-digit regex captured only `42`, which
+        # would have labelled every row of a 3-seed replicate run with one seed —
+        # making an unpairable table look pairable, the exact failure this tool is
+        # supposed to prevent.
+        mktempdir() do dir
+            log = joinpath(dir, "multi.log")
+            write(log,
+                "    ERR=0.01,0.05,0.10  READLEN=150,5000  COVERAGE=30x  K=21  " *
+                "SEED=42,123,456  QUAST=true\n")
+            msg = _sbf_throws_with(() -> recover_seed_from_log(log),
+                ["MORE THAN ONE seed", "42, 123, 456", "pairable"])
+            Test.@test occursin("per-row `seed` column", msg)
+
+            # A single-seed run in the new format still recovers cleanly.
+            single = joinpath(dir, "single.log")
+            write(single, "  ERR=0.01  K=21  SEED=123  QUAST=true\n")
+            Test.@test recover_seed_from_log(single) == 123
+
+            # And the export form with a list is caught too.
+            exp = joinpath(dir, "export.log")
+            write(exp, "export MYCELIA_RGV_SEED=\"42,123,456\"\n")
+            _sbf_throws_with(() -> recover_seed_from_log(exp), ["MORE THAN ONE seed"])
+        end
+    end
+
+    Test.@testset "a column present but entirely empty is filled, not refused" begin
+        # Legacy CSVs can carry the header with empty cells; CSV.jl reads those as
+        # `missing`. Treating that as a conflict made the documented workflow
+        # impossible on exactly the historical tables this tool targets.
+        mktempdir() do dir
+            src = joinpath(dir, "empty_col.csv")
+            write(src, "arm,k,seed,metric_source\nnaive,21,,\niterative,21,,\n")
+            out, _, _ = backfill_seed(src;
+                seed = 42, provenance = "explicit (test)", metric_source = "quast")
+            df = CSV.read(out, DataFrames.DataFrame)
+            Test.@test all(df.seed .== 42)
+            Test.@test all(df.metric_source .== "quast")
+        end
+    end
+
     Test.@testset "an ambiguous log raises instead of choosing" begin
         mktempdir() do dir
             log = joinpath(dir, "two-runs.log")
             write(log, "SEED=42\n...\nSEED=123\n")
             _sbf_throws_with(() -> recover_seed_from_log(log),
-                ["ambiguous seed", "42, 123", "more than one run"])
+                ["MORE THAN ONE seed", "42, 123"])
         end
     end
 

--- a/test/4_assembly/rgv_seed_backfill_test.jl
+++ b/test/4_assembly/rgv_seed_backfill_test.jl
@@ -186,8 +186,8 @@ Test.@testset "RGV seed backfill (td-59o7)" begin
         sweep = read(
             joinpath(@__DIR__, "..", "..", "benchmarking",
                 "rhizomorph_correction_validation_sweep.jl"), String)
-        Test.@test occursin(
-            "get(ENV, \"MYCELIA_RGV_SEED\", \"$(RGV_DEFAULT_SEED)\")", sweep)
+        Test.@test occursin("MYCELIA_RGV_SEED", sweep)
+        Test.@test occursin("[$(RGV_DEFAULT_SEED)]", sweep)   # the list default
         Test.@test RGV_DEFAULT_SEED == 42
     end
 
@@ -196,6 +196,71 @@ Test.@testset "RGV seed backfill (td-59o7)" begin
             text = read(
                 joinpath(@__DIR__, "..", "..", "benchmarking", wrapper), String)
             Test.@test occursin("SEED=\${MYCELIA_RGV_SEED}", text)
+        end
+    end
+
+    Test.@testset "C3: the documented backfill -> analyse workflow completes" begin
+        # A seed-only backfill DEAD-ENDED: the analysis accepted the seed and then
+        # refused the same file for carrying no metric-definition column, and
+        # nothing could supply one. The workflow the tools document has to finish.
+        mktempdir() do dir
+            src = _sbf_legacy_csv(joinpath(dir, "sweep.csv"))
+            out, sidecar, _ = backfill_seed(src;
+                seed = 42, provenance = "explicit (test)",
+                metric_source = "internal:quast-disabled", quast_min_contig = 200)
+            df = CSV.read(out, DataFrames.DataFrame)
+            for col in ("seed", "metric_source", "quast_min_contig")
+                Test.@test col in DataFrames.names(df)
+            end
+            Test.@test all(df.metric_source .== "internal:quast-disabled")
+            Test.@test all(df.quast_min_contig .== 200)
+
+            # Backfilled definitions are DISTINGUISHABLE from observed ones.
+            meta = JSON.parsefile(sidecar)
+            Test.@test meta["metric_source_backfilled"] == "internal:quast-disabled"
+            Test.@test meta["quast_min_contig_backfilled"] == 200
+
+            # Never inferred: with no flags the columns stay absent, so the
+            # analysis still fails closed rather than getting a fabricated value.
+            out2, _, _ = backfill_seed(src;
+                seed = 42, provenance = "explicit (test)",
+                output_path = joinpath(dir, "seed_only.csv"))
+            Test.@test !("metric_source" in
+                         DataFrames.names(CSV.read(out2, DataFrames.DataFrame)))
+        end
+    end
+
+    Test.@testset "an existing definition column is not silently overwritten" begin
+        mktempdir() do dir
+            src = _sbf_legacy_csv(joinpath(dir, "sweep.csv"))
+            out, _, _ = backfill_seed(src;
+                seed = 42, provenance = "t", metric_source = "quast")
+            df = CSV.read(out, DataFrames.DataFrame)
+            # Same value is a no-op, so a re-run is safe: the column keeps its
+            # value and no duplicate column is appended.
+            again = insert_definition_column!(copy(df), :metric_source, "quast")
+            Test.@test all(again.metric_source .== "quast")
+            Test.@test DataFrames.ncol(again) == DataFrames.ncol(df)
+            # A different value would assert a definition the run did not have.
+            _sbf_throws_with(
+                () -> insert_definition_column!(copy(df), :metric_source, "internal"),
+                ["already has a `metric_source` column", "refusing to overwrite"])
+        end
+    end
+
+    Test.@testset "I1: the launchers actually request the replicate seeds" begin
+        # The seed axis was asserted by the schema but not produced by anything: a
+        # scalar MYCELIA_RGV_SEED and no loop meant a pairable multi-seed table
+        # needed three manual submissions and an undocumented merge.
+        sweep = read(
+            joinpath(@__DIR__, "..", "..", "benchmarking",
+                "rhizomorph_correction_validation_sweep.jl"), String)
+        Test.@test occursin("_parse_int_list(get(ENV, \"MYCELIA_RGV_SEED\"", sweep)
+        Test.@test occursin("for seed in seeds", sweep)
+        for wrapper in ("run_rgv_sweep_lrc.sbatch", "run_rgv_sweep_nersc.sbatch")
+            text = read(
+                joinpath(@__DIR__, "..", "..", "benchmarking", wrapper), String)
+            Test.@test occursin("MYCELIA_RGV_SEED:-42,123,456", text)
         end
     end
 end

--- a/test/4_assembly/rgv_seed_backfill_test.jl
+++ b/test/4_assembly/rgv_seed_backfill_test.jl
@@ -1,0 +1,201 @@
+# Unit test for the RGV `seed` column backfill (bead td-59o7).
+#
+# The tool's job is narrow and its risk is specific: writing a seed value that was
+# never actually used would make an unpairable historical run LOOK pairable, which
+# is worse than leaving it unpairable. So the tests concentrate on provenance
+# discipline:
+#
+#   * a seed must be justified (explicit, recovered from a log, or an explicitly
+#     labelled fall back to the documented default)
+#   * an ambiguous log raises rather than picking one value
+#   * the input file is never modified, and the sidecar records how the seed was
+#     determined
+#   * an existing `seed` column is never silently overwritten
+#
+# Dependency-free apart from CSV / DataFrames / JSON (direct Mycelia deps).
+
+import Test
+import CSV
+import DataFrames
+import JSON
+
+include(joinpath(@__DIR__, "..", "..", "benchmarking", "rgv_seed_backfill.jl"))
+
+function _sbf_throws_with(f, needles::Vector{String})
+    try
+        f()
+    catch e
+        msg = sprint(showerror, e)
+        for needle in needles
+            Test.@test occursin(needle, msg)
+        end
+        return msg
+    end
+    Test.@test false
+    return ""
+end
+
+# A pre-`seed` sweep CSV, matching the real one committed at
+# benchmarking/results/rhizomorph_correction_validation_sweep_20260711_125013.csv.
+const _SBF_LEGACY_HEADER = "reference,genome_len,error_rate,regime,readlen,tech," *
+                           "target_coverage,effective_coverage,k,arm,ok,n_contigs,total_length," *
+                           "largest_contig,n50,genome_fraction,runtime_s,mode,scale_metric_bases," *
+                           "scale_floor_bases"
+
+function _sbf_legacy_csv(path)
+    open(path, "w") do io
+        println(io, _SBF_LEGACY_HEADER)
+        println(io,
+            "synthetic_2000bp,2000,0.05,short-low-error,150,illumina,10.0,10.05," *
+            "21,naive,true,935,49291,152,60,2464.5,9.606,SMOKE-ONLY,20100.0,1.0e6")
+        println(io,
+            "synthetic_2000bp,2000,0.05,short-low-error,150,illumina,10.0,10.05," *
+            "21,iterative,true,244,14097,153,62,704.8,17.107,SMOKE-ONLY,20100.0,1.0e6")
+    end
+    return path
+end
+
+Test.@testset "RGV seed backfill (td-59o7)" begin
+    Test.@testset "seed recovery from each run-log form" begin
+        mktempdir() do dir
+            # The sbatch echo form, as patched into run_rgv_sweep_{lrc,nersc}.sbatch.
+            sbatch_log = joinpath(dir, "sbatch.log")
+            write(sbatch_log,
+                ">>> RUN rhizomorph_correction_validation_sweep.jl  Fri Jul 25\n" *
+                "    ERR=0.01,0.05,0.10  READLEN=150,5000  COVERAGE=30x  K=21  " *
+                "SEED=123  QUAST=true\n")
+            Test.@test recover_seed_from_log(sbatch_log) == 123
+
+            # The export form.
+            export_log = joinpath(dir, "export.log")
+            write(export_log, "export MYCELIA_RGV_SEED=\"456\"\n")
+            Test.@test recover_seed_from_log(export_log) == 456
+
+            # The harness banner form, as added to the sweep's config printout.
+            banner_log = joinpath(dir, "banner.log")
+            write(banner_log, "k              : 21\nSeed           : 42\nArms: naive\n")
+            Test.@test recover_seed_from_log(banner_log) == 42
+
+            # All three forms agreeing in one log is fine.
+            combined = joinpath(dir, "combined.log")
+            write(combined,
+                "export MYCELIA_RGV_SEED=\"42\"\n  SEED=42  QUAST=true\nSeed           : 42\n")
+            Test.@test recover_seed_from_log(combined) == 42
+
+            # A log with no seed at all: nothing, not a guess.
+            silent = joinpath(dir, "silent.log")
+            write(silent, "ERR=0.01  READLEN=150  COVERAGE=30x  K=21  QUAST=true\n")
+            Test.@test recover_seed_from_log(silent) === nothing
+
+            _sbf_throws_with(() -> recover_seed_from_log(joinpath(dir, "nope.log")),
+                ["run log not found"])
+        end
+    end
+
+    Test.@testset "an ambiguous log raises instead of choosing" begin
+        mktempdir() do dir
+            log = joinpath(dir, "two-runs.log")
+            write(log, "SEED=42\n...\nSEED=123\n")
+            _sbf_throws_with(() -> recover_seed_from_log(log),
+                ["ambiguous seed", "42, 123", "more than one run"])
+        end
+    end
+
+    Test.@testset "backfill writes a new file and leaves the original alone" begin
+        mktempdir() do dir
+            src = _sbf_legacy_csv(joinpath(dir, "sweep.csv"))
+            before = read(src, String)
+
+            out, sidecar, n = backfill_seed(src; seed = 42, provenance = "explicit (test)")
+            Test.@test n == 2
+            Test.@test out == joinpath(dir, "sweep_seedbackfill.csv")
+            Test.@test read(src, String) == before      # input untouched
+
+            df = CSV.read(out, DataFrames.DataFrame)
+            Test.@test "seed" in DataFrames.names(df)
+            Test.@test all(df.seed .== 42)
+            # Placed right after `k`, matching the live sweep's column order.
+            cols = DataFrames.names(df)
+            Test.@test cols[findfirst(==("k"), cols) + 1] == "seed"
+            # Nothing else changed.
+            Test.@test DataFrames.nrow(df) == 2
+            Test.@test df.arm == ["naive", "iterative"]
+
+            meta = JSON.parsefile(sidecar)
+            Test.@test meta["seed"] == 42
+            Test.@test occursin("explicit", meta["seed_provenance"])
+            Test.@test meta["rows"] == 2
+            Test.@test meta["bead"] == "td-59o7"
+            Test.@test abspath(src) == meta["source_csv"]
+        end
+    end
+
+    Test.@testset "existing seed column: idempotent if equal, refused if not" begin
+        mktempdir() do dir
+            src = _sbf_legacy_csv(joinpath(dir, "sweep.csv"))
+            out, _, _ = backfill_seed(src; seed = 42, provenance = "explicit (test)")
+
+            # Re-running with the SAME seed is a no-op, so a re-run is safe.
+            df = CSV.read(out, DataFrames.DataFrame)
+            Test.@test insert_seed_column!(copy(df), 42).seed == [42, 42]
+
+            # A DIFFERENT seed would rewrite provenance — refuse.
+            _sbf_throws_with(() -> insert_seed_column!(copy(df), 123),
+                ["already has a `seed` column", "refusing to overwrite", "123"])
+        end
+    end
+
+    Test.@testset "appends when there is no `k` column to anchor to" begin
+        mktempdir() do dir
+            src = joinpath(dir, "nok.csv")
+            write(src, "arm,n50\nnaive,60\niterative,62\n")
+            out, _, _ = backfill_seed(src; seed = 42, provenance = "explicit (test)")
+            cols = DataFrames.names(CSV.read(out, DataFrames.DataFrame))
+            Test.@test cols == ["arm", "n50", "seed"]
+        end
+    end
+
+    Test.@testset "existing output is not clobbered without --force" begin
+        mktempdir() do dir
+            src = _sbf_legacy_csv(joinpath(dir, "sweep.csv"))
+            out, _, _ = backfill_seed(src; seed = 42, provenance = "explicit (test)")
+            _sbf_throws_with(
+                () -> backfill_seed(src; seed = 42, provenance = "explicit (test)"),
+                ["output already exists", "--force"])
+            # With force it succeeds.
+            out2, _,
+            _ = backfill_seed(src;
+                seed = 42, provenance = "explicit (test)", force = true)
+            Test.@test out2 == out
+        end
+    end
+
+    Test.@testset "missing input raises" begin
+        mktempdir() do dir
+            _sbf_throws_with(
+                () -> backfill_seed(joinpath(dir, "nope.csv");
+                    seed = 42, provenance = "explicit (test)"),
+                ["CSV not found"])
+        end
+    end
+
+    Test.@testset "the documented default matches the harness" begin
+        # RGV_DEFAULT_SEED is mirrored from the sweep's MYCELIA_RGV_SEED default.
+        # If the harness default changes, --assume-default-seed would attribute the
+        # wrong seed to historical runs.
+        sweep = read(
+            joinpath(@__DIR__, "..", "..", "benchmarking",
+                "rhizomorph_correction_validation_sweep.jl"), String)
+        Test.@test occursin(
+            "get(ENV, \"MYCELIA_RGV_SEED\", \"$(RGV_DEFAULT_SEED)\")", sweep)
+        Test.@test RGV_DEFAULT_SEED == 42
+    end
+
+    Test.@testset "the sbatch wrappers echo SEED so future runs are recoverable" begin
+        for wrapper in ("run_rgv_sweep_lrc.sbatch", "run_rgv_sweep_nersc.sbatch")
+            text = read(
+                joinpath(@__DIR__, "..", "..", "benchmarking", wrapper), String)
+            Test.@test occursin("SEED=\${MYCELIA_RGV_SEED}", text)
+        end
+    end
+end

--- a/test/4_assembly/track_a_merge_hosts_test.jl
+++ b/test/4_assembly/track_a_merge_hosts_test.jl
@@ -418,20 +418,92 @@ Test.@testset "Track A cross-host merge (td-bblmi)" begin
         _tam_throws_with(() -> _parse_host_spec("label="), ["path is empty"])
     end
 
-    Test.@testset "a nonexistent source is empty, not a crash" begin
+    Test.@testset "C10: a nonexistent source is FATAL, not silently empty" begin
         mktempdir() do dir
             cid = "Lambda__illumina__30x__seed42__qualmer"
             result = merge_hosts(["ghost" => joinpath(dir, "does-not-exist")];
                 expected_ids = [cid])
             Test.@test isempty(result.merged)
             Test.@test result.per_host[1].discovered == 0
+            Test.@test result.per_host[1].exists == false
             Test.@test result.missing_ids == [cid]
+            # A mistyped path or an unmounted filesystem must not read as "this
+            # host contributed nothing", which silently shrinks the matrix.
+            Test.@test result.unreachable_sources == ["ghost"]
+            code, problems = merge_exit_status(result)
+            Test.@test code == 1
+            Test.@test :unreachable_source in [p.kind for p in problems]
+            # NOT waivable: --allow-incomplete says the matrix is partial, not that
+            # a requested source may vanish.
+            code2, problems2 = merge_exit_status(result;
+                allow_incomplete = true, allow_collisions = true)
+            Test.@test code2 == 1
+            Test.@test any(p -> p.kind == :unreachable_source && p.fatal, problems2)
             # Empty tables still have the right schema, so a downstream reader
             # fails on emptiness rather than on a missing column.
             results_df, prov_df = merged_tables(result)
             Test.@test DataFrames.names(results_df) == TRACK_A_ROW_KEYS
             Test.@test "quast_evidence" in DataFrames.names(prov_df)
             Test.@test DataFrames.nrow(results_df) == 0
+        end
+    end
+
+    Test.@testset "C7: an unreadable field is malformed, never benign" begin
+        # `_as_number -> 0.0` used to route every read failure into a benign class:
+        # an unreadable n_contigs became "n/a:empty-assembly" and an unreadable
+        # largest_contig became "unknown:quast-unscored", so schema drift and
+        # truncated checkpoints passed at exit 0.
+        truncated = _tam_cell()
+        delete!(truncated, "n_contigs")
+        Test.@test quast_evidence(truncated) == "malformed:unreadable(n_contigs)"
+        Test.@test is_malformed_evidence(quast_evidence(truncated))
+
+        drifted = _tam_cell()
+        drifted["largest_contig"] = "n/a"          # schema change to a string
+        Test.@test quast_evidence(drifted) == "malformed:unreadable(largest_contig)"
+
+        nostatus = _tam_cell()
+        delete!(nostatus, "status")
+        Test.@test quast_evidence(nostatus) == "malformed:missing-field(status)"
+
+        # A genuine empty assembly is still benign — the classes stay distinct.
+        Test.@test !is_malformed_evidence(
+            quast_evidence(_tam_cell(n_contigs = 0, status = "empty_assembly")))
+
+        # And a malformed cell fails the merge rather than passing quietly.
+        mktempdir() do dir
+            host = joinpath(dir, "h")
+            cid = "Lambda__illumina__30x__seed42__qualmer"
+            _tam_write_cell(host, cid, truncated)
+            result = merge_hosts(["h" => host]; expected_ids = [cid])
+            Test.@test result.malformed_cells == [cid]
+            code, problems = merge_exit_status(result)
+            Test.@test code == 1
+            Test.@test :malformed_cells in [p.kind for p in problems]
+        end
+    end
+
+    Test.@testset "C10: tables are written only behind the gate, atomically" begin
+        mktempdir() do dir
+            out = joinpath(dir, "merged")
+            mkpath(out)
+            # A pre-existing, larger, correct table.
+            good = joinpath(out, "track_a_results.tsv")
+            write(good, "organism\taccession\n" * repeat("Lambda\tNC_001416\n", 6))
+            before = read(good, String)
+
+            host = joinpath(dir, "partial")
+            ids = expected_cell_ids(organisms = ("Lambda",),
+                technologies = ("illumina",), coverages = (10, 30), seeds = (42,))
+            _tam_write_cell(host, ids[1], _tam_cell())
+            result = merge_hosts(["partial" => host]; expected_ids = ids)
+            code, _ = merge_exit_status(result)
+            Test.@test code == 1          # incomplete
+
+            # The gate is what protects the table; `main` writes only when code==0.
+            # Assert the invariant the CLI relies on: a failing merge has a nonzero
+            # code, so the prior table survives untouched.
+            Test.@test read(good, String) == before
         end
     end
 end

--- a/test/4_assembly/track_a_merge_hosts_test.jl
+++ b/test/4_assembly/track_a_merge_hosts_test.jl
@@ -1,0 +1,437 @@
+# Unit test for the Track A cross-host checkpoint merge (bead td-bblmi).
+#
+# The merge's whole value is that it refuses to produce a plausible-looking
+# 288-cell matrix when the inputs do not justify one. So the tests are mostly
+# about the refusals:
+#
+#   * the same cell id with DIFFERENT content across hosts is a collision, is
+#     reported with a field-level diff, is EXCLUDED from the merged matrix, and
+#     fails the exit status
+#   * the same cell id with IDENTICAL content is benign and reported separately
+#   * missing cells are enumerated exactly, not just counted
+#   * per-cell host provenance is recorded
+#   * re-running is idempotent, and a previously merged cell that disagrees with
+#     its source is a collision rather than an overwrite
+#   * the expected-matrix constants mirrored from the harness have not drifted
+#
+# Dependency-free apart from JSON / SHA / DataFrames / CSV (all direct Mycelia
+# deps that load without importing Mycelia). No network, no QUAST, no assembly.
+
+import Test
+import JSON
+import DataFrames
+import CSV
+
+include(joinpath(@__DIR__, "..", "..", "benchmarking", "track_a_merge_hosts.jl"))
+
+function _tam_throws_with(f, needles::Vector{String})
+    try
+        f()
+    catch e
+        msg = sprint(showerror, e)
+        for needle in needles
+            Test.@test occursin(needle, msg)
+        end
+        return msg
+    end
+    Test.@test false
+    return ""
+end
+
+# A checkpoint shaped exactly like track_a_baseline_benchmark.jl's `cell_row`.
+function _tam_cell(; organism = "Lambda", technology = "illumina", coverage = 30,
+        seed = 42, arm = "qualmer", accession = "NC_001416", k = 31,
+        n_reads = 1000, n_contigs = 5, NGA50 = 1316.0, misassemblies = 0.0,
+        genome_fraction = 98.5, duplication_ratio = 1.0, largest_contig = 48000,
+        wall_seconds = 12.5, peak_rss_bytes = 1_000_000, status = "ok")
+    return Dict{String, Any}(
+        "organism" => organism, "accession" => accession, "technology" => technology,
+        "coverage" => coverage, "seed" => seed, "decoder_arm" => arm, "k" => k,
+        "n_reads" => n_reads, "n_contigs" => n_contigs, "NGA50" => NGA50,
+        "misassemblies" => misassemblies, "genome_fraction" => genome_fraction,
+        "duplication_ratio" => duplication_ratio, "largest_contig" => largest_contig,
+        "wall_seconds" => wall_seconds, "peak_rss_bytes" => peak_rss_bytes,
+        "status" => status)
+end
+
+function _tam_write_cell(root, cell_id, cell)
+    dir = joinpath(root, "cells", cell_id)
+    mkpath(dir)
+    open(joinpath(dir, "cell_result.json"), "w") do io
+        JSON.print(io, cell, 2)
+    end
+    return joinpath(dir, "cell_result.json")
+end
+
+Test.@testset "Track A cross-host merge (td-bblmi)" begin
+    Test.@testset "expected matrix mirrors the harness (drift guard)" begin
+        # These constants are DUPLICATED from track_a_baseline_benchmark.jl, which
+        # cannot be included (it runs the benchmark at include time). If the
+        # harness changes its matrix or its cell-id format, "missing" would be
+        # computed against the wrong set — so assert the mirror against the
+        # harness SOURCE rather than trusting the duplication.
+        harness = read(
+            joinpath(@__DIR__, "..", "..", "benchmarking",
+                "track_a_baseline_benchmark.jl"), String)
+        Test.@test occursin(
+            "cell_id = \"\$(org)__\$(tech)__\$(cov)x__seed\$(seed)__\$(arm)\"", harness)
+        for org in TRACK_A_ORGANISMS
+            Test.@test occursin("(\"$org\", ", harness)
+        end
+        Test.@test occursin(
+            "const TECHNOLOGIES = [" *
+            join(("\"$t\"" for t in TRACK_A_TECHNOLOGIES), ", ") * "]", harness)
+        Test.@test occursin(
+            "const COVERAGES = [" *
+            join(string.(TRACK_A_COVERAGES), ", ") * "]", harness)
+        Test.@test occursin(
+            "const SEEDS = [" * join(string.(TRACK_A_SEEDS), ", ") * "]", harness)
+        Test.@test occursin(
+            "const DECODER_ARMS = [" *
+            join(("\"$a\"" for a in TRACK_A_ARMS), ", ") * "]", harness)
+
+        ids = expected_cell_ids()
+        Test.@test length(ids) == 288           # the documented matrix size
+        Test.@test length(unique(ids)) == 288
+        Test.@test "Lambda__illumina__30x__seed42__qualmer" in ids
+        Test.@test "SARS-CoV-2__ont__100x__seed456__kmer" in ids
+        Test.@test track_a_cell_id("T4", "pacbio", 50, 123, "kmer") ==
+                   "T4__pacbio__50x__seed123__kmer"
+        # The real shard boundary the merge exists to reconcile.
+        Test.@test length(expected_cell_ids(organisms = ("phi29", "SARS-CoV-2"))) == 144
+    end
+
+    Test.@testset "canonicalization: representation drift is not a collision" begin
+        a = _tam_cell(n_contigs = 5, NGA50 = 1316.0)
+        b = _tam_cell(n_contigs = 5.0, NGA50 = 1316)   # int/float swap only
+        Test.@test cell_digest(a) == cell_digest(b)
+        Test.@test isempty(differing_fields(a, b))
+        # A genuine value difference always is a collision.
+        c = _tam_cell(NGA50 = 1402.0)
+        Test.@test cell_digest(a) != cell_digest(c)
+        Test.@test differing_fields(a, c) == ["NGA50: 1316 vs 1402"]  # a's value first
+        # Key-set differences are surfaced too.
+        d = copy(a)
+        delete!(d, "misassemblies")
+        Test.@test any(occursin("misassemblies", f) for f in differing_fields(a, d))
+        Test.@test any(occursin("<absent>", f) for f in differing_fields(a, d))
+    end
+
+    Test.@testset "quast_evidence is sound, not a guess" begin
+        # QUAST scored it: a real Largest contig.
+        Test.@test quast_evidence(_tam_cell(n_contigs = 5, largest_contig = 48_000)) ==
+                   "quast:scored"
+        # QUAST failed: contigs exist but empty_metrics() zeroed everything. A
+        # scored run cannot report Largest contig = 0 for a non-empty assembly.
+        Test.@test quast_evidence(_tam_cell(n_contigs = 5, largest_contig = 0,
+            NGA50 = 0.0, genome_fraction = 0.0)) == "unknown:quast-unscored"
+        # Nothing to score.
+        Test.@test quast_evidence(_tam_cell(n_contigs = 0, largest_contig = 0,
+            status = "empty_assembly")) == "n/a:empty-assembly"
+        Test.@test quast_evidence(_tam_cell(status = "error", n_contigs = 0)) ==
+                   "n/a:cell-error"
+        # The signal is largest_contig, NOT "all metrics zero": a genuinely
+        # unalignable assembly has genome_fraction 0 with a real largest_contig and
+        # must still count as scored.
+        Test.@test quast_evidence(_tam_cell(n_contigs = 3, largest_contig = 11_622,
+            NGA50 = 0.0, genome_fraction = 0.0, misassemblies = 0.0)) == "quast:scored"
+    end
+
+    Test.@testset "disjoint shards merge cleanly with host provenance" begin
+        mktempdir() do dir
+            lovelace = joinpath(dir, "lovelace")
+            lrc = joinpath(dir, "lrc")
+            ids = expected_cell_ids(organisms = ("Lambda", "phi29"),
+                technologies = ("illumina",), coverages = (30,), seeds = (42,))
+            lambda_ids = filter(id -> startswith(id, "Lambda"), ids)
+            phi29_ids = filter(id -> startswith(id, "phi29"), ids)
+            for id in lambda_ids
+                _tam_write_cell(lovelace, id, _tam_cell(organism = "Lambda"))
+            end
+            for id in phi29_ids
+                _tam_write_cell(lrc,
+                    id,
+                    _tam_cell(organism = "phi29",
+                        accession = "NC_011048", largest_contig = 19_000))
+            end
+
+            result = merge_hosts(["lovelace" => lovelace, "lrc" => lrc];
+                expected_ids = ids)
+            Test.@test length(result.merged) == length(ids)
+            Test.@test isempty(result.collisions)
+            Test.@test isempty(result.duplicates)
+            Test.@test isempty(result.missing_ids)
+            Test.@test isempty(result.unexpected_ids)
+            # Provenance: every cell attributed to the host that produced it.
+            for id in lambda_ids
+                Test.@test result.origin[id] == "lovelace"
+            end
+            for id in phi29_ids
+                Test.@test result.origin[id] == "lrc"
+            end
+            Test.@test all(haskey(result.digests, id) for id in ids)
+
+            code, problems = merge_exit_status(result)
+            Test.@test code == 0
+            Test.@test isempty(problems)
+        end
+    end
+
+    Test.@testset "CONTENT COLLISION: detected, diffed, excluded, and fatal" begin
+        mktempdir() do dir
+            a = joinpath(dir, "hostA")
+            b = joinpath(dir, "hostB")
+            cid = "Lambda__illumina__30x__seed42__qualmer"
+            other = "Lambda__illumina__30x__seed42__kmer"
+            _tam_write_cell(a, cid, _tam_cell(NGA50 = 1316.0, n_contigs = 5))
+            # Same cell id, different result: the shards were supposed to be
+            # disjoint, so this is a real anomaly (stale checkpoint / two SHAs).
+            _tam_write_cell(b, cid, _tam_cell(NGA50 = 1402.0, n_contigs = 7))
+            _tam_write_cell(a, other, _tam_cell())
+
+            ids = [cid, other]
+            result = merge_hosts(["hostA" => a, "hostB" => b]; expected_ids = ids)
+
+            Test.@test length(result.collisions) == 1
+            col = result.collisions[1]
+            Test.@test col.cell_id == cid
+            Test.@test sort(col.hosts) == ["hostA", "hostB"]
+            Test.@test length(col.pairs) == 1
+            diffs = col.pairs[1].diffs
+            Test.@test any(occursin("NGA50", d) for d in diffs)
+            Test.@test any(occursin("n_contigs", d) for d in diffs)
+            # NOT last-write-wins: there is no defensible winner, so the cell does
+            # not enter the analyzed matrix at all...
+            Test.@test !haskey(result.merged, cid)
+            # ...which means it also shows up as missing. Reported twice on purpose.
+            Test.@test result.missing_ids == [cid]
+            Test.@test haskey(result.merged, other)
+
+            code, problems = merge_exit_status(result)
+            Test.@test code == 1
+            Test.@test Set(p.kind for p in problems) == Set([:collisions, :incomplete])
+            Test.@test all(p -> p.fatal, problems)
+            # Waivers are visible, not silent.
+            code2,
+            problems2 = merge_exit_status(result;
+                allow_collisions = true, allow_incomplete = true)
+            Test.@test code2 == 0
+            Test.@test length(problems2) == 2
+            Test.@test all(p -> !p.fatal, problems2)
+            # Waiving only one is not enough.
+            Test.@test first(merge_exit_status(result; allow_collisions = true)) == 1
+        end
+    end
+
+    Test.@testset "identical duplicate across hosts is benign and reported" begin
+        mktempdir() do dir
+            a = joinpath(dir, "hostA")
+            b = joinpath(dir, "hostB")
+            cid = "T4__ont__100x__seed456__kmer"
+            cell = _tam_cell(organism = "T4", technology = "ont", coverage = 100,
+                seed = 456, arm = "kmer")
+            _tam_write_cell(a, cid, cell)
+            _tam_write_cell(b, cid, cell)
+
+            result = merge_hosts(["hostA" => a, "hostB" => b]; expected_ids = [cid])
+            Test.@test isempty(result.collisions)
+            Test.@test length(result.duplicates) == 1
+            Test.@test result.duplicates[1].cell_id == cid
+            Test.@test sort(result.duplicates[1].hosts) == ["hostA", "hostB"]
+            Test.@test haskey(result.merged, cid)
+            Test.@test isempty(result.missing_ids)
+            Test.@test first(merge_exit_status(result)) == 0
+        end
+    end
+
+    Test.@testset "incompleteness enumerates exactly which cells are missing" begin
+        mktempdir() do dir
+            host = joinpath(dir, "lovelace")
+            ids = expected_cell_ids(organisms = ("Lambda",),
+                technologies = ("illumina",), coverages = (10, 30), seeds = (42,))
+            Test.@test length(ids) == 4
+            present = ids[1:2]
+            for id in present
+                _tam_write_cell(host, id, _tam_cell())
+            end
+            result = merge_hosts(["lovelace" => host]; expected_ids = ids)
+            Test.@test sort(result.missing_ids) == sort(ids[3:4])
+            Test.@test result.expected_n == 4
+            code, problems = merge_exit_status(result)
+            Test.@test code == 1
+            Test.@test occursin("2 of 4 cells missing", problems[1].message)
+        end
+    end
+
+    Test.@testset "in-progress and unparseable checkpoints are reported, not dropped" begin
+        mktempdir() do dir
+            host = joinpath(dir, "lrc")
+            good = "phi29__illumina__30x__seed42__kmer"
+            running = "phi29__illumina__30x__seed42__qualmer"
+            broken = "phi29__illumina__50x__seed42__kmer"
+            _tam_write_cell(host, good, _tam_cell(organism = "phi29"))
+            mkpath(joinpath(host, "cells", running))            # no cell_result.json yet
+            mkpath(joinpath(host, "cells", broken))
+            write(joinpath(host, "cells", broken, "cell_result.json"), "{not json")
+
+            result = merge_hosts(["lrc" => host]; expected_ids = [good, running, broken])
+            Test.@test length(result.merged) == 1
+            unreadable = result.per_host[1].unreadable
+            Test.@test length(unreadable) == 2
+            byid = Dict(unreadable)
+            Test.@test occursin("no cell_result.json", byid[running])
+            Test.@test occursin("unparseable", byid[broken])
+            # Both are genuinely absent from the matrix.
+            Test.@test sort(result.missing_ids) == sort([broken, running])
+        end
+    end
+
+    Test.@testset "cell ids outside the expected matrix are flagged" begin
+        mktempdir() do dir
+            host = joinpath(dir, "h")
+            cid = "Lambda__illumina__30x__seed42__qualmer"
+            bogus = "Lambda__illumina__30x__seed99__qualmer"  # seed 99 not pre-registered
+            _tam_write_cell(host, cid, _tam_cell())
+            _tam_write_cell(host, bogus, _tam_cell(seed = 99))
+            result = merge_hosts(["h" => host]; expected_ids = [cid])
+            Test.@test result.unexpected_ids == [bogus]
+        end
+    end
+
+    Test.@testset "cells_root accepts a results root or a cells/ dir" begin
+        mktempdir() do dir
+            root = joinpath(dir, "run")
+            _tam_write_cell(root, "Lambda__illumina__30x__seed42__qualmer", _tam_cell())
+            Test.@test cells_root(root) == joinpath(root, "cells")
+            Test.@test cells_root(joinpath(root, "cells")) == joinpath(root, "cells")
+            # Both spellings discover the same cell.
+            Test.@test length(first(discover_cells(cells_root(root)))) == 1
+            Test.@test length(
+                first(discover_cells(cells_root(joinpath(root, "cells"))))) == 1
+        end
+    end
+
+    Test.@testset "output tables carry the harness schema plus provenance" begin
+        mktempdir() do dir
+            a = joinpath(dir, "lovelace")
+            b = joinpath(dir, "lrc")
+            # Lovelace: QUAST failing (largest_contig 0 despite contigs).
+            _tam_write_cell(a, "T4__illumina__30x__seed42__qualmer",
+                _tam_cell(organism = "T4", n_contigs = 12, largest_contig = 0,
+                    NGA50 = 0.0, genome_fraction = 0.0))
+            # Lawrencium: QUAST working.
+            _tam_write_cell(b, "phi29__illumina__30x__seed42__qualmer",
+                _tam_cell(organism = "phi29", largest_contig = 19_000))
+            ids = ["T4__illumina__30x__seed42__qualmer",
+                "phi29__illumina__30x__seed42__qualmer"]
+            result = merge_hosts(["lovelace" => a, "lrc" => b]; expected_ids = ids)
+
+            results_df, prov_df = merged_tables(result)
+            # Drop-in compatible with the harness's own aggregate.
+            Test.@test DataFrames.names(results_df) == TRACK_A_ROW_KEYS
+            Test.@test DataFrames.nrow(results_df) == 2
+            Test.@test "host" in DataFrames.names(prov_df)
+            Test.@test "quast_evidence" in DataFrames.names(prov_df)
+            Test.@test "source_digest" in DataFrames.names(prov_df)
+            Test.@test Set(prov_df.host) == Set(["lovelace", "lrc"])
+
+            # This is the item-1 <-> item-3 bridge: the merged matrix mixes metric
+            # definitions BY HOST, and the guard must see it.
+            breakdown = evidence_by_host(result)
+            Test.@test breakdown["lovelace"]["unknown:quast-unscored"] == 1
+            Test.@test breakdown["lrc"]["quast:scored"] == 1
+            _tam_throws_with(
+                () -> assert_single_metric_definition(prov_df;
+                    columns = (:quast_evidence,), context = "merged Track A matrix"),
+                ["quast_evidence", "quast:scored", "unknown:quast-unscored"])
+        end
+    end
+
+    Test.@testset "report names collisions, missing cells, and the host breakdown" begin
+        mktempdir() do dir
+            a = joinpath(dir, "hostA")
+            b = joinpath(dir, "hostB")
+            cid = "Lambda__illumina__30x__seed42__qualmer"
+            missing_id = "Lambda__illumina__30x__seed42__kmer"
+            _tam_write_cell(a, cid, _tam_cell(NGA50 = 1316.0))
+            _tam_write_cell(b, cid, _tam_cell(NGA50 = 1402.0))
+            result = merge_hosts(["hostA" => a, "hostB" => b];
+                expected_ids = [cid, missing_id])
+            out = joinpath(dir, "merged")
+            mkpath(out)
+            path = write_merge_report(joinpath(out, "merge_report.md"), result;
+                output_dir = out)
+            text = read(path, String)
+            Test.@test occursin("CONTENT COLLISIONS: 1", text)
+            Test.@test occursin("Matrix complete and collision-free: NO", text)
+            Test.@test occursin(cid, text)
+            Test.@test occursin("NGA50: 1316 vs 1402", text)
+            Test.@test occursin(missing_id, text)
+            Test.@test occursin("quast_evidence x host", text)
+        end
+    end
+
+    Test.@testset "materializing cells is idempotent; disagreement is a collision" begin
+        mktempdir() do dir
+            host = joinpath(dir, "lovelace")
+            cid = "Lambda__illumina__30x__seed42__qualmer"
+            _tam_write_cell(host, cid, _tam_cell())
+            out = joinpath(dir, "merged")
+            result = merge_hosts(["lovelace" => host]; expected_ids = [cid])
+
+            copied, skipped, conflicts = copy_merged_cells(result, out)
+            Test.@test copied == [cid]
+            Test.@test isempty(skipped)
+            Test.@test isempty(conflicts)
+            Test.@test isfile(joinpath(out, "cells", cid, "cell_result.json"))
+
+            # Re-run: nothing is rewritten, nothing is reported wrong. Both source
+            # runs are resumable, so re-merging after new cells appear must be safe.
+            copied2, skipped2, conflicts2 = copy_merged_cells(result, out)
+            Test.@test isempty(copied2)
+            Test.@test skipped2 == [cid]
+            Test.@test isempty(conflicts2)
+
+            # A previously merged cell that DISAGREES with its source is the same
+            # class of anomaly as a cross-host collision — never a silent overwrite.
+            _tam_write_cell(host, cid, _tam_cell(NGA50 = 9999.0))
+            result2 = merge_hosts(["lovelace" => host]; expected_ids = [cid])
+            copied3, skipped3, conflicts3 = copy_merged_cells(result2, out)
+            Test.@test isempty(copied3)
+            Test.@test isempty(skipped3)
+            Test.@test length(conflicts3) == 1
+            Test.@test conflicts3[1].cell_id == cid
+            Test.@test "<merged-output>" in conflicts3[1].hosts
+            # The destination on disk is untouched.
+            kept = JSON.parsefile(joinpath(out, "cells", cid, "cell_result.json"))
+            Test.@test kept["NGA50"] == 1316.0
+        end
+    end
+
+    Test.@testset "--host spec parsing" begin
+        Test.@test _parse_host_spec("lrc=/scratch/track_a") == ("lrc" => "/scratch/track_a")
+        # A path containing '=' still parses: only the FIRST '=' separates.
+        Test.@test _parse_host_spec("h=/a=b") == ("h" => "/a=b")
+        _tam_throws_with(() -> _parse_host_spec("no-equals-sign"),
+            ["--host expects LABEL=PATH"])
+        _tam_throws_with(() -> _parse_host_spec("=/path"), ["label is empty"])
+        _tam_throws_with(() -> _parse_host_spec("label="), ["path is empty"])
+    end
+
+    Test.@testset "a nonexistent source is empty, not a crash" begin
+        mktempdir() do dir
+            cid = "Lambda__illumina__30x__seed42__qualmer"
+            result = merge_hosts(["ghost" => joinpath(dir, "does-not-exist")];
+                expected_ids = [cid])
+            Test.@test isempty(result.merged)
+            Test.@test result.per_host[1].discovered == 0
+            Test.@test result.missing_ids == [cid]
+            # Empty tables still have the right schema, so a downstream reader
+            # fails on emptiness rather than on a missing column.
+            results_df, prov_df = merged_tables(result)
+            Test.@test DataFrames.names(results_df) == TRACK_A_ROW_KEYS
+            Test.@test "quast_evidence" in DataFrames.names(prov_df)
+            Test.@test DataFrames.nrow(results_df) == 0
+        end
+    end
+end

--- a/test/4_assembly/track_a_merge_hosts_test.jl
+++ b/test/4_assembly/track_a_merge_hosts_test.jl
@@ -487,7 +487,6 @@ Test.@testset "Track A cross-host merge (td-bblmi)" begin
         mktempdir() do dir
             out = joinpath(dir, "merged")
             mkpath(out)
-            # A pre-existing, larger, correct table.
             good = joinpath(out, "track_a_results.tsv")
             write(good, "organism\taccession\n" * repeat("Lambda\tNC_001416\n", 6))
             before = read(good, String)
@@ -498,12 +497,80 @@ Test.@testset "Track A cross-host merge (td-bblmi)" begin
             _tam_write_cell(host, ids[1], _tam_cell())
             result = merge_hosts(["partial" => host]; expected_ids = ids)
             code, _ = merge_exit_status(result)
-            Test.@test code == 1          # incomplete
-
-            # The gate is what protects the table; `main` writes only when code==0.
-            # Assert the invariant the CLI relies on: a failing merge has a nonzero
-            # code, so the prior table survives untouched.
+            Test.@test code == 1
             Test.@test read(good, String) == before
+
+            # ATOMICITY, asserted directly rather than implied: a write that throws
+            # part-way must leave the destination untouched and no temp behind.
+            Test.@test_throws ErrorException _atomic_write(good) do io
+                write(io, "partial junk")
+                error("simulated interruption")
+            end
+            Test.@test read(good, String) == before
+            Test.@test isempty(filter(f -> startswith(f, "."), readdir(out)))
+
+            # And a successful atomic write does replace the contents.
+            _atomic_write(good) do io
+                write(io, "replaced\n")
+            end
+            Test.@test read(good, String) == "replaced\n"
+        end
+    end
+
+    Test.@testset "CR: a path that exists but is not a cells tree is unreachable" begin
+        mktempdir() do dir
+            # A typo landing on some real-but-wrong directory used to report
+            # exists=true with zero cells and escape the guard.
+            notatree = joinpath(dir, "some-other-dir")
+            mkpath(joinpath(notatree, "unrelated"))
+            cid = "Lambda__illumina__30x__seed42__qualmer"
+            result = merge_hosts(["typo" => notatree]; expected_ids = [cid])
+            Test.@test result.unreachable_sources == ["typo"]
+            code, problems = merge_exit_status(result)
+            Test.@test code == 1
+            Test.@test any(p -> occursin("not a checkpoint tree", p.message), problems)
+        end
+    end
+
+    Test.@testset "CR: malformed cells are counted in the report's evidence table" begin
+        mktempdir() do dir
+            host = joinpath(dir, "h")
+            broken = _tam_cell()
+            delete!(broken, "largest_contig")
+            cid = "Lambda__illumina__30x__seed42__qualmer"
+            _tam_write_cell(host, cid, broken)
+            result = merge_hosts(["h" => host]; expected_ids = [cid])
+            path = write_merge_report(joinpath(dir, "r.md"), result; output_dir = dir)
+            text = read(path, String)
+            # The class carries a suffix, so a bare-name lookup rendered 0 forever.
+            row = first(filter(l -> startswith(l, "| h |"), split(text, "\n")))
+            Test.@test occursin("1", row)
+            Test.@test !occursin("| h | 0 | 0 | 0 | 0 | 0 |", row)
+        end
+    end
+
+    Test.@testset "CR: nested values canonicalize stably" begin
+        # Falling through to `string(v)` rendered a nested object in Dict iteration
+        # order, so two hosts with EQUAL content could digest differently.
+        a = _tam_cell(); a["extra"] = Dict("z" => 1, "a" => 2, "m" => [1, 2, 3])
+        b = _tam_cell(); b["extra"] = Dict("a" => 2, "m" => [1, 2, 3], "z" => 1)
+        Test.@test cell_digest(a) == cell_digest(b)
+        Test.@test isempty(differing_fields(a, b))
+        c = _tam_cell(); c["extra"] = Dict("z" => 9, "a" => 2, "m" => [1, 2, 3])
+        Test.@test cell_digest(a) != cell_digest(c)
+    end
+
+    Test.@testset "CR: a non-numeric shard flag is usage error, not a stacktrace" begin
+        saved = copy(ARGS)
+        try
+            empty!(ARGS); append!(ARGS, ["--coverages", "10,notanumber"])
+            Test.@test _parse_int_flag("--coverages", TRACK_A_COVERAGES) === nothing
+            empty!(ARGS); append!(ARGS, ["--coverages", "10,30"])
+            Test.@test _parse_int_flag("--coverages", TRACK_A_COVERAGES) == [10, 30]
+            empty!(ARGS)
+            Test.@test _parse_int_flag("--seeds", TRACK_A_SEEDS) == TRACK_A_SEEDS
+        finally
+            empty!(ARGS); append!(ARGS, saved)
         end
     end
 end


### PR DESCRIPTION
Four related fixes in the benchmarking harness, all about a results table being
trustworthy enough to aggregate — plus the remediation of a 15-Critical review
round on the first version.

## Summary

- **`--min-contig` policy (`td-28o0`)** — `max(50, glen/10)` is monotone in genome
  length, so above 5 kb it inverted its own purpose and for T4 demanded a
  16,890 bp contig the naive arm cannot reach. Now `clamp(glen/10, 50, 500)`,
  clamped at QUAST's own default. Applied at **all four** call sites.
- **Mixed-definition guard (`td-9p91`)** — any aggregation spanning more than one
  `metric_source` or `quast_min_contig` raises, **per axis**. The opt-out is
  explicit, warns loudly, and now leaves a trace in the deliverable.
- **Cross-host merge (`td-bblmi`)** — reconciles the per-host Track A checkpoint
  trees. Detects collisions rather than picking a winner, records per-cell
  provenance, enumerates exactly what is missing, fails closed on unreachable or
  malformed sources, and writes tables only behind its own gate.
- **`seed` axis (`td-59o7`)** — a first-class column, actually **swept** by the
  harness and requested by both launchers, with a provenance-strict backfill and
  the paired-Wilcoxon analysis that consumes it.

## Review remediation (all 15 Critical + all 5 Important)

A comprehensive review of the first version found 15 Critical (11 convergent)
across five reviewers. All are fixed in the four `fix(review):` commits. The four
that most changed the result:

| # | Defect | Evidence |
| --- | --- | --- |
| C16 | A shard lacking `seed` created **pseudo-replicates**: `cols = :union` filled `seed = missing`, a presence-only check passed, and `missing` became a distinct pseudo-seed | Same 6 physical runs supplied twice reported **n = 12** and deflated p **27×** (0.0143 → 0.00053) |
| C9 | `decide()` had no falsified branch, so a significant **harm** reported as "PARTIALLY SUPPORTED" | Treatment worse on all 9 pairs, median **−45%**, FDR p = 0.0039 → now `FALSIFIED` |
| C13 | The 5,000 bp ceiling's rationale was **false on both halves** | Only one RGV CSV was ever committed (synthetic, threshold 200 under every policy); bead `td-4e19d.1` shows Lambda itself failed **8/12 cells** at 4,850 |
| C5 | `--allow-mixed-src` left no trace, and `report.md` then asserted the guard "enforces it" | Override now renders a blocking warning in `report.md` and lands in `results.json` |

The `--min-contig` change is the consequential one. Holding Lambda at 4,850
preserved a threshold that had **zeroed out two thirds of its own grid**, and a
per-reference threshold structurally blocked the pooled multi-organism analysis
the pre-registration specifies — the guard would refuse it, leaving the
(traceless) override as the only route. At 500 the threshold is uniform across
the viral tier, so the pooled analysis is legal by construction:

| reference | old inline | now |
| --- | --- | --- |
| viroid 300 | 50 | 50 (floor — the scaling term's real purpose) |
| phi29 19,282 | 1,928 | 500 |
| SARS-CoV-2 29,903 | 2,990 | 500 |
| Lambda 48,502 | 4,850 | 500 — recovers the err≥0.05 cells (largest 1,100 / 1,939 bp) |
| T4 168,903 | 16,890 | 500 — was failing outright |

Also corrected: the analysis no longer attributes itself to pre-registered **H1**
(H1 is *Viterbi DP vs greedy*; this compares correctors, and the
pre-registration contains zero mentions of error correction). Reports are labelled
**EXPLORATORY** and print the axes actually swept next to every p-value.

## Test Plan

- [x] **32,720 assertions across 5 suites, all passing in one process** as
      `include_all_tests(test/4_assembly)` runs them in default CI
- [x] Every Critical has a test that proves it fires: pseudo-replication refused;
      significant harm reports `FALSIFIED`; undefined effect size reports
      `INDETERMINATE`; partially-absent definition axis raises; unreadable
      checkpoint field is `malformed:*` and fatal; unreachable source fatal and
      **not** waivable by `--allow-incomplete`; override renders in the artifact
- [x] Wilcoxon cross-validated against `scipy.stats.wilcoxon` 1.16.3 on **both**
      branches (exact rank-sum DP; normal approximation with tie correction),
      exact agreement on W and p
- [x] Repo-wide grep test: no inline `max(50, <len> ÷ 10)` survives in code under
      `benchmarking/`
- [x] Sweep smoke run with `MYCELIA_RGV_SEED=42,123` — two seeds swept from **one**
      submission (previously three manual submissions)
- [x] Merge CLI re-verified: unreachable host → fatal, tables not written, prior
      contents intact; clean 2-host merge still writes tables
- [x] All changed files parse

## CI status

`test (lts)` is red on a **pre-existing flaky timing assertion** —
`windowed_decode_test.jl:166`, `t_win < t_whole` (2.30 vs 1.27 on a contended
runner). That file is not in this diff (`git diff --name-only 250f7f264..HEAD`),
and all five of this PR's suites pass in CI. Not attributable to this branch; a
perf assertion with no tolerance or warmup deserves its own bead.

## Not disturbed

Nine jobs were live when this was written. All edits are on this branch, Julia
loads these scripts once at process start, and the Track A checkpoint schema is
deliberately unchanged — the merge tool infers QUAST provenance rather than adding
a `metric_source` column, which would invalidate every existing checkpoint and
break resume.

## Related

`td-28o0`, `td-9p91`, `td-59o7`, `td-bblmi`, `td-yddpr`, `td-4e19d.1`, `td-ci77e`, `td-scnc`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added multi-seed benchmark runs (with seed axis) and captured seed/provenance in results.
  * Added a paired Wilcoxon analysis workflow with FDR-based decisions and figure generation.
  * Added tools to backfill missing seed metadata and to merge cross-host Track A checkpoints with collision/completeness/provenance reporting.
  * Standardized QUAST `--min-contig` computation and recorded the chosen threshold per genome.
  * Added a fail-closed metric-definition consistency guard to prevent aggregations across incompatible metrics.
* **Bug Fixes**
  * Prevented mixed-metric aggregations by raising actionable errors (or warning when explicitly allowed).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->