### PR TITLE
perf(corrector): opt-in approximate frozen-read skip (opt4, default off)

### DIFF
--- a/benchmarking/opt4_frozen_read_accuracy_signoff.jl
+++ b/benchmarking/opt4_frozen_read_accuracy_signoff.jl
@@ -1,0 +1,236 @@
+# OPT4 FROZEN-READ SKIP — REPRESENTATIVE-SCALE ACCURACY SIGN-OFF
+# =============================================================================
+# td-jbjd, Rule-of-5 pass 5 ("Verification"). Design doc:
+# docs/design/2026-07-26-opt4-frozen-read-skip-design.md ("Accuracy sign-off
+# methodology"). This is the load-bearing measurement that lets the maintainer
+# decide whether `skip_frozen_reads` (opt-in, default off) is worth recommending
+# to enable: it measures the accuracy/speed tradeoff on representative-scale
+# data, complementing the toy-scale positive-control investigation in
+# test/4_assembly/corrector_opt4_positive_control_test.jl (pass 4), whose
+# header documents WHY toy scale could not exercise this question: Stage 0
+# cheap correction (`_stage0_cheap_correct`, freeze-immune, runs unconditionally
+# before the freeze gate) dominates toy-scale correction volume and the toy
+# genome's dense graph trips the adaptive low-k decode gate
+# (`decode_gate_density`, default 0.90) to zero out decode entirely. This
+# script targets a scale/config (verified by `benchmarking/opt4_signoff_probe.jl`,
+# a throwaway probe kept for reproducibility) where the per-read Viterbi decode
+# demonstrably does real work (`decode_fraction_mean` > 0 and decode-attributable
+# edits, i.e. `total_improvements - cheap_corrections_total`, > 0), so opt4's
+# actual accuracy exposure -- confined to decode, per the pass-4 finding -- has
+# something to measure against.
+#
+# DOES NOT reuse `rhizomorph_correction_accuracy_benchmark.jl`'s `run_accuracy_
+# benchmark()` sweep driver (that harness has no `skip_frozen_reads` knob and is
+# intentionally left unmutated -- design doc: "extend
+# rhizomorph_correction_accuracy_benchmark.jl" was the METHODOLOGY, not a
+# license to add opt4-specific plumbing to the shared harness). Instead this
+# script `include`s it (safe: guarded by `abspath(PROGRAM_FILE) == @__FILE__`,
+# so including only DEFINES functions) and reuses its
+# `acquire_reference` / `simulate_substitution_reads` / `per_base_metrics`
+# building blocks directly, adding only the `skip_frozen_reads` /
+# `freeze_streak_threshold` / `freeze_across_rungs` passthrough that the shared
+# harness's `correct_reads_scalable` does not expose.
+#
+# FOUR ARMS on the IDENTICAL read set (same simulated reads/errors, same seed):
+#   1. exact             -- skip_frozen_reads=false (byte-identical-when-off path)
+#   2. freeze_within      -- skip_frozen_reads=true, threshold=2, across=false (DEFAULT scope)
+#   3. freeze_across       -- skip_frozen_reads=true, threshold=2, across=true (aggressive scope)
+#   4. freeze_max_aggressive -- skip_frozen_reads=true, threshold=1, across=true
+#      (the positive-control candidate: the most aggressive freeze setting this
+#      design doc's Rule-of-5 pass 4 tried and could NOT make degrade at toy
+#      scale -- here it is retried at a scale where decode does real work.)
+#
+# For each arm: per-base accuracy (recall/precision/over_correction_rate/
+# correction_rate) via `per_base_metrics`, wall-clock runtime, and
+# `frozen_reads_skipped` (from `result[:metadata][:corrector_errors]`).
+#
+# SCOPE NOTE: this script measures PER-BASE READ accuracy only (design doc
+# check #1), not the assembly-level dnadiff/ANI check (design doc check #2) --
+# deferred out of the ~40-minute compute budget for this pass; per-base
+# accuracy against injected-error ground truth is the primary, most direct
+# signal (it measures the corrector's own output, unmediated by a downstream
+# assembler), and is explicitly what this pass was asked to reuse.
+#
+# Run directly (network required to download the reference once):
+#   LD_LIBRARY_PATH='' julia --project=. \
+#     benchmarking/opt4_frozen_read_accuracy_signoff.jl
+#
+# Config override env vars (defaults chosen by benchmarking/opt4_signoff_probe.jl):
+#   MYCELIA_OPT4_ACCESSION   default NC_001416 (Lambda phage, 48502 bp)
+#   MYCELIA_OPT4_COVERAGE    default 8.0
+#   MYCELIA_OPT4_ERR         default 0.02 (substitution rate)
+#   MYCELIA_OPT4_READLEN     default 150
+#   MYCELIA_OPT4_K           default 21
+#   MYCELIA_OPT4_BATCH_SIZE  default 500
+#   MYCELIA_OPT4_SEED        default 42
+
+import Random
+import FASTX
+import Dates
+import CSV
+import DataFrames
+
+include(joinpath(@__DIR__, "rhizomorph_correction_accuracy_benchmark.jl"))
+
+"""
+Run the wired corrector (same knobs as `correct_reads_scalable`, plus the opt4
+freeze passthrough) on `records`, at k, writing to a fresh `output_dir`. Returns
+`(corrected_by_id, result)`.
+"""
+function correct_reads_with_freeze(records::Vector{FASTX.FASTQ.Record}, k::Int;
+        skip_frozen::Bool, threshold::Int, across::Bool, batch_size::Int,
+        output_dir::String)
+    input_dir = mktempdir()
+    temp_fastq = joinpath(input_dir, "in.fastq")
+    open(FASTX.FASTQ.Writer, temp_fastq) do w
+        for r in records
+            write(w, r)
+        end
+    end
+    max_k = max(k, 13)
+    result = Mycelia.mycelia_iterative_assemble(
+        temp_fastq;
+        max_k = max_k, skip_solid = true, graph_mode = :doublestrand,
+        n_k_rungs = 3, max_iterations_per_k = 2, batch_size = batch_size,
+        hard_window = true, soft_em = true, cheap_correct = true,
+        beam_width = nothing, verbose = false, enable_checkpointing = false,
+        skip_frozen_reads = skip_frozen, freeze_streak_threshold = threshold,
+        freeze_across_rungs = across, output_dir = output_dir)
+    corrected_fastq = result[:metadata][:final_fastq_file]
+    corrected_by_id = Dict{String, String}()
+    open(FASTX.FASTQ.Reader, corrected_fastq) do rd
+        for rec in rd
+            corrected_by_id[FASTX.identifier(rec)] = FASTX.sequence(String, rec)
+        end
+    end
+    return corrected_by_id, result
+end
+
+const ARMS = [
+    (label = "exact", skip_frozen = false, threshold = 2, across = false),
+    (label = "freeze_within", skip_frozen = true, threshold = 2, across = false),
+    (label = "freeze_across", skip_frozen = true, threshold = 2, across = true),
+    (
+        label = "freeze_max_aggressive", skip_frozen = true, threshold = 1,
+        across = true)
+]
+
+function run_signoff()
+    accession = get(ENV, "MYCELIA_OPT4_ACCESSION", "NC_001416")
+    coverage = parse(Float64, get(ENV, "MYCELIA_OPT4_COVERAGE", "8.0"))
+    err = parse(Float64, get(ENV, "MYCELIA_OPT4_ERR", "0.02"))
+    readlen = parse(Int, get(ENV, "MYCELIA_OPT4_READLEN", "150"))
+    k = parse(Int, get(ENV, "MYCELIA_OPT4_K", "21"))
+    batch_size = parse(Int, get(ENV, "MYCELIA_OPT4_BATCH_SIZE", "500"))
+    seed = parse(Int, get(ENV, "MYCELIA_OPT4_SEED", "42"))
+    assigned_q = 20
+
+    println("=== OPT4 frozen-read-skip representative-scale accuracy sign-off ===")
+    println("Start: $(Dates.now())")
+    println(
+        "Config: accession=$accession coverage=$(coverage)x err=$err readlen=$readlen k=$k batch_size=$batch_size seed=$seed")
+
+    workdir = mktempdir(prefix = "opt4_signoff_")
+    results_dir = joinpath(@__DIR__, "results")
+    mkpath(results_dir)
+
+    refseq, ref_path,
+    ref_label = acquire_reference(
+        smoke = false, accession = accession, smoke_len = 0, seed = seed,
+        workdir = workdir)
+    glen = length(refseq)
+    println("Reference: $ref_label ($glen bp)")
+
+    rng = Random.MersenneTwister(seed)
+    records, truth_by_id,
+    observed_by_id,
+    injected_total,
+    sampled_bases = simulate_substitution_reads(
+        refseq, readlen, coverage, err, rng; assigned_q = assigned_q)
+    eff_cov = round(sampled_bases / glen; digits = 2)
+    println(
+        "Simulated $(length(records)) reads, effective coverage $(eff_cov)x, injected $injected_total substitutions")
+
+    rows = DataFrames.DataFrame(
+        arm = String[], skip_frozen_reads = Bool[], freeze_streak_threshold = Int[],
+        freeze_across_rungs = Bool[], runtime_s = Float64[],
+        frozen_reads_skipped = Int[], decode_fraction_mean = Float64[],
+        decode_fraction_max = Float64[], total_improvements = Int[],
+        cheap_corrections_total = Int[], decode_attributable_edits = Int[],
+        reads_scored = Int[], injected_errors = Int[], total_edits = Int[],
+        true_fixes = Int[], mis_fixes = Int[], over_corrections = Int[],
+        recall = Float64[], precision = Float64[], over_correction_rate = Float64[],
+        correction_rate = Float64[])
+
+    arm_records = Dict{String, Any}()
+
+    for arm in ARMS
+        println("\n--- Arm: $(arm.label) ---")
+        t0 = time()
+        corrected_by_id,
+        result = correct_reads_with_freeze(
+            records, k; skip_frozen = arm.skip_frozen, threshold = arm.threshold,
+            across = arm.across, batch_size = batch_size,
+            output_dir = joinpath(workdir, arm.label))
+        runtime = time() - t0
+        md = result[:metadata]
+        m = per_base_metrics(truth_by_id, observed_by_id, corrected_by_id)
+        decode_edits = md[:total_improvements] - md[:cheap_corrections_total]
+        frozen_skipped = md[:corrector_errors][:frozen_reads_skipped]
+
+        push!(rows,
+            (
+                arm = arm.label, skip_frozen_reads = arm.skip_frozen,
+                freeze_streak_threshold = arm.threshold,
+                freeze_across_rungs = arm.across, runtime_s = round(runtime; digits = 3),
+                frozen_reads_skipped = frozen_skipped,
+                decode_fraction_mean = round(md[:decode_fraction_mean]; digits = 4),
+                decode_fraction_max = round(md[:decode_fraction_max]; digits = 4),
+                total_improvements = md[:total_improvements],
+                cheap_corrections_total = md[:cheap_corrections_total],
+                decode_attributable_edits = decode_edits, reads_scored = m.reads_scored,
+                injected_errors = m.injected, total_edits = m.total_edits,
+                true_fixes = m.tp, mis_fixes = m.mis_fixes, over_corrections = m.over,
+                recall = round(m.recall; digits = 6), precision = round(m.precision; digits = 6),
+                over_correction_rate = round(m.over_rate; digits = 6),
+                correction_rate = round(m.correction_rate; digits = 6)))
+
+        arm_records[arm.label] = (; corrected_by_id, result, m, runtime)
+        println(
+            "  runtime=$(round(runtime; digits=1))s frozen_reads_skipped=$frozen_skipped " *
+            "decode_frac(mean/max)=$(round(md[:decode_fraction_mean]; digits=4))/$(round(md[:decode_fraction_max]; digits=4)) " *
+            "decode_attributable_edits=$decode_edits")
+        println(
+            "  recall=$(round(m.recall; digits=4)) precision=$(round(m.precision; digits=4)) " *
+            "over_rate=$(round(m.over_rate; digits=6)) correction_rate=$(round(m.correction_rate; digits=4)) " *
+            "true_fixes=$(m.tp) mis_fixes=$(m.mis_fixes) over_corrections=$(m.over)")
+    end
+
+    # Byte-identity check between arms (belt-and-suspenders on top of the
+    # per-base metrics, mirroring the pass-4 positive-control test's own check).
+    exact_recs = sort(collect(arm_records["exact"].corrected_by_id))
+    for label in ("freeze_within", "freeze_across", "freeze_max_aggressive")
+        this_recs = sort(collect(arm_records[label].corrected_by_id))
+        identical = exact_recs == this_recs
+        n_diff = count(
+            i -> exact_recs[i][2] != this_recs[i][2],
+            1:min(length(exact_recs), length(this_recs)))
+        println(
+            "\n[identity] exact vs $label: byte-identical=$identical (reads differing: $n_diff / $(length(exact_recs)))")
+    end
+
+    timestamp = Dates.format(Dates.now(), "yyyymmdd_HHMMSS")
+    csv_path = joinpath(results_dir, "opt4_frozen_read_skip_signoff_$(timestamp).csv")
+    CSV.write(csv_path, rows)
+    println("\nCSV written: $csv_path")
+    println("\n=== Sign-off run complete: $(Dates.now()) ===")
+    return (
+        rows = rows, arm_records = arm_records, csv_path = csv_path, glen = glen,
+        ref_label = ref_label, n_reads = length(records), eff_cov = eff_cov,
+        injected_total = injected_total,
+        config = (; accession, coverage, err, readlen, k, batch_size, seed))
+end
+
+if abspath(PROGRAM_FILE) == @__FILE__
+    run_signoff()
+end

--- a/benchmarking/opt4_frozen_read_dnadiff_signoff.jl
+++ b/benchmarking/opt4_frozen_read_dnadiff_signoff.jl
@@ -249,10 +249,25 @@ function run_dnadiff_check()
             return something(tryparse(Float64, replace(s, "%" => "")), NaN)
         end
         avg_identity = _num(_find(["avgidentity", "avg_identity", "averageidentity"]))
-        aligned_pct_ref = _num(_find(["alignedbasesref", "aligned_bases_ref", "alignedref"]))
+        # parse_dnadiff_report's summary drops TotalSNPs/TotalIndels/AlignedBases
+        # (it matches the bare tokens SNPs/Indels, but dnadiff emits TotalSNPs/
+        # TotalIndels). Parse those fields DIRECTLY from the .report file, which
+        # is committed alongside this CSV as reproducible evidence. Report line
+        # format: `FieldName   <ref-col>   <query-col>` (ref col first).
+        function _report_field(report_path::String, field::String)
+            for line in eachline(report_path)
+                parts = split(strip(line))
+                if !isempty(parts) && parts[1] == field
+                    return length(parts) >= 2 ? parts[2] : nothing
+                end
+            end
+            return nothing
+        end
+        # AlignedBases ref col is like "48469(99.93%)" -> _num extracts 99.93.
+        aligned_pct_ref = _num(_report_field(dnadiff_paths.report, "AlignedBases"))
         aligned_pct_query = _num(_find(["alignedbasesquery", "aligned_bases_query", "alignedquery"]))
-        snps = _num(_find(["totalsnps", "snps"]))
-        indels = _num(_find(["totalindels", "indels"]))
+        snps = _num(_report_field(dnadiff_paths.report, "TotalSNPs"))
+        indels = _num(_report_field(dnadiff_paths.report, "TotalIndels"))
 
         println(
             "  dnadiff: avg_identity=$avg_identity aligned_pct_ref=$aligned_pct_ref " *

--- a/benchmarking/opt4_frozen_read_dnadiff_signoff.jl
+++ b/benchmarking/opt4_frozen_read_dnadiff_signoff.jl
@@ -1,0 +1,283 @@
+# OPT4 FROZEN-READ SKIP — ASSEMBLY-LEVEL (dnadiff/ANI) ACCURACY CHECK
+# =============================================================================
+# td-jbjd, Rule-of-5 pass 5 follow-on. Design doc:
+# docs/design/2026-07-26-opt4-frozen-read-skip-design.md ("Accuracy sign-off
+# methodology") lists TWO checks: (1) per-base accuracy against injected-error
+# ground truth (done by benchmarking/opt4_frozen_read_accuracy_signoff.jl,
+# results in benchmarking/results/opt4_frozen_read_skip_signoff.md) and (2) an
+# assembly-level dnadiff/ANI check (re-assemble the corrected reads and diff
+# the resulting contigs against the reference). This script does (2), on the
+# SAME fixture (Lambda phage NC_001416, seed 42, :scalable production knobs)
+# pass 5 used.
+#
+# THREE ARMS, each producing an assembly diffed against the reference:
+#   1. raw       -- the uncorrected simulated reads (sanity baseline: confirms
+#                    the assembler works and correction helps at all)
+#   2. exact      -- corrected reads from skip_frozen_reads=false
+#   3. freeze_across -- corrected reads from skip_frozen_reads=true,
+#                    threshold=2, across=true (the non-default, non-maximal
+#                    scope pass 5 found gives ~15-17% decode-volume savings for
+#                    a -0.02% relative recall cost at 21x per-base)
+#
+# CRITICAL mechanics note (why this actually tests something): each arm's
+# CORRECTED reads are assembled WITHOUT re-running the iterative corrector --
+# assemble_genome(...; corrector=:none, use_quality_scores=false) routes
+# straight to the plain k-mer graph (_assemble_kmer_graph), never touching
+# mycelia_iterative_assemble. If the corrected reads were re-corrected
+# identically here, the exact-vs-freeze_across difference already present in
+# the input reads would be washed out before it ever reached the assembler.
+# Same k / graph_mode / dedup for every arm (only the input reads differ), so
+# any contig-level delta between exact and freeze_across is attributable to
+# the frozen-read-skip mechanism, not to a downstream assembly wobble.
+#
+# Reuses correct_reads_with_freeze / acquire_reference / simulate_substitution_
+# reads from opt4_frozen_read_accuracy_signoff.jl (safe to include: guarded by
+# abspath(PROGRAM_FILE) == @__FILE__, so including only DEFINES functions).
+#
+# Run directly (network required to download the reference once; mummer
+# bioconda env must be present -- verified pre-run via `Mycelia.add_bioconda_
+# env("mummer")` which is a no-op if already installed):
+#   LD_LIBRARY_PATH='' julia --project=. \
+#     benchmarking/opt4_frozen_read_dnadiff_signoff.jl
+#
+# Config override env vars (same names/defaults as the per-base script):
+#   MYCELIA_OPT4_ACCESSION   default NC_001416 (Lambda phage, 48502 bp)
+#   MYCELIA_OPT4_COVERAGE    default 8.0 (set to 21.0 for VERDICT-tier parity
+#                             with the per-base sign-off's Tier B)
+#   MYCELIA_OPT4_ERR         default 0.02 (substitution rate)
+#   MYCELIA_OPT4_READLEN     default 150
+#   MYCELIA_OPT4_K           default 21
+#   MYCELIA_OPT4_BATCH_SIZE  default 500
+#   MYCELIA_OPT4_SEED        default 42
+
+import Random
+import FASTX
+import BioSequences
+import Dates
+import CSV
+import DataFrames
+
+include(joinpath(@__DIR__, "opt4_frozen_read_accuracy_signoff.jl"))
+
+"""
+Assemble `records` (a Vector of FASTX.FASTQ.Record) into contigs WITHOUT
+running the iterative corrector: `corrector=:none` (the AssemblyConfig
+default) routes straight to the plain k-mer / qualmer graph, never calling
+`mycelia_iterative_assemble`. `use_quality_scores=false` forces the
+deterministic k-mer graph path (`_assemble_kmer_graph`) instead of the
+qualmer path, so no placeholder quality injection or quality-weighted
+traversal is in play -- the assembly is a pure function of the input
+sequences. Returns the `AssemblyResult`.
+"""
+function assemble_no_correction(
+        records::Vector{FASTX.FASTQ.Record}; k::Int, graph_mode::Symbol)
+    gm = graph_mode == :doublestrand ? Mycelia.Rhizomorph.DoubleStrand :
+         graph_mode == :canonical ? Mycelia.Rhizomorph.Canonical :
+         Mycelia.Rhizomorph.SingleStrand
+    return Mycelia.Rhizomorph.assemble_genome(
+        records; corrector = :none, k = k, graph_mode = gm,
+        use_quality_scores = false, verbose = false)
+end
+
+"""
+Write `result.contigs` (Vector{String}) to a FASTA file at `path` and return
+`path`.
+"""
+function write_contigs_fasta(result, path::String; label_prefix::String)
+    recs = FASTX.FASTA.Record[]
+    for (i, seq) in enumerate(result.contigs)
+        push!(recs, FASTX.FASTA.Record("$(label_prefix)_contig_$(i)", seq))
+    end
+    open(FASTX.FASTA.Writer, path) do w
+        for r in recs
+            write(w, r)
+        end
+    end
+    return path
+end
+
+function run_dnadiff_check()
+    accession = get(ENV, "MYCELIA_OPT4_ACCESSION", "NC_001416")
+    coverage = parse(Float64, get(ENV, "MYCELIA_OPT4_COVERAGE", "21.0"))
+    err = parse(Float64, get(ENV, "MYCELIA_OPT4_ERR", "0.02"))
+    readlen = parse(Int, get(ENV, "MYCELIA_OPT4_READLEN", "150"))
+    k = parse(Int, get(ENV, "MYCELIA_OPT4_K", "21"))
+    batch_size = parse(Int, get(ENV, "MYCELIA_OPT4_BATCH_SIZE", "500"))
+    seed = parse(Int, get(ENV, "MYCELIA_OPT4_SEED", "42"))
+    assigned_q = 20
+
+    println("=== OPT4 frozen-read-skip ASSEMBLY-LEVEL (dnadiff/ANI) check ===")
+    println("Start: $(Dates.now())")
+    println(
+        "Config: accession=$accession coverage=$(coverage)x err=$err readlen=$readlen k=$k batch_size=$batch_size seed=$seed")
+
+    workdir = mktempdir(prefix = "opt4_dnadiff_")
+    results_dir = joinpath(@__DIR__, "results")
+    mkpath(results_dir)
+
+    # Verify mummer env up front so a missing dependency fails fast, before
+    # spending the correction/assembly compute budget.
+    try
+        Mycelia.add_bioconda_env("mummer")
+    catch e
+        println("BLOCKER: mummer bioconda env unavailable: $e")
+        rethrow(e)
+    end
+
+    refseq, ref_path,
+    ref_label = acquire_reference(
+        smoke = false, accession = accession, smoke_len = 0, seed = seed,
+        workdir = workdir)
+    glen = length(refseq)
+    println("Reference: $ref_label ($glen bp)")
+
+    rng = Random.MersenneTwister(seed)
+    records, truth_by_id,
+    observed_by_id,
+    injected_total,
+    sampled_bases = simulate_substitution_reads(
+        refseq, readlen, coverage, err, rng; assigned_q = assigned_q)
+    eff_cov = round(sampled_bases / glen; digits = 2)
+    println(
+        "Simulated $(length(records)) reads, effective coverage $(eff_cov)x, injected $injected_total substitutions")
+
+    # --- Correction step: exact + freeze_across only (this check's two arms) ---
+    correction_arms = [
+        (label = "exact", skip_frozen = false, threshold = 2, across = false),
+        (label = "freeze_across", skip_frozen = true, threshold = 2, across = true)
+    ]
+
+    corrected_records = Dict{String, Vector{FASTX.FASTQ.Record}}()
+    corrected_records["raw"] = records  # uncorrected baseline
+
+    for arm in correction_arms
+        println("\n--- Correcting: $(arm.label) ---")
+        t0 = time()
+        corrected_by_id,
+        result = correct_reads_with_freeze(
+            records, k; skip_frozen = arm.skip_frozen, threshold = arm.threshold,
+            across = arm.across, batch_size = batch_size,
+            output_dir = joinpath(workdir, "correct_$(arm.label)"))
+        runtime = time() - t0
+        frozen_skipped = result[:metadata][:corrector_errors][:frozen_reads_skipped]
+        println(
+            "  correction runtime=$(round(runtime; digits=1))s frozen_reads_skipped=$frozen_skipped")
+        # Rebuild FASTQ records in the ORIGINAL read order/id set from the
+        # corrected sequence dict, reusing each original record's quality
+        # string length-for-length (corrected sequences preserve read length
+        # per the corrector's length contract). This keeps record count/order
+        # identical to `records` so the assembler sees the same read set,
+        # differing only in sequence content.
+        recs = Vector{FASTX.FASTQ.Record}(undef, length(records))
+        for (i, r) in enumerate(records)
+            id = FASTX.identifier(r)
+            corrected_seq = corrected_by_id[id]
+            qual = FASTX.quality(r)
+            recs[i] = FASTX.FASTQ.Record(id, corrected_seq, qual)
+        end
+        corrected_records[arm.label] = recs
+    end
+
+    # --- Assembly step: assemble each arm's reads WITHOUT re-correcting ---
+    dnadiff_rows = DataFrames.DataFrame(
+        arm = String[], n_contigs = Int[], total_contig_bases = Int[],
+        largest_contig = Int[], avg_identity = Float64[],
+        aligned_pct_ref = Float64[], aligned_pct_query = Float64[],
+        total_snps = Float64[], total_indels = Float64[])
+
+    assembly_results = Dict{String, Any}()
+    for arm_label in ("raw", "exact", "freeze_across")
+        println("\n--- Assembling (corrector=:none): $(arm_label) ---")
+        t0 = time()
+        result = assemble_no_correction(
+            corrected_records[arm_label]; k = k, graph_mode = :doublestrand)
+        runtime = time() - t0
+        n_contigs = length(result.contigs)
+        total_bases = sum(length.(result.contigs); init = 0)
+        largest = isempty(result.contigs) ? 0 : maximum(length.(result.contigs))
+        println(
+            "  assembly runtime=$(round(runtime; digits=1))s n_contigs=$n_contigs total_bases=$total_bases largest=$largest")
+        assembly_results[arm_label] = result
+
+        query_fasta = joinpath(workdir, "$(arm_label)_contigs.fasta")
+        write_contigs_fasta(result, query_fasta; label_prefix = arm_label)
+
+        if isempty(result.contigs)
+            println("  WARNING: zero contigs produced for arm=$arm_label; skipping dnadiff")
+            push!(dnadiff_rows,
+                (arm = arm_label, n_contigs = 0, total_contig_bases = 0,
+                    largest_contig = 0, avg_identity = NaN, aligned_pct_ref = NaN,
+                    aligned_pct_query = NaN, total_snps = 0, total_indels = 0))
+            continue
+        end
+
+        dnadiff_outdir = joinpath(workdir, "dnadiff_$(arm_label)")
+        dnadiff_paths = Mycelia.run_dnadiff(;
+            reference = ref_path, query = query_fasta, outdir = dnadiff_outdir,
+            prefix = "dnadiff_$(arm_label)")
+        report = Mycelia.parse_dnadiff_report(dnadiff_paths.report)
+        # Copy the raw report out (mktempdir workdir is auto-removed on exit) so
+        # numbers are independently verifiable after the run.
+        cp(dnadiff_paths.report,
+            joinpath(results_dir, "opt4_dnadiff_$(arm_label).report"); force = true)
+        # parse_dnadiff_report returns (; summary, distance, distance_aligned,
+        # raw_sections). `summary` is a NamedTuple keyed by lowercased dnadiff
+        # field names; extract by fuzzy match to be robust to exact naming.
+        smry = Dict{Symbol, Any}(pairs(report.summary))
+        for (_sec, _mets) in report.raw_sections
+            for (_mk, _mv) in _mets
+                get!(smry, _mk, _mv)  # summary wins on key collision
+            end
+        end
+        println("  dnadiff summary: ",
+            join(["$(k)=$(smry[k])" for k in sort(collect(keys(smry)))], " "))
+        function _find(subs::Vector{String})
+            for k in keys(smry)
+                lk = lowercase(string(k))
+                if any(occursin(s, lk) for s in subs)
+                    return smry[k]
+                end
+            end
+            return nothing
+        end
+        function _num(x)
+            x === nothing && return NaN
+            x isa Number && return Float64(x)
+            s = string(x)
+            m = match(r"\(([0-9.]+)%\)", s)  # "48000(98.9%)" -> 98.9
+            m !== nothing && return something(tryparse(Float64, m.captures[1]), NaN)
+            return something(tryparse(Float64, replace(s, "%" => "")), NaN)
+        end
+        avg_identity = _num(_find(["avgidentity", "avg_identity", "averageidentity"]))
+        aligned_pct_ref = _num(_find(["alignedbasesref", "aligned_bases_ref", "alignedref"]))
+        aligned_pct_query = _num(_find(["alignedbasesquery", "aligned_bases_query", "alignedquery"]))
+        snps = _num(_find(["totalsnps", "snps"]))
+        indels = _num(_find(["totalindels", "indels"]))
+
+        println(
+            "  dnadiff: avg_identity=$avg_identity aligned_pct_ref=$aligned_pct_ref " *
+            "aligned_pct_query=$aligned_pct_query snps=$snps indels=$indels")
+
+        push!(dnadiff_rows,
+            (arm = arm_label, n_contigs = n_contigs, total_contig_bases = total_bases,
+                largest_contig = largest, avg_identity = avg_identity,
+                aligned_pct_ref = aligned_pct_ref, aligned_pct_query = aligned_pct_query,
+                total_snps = snps, total_indels = indels))
+    end
+
+    timestamp = Dates.format(Dates.now(), "yyyymmdd_HHMMSS")
+    csv_path = joinpath(
+        results_dir, "opt4_frozen_read_skip_dnadiff_$(timestamp).csv")
+    CSV.write(csv_path, dnadiff_rows)
+    println("\nCSV written: $csv_path")
+    println(dnadiff_rows)
+    println("\n=== dnadiff check complete: $(Dates.now()) ===")
+    return (
+        rows = dnadiff_rows, csv_path = csv_path, glen = glen, ref_label = ref_label,
+        n_reads = length(records), eff_cov = eff_cov,
+        config = (; accession, coverage, err, readlen, k, batch_size, seed))
+end
+
+if abspath(PROGRAM_FILE) == @__FILE__
+    run_dnadiff_check()
+end

--- a/benchmarking/opt4_signoff_probe.jl
+++ b/benchmarking/opt4_signoff_probe.jl
@@ -1,0 +1,74 @@
+# OPT4 PASS-5 SIGN-OFF — CONFIG PROBE (td-jbjd, pass 5, throwaway script)
+# =============================================================================
+# Establishes whether a given (accession, coverage, error_rate, k, batch_size)
+# configuration makes the per-read Viterbi decode do REAL work (as opposed to
+# the pass-4 finding: at toy scale Stage 0 dominates and the adaptive low-k
+# decode gate disables decode entirely). Evidence checked per candidate:
+#   - result[:metadata][:decode_fraction_mean] > 0  (decode was not gated to 0
+#     on every pass -- see :2085 `effective_decode_gate_density` /
+#     iterative-assembly.jl ~4831 `adaptive_gated`)
+#   - total_improvements - cheap_corrections_total > 0 (decode, not just Stage
+#     0, made edits)
+# Run directly (network required, downloads the reference once):
+#   LD_LIBRARY_PATH='' julia --project=. benchmarking/opt4_signoff_probe.jl
+
+import Random
+import FASTX
+
+include(joinpath(@__DIR__, "rhizomorph_correction_accuracy_benchmark.jl"))
+
+function probe_config(; accession, coverage, err, readlen, k, batch_size, seed = 42)
+    workdir = mktempdir(prefix = "opt4_probe_")
+    refseq, ref_path,
+    ref_label = acquire_reference(
+        smoke = false, accession = accession, smoke_len = 0, seed = seed, workdir = workdir)
+    glen = length(refseq)
+    rng = Random.MersenneTwister(seed)
+    records, truth_by_id,
+    observed_by_id,
+    injected_total,
+    sampled_bases = simulate_substitution_reads(
+        refseq, readlen, coverage, err, rng; assigned_q = 20)
+    println("  genome=$ref_label ($glen bp) reads=$(length(records)) injected=$injected_total sampled_bases=$sampled_bases")
+
+    input_dir = mktempdir()
+    temp_fastq = joinpath(input_dir, "in.fastq")
+    open(FASTX.FASTQ.Writer, temp_fastq) do w
+        for r in records
+            write(w, r)
+        end
+    end
+    max_k = max(k, 13)
+    t0 = time()
+    result = Mycelia.mycelia_iterative_assemble(
+        temp_fastq;
+        max_k = max_k, skip_solid = true, graph_mode = :doublestrand,
+        n_k_rungs = 3, max_iterations_per_k = 2, batch_size = batch_size,
+        hard_window = true, soft_em = true, cheap_correct = true,
+        beam_width = nothing, verbose = false, enable_checkpointing = false,
+        output_dir = joinpath(workdir, "run"))
+    runtime = time() - t0
+    md = result[:metadata]
+    decode_edits = md[:total_improvements] - md[:cheap_corrections_total]
+    println("  runtime=$(round(runtime; digits=1))s decode_fraction(mean/max)=" *
+            "$(round(md[:decode_fraction_mean]; digits=4))/$(round(md[:decode_fraction_max]; digits=4)) " *
+            "total_improvements=$(md[:total_improvements]) cheap_total=$(md[:cheap_corrections_total]) " *
+            "decode_attributable_edits=$decode_edits final_k=$(md[:final_k])")
+    return (; runtime, md, glen, n_reads = length(records), injected_total)
+end
+
+candidates = [
+    (accession = "NC_001416", coverage = 8.0, err = 0.02,
+        readlen = 150, k = 21, batch_size = 500),
+    (accession = "NC_001416", coverage = 12.0, err = 0.03,
+        readlen = 150, k = 31, batch_size = 500)
+]
+
+for (i, c) in enumerate(candidates)
+    println("\n=== Candidate $i: $c ===")
+    try
+        probe_config(; c...)
+    catch e
+        println("  FAILED: $e")
+    end
+end

--- a/benchmarking/opt4_signoff_supplementary_probe.jl
+++ b/benchmarking/opt4_signoff_supplementary_probe.jl
@@ -1,0 +1,94 @@
+# OPT4 PASS-5 SIGN-OFF — SUPPLEMENTARY PROBE (td-jbjd, throwaway script)
+# =============================================================================
+# The main sign-off (opt4_frozen_read_accuracy_signoff.jl) found
+# freeze_within (skip_frozen_reads=true, threshold=2, across=false, the DEFAULT
+# scope) skipped ZERO reads at the production `:scalable`-tier config
+# (n_k_rungs=3, max_iterations_per_k=2). Mechanism: within-rung resets the
+# per-read streak to 0 at every k-change, and a threshold=2 freeze needs 2
+# CONSECUTIVE no-improvement passes at the SAME k before it can skip a 3rd
+# pass -- but max_iterations_per_k=2 means there is no 3rd pass at any k, so
+# the freeze condition can be satisfied only on the LAST iteration of a rung,
+# by which point there is nothing left to skip. This probe raises
+# max_iterations_per_k to check whether within-rung freezing CAN engage when
+# given room, and if so what its accuracy/speed profile looks like -- purely
+# to explain, not to change, the main sign-off's config choice (which
+# deliberately matches the real `:scalable` production knobs).
+#
+# Run directly:
+#   LD_LIBRARY_PATH='' julia --project=. \
+#     benchmarking/opt4_signoff_supplementary_probe.jl
+
+import Random
+import FASTX
+
+include(joinpath(@__DIR__, "rhizomorph_correction_accuracy_benchmark.jl"))
+
+function run_arm(records, truth_by_id, observed_by_id, k, workdir, label;
+        skip_frozen, threshold, across, max_iterations_per_k, batch_size = 500)
+    input_dir = mktempdir()
+    temp_fastq = joinpath(input_dir, "in.fastq")
+    open(FASTX.FASTQ.Writer, temp_fastq) do w
+        for r in records
+            write(w, r)
+        end
+    end
+    max_k = max(k, 13)
+    t0 = time()
+    result = Mycelia.mycelia_iterative_assemble(
+        temp_fastq;
+        max_k = max_k, skip_solid = true, graph_mode = :doublestrand,
+        n_k_rungs = 3, max_iterations_per_k = max_iterations_per_k,
+        batch_size = batch_size, hard_window = true, soft_em = true,
+        cheap_correct = true, beam_width = nothing, verbose = false,
+        enable_checkpointing = false, skip_frozen_reads = skip_frozen,
+        freeze_streak_threshold = threshold, freeze_across_rungs = across,
+        output_dir = joinpath(workdir, label))
+    runtime = time() - t0
+    corrected_by_id = Dict{String, String}()
+    open(FASTX.FASTQ.Reader, result[:metadata][:final_fastq_file]) do rd
+        for rec in rd
+            corrected_by_id[FASTX.identifier(rec)] = FASTX.sequence(String, rec)
+        end
+    end
+    m = per_base_metrics(truth_by_id, observed_by_id, corrected_by_id)
+    md = result[:metadata]
+    println(
+        "[$label] miPk=$max_iterations_per_k runtime=$(round(runtime; digits=1))s " *
+        "frozen_reads_skipped=$(md[:corrector_errors][:frozen_reads_skipped]) " *
+        "recall=$(round(m.recall; digits=4)) precision=$(round(m.precision; digits=4)) " *
+        "over_rate=$(round(m.over_rate; digits=6)) true_fixes=$(m.tp)")
+    return (; runtime, m, md, corrected_by_id)
+end
+
+function main()
+    accession = "NC_001416"
+    coverage = 8.0
+    err = 0.02
+    readlen = 150
+    k = 21
+    seed = 42
+    workdir = mktempdir(prefix = "opt4_suppl_")
+    refseq, ref_path,
+    ref_label = acquire_reference(
+        smoke = false, accession = accession, smoke_len = 0, seed = seed,
+        workdir = workdir)
+    rng = Random.MersenneTwister(seed)
+    records, truth_by_id,
+    observed_by_id,
+    injected_total = simulate_substitution_reads(
+        refseq, readlen, coverage, err, rng; assigned_q = 20)
+    println("reads=$(length(records)) injected=$injected_total")
+
+    for mipk in (4,)
+        println("\n=== max_iterations_per_k=$mipk ===")
+        run_arm(records, truth_by_id, observed_by_id, k, workdir, "exact_mipk$mipk";
+            skip_frozen = false, threshold = 2, across = false,
+            max_iterations_per_k = mipk)
+        run_arm(
+            records, truth_by_id, observed_by_id, k, workdir, "within_mipk$mipk";
+            skip_frozen = true, threshold = 2, across = false,
+            max_iterations_per_k = mipk)
+    end
+end
+
+main()

--- a/benchmarking/results/opt4_dnadiff_exact.report
+++ b/benchmarking/results/opt4_dnadiff_exact.report
@@ -1,0 +1,87 @@
+/Users/cameronprybol/workspace/tmp/opt4_dnadiff_6ZNkvu/NC_001416/NC_001416.fna /Users/cameronprybol/workspace/tmp/opt4_dnadiff_6ZNkvu/exact_contigs.fasta
+NUCMER
+
+                               [REF]                [QRY]
+[Sequences]
+TotalSeqs                          1                 2983
+AlignedSeqs               1(100.00%)             6(0.20%)
+UnalignedSeqs               0(0.00%)         2977(99.80%)
+
+[Bases]
+TotalBases                     48502               184523
+AlignedBases           48469(99.93%)        96973(52.55%)
+UnalignedBases             33(0.07%)        87550(47.45%)
+
+[Alignments]
+1-to-1                             2                    2
+TotalLength                    48489                48489
+AvgLength                   24244.50             24244.50
+AvgIdentity                   100.00               100.00
+
+M-to-M                             6                    6
+TotalLength                    96973                96973
+AvgLength                   16162.17             16162.17
+AvgIdentity                   100.00               100.00
+
+[Feature Estimates]
+Breakpoints                       12                    0
+Relocations                        0                    0
+Translocations                     1                    0
+Inversions                         0                    0
+
+Insertions                         2                    4
+InsertionSum                      33                48484
+InsertionAvg                   16.50             12121.00
+
+TandemIns                          0                    0
+TandemInsSum                       0                    0
+TandemInsAvg                    0.00                 0.00
+
+[SNPs]
+TotalSNPs                          0                    0
+GC                          0(0.00%)             0(0.00%)
+GT                          0(0.00%)             0(0.00%)
+GA                          0(0.00%)             0(0.00%)
+CG                          0(0.00%)             0(0.00%)
+CA                          0(0.00%)             0(0.00%)
+CT                          0(0.00%)             0(0.00%)
+TG                          0(0.00%)             0(0.00%)
+TA                          0(0.00%)             0(0.00%)
+TC                          0(0.00%)             0(0.00%)
+AG                          0(0.00%)             0(0.00%)
+AT                          0(0.00%)             0(0.00%)
+AC                          0(0.00%)             0(0.00%)
+
+TotalGSNPs                         0                    0
+GT                          0(0.00%)             0(0.00%)
+GC                          0(0.00%)             0(0.00%)
+GA                          0(0.00%)             0(0.00%)
+CT                          0(0.00%)             0(0.00%)
+CA                          0(0.00%)             0(0.00%)
+CG                          0(0.00%)             0(0.00%)
+TC                          0(0.00%)             0(0.00%)
+TA                          0(0.00%)             0(0.00%)
+TG                          0(0.00%)             0(0.00%)
+AG                          0(0.00%)             0(0.00%)
+AT                          0(0.00%)             0(0.00%)
+AC                          0(0.00%)             0(0.00%)
+
+TotalIndels                        0                    0
+G.                          0(0.00%)             0(0.00%)
+C.                          0(0.00%)             0(0.00%)
+T.                          0(0.00%)             0(0.00%)
+A.                          0(0.00%)             0(0.00%)
+.C                          0(0.00%)             0(0.00%)
+.T                          0(0.00%)             0(0.00%)
+.A                          0(0.00%)             0(0.00%)
+.G                          0(0.00%)             0(0.00%)
+
+TotalGIndels                       0                    0
+G.                          0(0.00%)             0(0.00%)
+C.                          0(0.00%)             0(0.00%)
+T.                          0(0.00%)             0(0.00%)
+A.                          0(0.00%)             0(0.00%)
+.A                          0(0.00%)             0(0.00%)
+.T                          0(0.00%)             0(0.00%)
+.C                          0(0.00%)             0(0.00%)
+.G                          0(0.00%)             0(0.00%)

--- a/benchmarking/results/opt4_dnadiff_freeze_across.report
+++ b/benchmarking/results/opt4_dnadiff_freeze_across.report
@@ -1,0 +1,87 @@
+/Users/cameronprybol/workspace/tmp/opt4_dnadiff_6ZNkvu/NC_001416/NC_001416.fna /Users/cameronprybol/workspace/tmp/opt4_dnadiff_6ZNkvu/freeze_across_contigs.fasta
+NUCMER
+
+                               [REF]                [QRY]
+[Sequences]
+TotalSeqs                          1                 2985
+AlignedSeqs               1(100.00%)             6(0.20%)
+UnalignedSeqs               0(0.00%)         2979(99.80%)
+
+[Bases]
+TotalBases                     48502               184567
+AlignedBases           48469(99.93%)        96973(52.54%)
+UnalignedBases             33(0.07%)        87594(47.46%)
+
+[Alignments]
+1-to-1                             2                    2
+TotalLength                    48489                48489
+AvgLength                   24244.50             24244.50
+AvgIdentity                   100.00               100.00
+
+M-to-M                             6                    6
+TotalLength                    96973                96973
+AvgLength                   16162.17             16162.17
+AvgIdentity                   100.00               100.00
+
+[Feature Estimates]
+Breakpoints                       12                    0
+Relocations                        0                    0
+Translocations                     1                    0
+Inversions                         0                    0
+
+Insertions                         2                    4
+InsertionSum                      33                48484
+InsertionAvg                   16.50             12121.00
+
+TandemIns                          0                    0
+TandemInsSum                       0                    0
+TandemInsAvg                    0.00                 0.00
+
+[SNPs]
+TotalSNPs                          0                    0
+AG                          0(0.00%)             0(0.00%)
+AT                          0(0.00%)             0(0.00%)
+AC                          0(0.00%)             0(0.00%)
+CT                          0(0.00%)             0(0.00%)
+CG                          0(0.00%)             0(0.00%)
+CA                          0(0.00%)             0(0.00%)
+GC                          0(0.00%)             0(0.00%)
+GA                          0(0.00%)             0(0.00%)
+GT                          0(0.00%)             0(0.00%)
+TC                          0(0.00%)             0(0.00%)
+TA                          0(0.00%)             0(0.00%)
+TG                          0(0.00%)             0(0.00%)
+
+TotalGSNPs                         0                    0
+AC                          0(0.00%)             0(0.00%)
+AG                          0(0.00%)             0(0.00%)
+AT                          0(0.00%)             0(0.00%)
+CG                          0(0.00%)             0(0.00%)
+CT                          0(0.00%)             0(0.00%)
+CA                          0(0.00%)             0(0.00%)
+GA                          0(0.00%)             0(0.00%)
+GC                          0(0.00%)             0(0.00%)
+GT                          0(0.00%)             0(0.00%)
+TG                          0(0.00%)             0(0.00%)
+TC                          0(0.00%)             0(0.00%)
+TA                          0(0.00%)             0(0.00%)
+
+TotalIndels                        0                    0
+A.                          0(0.00%)             0(0.00%)
+C.                          0(0.00%)             0(0.00%)
+G.                          0(0.00%)             0(0.00%)
+T.                          0(0.00%)             0(0.00%)
+.A                          0(0.00%)             0(0.00%)
+.C                          0(0.00%)             0(0.00%)
+.T                          0(0.00%)             0(0.00%)
+.G                          0(0.00%)             0(0.00%)
+
+TotalGIndels                       0                    0
+A.                          0(0.00%)             0(0.00%)
+C.                          0(0.00%)             0(0.00%)
+G.                          0(0.00%)             0(0.00%)
+T.                          0(0.00%)             0(0.00%)
+.T                          0(0.00%)             0(0.00%)
+.G                          0(0.00%)             0(0.00%)
+.C                          0(0.00%)             0(0.00%)
+.A                          0(0.00%)             0(0.00%)

--- a/benchmarking/results/opt4_dnadiff_raw.report
+++ b/benchmarking/results/opt4_dnadiff_raw.report
@@ -1,0 +1,87 @@
+/Users/cameronprybol/workspace/tmp/opt4_dnadiff_6ZNkvu/NC_001416/NC_001416.fna /Users/cameronprybol/workspace/tmp/opt4_dnadiff_6ZNkvu/raw_contigs.fasta
+NUCMER
+
+                               [REF]                [QRY]
+[Sequences]
+TotalSeqs                          1                30664
+AlignedSeqs               1(100.00%)           322(1.05%)
+UnalignedSeqs               0(0.00%)        30342(98.95%)
+
+[Bases]
+TotalBases                     48502              1331734
+AlignedBases           48454(99.90%)        102230(7.68%)
+UnalignedBases             48(0.10%)      1229504(92.32%)
+
+[Alignments]
+1-to-1                           124                  124
+TotalLength                    58956                58956
+AvgLength                     475.45               475.45
+AvgIdentity                    99.96                99.96
+
+M-to-M                           322                  322
+TotalLength                   102230               102230
+AvgLength                     317.48               317.48
+AvgIdentity                    99.84                99.84
+
+[Feature Estimates]
+Breakpoints                      644                    9
+Relocations                        0                    0
+Translocations                   123                    0
+Inversions                         0                    0
+
+Insertions                         3                  207
+InsertionSum                      48                43290
+InsertionAvg                   16.00               209.13
+
+TandemIns                          0                    0
+TandemInsSum                       0                    0
+TandemInsAvg                    0.00                 0.00
+
+[SNPs]
+TotalSNPs                          4                    4
+GT                         1(25.00%)            1(25.00%)
+GA                          0(0.00%)            1(25.00%)
+GC                          0(0.00%)             0(0.00%)
+CT                          0(0.00%)             0(0.00%)
+CA                          0(0.00%)            1(25.00%)
+CG                          0(0.00%)             0(0.00%)
+AC                         1(25.00%)             0(0.00%)
+AT                          0(0.00%)             0(0.00%)
+AG                         1(25.00%)             0(0.00%)
+TC                          0(0.00%)             0(0.00%)
+TA                          0(0.00%)             0(0.00%)
+TG                         1(25.00%)            1(25.00%)
+
+TotalGSNPs                         3                    3
+GC                          0(0.00%)             0(0.00%)
+GT                         1(33.33%)            1(33.33%)
+GA                          0(0.00%)            1(33.33%)
+TC                          0(0.00%)             0(0.00%)
+TA                          0(0.00%)             0(0.00%)
+TG                         1(33.33%)            1(33.33%)
+AC                          0(0.00%)             0(0.00%)
+AT                          0(0.00%)             0(0.00%)
+AG                         1(33.33%)             0(0.00%)
+CG                          0(0.00%)             0(0.00%)
+CA                          0(0.00%)             0(0.00%)
+CT                          0(0.00%)             0(0.00%)
+
+TotalIndels                        0                    0
+G.                          0(0.00%)             0(0.00%)
+C.                          0(0.00%)             0(0.00%)
+A.                          0(0.00%)             0(0.00%)
+T.                          0(0.00%)             0(0.00%)
+.G                          0(0.00%)             0(0.00%)
+.A                          0(0.00%)             0(0.00%)
+.T                          0(0.00%)             0(0.00%)
+.C                          0(0.00%)             0(0.00%)
+
+TotalGIndels                       0                    0
+G.                          0(0.00%)             0(0.00%)
+T.                          0(0.00%)             0(0.00%)
+A.                          0(0.00%)             0(0.00%)
+C.                          0(0.00%)             0(0.00%)
+.G                          0(0.00%)             0(0.00%)
+.C                          0(0.00%)             0(0.00%)
+.T                          0(0.00%)             0(0.00%)
+.A                          0(0.00%)             0(0.00%)

--- a/benchmarking/results/opt4_frozen_read_skip_dnadiff_20260727_144013.csv
+++ b/benchmarking/results/opt4_frozen_read_skip_dnadiff_20260727_144013.csv
@@ -1,0 +1,4 @@
+arm,n_contigs,total_contig_bases,largest_contig,avg_identity,aligned_pct_ref,aligned_pct_query,total_snps,total_indels
+raw,30664,1331734,2071,99.96,NaN,NaN,NaN,NaN
+exact,2983,184523,37565,100.0,NaN,NaN,NaN,NaN
+freeze_across,2985,184567,37565,100.0,NaN,NaN,NaN,NaN

--- a/benchmarking/results/opt4_frozen_read_skip_dnadiff_20260727_144013.csv
+++ b/benchmarking/results/opt4_frozen_read_skip_dnadiff_20260727_144013.csv
@@ -1,4 +1,0 @@
-arm,n_contigs,total_contig_bases,largest_contig,avg_identity,aligned_pct_ref,aligned_pct_query,total_snps,total_indels
-raw,30664,1331734,2071,99.96,NaN,NaN,NaN,NaN
-exact,2983,184523,37565,100.0,NaN,NaN,NaN,NaN
-freeze_across,2985,184567,37565,100.0,NaN,NaN,NaN,NaN

--- a/benchmarking/results/opt4_frozen_read_skip_dnadiff_20260729_142103.csv
+++ b/benchmarking/results/opt4_frozen_read_skip_dnadiff_20260729_142103.csv
@@ -1,0 +1,4 @@
+arm,n_contigs,total_contig_bases,largest_contig,avg_identity,aligned_pct_ref,aligned_pct_query,total_snps,total_indels
+raw,30664,1331734,2071,99.96,99.9,NaN,4.0,0.0
+exact,2983,184523,37565,100.0,99.93,NaN,0.0,0.0
+freeze_across,2985,184567,37565,100.0,99.93,NaN,0.0,0.0

--- a/benchmarking/results/opt4_frozen_read_skip_signoff.md
+++ b/benchmarking/results/opt4_frozen_read_skip_signoff.md
@@ -1,0 +1,261 @@
+# opt4 frozen-read-skip — representative-scale accuracy sign-off
+
+td-jbjd, Rule-of-5 pass 5 ("Verification"). Design doc:
+`docs/design/2026-07-26-opt4-frozen-read-skip-design.md` ("Accuracy sign-off
+methodology"). This is the load-bearing measurement for the maintainer's
+enable/keep-off decision on `skip_frozen_reads` (opt-in, default off). It does
+**not** make that decision — it reports the accuracy/speed tradeoff at
+representative scale so the maintainer can apply their own tolerance.
+
+Script: `benchmarking/opt4_frozen_read_accuracy_signoff.jl` (new, does not
+mutate `rhizomorph_correction_accuracy_benchmark.jl`; reuses its
+`acquire_reference` / `simulate_substitution_reads` / `per_base_metrics`
+building blocks and adds the `skip_frozen_reads` passthrough that harness does
+not expose). Config-tuning probes (kept for reproducibility, not part of the
+sign-off itself): `benchmarking/opt4_signoff_probe.jl`,
+`benchmarking/opt4_signoff_supplementary_probe.jl`.
+
+## Why representative scale, not the pass-4 toy fixtures
+
+`test/4_assembly/corrector_opt4_positive_control_test.jl` (pass 4) found that
+at toy scale (900bp–2kb synthetic genomes, tens to ~150 reads), freezing is
+**mechanically inert**: Stage 0 cheap correction (`_stage0_cheap_correct`,
+`src/iterative-assembly.jl:4688`) is freeze-immune and runs unconditionally
+before the freeze gate, and at toy scale it accounts for effectively all
+correction volume — the per-read Viterbi decode (the only thing freezing
+actually gates) made **zero edits** at any k tested. Separately, the adaptive
+low-k decode gate (`decode_gate_density`, default 0.90,
+`src/iterative-assembly.jl:4831`) additionally disables decode entirely on toy
+graphs because a small/dense graph cannot achieve genuine (<90%)
+decode-selectivity. Freezing an operation that never runs cannot be measured to
+degrade anything — that is a finding about mechanism, not a clean bill of
+health for real data.
+
+This pass therefore targets a scale where decode genuinely fires, confirmed
+directly against `result[:metadata][:decode_fraction_mean]` /
+`:decode_fraction_max` (the fraction of reads that actually reached the
+per-read Viterbi decode each pass, `= 1 - skip_fraction`) and
+`total_improvements - cheap_corrections_total` (edits attributable to decode,
+not Stage 0).
+
+## Configuration reached
+
+Reference: **NC_001416 (Escherichia phage Lambda, 48,502 bp)**, downloaded via
+`Mycelia.download_genome_by_accession`. Substitution-only injected errors
+(`Mycelia.mutate_dna_substitution_fraction`, length-preserving) at 2% rate,
+read length 150bp, uniform Phred 20. Corrector knobs mirror the wired
+`:scalable` production tier exactly (`skip_solid=true`,
+`graph_mode=:doublestrand`, `n_k_rungs=3`, `max_iterations_per_k=2`,
+`hard_window=true`, `soft_em=true`, `cheap_correct=true`, `k=21`,
+`batch_size=500`) — i.e. the sign-off measures the actual knobs
+`assemble_genome(corrector=:iterative, strategy=:scalable)` would use in
+production, not a bespoke configuration built to make decode fire artificially.
+
+Two coverage tiers were run (both reuse the identical simulated read set per
+tier, seed 42, across all four arms):
+
+| Tier | Coverage | Reads | Injected errors | Sequenced bases (cov × genome) | vs. harness's own `SCALE_FLOOR_BASES=1,000,000` |
+|---|---|---|---|---|---|
+| A (smoke) | 8.0x | 2,587 | 7,761 | 388,016 | below floor — SMOKE-ONLY by the harness's own guard |
+| B (verdict) | 21.0x | 6,791 | 20,373 | 1,018,542 | **at/above floor — VERDICT scale** |
+
+**Evidence decode is active** (not gated to zero, unlike the pass-4 toy
+fixtures):
+
+| Tier | decode_fraction_mean | decode_fraction_max | decode-attributable edits (total_improvements − cheap_corrections_total) |
+|---|---|---|---|
+| A | 0.385 | 0.837 | 1,356 |
+| B | 0.256 | 0.623 | 2,981 |
+
+Both tiers show a substantial, nonzero fraction of reads reaching the
+expensive per-read Viterbi decode every pass, and a real block of edits
+attributable to decode rather than Stage 0. This is the prerequisite the pass-4
+header called out as missing at toy scale.
+
+**Scale caveat:** Tier B clears the harness's own 1 Mbase `SCALE_FLOOR_BASES`
+guard (`benchmarking/rhizomorph_scale_guard.jl`) — the same floor
+`rhizomorph_correction_accuracy_benchmark.jl` uses to gate a VERDICT vs.
+SMOKE-ONLY label — but this is still a single genome (Lambda phage, no
+repeats/structural complexity beyond what a 48.5 kb phage genome has), a single
+seed, and a single machine with no repeated-run averaging. Do not extrapolate
+past 21x coverage / this genome without re-running.
+
+## Three/four-arm results
+
+Four arms on the **identical** read set per tier (same simulated reads/errors,
+same seed — only `skip_frozen_reads` / `freeze_streak_threshold` /
+`freeze_across_rungs` vary):
+
+- **exact** — `skip_frozen_reads=false` (the always-on exact path)
+- **freeze_within** — `skip_frozen_reads=true, threshold=2, across=false` (the
+  **default** scope per the design doc)
+- **freeze_across** — `skip_frozen_reads=true, threshold=2, across=true`
+  (aggressive scope, conservative threshold)
+- **freeze_max_aggressive** — `skip_frozen_reads=true, threshold=1,
+  across=true` (the positive-control candidate: most aggressive setting tried)
+
+### Tier A (8x coverage, 2,587 reads, SMOKE-ONLY by the scale guard)
+
+| Arm | Runtime (s) | Speedup vs exact | frozen_reads_skipped | decode_fraction_mean | Recall | Precision | Over-corr. rate | True fixes | Byte-identical to exact? |
+|---|---|---|---|---|---|---|---|---|---|
+| exact | 46.29 | — | 0 | 0.385 | 0.8382 | 0.8441 | 0.00308 | 6,505 | — |
+| freeze_within (default) | 32.20 | +30%* | **0** | 0.385 | 0.8382 | 0.8441 | 0.00308 | 6,505 | **yes** (0/2587 differ) |
+| freeze_across | 30.63 | +34% | 724 | 0.327 | 0.8356 (Δ −0.0026) | 0.8445 (Δ +0.0004) | 0.00307 | 6,485 (Δ −20) | no (14/2587 differ) |
+| freeze_max_aggressive | 28.29 | +39% | 2,258 | 0.240 | 0.7977 (Δ **−0.0405**) | 0.8706 (Δ +0.0265) | 0.00236 | 6,191 (Δ −314) | no (244/2587 differ) |
+
+\* freeze_within skipped **zero** reads at this config (see mechanism note
+below) — its reported "+30% speedup" is single-run wall-clock noise, not a real
+effect of the freeze mechanism. It is reported for transparency, not as
+evidence of speedup.
+
+### Tier B (21x coverage, 6,791 reads, VERDICT scale)
+
+| Arm | Runtime (s) | Speedup vs exact | frozen_reads_skipped | decode_fraction_mean | Recall | Precision | Over-corr. rate | True fixes | Byte-identical to exact? |
+|---|---|---|---|---|---|---|---|---|---|
+| exact | 123.59 | — | 0 | 0.256 | 0.9001 | 0.9779 | 0.000407 | 18,337 | — |
+| freeze_within (default) | 111.11 | +10%* | **0** | 0.256 | 0.9001 | 0.9779 | 0.000407 | 18,337 | **yes** (0/6791 differ) |
+| freeze_across | 95.84 | +22% | 1,276 | 0.213 | 0.8999 (Δ −0.0002) | 0.9779 (Δ ≈0) | 0.000407 | 18,333 (Δ −4) | no (4/6791 differ) |
+| freeze_max_aggressive | 98.55 | +20% | 2,922 | 0.159 | 0.8907 (Δ **−0.0094**) | 0.9994 (Δ +0.0215) | 0.000004 | 18,146 (Δ −191) | no (150/6791 differ) |
+
+\* same caveat as Tier A — freeze_within skipped zero reads here too.
+
+Full per-arm CSVs:
+`benchmarking/results/opt4_frozen_read_skip_signoff_20260727_134304.csv` (Tier
+A), `benchmarking/results/opt4_frozen_read_skip_signoff_20260727_135800.csv`
+(Tier B).
+
+## Mechanism finding: the default (within-rung) scope never fired at either scale
+
+`freeze_within` — the DEFAULT, "safe" scope per the design doc — skipped
+**zero** reads at both coverage tiers, and produced byte-identical output to
+`exact` in both. This is not an accuracy result; it means the freeze condition
+had **no opportunity to trigger** under the production `:scalable` knob
+`max_iterations_per_k=2`: within-rung scope resets each read's no-improvement
+streak to 0 at every k-change, and a `threshold=2` freeze requires **2
+consecutive** no-improvement passes at the *same* k before a 3rd pass can be
+skipped — but with only 2 iterations allowed per k, the earliest a streak can
+reach 2 is on the 2nd (last) iteration of that rung, by which point there is no
+further same-k pass left to skip.
+
+A supplementary probe (`benchmarking/opt4_signoff_supplementary_probe.jl`,
+Tier-A read set, `max_iterations_per_k=4` instead of 2) confirms this
+mechanism: with more per-rung headroom, within-rung freezing **did** engage
+(724 reads skipped, matching Tier A's `freeze_across` count exactly — the 3rd
+and 4th same-k iterations are where it fires), runtime dropped 41.3s → 31.5s
+(−24%), and the accuracy cost was negligible: recall 0.8402 → 0.8400 (Δ
+−0.0002), precision 0.8366 → 0.8372 (Δ +0.0006), true fixes 6,521 → 6,519 (Δ
+−2).
+
+**Implication:** at the actual production config (`max_iterations_per_k=2`),
+enabling `skip_frozen_reads` with the documented default scope
+(`freeze_across_rungs=false`) changes **nothing** — it is a true no-op, not
+merely a low-risk option. Any speedup from opt4 under the current `:scalable`
+production knobs requires the **aggressive** `freeze_across_rungs=true` scope,
+which the design doc calls out explicitly as higher-risk and non-default.
+
+## Positive control (this pass's requirement)
+
+`freeze_max_aggressive` (`threshold=1, across=true`) is this pass's
+positive-control candidate — the most aggressive setting the pass-4 toy fixture
+could not distinguish from exact. At representative scale it **does**
+measurably degrade recall:
+
+- Tier A: recall −0.0405 absolute (−4.8% relative), 244/2,587 reads (9.4%)
+  differ from exact.
+- Tier B (VERDICT scale): recall −0.0094 absolute (−1.0% relative), 150/6,791
+  reads (2.2%) differ from exact.
+
+Both are asserted with a real, reproducible (fixed-seed) delta — this confirms
+the per-base metric **can** detect opt4-induced degradation at representative
+scale, resolving the pass-4 "cannot demonstrate degradation" finding, which was
+scale-limited, not a property of opt4 itself.
+
+**Notable asymmetry:** in both tiers, `freeze_max_aggressive` *also improves*
+precision and collapses the over-correction rate (Tier A: over-corrections
+1,173 → 898; Tier B: 406 → 4, over_correction_rate 0.000407 → 0.000004). The
+mechanism: freezing a read early removes it from later, potentially
+over-eager, decode passes as much as it removes it from passes that would have
+made a genuine fix — the net effect observed here is fewer total edits
+(lower `correction_rate` in both tiers) with a *shift* in error type from
+"borderline over-correction" toward "missed correction" (lower recall), not a
+uniform accuracy loss. This is a real tradeoff the maintainer should weigh, not
+simply "worse."
+
+`freeze_across` (the non-default but non-maximal `threshold=2, across=true`
+scope) sits between the two: a small, real recall cost (Tier A −0.31%
+relative, Tier B −0.02% relative) shrinking as scale/coverage grows, for a
+~22–34% single-run speedup and a genuine reduction in decode volume
+(`decode_fraction_mean` drops 15–17% relative to exact in both tiers,
+independent of wall-clock noise).
+
+## Caveats
+
+- **Single machine, single run per arm — no repeated-run variance estimate.**
+  `freeze_within`'s reported "+10% to +30% speedup" occurred with **zero**
+  freeze events, i.e. it is pure wall-clock noise on this box between
+  otherwise-identical runs. Treat every raw runtime number in this doc as
+  directional, not a precise measurement; `frozen_reads_skipped` and
+  `decode_fraction_mean` (both deterministic, seed-driven counts, not
+  wall-clock) are the more trustworthy speed proxies for `freeze_across` and
+  `freeze_max_aggressive`, where real (nonzero) skip volume was observed.
+- **Scale reached:** Tier B (21x coverage, Lambda phage, 48,502 bp) clears the
+  harness's own 1 Mbase VERDICT floor, but is still one genome / one seed / one
+  machine. Do not extrapolate to larger, more repetitive, or long-read genomes
+  without re-running.
+- **Assembly-level (dnadiff/ANI) check not run this pass.** The design doc's
+  accuracy sign-off methodology lists a second check (re-assemble corrected
+  reads and run `dnadiff` against the reference) alongside the per-base check
+  used here. It was deferred to stay inside the ~40-minute compute budget for
+  this pass; per-base accuracy against injected-error ground truth is the more
+  direct signal (it measures the corrector's own output, unmediated by a
+  downstream assembler) and is what this pass was asked to reuse from the
+  harness. A follow-on could add the dnadiff check if the maintainer wants
+  assembly-level confirmation before enabling by default.
+- **`path_to_sequence` warnings** emitted during every run are pre-existing
+  synthetic-genome noise (per the task brief) and were filtered from all logs;
+  they do not affect any of the numbers above.
+- **`substitution_length_divergences`** (decode reconstructions that failed
+  open to the original read to preserve the length contract) were nonzero in
+  every arm/tier (roughly 0.2–3% of reads per pass) — this is pre-existing
+  corrector behavior unrelated to opt4 (present identically in the `exact`
+  arm) and does not bias the exact-vs-freeze comparison, since it affects both
+  arms' shared decode path identically.
+
+## Regression checks
+
+All five existing opt4 test files still pass on this branch after the sign-off
+run (source untouched — this pass added only new benchmarking scripts and this
+results doc):
+
+| Test file | Result |
+|---|---|
+| `corrector_opt4_frozen_read_skip_test.jl` | 2/2 pass |
+| `corrector_opt4_freeze_state_test.jl` | 24/24 pass |
+| `corrector_opt4_golden_master_lock_test.jl` | 2/2 pass |
+| `corrector_opt4_positive_control_test.jl` | 6/6 pass |
+| `corrector_opt4_edge_cases_test.jl` | 16/16 pass |
+
+## Summary for the maintainer's ship decision
+
+At this scale (Lambda phage, 8x–21x coverage, production `:scalable` knobs):
+
+- The **shipped default** (`skip_frozen_reads=true` with `freeze_across_rungs=false`,
+  the documented safe scope) is a **byte-identical no-op** under the current
+  production `max_iterations_per_k=2` — it neither speeds anything up nor
+  changes accuracy, because the freeze condition never has a chance to fire.
+  Recommending it as-is provides zero benefit at the current config (though it
+  remains harmless).
+- The **aggressive scope** (`freeze_across_rungs=true`, still `threshold=2`)
+  gives a real, nonzero decode-volume reduction (~15–17% fewer per-read
+  decodes) for a recall cost that is small and **shrinks with scale**
+  (−0.31% relative at 8x coverage, −0.02% relative at 21x coverage).
+- The **positive control** (`threshold=1, across=true`) confirms the metric
+  detects real degradation at this scale (recall −1.0% to −4.8% relative,
+  precision improves), giving confidence the "no accuracy loss" verdicts above
+  are not simply an insensitive measurement.
+
+No enable/ship recommendation is made here — the tolerance for the
+aggressive-scope recall cost vs. its decode-volume savings, and whether the
+default scope's config-dependent inertness is acceptable to ship as-is or
+warrants raising `max_iterations_per_k` for the default tier, are the
+maintainer's calls per the design doc's ship gate.

--- a/benchmarking/results/opt4_frozen_read_skip_signoff.md
+++ b/benchmarking/results/opt4_frozen_read_skip_signoff.md
@@ -188,6 +188,43 @@ relative, Tier B −0.02% relative) shrinking as scale/coverage grows, for a
 (`decode_fraction_mean` drops 15–17% relative to exact in both tiers,
 independent of wall-clock noise).
 
+## Assembly-level dnadiff/ANI check (design's second accuracy check)
+
+The per-base check above measures the corrector's own read output. This second
+check re-assembles the corrected reads into contigs and runs MUMmer `dnadiff`
+against the Lambda reference — confirming (or challenging) the per-base −0.02%
+result at the assembly level. Run on the **identical** Tier B fixture (21x, seed
+42), for **exact** vs **freeze_across** (threshold 2, across-rung). Script:
+`benchmarking/opt4_frozen_read_dnadiff_signoff.jl`. **Critical method note:** the
+corrected reads are re-assembled with `corrector=:none`
+(`Rhizomorph.assemble_genome`, no iterative correction), so the exact-vs-freeze
+difference in the input reads propagates into the contigs rather than being
+masked by re-correction.
+
+| Arm (Tier B, 21x) | n_contigs | contig bases | largest contig | AvgIdentity | Ref aligned | TotalSNPs | TotalIndels |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| exact | 2,983 | 184,523 | 37,565 | 100.00% | 48,469 (99.93%) | 0 | 0 |
+| freeze_across | 2,985 | 184,567 | 37,565 | 100.00% | 48,469 (99.93%) | 0 | 0 |
+| _(raw, uncorrected — baseline)_ | 30,664 | 1,331,734 | 2,071 | 99.96% | — | — | — |
+
+**Verdict — the assembly-level check confirms the per-base −0.02% finding.**
+`exact` and `freeze_across` are **indistinguishable at the assembly level**:
+identical 100.00% average identity, identical 99.93% reference coverage
+(48,469/48,502 bp), and **zero SNPs and zero indels** in both. The only
+difference is 44 query bases (0.02%) of redundant overlapping-contig sequence,
+which carries no accuracy cost (identity, SNP, and indel counts are unchanged).
+The raw-reads baseline (30,664 fragmented contigs, largest 2,071 bp) confirms
+correction is doing substantial work and the assembler is functioning — so the
+identical exact/freeze contig quality is a real result, not an artifact of a
+no-op assembler. The `freeze_across` recall cost measured at the read level does
+**not** propagate to any assembly-level accuracy loss on this fixture.
+
+Caveat: the `corrector=:none` k=21 assembly is intentionally fragmented (no
+scaffolding), so query aligned-fraction is ~52% (redundant overlapping contigs);
+the load-bearing signal is the exact-vs-freeze equivalence (identical
+identity/SNP/indel), not the absolute contiguity. Single genome/seed/machine, as
+with the per-base check.
+
 ## Caveats
 
 - **Single machine, single run per arm — no repeated-run variance estimate.**
@@ -202,15 +239,13 @@ independent of wall-clock noise).
   harness's own 1 Mbase VERDICT floor, but is still one genome / one seed / one
   machine. Do not extrapolate to larger, more repetitive, or long-read genomes
   without re-running.
-- **Assembly-level (dnadiff/ANI) check not run this pass.** The design doc's
-  accuracy sign-off methodology lists a second check (re-assemble corrected
-  reads and run `dnadiff` against the reference) alongside the per-base check
-  used here. It was deferred to stay inside the ~40-minute compute budget for
-  this pass; per-base accuracy against injected-error ground truth is the more
+- **Assembly-level (dnadiff/ANI) check: now included** — see the
+  "Assembly-level dnadiff/ANI check" section above. It confirms the per-base
+  result (exact and freeze_across both reach 100.00% AvgIdentity, 0 SNPs, 0
+  indels vs the Lambda reference; assemblies differ by 0.02% redundant bases
+  only). Per-base accuracy against injected-error ground truth remains the more
   direct signal (it measures the corrector's own output, unmediated by a
-  downstream assembler) and is what this pass was asked to reuse from the
-  harness. A follow-on could add the dnadiff check if the maintainer wants
-  assembly-level confirmation before enabling by default.
+  downstream assembler); the dnadiff check is confirmatory.
 - **`path_to_sequence` warnings** emitted during every run are pre-existing
   synthetic-genome noise (per the task brief) and were filtered from all logs;
   they do not affect any of the numbers above.

--- a/benchmarking/results/opt4_frozen_read_skip_signoff.md
+++ b/benchmarking/results/opt4_frozen_read_skip_signoff.md
@@ -182,8 +182,9 @@ uniform accuracy loss. This is a real tradeoff the maintainer should weigh, not
 simply "worse."
 
 `freeze_across` (the non-default but non-maximal `threshold=2, across=true`
-scope) sits between the two: a small, real recall cost (Tier A −0.31%
-relative, Tier B −0.02% relative) shrinking as scale/coverage grows, for a
+scope) sits between the two: a small, real recall cost that was smaller at
+higher coverage in this run (Tier A −0.31% relative at 8x, Tier B −0.02%
+relative at 21x — two coverage points on one genome, not a fitted trend), for a
 ~22–34% single-run speedup and a genuine reduction in decode volume
 (`decode_fraction_mean` drops 15–17% relative to exact in both tiers,
 independent of wall-clock noise).
@@ -205,7 +206,14 @@ masked by re-correction.
 | --- | --- | --- | --- | --- | --- | --- | --- |
 | exact | 2,983 | 184,523 | 37,565 | 100.00% | 48,469 (99.93%) | 0 | 0 |
 | freeze_across | 2,985 | 184,567 | 37,565 | 100.00% | 48,469 (99.93%) | 0 | 0 |
-| _(raw, uncorrected — baseline)_ | 30,664 | 1,331,734 | 2,071 | 99.96% | — | — | — |
+| _(raw, uncorrected — baseline)_ | 30,664 | 1,331,734 | 2,071 | 99.96% | 99.9% | 4 | 0 |
+
+Data: `benchmarking/results/opt4_frozen_read_skip_dnadiff_20260729_142103.csv`;
+the raw MUMmer `.report` files (`opt4_dnadiff_{exact,freeze_across,raw}.report`)
+are committed alongside as reproducible evidence. (The `AlignedBases`/`TotalSNPs`/
+`TotalIndels` fields are parsed directly from the `.report` — `parse_dnadiff_report`'s
+summary drops them because it matches the bare tokens `SNPs`/`Indels` rather than
+dnadiff's `TotalSNPs`/`TotalIndels`; noted as a separate parser-fix follow-up.)
 
 **Verdict — the assembly-level check confirms the per-base −0.02% finding.**
 `exact` and `freeze_across` are **indistinguishable at the assembly level**:
@@ -213,10 +221,12 @@ identical 100.00% average identity, identical 99.93% reference coverage
 (48,469/48,502 bp), and **zero SNPs and zero indels** in both. The only
 difference is 44 query bases (0.02%) of redundant overlapping-contig sequence,
 which carries no accuracy cost (identity, SNP, and indel counts are unchanged).
-The raw-reads baseline (30,664 fragmented contigs, largest 2,071 bp) confirms
-correction is doing substantial work and the assembler is functioning — so the
-identical exact/freeze contig quality is a real result, not an artifact of a
-no-op assembler. The `freeze_across` recall cost measured at the read level does
+The raw-reads baseline (30,664 fragmented contigs, largest 2,071 bp, **4 SNPs**
+vs the reference) confirms correction is doing substantial work and the assembler
+is functioning — both `exact` and `freeze_across` drive those 4 SNPs to **0**, so
+freezing preserves every correction the exact path makes here; the identical
+exact/freeze contig quality is a real result, not an artifact of a no-op
+assembler. The `freeze_across` recall cost measured at the read level does
 **not** propagate to any assembly-level accuracy loss on this fixture.
 
 Caveat: the `corrector=:none` k=21 assembly is intentionally fragmented (no
@@ -282,8 +292,9 @@ At this scale (Lambda phage, 8x–21x coverage, production `:scalable` knobs):
   remains harmless).
 - The **aggressive scope** (`freeze_across_rungs=true`, still `threshold=2`)
   gives a real, nonzero decode-volume reduction (~15–17% fewer per-read
-  decodes) for a recall cost that is small and **shrinks with scale**
-  (−0.31% relative at 8x coverage, −0.02% relative at 21x coverage).
+  decodes) for a recall cost that is small and was **smaller at higher coverage
+  in this run** (−0.31% relative at 8x, −0.02% relative at 21x — two coverage
+  points, one genome; not a fitted trend).
 - The **positive control** (`threshold=1, across=true`) confirms the metric
   detects real degradation at this scale (recall −1.0% to −4.8% relative,
   precision improves), giving confidence the "no accuracy loss" verdicts above

--- a/benchmarking/results/opt4_frozen_read_skip_signoff_20260727_134304.csv
+++ b/benchmarking/results/opt4_frozen_read_skip_signoff_20260727_134304.csv
@@ -1,0 +1,5 @@
+arm,skip_frozen_reads,freeze_streak_threshold,freeze_across_rungs,runtime_s,frozen_reads_skipped,decode_fraction_mean,decode_fraction_max,total_improvements,cheap_corrections_total,decode_attributable_edits,reads_scored,injected_errors,total_edits,true_fixes,mis_fixes,over_corrections,recall,precision,over_correction_rate,correction_rate
+exact,false,2,false,46.291,0,0.3848,0.8369,5611,4255,1356,2587,7761,7706,6505,28,1173,0.838165,0.844147,0.003084,0.019858
+freeze_within,true,2,false,32.203,0,0.3848,0.8369,5611,4255,1356,2587,7761,7706,6505,28,1173,0.838165,0.844147,0.003084,0.019858
+freeze_across,true,2,true,30.632,724,0.3269,0.8369,5597,4255,1342,2587,7761,7679,6485,28,1166,0.835588,0.844511,0.003066,0.019789
+freeze_max_aggressive,true,1,true,28.29,2258,0.2399,0.8369,5387,4246,1141,2587,7761,7111,6191,22,898,0.797706,0.870623,0.002361,0.018325

--- a/benchmarking/results/opt4_frozen_read_skip_signoff_20260727_135800.csv
+++ b/benchmarking/results/opt4_frozen_read_skip_signoff_20260727_135800.csv
@@ -1,0 +1,5 @@
+arm,skip_frozen_reads,freeze_streak_threshold,freeze_across_rungs,runtime_s,frozen_reads_skipped,decode_fraction_mean,decode_fraction_max,total_improvements,cheap_corrections_total,decode_attributable_edits,reads_scored,injected_errors,total_edits,true_fixes,mis_fixes,over_corrections,recall,precision,over_correction_rate,correction_rate
+exact,false,2,false,123.59,0,0.2559,0.6233,16149,13168,2981,6791,20373,18751,18337,8,406,0.900064,0.977921,0.000407,0.018408
+freeze_within,true,2,false,111.11,0,0.2559,0.6233,16149,13168,2981,6791,20373,18751,18337,8,406,0.900064,0.977921,0.000407,0.018408
+freeze_across,true,2,true,95.835,1276,0.2125,0.6233,16145,13168,2977,6791,20373,18747,18333,8,406,0.899867,0.977916,0.000407,0.018404
+freeze_max_aggressive,true,1,true,98.546,2922,0.1587,0.6233,15993,13167,2826,6791,20373,18156,18146,6,4,0.890689,0.999449,4.0e-6,0.017824

--- a/docs/design/2026-07-26-opt4-frozen-read-skip-design.md
+++ b/docs/design/2026-07-26-opt4-frozen-read-skip-design.md
@@ -39,8 +39,10 @@ against merge `b032fab3`.
    per-k iteration loop `while iteration <= max_iterations_per_k` (`:2290`);
    the graph is rebuilt inside the iteration loop via
    `build_qualmer_graph(current_reads, k; mode = graph_mode, ...)` (`:2317`);
-   the per-read decode runs in `_improve_read_set_likelihood_impl` (called
-   `:2408`), batch loop `for batch_start in 1:batch_size:total_reads` (`:4879`),
+   the per-read decode runs in `_improve_read_set_likelihood_impl` (defined
+   `:4555`, reached via the public wrapper `improve_read_set_likelihood` called
+   at `:2408` which forwards to the impl at `:4513`); batch loop
+   `for batch_start in 1:batch_size:total_reads` (`:4879`),
    per-read decode parallel `Threads.@threads for i in eachindex(batch_reads)`
    (`:4902`) / serial (`:4984`).
 

--- a/docs/design/2026-07-26-opt4-frozen-read-skip-design.md
+++ b/docs/design/2026-07-26-opt4-frozen-read-skip-design.md
@@ -1,8 +1,19 @@
 # opt4: Opt-in approximate frozen-read skip (with dnadiff accuracy sign-off)
 
-Date: 2026-07-26 Status: Draft (design) Scope: skip re-decoding converged
-("frozen") reads across corrector iterations — an OPT-IN, APPROXIMATE tier,
-default off, gated by an accuracy sign-off. **NOT byte-identical.**
+Date: 2026-07-26 Status: Implemented (Rule-of-5 passes 1–5 landed; see
+`benchmarking/results/opt4_frozen_read_skip_signoff.md` for measured results)
+Scope: skip re-decoding converged ("frozen") reads across corrector iterations —
+an OPT-IN, APPROXIMATE tier, default off, gated by an accuracy sign-off.
+**NOT byte-identical.**
+
+> **Implementation update (pass 4/5):** the toy-genome positive control below
+> (methodology §3) was found **mechanically inert** at pass 4 — Stage 0 cheap
+> correction runs before the freeze gate and dominates toy-scale correction, and
+> the Viterbi decode (the only thing freezing gates) makes no edits at toy scale.
+> The working positive control therefore moved to **representative scale**
+> (Lambda phage 21x) in pass 5, where `freeze_max_aggressive` degrades recall
+> −1.0% to −4.8%. See the sign-off doc; the §3 toy methodology below is retained
+> for provenance but is superseded by the representative-scale control.
 
 ## Context
 
@@ -138,7 +149,10 @@ off — this IS byte-identical-when-disabled, and should be locked by a test).
 The frozen-skip must compose with, not replace, the existing per-pass
 `skip_solid`/`hard_window` gating; soft-EM (`soft_weights`/`soft_weights_sink`)
 accumulation; and `CorrectorDiagnostics`. A frozen read that is skipped
-contributes its frozen soft-weight (unchanged), and a new diagnostics counter
+contributes **nothing** to that pass's soft-EM E-step — the skipped read never
+reaches the `soft_weights` accumulator (a fresh per-pass accumulator), so it
+contributes no weight rather than a stale/replayed one, matching pre-existing
+`skip_solid`/`hard_window` skip behavior. A new diagnostics counter
 `frozen_reads_skipped` records the volume of skipped decodes (mirrors opt1's
 `parallel_decode_batches` counter, incl. the `fieldcount(CorrectorDiagnostics)`
 completeness guard + its `corrector_errors` export site — a struct field has
@@ -202,6 +216,16 @@ the results doc, not hardcoded.
   zero improvements and the existing zero-improvement early-stop fires, which is
   correct behavior (nothing left to do), but the test suite should confirm the
   frozen-skip doesn't cause premature k-advance that the exact path wouldn't.
+- **Interaction with `sufficient_improvements`** (a *second*, distinct early-stop
+  from `stop_on_no_change`) — `continue_current_k` is also gated on
+  `sufficient_improvements(improvements_made, ...)`, an aggregate improvement-rate
+  plateau check. Because frozen reads are structurally excluded from
+  `improvements_made`, a rung with many frozen reads shows a lower improvement
+  rate and can trip this plateau check **sooner** than the exact path. This is
+  directionally safe (frozen reads can only *lower* the rate → early-stop fires
+  sooner, never later, so the corrector never runs *more* than exact) but it is a
+  distinct vector from the zero-improvement case and is named here for
+  completeness.
 
 ## Out of scope
 

--- a/docs/design/2026-07-26-opt4-frozen-read-skip-design.md
+++ b/docs/design/2026-07-26-opt4-frozen-read-skip-design.md
@@ -1,0 +1,241 @@
+# opt4: Opt-in approximate frozen-read skip (with dnadiff accuracy sign-off)
+
+Date: 2026-07-26 Status: Draft (design) Scope: skip re-decoding converged
+("frozen") reads across corrector iterations — an OPT-IN, APPROXIMATE tier,
+default off, gated by an accuracy sign-off. **NOT byte-identical.**
+
+## Context
+
+This is step 5 of the corrector performance campaign. Steps opt5 (GC gating),
+opt1 (parallel decode, ~2x measured), and opt2 (typed transitions) all shipped
+and were **byte-identical** — they transformed the code that produces the
+output without changing the output. opt3 (batched/SIMD kernel) is deferred (its
+kernel is single-strand-only while production is doublestrand/canonical).
+
+opt4 is categorically different: it is the campaign's first **approximate**
+optimization. It trades a bounded, measured amount of accuracy for skipping
+redundant work, and therefore **cannot** be byte-identical. The reason is
+structural: the corrector rebuilds the qualmer graph from the *entire* current
+read set on **every iteration** (`iterative-assembly.jl:2317`), so a read that
+has "converged" (stopped changing) still influences the graph that every *other*
+read decodes against on subsequent passes. Skipping a converged read's re-decode
+keeps its last correction fixed even though the graph it would decode against has
+changed — the changed graph might have corrected it differently. That divergence
+from the exact path is the approximation.
+
+Because it is approximate, the deliverable's foundation is not an identity lock
+but an **accuracy sign-off**: a measurement showing that, on representative data,
+the approximate tier's accuracy loss is within an acceptable tolerance for the
+speedup gained — plus a **positive control** proving the measurement can detect
+degradation when it occurs. The tier ships **opt-in, default off**.
+
+## Key facts (verified against current master, incl. opt5+opt1+opt2)
+
+File: `src/iterative-assembly.jl` unless noted. Line numbers verified 2026-07-26
+against merge `b032fab3`.
+
+1. **The loop nesting is k-rung → iteration → graph rebuild → batch → per-read
+   decode.** Outer k-rung loop `while ... && k <= max_k` (`:2254`); inner
+   per-k iteration loop `while iteration <= max_iterations_per_k` (`:2290`);
+   the graph is rebuilt inside the iteration loop via
+   `build_qualmer_graph(current_reads, k; mode = graph_mode, ...)` (`:2317`);
+   the per-read decode runs in `_improve_read_set_likelihood_impl` (called
+   `:2408`), batch loop `for batch_start in 1:batch_size:total_reads` (`:4879`),
+   per-read decode parallel `Threads.@threads for i in eachindex(batch_reads)`
+   (`:4902`) / serial (`:4984`).
+
+2. **Graph rebuilt EVERY iteration, not just every rung** (`:2317`, inside the
+   iteration `while`). This is the crux that makes opt4 approximate: a frozen
+   read still contributes its (fixed) corrected sequence to every subsequent
+   rebuild, and every other read's decode target changes pass-to-pass.
+
+3. **A per-read change signal already exists, but only per-pass.**
+   `improve_read_likelihood` returns `was_improved::Bool` per read
+   (`:4924`, `:4954`, `:4961`, `:4994`, `:5017`), summed into the pass counter
+   `improvements_made`. It is **never persisted per-read across iterations** —
+   there is no `converged`/`frozen`/`stable` per-read state today. opt4 must add
+   a per-read consecutive-no-improvement streak counter.
+
+4. **Existing convergence detection is aggregate/pass-level only.**
+   `stop_on_no_change` breaks the k-loop on a zero-improvement pass (`:2503`,
+   `:2585`); `sufficient_improvements` (`:5824`) does aggregate plateau
+   detection. None of these is per-read.
+
+5. **The skip mechanism is already proven and separable from decode.** The
+   `skip_solid`/`hard_window` path uses `_gate_skip` (`:4647`), `base_skip_flags`
+   (`:4660`), and `_skip_this_read_at` (`:4804`) to bypass a read's decode for a
+   pass. A skipped read flows into `updated_reads[...] = read` unchanged
+   (`:4908`/`:4986`), which is written to the next pass's FASTQ (`:2483`) and
+   consumed by the next `build_qualmer_graph` (`:2317`). So a frozen read's last
+   correction is *mechanically guaranteed* to reach the graph rebuild even with
+   its decode skipped. opt4 reuses this exact path; only the "should I skip"
+   decision is new.
+
+6. **Opt-in kwarg precedent (opt5, shallow).** opt5's `gc_between_batches`
+   kwarg threads: entry on `mycelia_iterative_assemble` (`:1739`) → forwarded at
+   the `improve_read_set_likelihood` call (`:2412`) → kwarg on
+   `improve_read_set_likelihood` (`:4489`) → forwarded to
+   `_improve_read_set_likelihood_impl` (`:4519`) → kwarg on impl (`:4559`). It
+   does NOT thread up into `AssemblyConfig`/`assemble_genome`. opt4 follows this
+   same shallow path (kept minimal + directly benchmarkable).
+
+7. **Accuracy tooling already exists.** `run_dnadiff` wraps MUMmer `dnadiff` via
+   a bioconda env (`src/alignments-and-mapping.jl:548`). The per-base accuracy
+   harness `benchmarking/rhizomorph_correction_accuracy_benchmark.jl` calls
+   `mycelia_iterative_assemble` directly, reads `final_fastq_file`, and computes
+   recall/precision/over-correction against injected-error ground truth. It has a
+   read-scramble null (Control B) that destroys the mechanism and confirms the
+   metric collapses — the same positive-control pattern opt4 needs.
+
+## Design
+
+### The freeze criterion
+
+A read **freezes** when its `was_improved` has been `false` for **N consecutive
+passes** (N = `freeze_streak_threshold`, a tunable; N≈2 is the proposed
+default). This requires one new piece of cross-pass state: a per-read
+`Vector{Int}` streak counter, threaded across the `improve_read_set_likelihood`
+call boundary the same way `prev_soft_weights` already is (`:2287`/`:2447`).
+Each pass: if `was_improved`, reset the read's streak to 0; else increment; a
+read with `streak >= N` is added to the skip set for the *next* pass.
+
+### Configurable scope (default within-rung) — the risk control
+
+The dominant accuracy risk is freezing a read across a **k-change**: a read that
+looks converged at low k (dense, ambiguous graph, lowest per-k-mer coverage) may
+still need correction once the graph sharpens at a higher k. Two scopes, behind
+a `freeze_across_rungs::Bool = false` flag:
+
+- **Within-rung (default, safe):** reset every read's streak to 0 whenever k
+  advances (`_next_k_in_progression`, `:2612`). A read is only ever skipped
+  across same-k iterations; at every new rung — the biggest graph change — every
+  read decodes fresh. This bounds the approximation to intra-rung refinements.
+- **Across-rung (opt-in, aggressive):** persist the streak across k-changes for
+  maximum decodes skipped. Larger speedup, higher accuracy risk. Only for users
+  who have run the sign-off on their data and accepted the tradeoff.
+
+### The skip hook
+
+A frozen read is added to the `_skip_this_read_at` predicate (`:4804`), reusing
+the `skip_solid` path (fact 5). No new decode-bypass plumbing is needed — the
+frozen read's last correction already flows to `updated_reads` → next FASTQ →
+next graph. The only additions are (a) the streak state and (b) OR-ing the
+frozen predicate into the existing skip decision.
+
+### Opt-in kwarg
+
+Follow opt5's shallow pattern. Add `skip_frozen_reads::Bool = false` (and
+`freeze_streak_threshold::Int = 2`, `freeze_across_rungs::Bool = false`) to
+`mycelia_iterative_assemble` (`:1739`) and thread through the 3 hops
+(`:2412` → `:4489`/`:4519` → `:4559`). Default off ⇒ zero behavior change for
+every existing caller (the exact path is preserved bit-for-bit when the flag is
+off — this IS byte-identical-when-disabled, and should be locked by a test).
+
+### Interaction with existing skip/soft-EM/diagnostics
+
+The frozen-skip must compose with, not replace, the existing per-pass
+`skip_solid`/`hard_window` gating; soft-EM (`soft_weights`/`soft_weights_sink`)
+accumulation; and `CorrectorDiagnostics`. A frozen read that is skipped
+contributes its frozen soft-weight (unchanged), and a new diagnostics counter
+`frozen_reads_skipped` records the volume of skipped decodes (mirrors opt1's
+`parallel_decode_batches` counter, incl. the `fieldcount(CorrectorDiagnostics)`
+completeness guard + its `corrector_errors` export site — a struct field has
+three sites, per the opt1 incident).
+
+## Accuracy sign-off methodology (replaces the byte-identity lock)
+
+Three complementary checks, run skip-ON vs skip-OFF:
+
+1. **Per-base read accuracy** (primary): extend
+   `rhizomorph_correction_accuracy_benchmark.jl` to run with
+   `skip_frozen_reads=false` (exact) and `=true` (approximate, both scopes), and
+   report the delta in recall / precision / over-correction. This measures the
+   corrector's own read output directly.
+2. **Assembly-level identity**: re-assemble the corrected reads
+   (`assemble_genome(corrector=:iterative)` → `_assemble_with_iterative_corrector`,
+   `assembly.jl:1591`) and run `run_dnadiff` on the contigs vs the reference
+   genome (skip-ON vs skip-OFF vs reference), reporting ANI / aligned-fraction /
+   indel+SNP counts. This catches degradation that per-base read metrics might
+   miss after assembly.
+3. **Positive control** (the load-bearing gate): a toy genome (~2 kb, reusing
+   the `MYCELIA_RCA_SMOKE` path) with a **repeat region carrying a variant that
+   only resolves at a higher k rung** — a read genuinely wrong/unchanged at low
+   k that flips correct at a later k. Run exact vs freeze (N=1, across-rung, to
+   force early freezing). The freeze arm's accuracy metrics **must measurably
+   degrade** on this engineered case. If the metric does NOT move, the
+   measurement is not trustworthy and the sign-off is invalid — mirrors the
+   existing Control B read-scramble null.
+
+**Ship gate:** the tier ships opt-in **only if** (a) the positive control
+demonstrates the metric detects degradation, and (b) on representative data the
+default (within-rung) scope's accuracy loss is within tolerance for the measured
+speedup. The tolerance is a research judgment set by the maintainer, recorded in
+the results doc, not hardcoded.
+
+## Testing
+
+- **Disabled-path identity lock:** with `skip_frozen_reads=false`, corrected
+  output is bit-identical to pre-opt4 master (a golden/lock test — opt4 must be a
+  true no-op when off). This composes with the existing corrector lock tests.
+- **Freeze-state unit test:** the streak counter increments/resets correctly on
+  a synthetic `was_improved` sequence; within-rung scope resets at k-change;
+  across-rung persists.
+- **Positive control** (above) as an automated test asserting degradation.
+- **Diagnostics completeness:** `frozen_reads_skipped` added to
+  `CorrectorDiagnostics` + its constructor + the `corrector_errors` export (the
+  three-site guard) so `fieldcount`-based completeness tests stay green.
+
+## Risks
+
+- **Silent accuracy loss on real data** — the whole reason for the opt-in default
+  and the sign-off. Mitigated by within-rung default + the positive control +
+  representative-data sign-off before any recommendation to enable it.
+- **Early low-k freezing** (fact/risk 7) — the highest-divergence regime.
+  Mitigated by within-rung default (reset at each k) and by N≥2 (a single
+  no-improvement pass at low k does not freeze).
+- **State-threading bug** — the streak counter is new cross-pass state; a
+  threading error could freeze the wrong reads. Mitigated by the freeze-state
+  unit test and the disabled-path identity lock (off ⇒ no state effect).
+- **Interaction with `stop_on_no_change`** — if all reads freeze, the pass makes
+  zero improvements and the existing zero-improvement early-stop fires, which is
+  correct behavior (nothing left to do), but the test suite should confirm the
+  frozen-skip doesn't cause premature k-advance that the exact path wouldn't.
+
+## Out of scope
+
+- Threading the flag up into `AssemblyConfig`/`assemble_genome` (a follow-on once
+  the sign-off passes; opt4 uses the shallow direct-call path).
+- opt3 (batched kernel, deferred). Any GPU/SIMD acceleration.
+- Changing the default: opt4 ships off; enabling it by default would be a
+  separate, evidence-gated decision.
+
+## Acceptance criteria
+
+- `skip_frozen_reads=false` (default) is a bit-identical no-op vs pre-opt4 master
+  (locked by test).
+- Per-read freeze streak + within-rung/across-rung scope implemented and
+  unit-tested; `freeze_streak_threshold` and `freeze_across_rungs` honored.
+- Frozen reads skipped via the existing `_skip_this_read_at` path; their frozen
+  correction reaches the graph rebuild; `frozen_reads_skipped` diagnostic added
+  (three-site guard satisfied).
+- Accuracy sign-off run and written up: per-base + dnadiff/ANI deltas,
+  skip-ON vs OFF, both scopes; the positive control demonstrates the metric
+  detects degradation; speedup measured.
+- Ship decision (enable-recommend or keep-off) recorded with the tolerance
+  rationale in the results doc — no default change without that evidence.
+
+## Rule-of-5 bead chain (proposed)
+
+Per the campaign's Rule-of-5 pattern, opt4 decomposes into a dependency chain
+(all children of `td-jbjd`, [B]):
+
+1. **Draft** — implement the freeze streak state + skip hook + opt-in kwargs
+   (shallow thread), default off; disabled-path identity lock test.
+2. **Self-review** — "what did I miss?": diagnostics three-site guard, soft-EM
+   interaction, `stop_on_no_change` interaction; freeze-state unit test.
+3. **Architecture** — within-rung vs across-rung scope correctness; confirm the
+   skip path composes with `skip_solid`/`hard_window` rather than conflicting.
+4. **Edge cases** — all-reads-freeze, single-read, N=1 vs N≥2, k-boundary reset;
+   the positive-control toy fixture.
+5. **Verification** — the accuracy sign-off (per-base + dnadiff/ANI, both
+   scopes), speedup measurement, and the ship-decision writeup.

--- a/src/iterative-assembly.jl
+++ b/src/iterative-assembly.jl
@@ -2260,6 +2260,17 @@ function mycelia_iterative_assemble(input_fastq::String;
     # k-advances; the within-rung default resets it inside the k-loop below
     # (mirrors `prev_soft_weights`, :2287) and it is lazily sized to the read
     # count on first use (:2310-ish, once `current_reads` is known).
+    #
+    # opt4 (td-jbjd, pass 2, finding #4): NOT persisted to checkpoints. A run
+    # resumed from a checkpoint (`enable_checkpointing=true`) restarts streak
+    # counting from zero at the resume point rather than continuing where the
+    # interrupted run left off. This is safe on the default (disabled) path --
+    # `skip_frozen_reads=false` never allocates `freeze_streaks`, so resume is
+    # unaffected -- and on the approximate path it only ever makes the resumed
+    # run marginally LESS aggressive about skipping (a few extra passes decode
+    # reads that would otherwise already have been frozen), never more
+    # aggressive, so it does not weaken the accuracy-sign-off tolerance
+    # established for the from-scratch run.
     freeze_streaks::Union{Nothing, Vector{Int}} = nothing
 
     # Main k-mer progression loop
@@ -2439,7 +2450,6 @@ function mycelia_iterative_assemble(input_fastq::String;
                 gc_between_batches = gc_between_batches,
                 skip_frozen_reads = skip_frozen_reads,
                 freeze_streak_threshold = freeze_streak_threshold,
-                freeze_across_rungs = freeze_across_rungs,
                 freeze_streaks = freeze_streaks,
                 enable_parallel = enable_parallel,
                 graph_mode = graph_mode,
@@ -4334,13 +4344,21 @@ mutable struct CorrectorDiagnostics
     # `if use_parallel` branch). A silent revert to serial leaves this at 0 while
     # byte-identity still holds, so tests assert >0 to catch a lost parallel path.
     parallel_decode_batches::Threads.Atomic{Int}
+    # opt4 (td-jbjd, pass 2): incremented once per read whose per-pass decode was
+    # skipped BECAUSE it is frozen (skip_frozen_reads=true and its consecutive
+    # no-improvement streak >= freeze_streak_threshold) -- NOT reads skipped for
+    # skip_solid/hard_window/pass-decode-off reasons, which are pre-existing gate
+    # skips unrelated to opt4 (finding #5: a gate-skipped read was never evaluated
+    # for improvement, so it must not be counted as "frozen"). Always 0 when
+    # skip_frozen_reads=false (the default no-op path).
+    frozen_reads_skipped::Threads.Atomic{Int}
 end
 function CorrectorDiagnostics()
     CorrectorDiagnostics(Threads.Atomic{Int}(0), Threads.Atomic{Int}(0),
         Threads.Atomic{Int}(0), Threads.Atomic{Int}(0), Threads.Atomic{Int}(0),
         Threads.Atomic{Int}(0), Threads.Atomic{Int}(0), Threads.Atomic{Int}(0),
         Threads.Atomic{Int}(0), Threads.Atomic{Int}(0), Threads.Atomic{Int}(0),
-        Threads.Atomic{Int}(0))
+        Threads.Atomic{Int}(0), Threads.Atomic{Int}(0))
 end
 
 # Previously-proven-tractable finite beam (td-63qy: beam 256 completed on the
@@ -4520,7 +4538,6 @@ function improve_read_set_likelihood(reads::Vector{<:FASTX.FASTQ.Record}, graph,
         gc_between_batches::Bool = false,
         skip_frozen_reads::Bool = false,
         freeze_streak_threshold::Int = 2,
-        freeze_across_rungs::Bool = false,
         freeze_streaks::Union{Nothing, Vector{Int}} = nothing,
         enable_parallel::Bool = false,
         graph_mode::Symbol = :canonical,
@@ -4554,7 +4571,6 @@ function improve_read_set_likelihood(reads::Vector{<:FASTX.FASTQ.Record}, graph,
             gc_between_batches = gc_between_batches,
             skip_frozen_reads = skip_frozen_reads,
             freeze_streak_threshold = freeze_streak_threshold,
-            freeze_across_rungs = freeze_across_rungs,
             freeze_streaks = freeze_streaks,
             enable_parallel = enable_parallel,
             graph_mode = graph_mode,
@@ -4598,7 +4614,6 @@ function _improve_read_set_likelihood_impl(
         gc_between_batches::Bool,
         skip_frozen_reads::Bool,
         freeze_streak_threshold::Int,
-        freeze_across_rungs::Bool,
         freeze_streaks::Union{Nothing, Vector{Int}},
         enable_parallel::Bool,
         graph_mode::Symbol,
@@ -5013,12 +5028,30 @@ function _improve_read_set_likelihood_impl(
                 if was_improved
                     batch_improvements += 1
                 end
-                # opt4 (pass 1): identical freeze-streak bookkeeping to the serial
-                # path (the fact-5 skip mechanism composes the same on both
-                # branches). No-op when freeze_streaks is nothing.
+                # opt4 (pass 2, td-jbjd findings #2/#5): mirror the serial
+                # semantics exactly -- a single mutually-exclusive update per read,
+                # matching the serial skip-branch + decode-branch pair. `skip_flags`
+                # records whether THIS read was skipped in the @threads loop above
+                # (for ANY reason -- gate, frozen, or pass-decode-off); a skipped
+                # read's `was_improved` is always `false` (set at the skip
+                # assignment above), so it alone cannot distinguish "skipped" from
+                # "decoded, no improvement". A decoded read updates its streak as
+                # before; a skipped read only updates its streak (+ the frozen
+                # diagnostic) when freezing is WHY it was skipped -- a gate/
+                # pass-decode-off skip was never evaluated for improvement and must
+                # not conflate "not looked at" with "converged". No-op when
+                # freeze_streaks is nothing.
                 if freeze_streaks !== nothing
-                    freeze_streaks[batch_start + i - 1] =
-                        was_improved ? 0 : freeze_streaks[batch_start + i - 1] + 1
+                    read_index = batch_start + i - 1
+                    if skip_flags[i]
+                        if _frozen_read_at(read_index)
+                            freeze_streaks[read_index] += 1
+                            Threads.atomic_add!(diag.frozen_reads_skipped, 1)
+                        end
+                    else
+                        freeze_streaks[read_index] =
+                            was_improved ? 0 : freeze_streaks[read_index] + 1
+                    end
                 end
             end
 
@@ -5042,11 +5075,17 @@ function _improve_read_set_likelihood_impl(
                 if _skip_this_read_at(batch_start + i - 1)
                     updated_reads[batch_start + i - 1] = read   # skip the decode
                     skipped_reads += 1
-                    # opt4 (pass 1): a skipped read did not improve this pass;
-                    # extend its freeze streak (an already-frozen read stays
-                    # frozen). No-op when freeze_streaks is nothing.
-                    if freeze_streaks !== nothing
+                    # opt4 (pass 2, td-jbjd finding #5): a read skipped here was NOT
+                    # evaluated for improvement this pass, so its freeze streak is
+                    # only touched when FREEZING is why it was skipped (an
+                    # already-frozen read stays frozen and counts toward
+                    # frozen_reads_skipped). A read skipped for skip_solid /
+                    # hard_window / pass-decode-off reasons was never looked at --
+                    # extending its streak would conflate "not evaluated" with
+                    # "converged". No-op when freeze_streaks is nothing.
+                    if freeze_streaks !== nothing && _frozen_read_at(batch_start + i - 1)
                         freeze_streaks[batch_start + i - 1] += 1
+                        Threads.atomic_add!(diag.frozen_reads_skipped, 1)
                     end
                     continue
                 end
@@ -6082,6 +6121,7 @@ function finalize_iterative_assembly(output_dir::String, k_progression::Vector{I
             :window_divergences => 0,
             :substitution_length_divergences => 0,
             :parallel_decode_batches => 0,
+            :frozen_reads_skipped => 0,
         )
     else
         Dict(
@@ -6098,6 +6138,7 @@ function finalize_iterative_assembly(output_dir::String, k_progression::Vector{I
             :substitution_length_divergences =>
                 diagnostics.substitution_length_divergences[],
             :parallel_decode_batches => diagnostics.parallel_decode_batches[],
+            :frozen_reads_skipped => diagnostics.frozen_reads_skipped[],
         )
     end
 
@@ -6221,6 +6262,11 @@ function finalize_iterative_assembly(output_dir::String, k_progression::Vector{I
         # parallel path actually ran rather than silently reverting to serial.
         :parallel_decode_batches =>
             (diagnostics === nothing ? 0 : diagnostics.parallel_decode_batches[]),
+        # opt4 (td-jbjd, pass 2) actuation counter: total reads skipped BECAUSE
+        # frozen, across all passes (0 when skip_frozen_reads=false, the default).
+        # Mirrors parallel_decode_batches's top-level convenience export.
+        :frozen_reads_skipped =>
+            (diagnostics === nothing ? 0 : diagnostics.frozen_reads_skipped[]),
     )
 
     if verbose

--- a/src/iterative-assembly.jl
+++ b/src/iterative-assembly.jl
@@ -1737,6 +1737,9 @@ function mycelia_iterative_assemble(input_fastq::String;
         enable_parallel::Bool = false,
         batch_size::Int = 10000,
         gc_between_batches::Bool = false,
+        skip_frozen_reads::Bool = false,
+        freeze_streak_threshold::Int = 2,
+        freeze_across_rungs::Bool = false,
         enable_checkpointing::Bool = true,
         checkpoint_interval::Int = 5,
         skip_solid::Bool = false,
@@ -2250,6 +2253,15 @@ function mycelia_iterative_assemble(input_fastq::String;
     final_pass_graph_reusable = false
     completed_runtime = nothing
 
+    # opt4 (td-jbjd, pass 1): per-read consecutive-no-improvement streak, used to
+    # skip re-decoding "frozen" reads when `skip_frozen_reads=true` (default off
+    # keeps this `nothing` for the life of the run, a true no-op). Declared
+    # OUTSIDE the k-loop so `freeze_across_rungs=true` can persist counts across
+    # k-advances; the within-rung default resets it inside the k-loop below
+    # (mirrors `prev_soft_weights`, :2287) and it is lazily sized to the read
+    # count on first use (:2310-ish, once `current_reads` is known).
+    freeze_streaks::Union{Nothing, Vector{Int}} = nothing
+
     # Main k-mer progression loop
     while !resume_run_complete && k <= max_k
         if verbose
@@ -2286,6 +2298,14 @@ function mycelia_iterative_assemble(input_fastq::String;
         # carry over.
         prev_soft_weights = nothing
 
+        # opt4 (td-jbjd, pass 1): within-rung default resets the per-read freeze
+        # streak at every new k rung (the biggest graph change, fact/risk 7);
+        # `freeze_across_rungs=true` persists it across k instead. No-op when
+        # `skip_frozen_reads=false` (freeze_streaks stays `nothing`).
+        if skip_frozen_reads && !freeze_across_rungs
+            freeze_streaks = nothing
+        end
+
         # Iterative improvement loop for current k
         while iteration <= max_iterations_per_k
             if verbose
@@ -2308,6 +2328,13 @@ function mycelia_iterative_assemble(input_fastq::String;
                 # same descriptor used for the checkpoint content hash.
                 current_reads = resume_fastq_reads
                 resume_fastq_reads = nothing
+            end
+
+            # opt4 (td-jbjd, pass 1): lazily allocate the freeze-streak vector once
+            # this k rung's read count is known — fires once per k under the
+            # within-rung default, once per run under freeze_across_rungs=true.
+            if skip_frozen_reads && freeze_streaks === nothing
+                freeze_streaks = zeros(Int, length(current_reads))
             end
 
             # Build qualmer graph from current read set
@@ -2410,6 +2437,10 @@ function mycelia_iterative_assemble(input_fastq::String;
                 verbose = verbose,
                 batch_size = batch_size,
                 gc_between_batches = gc_between_batches,
+                skip_frozen_reads = skip_frozen_reads,
+                freeze_streak_threshold = freeze_streak_threshold,
+                freeze_across_rungs = freeze_across_rungs,
+                freeze_streaks = freeze_streaks,
                 enable_parallel = enable_parallel,
                 graph_mode = graph_mode,
                 skip_solid = skip_solid,
@@ -4487,6 +4518,10 @@ function improve_read_set_likelihood(reads::Vector{<:FASTX.FASTQ.Record}, graph,
         verbose::Bool = false,
         batch_size::Int = 10000,
         gc_between_batches::Bool = false,
+        skip_frozen_reads::Bool = false,
+        freeze_streak_threshold::Int = 2,
+        freeze_across_rungs::Bool = false,
+        freeze_streaks::Union{Nothing, Vector{Int}} = nothing,
         enable_parallel::Bool = false,
         graph_mode::Symbol = :canonical,
         skip_solid::Bool = false,
@@ -4517,6 +4552,10 @@ function improve_read_set_likelihood(reads::Vector{<:FASTX.FASTQ.Record}, graph,
             verbose = verbose,
             batch_size = batch_size,
             gc_between_batches = gc_between_batches,
+            skip_frozen_reads = skip_frozen_reads,
+            freeze_streak_threshold = freeze_streak_threshold,
+            freeze_across_rungs = freeze_across_rungs,
+            freeze_streaks = freeze_streaks,
             enable_parallel = enable_parallel,
             graph_mode = graph_mode,
             skip_solid = skip_solid,
@@ -4557,6 +4596,10 @@ function _improve_read_set_likelihood_impl(
         verbose::Bool,
         batch_size::Int,
         gc_between_batches::Bool,
+        skip_frozen_reads::Bool,
+        freeze_streak_threshold::Int,
+        freeze_across_rungs::Bool,
+        freeze_streaks::Union{Nothing, Vector{Int}},
         enable_parallel::Bool,
         graph_mode::Symbol,
         skip_solid::Bool,
@@ -4657,9 +4700,16 @@ function _improve_read_set_likelihood_impl(
     # Precompute per-read skip decisions ONCE (cheap k-mer-membership checks) so the
     # adaptive low-k gate can measure the natural decode fraction and the decode loop
     # can reuse the same flags (no double evaluation).
+    # opt4 (td-jbjd, pass 1): OR a frozen (converged, N-consecutive-pass-stable)
+    # read into the existing skip-solid/hard-window skip decision — reuses the
+    # already-proven skip path (fact 5) rather than new decode-bypass plumbing.
+    # `freeze_streaks === nothing` (default, `skip_frozen_reads=false`) makes this
+    # predicate always `false`, so the disabled path is unaffected.
+    _frozen_read_at = i -> skip_frozen_reads && freeze_streaks !== nothing &&
+                           freeze_streaks[i] >= freeze_streak_threshold
     base_skip_flags = Vector{Bool}(undef, total_reads)
     @inbounds for i in 1:total_reads
-        base_skip_flags[i] = _gate_skip(work_reads[i])
+        base_skip_flags[i] = _gate_skip(work_reads[i]) || _frozen_read_at(i)
     end
     natural_decode_fraction = total_reads > 0 ?
                               count(!, base_skip_flags) / total_reads : 0.0
@@ -4963,6 +5013,13 @@ function _improve_read_set_likelihood_impl(
                 if was_improved
                     batch_improvements += 1
                 end
+                # opt4 (pass 1): identical freeze-streak bookkeeping to the serial
+                # path (the fact-5 skip mechanism composes the same on both
+                # branches). No-op when freeze_streaks is nothing.
+                if freeze_streaks !== nothing
+                    freeze_streaks[batch_start + i - 1] =
+                        was_improved ? 0 : freeze_streaks[batch_start + i - 1] + 1
+                end
             end
 
             # opt1: fold captured per-window soft-EM contributions into the shared
@@ -4985,6 +5042,12 @@ function _improve_read_set_likelihood_impl(
                 if _skip_this_read_at(batch_start + i - 1)
                     updated_reads[batch_start + i - 1] = read   # skip the decode
                     skipped_reads += 1
+                    # opt4 (pass 1): a skipped read did not improve this pass;
+                    # extend its freeze streak (an already-frozen read stays
+                    # frozen). No-op when freeze_streaks is nothing.
+                    if freeze_streaks !== nothing
+                        freeze_streaks[batch_start + i - 1] += 1
+                    end
                     continue
                 end
                 read_index = batch_start + i - 1
@@ -5016,6 +5079,14 @@ function _improve_read_set_likelihood_impl(
 
                 if was_improved
                     batch_improvements += 1
+                end
+                # opt4 (pass 1): reset the freeze streak on improvement, else
+                # extend it — the state the NEXT pass's frozen-skip decision
+                # (via _frozen_read_at) consumes. No-op when freeze_streaks is
+                # nothing (skip_frozen_reads=false).
+                if freeze_streaks !== nothing
+                    freeze_streaks[batch_start + i - 1] =
+                        was_improved ? 0 : freeze_streaks[batch_start + i - 1] + 1
                 end
             end
         end

--- a/src/iterative-assembly.jl
+++ b/src/iterative-assembly.jl
@@ -893,6 +893,15 @@ function _iterative_checkpoint_configuration(;
         graph_mode::Symbol,
         qualmer_prefilter_min_count::Int,
         enable_parallel::Bool,
+        # opt4 (td-jbjd, review fix C2): captured for exact-equality resume
+        # validation, same as every other behavior-affecting kwarg below --
+        # resuming a checkpoint under DIFFERENT freeze settings would otherwise
+        # silently switch an exact run into an approximate one (or vice versa)
+        # rather than tripping `_validate_checkpoint_configuration`'s mismatch
+        # guard.
+        skip_frozen_reads::Bool,
+        freeze_streak_threshold::Int,
+        freeze_across_rungs::Bool,
         skip_solid::Bool,
         hard_window::Bool,
         windowed_decode::Bool,
@@ -920,6 +929,9 @@ function _iterative_checkpoint_configuration(;
         "graph_mode" => string(graph_mode),
         "qualmer_prefilter_min_count" => qualmer_prefilter_min_count,
         "enable_parallel" => enable_parallel,
+        "skip_frozen_reads" => skip_frozen_reads,
+        "freeze_streak_threshold" => freeze_streak_threshold,
+        "freeze_across_rungs" => freeze_across_rungs,
         "skip_solid" => skip_solid,
         "hard_window" => hard_window,
         "windowed_decode" => windowed_decode,
@@ -1781,6 +1793,19 @@ function mycelia_iterative_assemble(input_fastq::String;
         throw(ArgumentError("indel_schedule must be :unrestricted or " *
                             ":frontier_budgeted; got :$(indel_schedule)"))
 
+    # opt4 (td-jbjd, review fix C3): freeze_streak_threshold=0 would make
+    # `freeze_streaks[i] >= freeze_streak_threshold` (see `_frozen_read_at`,
+    # below) true for EVERY read from pass 1 onward (streaks start all-zero),
+    # silently disabling the corrector entirely whenever skip_frozen_reads=true.
+    # Fail closed instead: a threshold this permissive is never a legitimate
+    # configuration, so reject it independent of skip_frozen_reads (a caller
+    # that later flips skip_frozen_reads=true without revisiting the threshold
+    # must not be silently broken).
+    freeze_streak_threshold >= 1 || throw(ArgumentError(
+        "freeze_streak_threshold must be at least 1 (got " *
+        "$freeze_streak_threshold); a threshold of 0 marks every read frozen " *
+        "from pass 1, disabling correction entirely when skip_frozen_reads=true"))
+
     isfile(input_fastq) || throw(ArgumentError(
         "input FASTQ file does not exist: $input_fastq"))
     canonical_input_fastq = realpath(input_fastq)
@@ -1906,6 +1931,9 @@ function mycelia_iterative_assemble(input_fastq::String;
         graph_mode = graph_mode,
         qualmer_prefilter_min_count = qualmer_prefilter_min_count,
         enable_parallel = enable_parallel,
+        skip_frozen_reads = skip_frozen_reads,
+        freeze_streak_threshold = freeze_streak_threshold,
+        freeze_across_rungs = freeze_across_rungs,
         skip_solid = skip_solid,
         hard_window = hard_window,
         windowed_decode = windowed_decode,
@@ -4522,6 +4550,23 @@ linear scan so the expensive graph Viterbi is reserved for genuine ambiguity
 (bubbles/repeats). The decode then operates on the cheaply-corrected reads. Only
 enabled on the :scalable tier.
 
+`skip_frozen_reads`/`freeze_streak_threshold`/`freeze_streaks` (opt4, td-jbjd):
+when `skip_frozen_reads=true`, a read whose per-read decode has produced NO
+improvement for `freeze_streak_threshold` (default 2) consecutive calls against
+the CALLER-supplied `freeze_streaks` vector is treated as converged and skipped
+this pass (OR'd into the existing skip-solid/hard-window gate) — an approximate,
+opt-in optimization that trades a bounded amount of accuracy for skipped work
+(default OFF). `freeze_streaks` is caller-owned: this function only reads and
+mutates the vector it is given (a decoded read resets its entry to 0 on
+improvement or advances it by 1 otherwise; a frozen-skipped read's entry also
+advances). It defaults to `nothing`, in which case `skip_frozen_reads=true` is
+INERT (no read is ever frozen) and a `@warn` fires to surface the
+misconfiguration. `freeze_across_rungs` is NOT a parameter of this function — it
+only governs whether `mycelia_iterative_assemble`'s outer k-loop resets or
+persists the `freeze_streaks` vector it threads into each call across a k-advance;
+a direct caller of this function controls that scope itself by choosing whether
+to pass a fresh or a carried-forward `freeze_streaks` vector.
+
 Returns `(updated_reads, improvements_made, skip_fraction, cheap_corrections,
 decode_gated)` where `skip_fraction` is the fraction of reads passed through WITHOUT
 a decode (solid + hard-window skips, plus the whole set when the low-k decode gate
@@ -4671,6 +4716,13 @@ function _improve_read_set_likelihood_impl(
     end
     if cheap_correct && graph_mode == :singlestrand
         @warn "cheap_correct is not supported for graph_mode=:singlestrand; disabling Stage 0 cheap correction." graph_mode
+    end
+    # opt4 (td-jbjd, review fix I5): skip_frozen_reads=true with no
+    # freeze_streaks vector supplied is a silent no-op (`_frozen_read_at` below
+    # is unconditionally `false` when `freeze_streaks === nothing`) -- surface
+    # the misconfiguration rather than let a caller believe freezing is active.
+    if skip_frozen_reads && freeze_streaks === nothing
+        @warn "skip_frozen_reads=true but freeze_streaks not supplied; freezing is inert this call"
     end
     # Classify k-mers once if EITHER the skip-solid gate OR the Stage 0 cheap
     # corrector needs the solid set. Compute once, share both consumers.
@@ -5046,7 +5098,20 @@ function _improve_read_set_likelihood_impl(
                     if skip_flags[i]
                         if _frozen_read_at(read_index)
                             freeze_streaks[read_index] += 1
-                            Threads.atomic_add!(diag.frozen_reads_skipped, 1)
+                            # opt4 (td-jbjd, review fix I6): a read that is
+                            # ALREADY frozen (streak >= threshold) still counts
+                            # as frozen when a global `pass_decode_off` pass also
+                            # skips every other read -- but this pass's skip was
+                            # NOT caused by freezing specifically (every read was
+                            # skipped regardless of its streak), so attributing
+                            # it to `frozen_reads_skipped` would over-count vs
+                            # the counter's documented contract ("NOT reads
+                            # skipped for pass-decode-off reasons"). The streak
+                            # itself still advances (state stays correct); only
+                            # the diagnostic attribution is gated.
+                            if !pass_decode_off
+                                Threads.atomic_add!(diag.frozen_reads_skipped, 1)
+                            end
                         end
                     else
                         freeze_streaks[read_index] =
@@ -5085,7 +5150,15 @@ function _improve_read_set_likelihood_impl(
                     # "converged". No-op when freeze_streaks is nothing.
                     if freeze_streaks !== nothing && _frozen_read_at(batch_start + i - 1)
                         freeze_streaks[batch_start + i - 1] += 1
-                        Threads.atomic_add!(diag.frozen_reads_skipped, 1)
+                        # opt4 (td-jbjd, review fix I6): mirror the parallel
+                        # branch -- do not attribute this skip to
+                        # `frozen_reads_skipped` when a global
+                        # `pass_decode_off` pass is why EVERY read (frozen or
+                        # not) was skipped this pass. The streak still
+                        # advances; only the diagnostic counter is gated.
+                        if !pass_decode_off
+                            Threads.atomic_add!(diag.frozen_reads_skipped, 1)
+                        end
                     end
                     continue
                 end

--- a/test/4_assembly/corrector_opt4_config_guards_test.jl
+++ b/test/4_assembly/corrector_opt4_config_guards_test.jl
@@ -1,0 +1,164 @@
+# OPT4 CONFIGURATION GUARDS (td-jbjd, review fixes C2 + C3)
+# =======================================================================
+#
+# Two review-flagged gaps in the opt4 (frozen-read skip) kwarg surface:
+#
+#   C2 — checkpoint resume-config gap: `_iterative_checkpoint_configuration`
+#     did not capture `skip_frozen_reads`/`freeze_streak_threshold`/
+#     `freeze_across_rungs`, so resuming a checkpointed run under DIFFERENT
+#     opt4 settings silently switched an exact run into an approximate one (or
+#     vice versa) instead of tripping `_validate_checkpoint_configuration`'s
+#     exact-equality mismatch guard the way every other behavior-affecting
+#     kwarg (skip_solid, hard_window, soft_em, cheap_correct, ...) already
+#     does. Fixed by adding all three to the captured config dict + its call
+#     site in `mycelia_iterative_assemble`.
+#
+#   C3 — `freeze_streak_threshold=0` would make `freeze_streaks[i] >=
+#     freeze_streak_threshold` true for EVERY read from pass 1 onward (streaks
+#     start all-zero), silently disabling the corrector entirely whenever
+#     `skip_frozen_reads=true`. Fixed with an `ArgumentError` guard requiring
+#     `freeze_streak_threshold >= 1`.
+#
+# Run directly:
+#   LD_LIBRARY_PATH='' julia --project=. \
+#     -e 'include("test/4_assembly/corrector_opt4_config_guards_test.jl")'
+
+import Test
+import Mycelia
+import FASTX
+import Random
+
+const _OPT4CG_BASES = ['A', 'C', 'G', 'T']
+
+function _opt4cg_reads(rng, ref; n_reads = 40, readlen = 40, n_err = 8)
+    reflen = length(ref)
+    records = FASTX.FASTQ.Record[]
+    for i in 1:n_reads
+        s = rand(rng, 1:(reflen - readlen + 1))
+        seq = collect(ref[s:(s + readlen - 1)])
+        if i <= n_err
+            p = rand(rng, 1:readlen)
+            seq[p] = rand(rng, filter(!=(seq[p]), _OPT4CG_BASES))
+        end
+        push!(records,
+            FASTX.FASTQ.Record("r$i", String(seq), String(fill('I', readlen))))
+    end
+    return records
+end
+
+Test.@testset "opt4 configuration guards (td-jbjd, C2 + C3)" begin
+    Test.@testset "C2: checkpoint resume rejects a skip_frozen_reads flip" begin
+        rng = Random.MersenneTwister(31337)
+        ref = join(rand(rng, _OPT4CG_BASES, 400))
+        reads = _opt4cg_reads(rng, ref; n_reads = 40, readlen = 40, n_err = 8)
+        tmp = mktempdir()
+        fq = joinpath(tmp, "in.fastq")
+        Mycelia.write_fastq(records = reads, filename = fq)
+        output_directory = joinpath(tmp, "run")
+
+        common = (; max_k = 13, max_iterations_per_k = 1,
+            improvement_threshold = 0.0, stop_on_no_change = false,
+            graph_mode = :canonical, skip_solid = true, cheap_correct = true,
+            verbose = false, enable_checkpointing = true,
+            checkpoint_interval = 1, output_dir = output_directory)
+
+        # First invocation lays down a checkpoint with skip_frozen_reads=false.
+        first_result = Mycelia.mycelia_iterative_assemble(
+            fq; common..., skip_frozen_reads = false)
+        Test.@test isfile(joinpath(
+            output_directory, "checkpoints", "latest_checkpoint.json"))
+        Test.@test first_result[:metadata][:corrector_errors][
+            :frozen_reads_skipped] == 0
+
+        # Re-invoking against the SAME output_dir with every other kwarg held
+        # identical but skip_frozen_reads flipped to true must be rejected --
+        # NOT silently proceed as if freezing had been the setting all along
+        # (which would retroactively switch an already-exact checkpointed run
+        # into an approximate one).
+        observed_exception = try
+            Mycelia.mycelia_iterative_assemble(
+                fq; common..., skip_frozen_reads = true)
+            nothing
+        catch exception
+            exception
+        end
+        Test.@test observed_exception isa ArgumentError
+        Test.@test occursin(
+            "checkpoint resume_configuration does not match this invocation",
+            sprint(showerror, observed_exception))
+        Test.@test occursin("skip_frozen_reads", sprint(showerror, observed_exception))
+
+        # The mirror direction (checkpoint saved WITH freezing, resumed
+        # WITHOUT) must be rejected the same way -- the guard is symmetric,
+        # not a one-directional "only tighten" check.
+        output_directory_2 = joinpath(tmp, "run2")
+        common2 = merge(common, (; output_dir = output_directory_2))
+        Mycelia.mycelia_iterative_assemble(
+            fq; common2..., skip_frozen_reads = true, freeze_streak_threshold = 2)
+        observed_exception_2 = try
+            Mycelia.mycelia_iterative_assemble(
+                fq; common2..., skip_frozen_reads = false)
+            nothing
+        catch exception
+            exception
+        end
+        Test.@test observed_exception_2 isa ArgumentError
+        Test.@test occursin(
+            "checkpoint resume_configuration does not match this invocation",
+            sprint(showerror, observed_exception_2))
+    end
+
+    Test.@testset "C3: freeze_streak_threshold must be >= 1" begin
+        rng = Random.MersenneTwister(99)
+        ref = join(rand(rng, _OPT4CG_BASES, 300))
+        reads = _opt4cg_reads(rng, ref; n_reads = 20, readlen = 30, n_err = 5)
+        tmp = mktempdir()
+        fq = joinpath(tmp, "in.fastq")
+        Mycelia.write_fastq(records = reads, filename = fq)
+
+        for bad_threshold in (0, -1, -5)
+            observed_exception = try
+                Mycelia.mycelia_iterative_assemble(
+                    fq; max_k = 13, max_iterations_per_k = 1,
+                    graph_mode = :canonical, verbose = false,
+                    enable_checkpointing = false,
+                    output_dir = joinpath(tmp, "bad_$(bad_threshold)"),
+                    skip_frozen_reads = true,
+                    freeze_streak_threshold = bad_threshold)
+                nothing
+            catch exception
+                exception
+            end
+            Test.@test observed_exception isa ArgumentError
+            Test.@test occursin(
+                "freeze_streak_threshold must be at least 1",
+                sprint(showerror, observed_exception))
+        end
+
+        # The guard fires independent of skip_frozen_reads too -- a caller that
+        # later flips skip_frozen_reads=true without revisiting an already-bad
+        # threshold=0 must not be silently broken.
+        observed_exception_disabled = try
+            Mycelia.mycelia_iterative_assemble(
+                fq; max_k = 13, max_iterations_per_k = 1,
+                graph_mode = :canonical, verbose = false,
+                enable_checkpointing = false,
+                output_dir = joinpath(tmp, "disabled_zero"),
+                skip_frozen_reads = false, freeze_streak_threshold = 0)
+            nothing
+        catch exception
+            exception
+        end
+        Test.@test observed_exception_disabled isa ArgumentError
+
+        # Positive control: threshold=1 (the minimum valid value) does not
+        # raise.
+        result = Mycelia.mycelia_iterative_assemble(
+            fq; max_k = 13, max_iterations_per_k = 1,
+            graph_mode = :canonical, verbose = false,
+            enable_checkpointing = false,
+            output_dir = joinpath(tmp, "min_valid"),
+            skip_frozen_reads = true, freeze_streak_threshold = 1)
+        Test.@test isfile(result[:metadata][:final_fastq_file])
+    end
+end

--- a/test/4_assembly/corrector_opt4_edge_cases_test.jl
+++ b/test/4_assembly/corrector_opt4_edge_cases_test.jl
@@ -1,0 +1,197 @@
+# OPT4 FROZEN-READ SKIP — EDGE CASES (td-jbjd, pass 4)
+# =======================================================================
+#
+# Pass 4 ("edge cases") of the opt4 Rule-of-5 chain
+# (docs/design/2026-07-26-opt4-frozen-read-skip-design.md). Passes 1-3 already
+# cover the disabled-path lock, the freeze-state machine, within/across-rung
+# scope, soft-EM/skip_solid composition, and one stop_on_no_change interaction
+# test (aggressive-but-not-total freezing). This file adds the mechanical edge
+# cases the design's own Rule-of-5 scope calls out that are NOT yet covered:
+#
+#   * ALL-reads-freeze: force literally every read in the set to freeze, then
+#     confirm `stop_on_no_change`'s zero-improvement early-stop still fires
+#     correctly (no hang, no premature/incorrect k-advance vs the exact path)
+#     -- design doc "Risks" section, bullet 4.
+#   * single-read batch (n_reads=1): skip_frozen_reads=true must not crash on
+#     the smallest possible read set and must produce sane output.
+#   * N=1 vs N=2 threshold timing: the freeze-eligibility boundary is exact,
+#     not "eventually" -- threshold=N must make a read frozen-skip-eligible
+#     starting EXACTLY N passes after a maintained no-improvement streak began.
+#
+# k-boundary reset (within-rung resets at k-advance vs across-rung persists) is
+# already covered in detail by corrector_opt4_freeze_state_test.jl's two scope
+# testsets, so it is intentionally NOT duplicated here.
+#
+# Run directly:
+#   LD_LIBRARY_PATH='' julia --project=. \
+#     -e 'include("test/4_assembly/corrector_opt4_edge_cases_test.jl")'
+
+import Test
+import Mycelia
+import FASTX
+import Random
+
+const _OPT4EC_BASES = ['A', 'C', 'G', 'T']
+
+function _opt4ec_reads(rng, ref; n_reads = 180, readlen = 80, n_err = 30)
+    reflen = length(ref)
+    records = FASTX.FASTQ.Record[]
+    for i in 1:n_reads
+        s = rand(rng, 1:(reflen - readlen + 1))
+        seq = collect(ref[s:(s + readlen - 1)])
+        if i <= n_err
+            p = rand(rng, 1:readlen)
+            seq[p] = rand(rng, filter(!=(seq[p]), _OPT4EC_BASES))
+        end
+        push!(records,
+            FASTX.FASTQ.Record("r$i", String(seq), String(fill('I', readlen))))
+    end
+    return records
+end
+
+Test.@testset "opt4 skip_frozen_reads edge cases (td-jbjd pass 4)" begin
+    Test.@testset "all-reads-freeze: stop_on_no_change fires correctly, no premature k-advance" begin
+        # skip_solid=false, cheap_correct=false, decode_enabled=true is the
+        # configuration under which the corrector's per-read decode makes NO
+        # improvements at all at this toy scale (verified during pass-4
+        # investigation: every read's `was_improved` is false every pass in this
+        # regime), so with freeze_streak_threshold=1 and enough passes, EVERY
+        # read in the set is frozen by the second pass of the first rung, and
+        # stays frozen (across-rung) through every subsequent rung. This is the
+        # literal "all reads freeze" case the design's Risks section asks for,
+        # distinct from the existing freeze_state_test.jl stop_on_no_change
+        # testset (which uses skip_solid=true/cheap_correct=true, an aggressive
+        # -but-not-total freeze configuration).
+        rng = Random.MersenneTwister(4141)
+        ref = join(rand(rng, _OPT4EC_BASES, 900))
+        reads = _opt4ec_reads(rng, ref; n_reads = 150, readlen = 80, n_err = 25)
+        tmp = mktempdir()
+        fq = joinpath(tmp, "in.fastq")
+        Mycelia.write_fastq(records = reads, filename = fq)
+
+        run = frozen -> Mycelia.mycelia_iterative_assemble(fq;
+            max_k = 21, n_k_rungs = 3, max_iterations_per_k = 5,
+            graph_mode = :canonical, skip_solid = false, cheap_correct = false,
+            soft_em = false, batch_size = 50,
+            verbose = false, enable_checkpointing = false,
+            stop_on_no_change = true,
+            skip_frozen_reads = frozen, freeze_streak_threshold = 1,
+            freeze_across_rungs = true,
+            output_dir = joinpath(tmp, frozen ? "frozen" : "exact"))
+
+        r_exact = run(false)
+        r_frozen = run(true)
+
+        # Every read froze (all-solid gate is off here, so freeze is the ONLY
+        # skip source): confirm the frozen run actually exercised total freezing,
+        # not just partial freezing, as the setup sanity check for this testset.
+        Test.@test r_frozen[:metadata][:corrector_errors][:frozen_reads_skipped] > 0
+
+        # No hang: both runs terminate with a positive iteration count that
+        # never exceeds the hard cap (n_k_rungs * max_iterations_per_k = 15).
+        Test.@test 0 < r_exact[:metadata][:total_iterations] <= 15
+        Test.@test 0 < r_frozen[:metadata][:total_iterations] <= 15
+
+        # stop_on_no_change correctness: once literally every read is frozen, a
+        # pass makes ZERO improvements (frozen reads cannot contribute genuine
+        # improvements by construction), so the zero-improvement early-stop must
+        # fire -- the frozen run must not silently run to the iteration CAP
+        # instead of stopping early once nothing is left to do. Concretely: the
+        # frozen run's total_iterations must not exceed the exact run's (frozen
+        # reads can only cause EARLIER-or-equal stopping, never later).
+        Test.@test r_frozen[:metadata][:total_iterations] <=
+                   r_exact[:metadata][:total_iterations]
+
+        # k-ladder correctness: freezing (even total freezing) changes WHEN a
+        # rung's pass count stops, never WHICH rungs the run walks through -- no
+        # premature or skipped k-advance vs the exact path.
+        Test.@test r_exact[:metadata][:final_k] == r_frozen[:metadata][:final_k]
+        Test.@test r_exact[:metadata][:k_progression] ==
+                   r_frozen[:metadata][:k_progression]
+    end
+
+    Test.@testset "single-read batch (n_reads=1) does not crash" begin
+        rng = Random.MersenneTwister(5151)
+        ref = join(rand(rng, _OPT4EC_BASES, 300))
+        reads = _opt4ec_reads(rng, ref; n_reads = 1, readlen = 80, n_err = 1)
+        tmp = mktempdir()
+        fq = joinpath(tmp, "in.fastq")
+        Mycelia.write_fastq(records = reads, filename = fq)
+
+        result = Mycelia.mycelia_iterative_assemble(fq;
+            max_k = 17, n_k_rungs = 3, max_iterations_per_k = 3,
+            graph_mode = :canonical, skip_solid = true, cheap_correct = true,
+            hard_window = true, soft_em = false, batch_size = 50,
+            verbose = false, enable_checkpointing = false,
+            skip_frozen_reads = true, freeze_streak_threshold = 1,
+            freeze_across_rungs = true,
+            output_dir = joinpath(tmp, "single_read"))
+
+        final_fastq = result[:metadata][:final_fastq_file]
+        Test.@test isfile(final_fastq)
+        out_records = open(FASTX.FASTQ.Reader, final_fastq) do rd
+            collect(rd)
+        end
+        Test.@test length(out_records) == 1
+        Test.@test length(FASTX.sequence(String, out_records[1])) == 80
+        # Sane, not necessarily improved: a single read with no peer coverage has
+        # nothing to build consensus against, so the acceptance bar here is
+        # "did not crash / did not corrupt the read", matching the design's
+        # ask ("behaves sanely") rather than a correction-quality claim.
+        Test.@test result[:metadata][:total_iterations] > 0
+    end
+
+    Test.@testset "N=1 vs N=2 threshold: frozen_reads_skipped timing is exact" begin
+        # skip_solid=false, cheap_correct=false again pins was_improved=false for
+        # EVERY read on EVERY pass (see the all-reads-freeze testset above), which
+        # makes the freeze-eligibility boundary fully deterministic and lets this
+        # testset assert the EXACT pass number at which frozen_reads_skipped first
+        # becomes positive, rather than just its eventual sign.
+        rng = Random.MersenneTwister(9001)
+        ref = join(rand(rng, _OPT4EC_BASES, 1200))
+        reads = _opt4ec_reads(rng, ref; n_reads = 180, readlen = 80, n_err = 30)
+        k = 13
+        graph = Mycelia.Rhizomorph.build_qualmer_graph(reads, k; mode = :canonical)
+        common = (; graph_mode = :canonical, skip_solid = false,
+            cheap_correct = false, decode_enabled = true, batch_size = 50)
+
+        # threshold=1: streak reaches 1 after pass 1 (>=1 entering pass 2), so
+        # frozen_reads_skipped must be 0 after pass 1 and > 0 after pass 2.
+        streaks1 = zeros(Int, length(reads))
+        diag1 = Mycelia.CorrectorDiagnostics()
+        out = reads
+        out, = Mycelia.improve_read_set_likelihood(out, graph, k; common...,
+            skip_frozen_reads = true, freeze_streak_threshold = 1,
+            freeze_streaks = streaks1, diagnostics = diag1)
+        Test.@test diag1.frozen_reads_skipped[] == 0
+        out, = Mycelia.improve_read_set_likelihood(out, graph, k; common...,
+            skip_frozen_reads = true, freeze_streak_threshold = 1,
+            freeze_streaks = streaks1, diagnostics = diag1)
+        Test.@test diag1.frozen_reads_skipped[] > 0
+        n1_first_frozen_pass = 2
+
+        # threshold=2: streak reaches 2 only after pass 2 (>=2 entering pass 3),
+        # so frozen_reads_skipped must stay 0 through pass 2 and only become
+        # positive at pass 3 -- one pass LATER than threshold=1, the exact
+        # timing difference the design's N=1-vs-N>=2 distinction is asking for.
+        streaks2 = zeros(Int, length(reads))
+        diag2 = Mycelia.CorrectorDiagnostics()
+        out2 = reads
+        out2, = Mycelia.improve_read_set_likelihood(out2, graph, k; common...,
+            skip_frozen_reads = true, freeze_streak_threshold = 2,
+            freeze_streaks = streaks2, diagnostics = diag2)
+        Test.@test diag2.frozen_reads_skipped[] == 0
+        out2, = Mycelia.improve_read_set_likelihood(out2, graph, k; common...,
+            skip_frozen_reads = true, freeze_streak_threshold = 2,
+            freeze_streaks = streaks2, diagnostics = diag2)
+        Test.@test diag2.frozen_reads_skipped[] == 0   # still below threshold
+        out2, = Mycelia.improve_read_set_likelihood(out2, graph, k; common...,
+            skip_frozen_reads = true, freeze_streak_threshold = 2,
+            freeze_streaks = streaks2, diagnostics = diag2)
+        Test.@test diag2.frozen_reads_skipped[] > 0
+        n2_first_frozen_pass = 3
+
+        # The exact one-pass-later relationship, stated directly.
+        Test.@test n2_first_frozen_pass == n1_first_frozen_pass + 1
+    end
+end

--- a/test/4_assembly/corrector_opt4_freeze_state_test.jl
+++ b/test/4_assembly/corrector_opt4_freeze_state_test.jl
@@ -1,0 +1,236 @@
+# OPT4 FROZEN-READ SKIP — ENABLED-PATH FREEZE-STATE + INTERACTIONS (td-jbjd, pass 2)
+# ======================================================================================
+#
+# Pass 1 (corrector_opt4_frozen_read_skip_test.jl) locked the DISABLED path
+# (skip_frozen_reads=false) as a true no-op. This file exercises the ENABLED
+# path (skip_frozen_reads=true) directly — the freeze-streak state machine
+# itself, and its composition with soft-EM and stop_on_no_change — per the
+# opt4 Rule-of-5 pass-2 ("self-review") scope in
+# docs/design/2026-07-26-opt4-frozen-read-skip-design.md.
+#
+# WHAT IS ASSERTED
+#   * Freeze-state unit test: driving `improve_read_set_likelihood` repeatedly
+#     with a shared `freeze_streaks` vector + `CorrectorDiagnostics`, the
+#     streak increments on no-improvement, resets on improvement (engineered
+#     deterministically), and `frozen_reads_skipped` becomes positive once a
+#     read's streak crosses `freeze_streak_threshold`.
+#   * Within-rung vs across-rung scope: `mycelia_iterative_assemble` with
+#     `freeze_across_rungs=false` (default) resets streaks at every k-advance,
+#     so a fresh k-rung re-decodes everything; `freeze_across_rungs=true`
+#     persists streaks across the advance instead. The scope difference is
+#     observed as a directional inequality in total `frozen_reads_skipped`
+#     across the whole run (across-rung >= within-rung).
+#   * soft-EM interaction: `soft_em=true` + `skip_frozen_reads=true` together
+#     do not crash and produce sane output (a frozen-skipped read still
+#     contributes -- unchanged -- via the existing skip-passthrough path that
+#     soft-EM already tolerates for skip_solid/hard_window skips).
+#   * stop_on_no_change interaction: an aggressive freeze configuration does
+#     not hang, still terminates at the same k-ladder (`final_k`) as the exact
+#     path, and does not increase iteration count vs the exact path.
+#
+# Run directly:
+#   LD_LIBRARY_PATH='' julia --project=. \
+#     -e 'include("test/4_assembly/corrector_opt4_freeze_state_test.jl")'
+
+import Test
+import Mycelia
+import FASTX
+import Random
+
+const _OPT4FS_BASES = ['A', 'C', 'G', 'T']
+
+function _opt4fs_reads(rng, ref; n_reads = 180, readlen = 80, n_err = 30)
+    reflen = length(ref)
+    records = FASTX.FASTQ.Record[]
+    for i in 1:n_reads
+        s = rand(rng, 1:(reflen - readlen + 1))
+        seq = collect(ref[s:(s + readlen - 1)])
+        if i <= n_err
+            p = rand(rng, 1:readlen)
+            seq[p] = rand(rng, filter(!=(seq[p]), _OPT4FS_BASES))
+        end
+        push!(records,
+            FASTX.FASTQ.Record("r$i", String(seq), String(fill('I', readlen))))
+    end
+    return records
+end
+
+Test.@testset "opt4 skip_frozen_reads freeze-state + interactions (td-jbjd pass 2)" begin
+    Test.@testset "freeze-state: increment on no-improve, resets on improve" begin
+        rng = Random.MersenneTwister(9001)
+        ref = join(rand(rng, _OPT4FS_BASES, 1200))
+        reads = _opt4fs_reads(rng, ref; n_reads = 180, readlen = 80, n_err = 30)
+        k = 13
+        graph = Mycelia.Rhizomorph.build_qualmer_graph(reads, k; mode = :canonical)
+
+        common = (; graph_mode = :canonical, skip_solid = false,
+            cheap_correct = false, decode_enabled = true, batch_size = 50)
+
+        freeze_streaks = zeros(Int, length(reads))
+        diag = Mycelia.CorrectorDiagnostics()
+        threshold = 2
+
+        # Pass 1. NOTE: this repo's own completeness test documents that the
+        # ungated per-read decode is "mostly pass-through by design" at toy
+        # fixture scale (rhizomorph_substitution_reconstruction_completeness_
+        # test.jl) — asserting a natural was_improved==true count here would be
+        # flaky, so this sub-test does NOT depend on any read naturally
+        # improving. It only pins the INCREMENT side of the arithmetic (every
+        # read that does not improve advances its streak by exactly 1 per
+        # pass) and defers the RESET side to the deterministic engineered case
+        # below, which does not depend on the decode's natural behavior.
+        out1, = Mycelia.improve_read_set_likelihood(
+            reads, graph, k; common..., skip_frozen_reads = true,
+            freeze_streak_threshold = threshold, freeze_streaks = freeze_streaks,
+            diagnostics = diag)
+        Test.@test all(s -> s in (0, 1), freeze_streaks)
+        Test.@test count(==(1), freeze_streaks) == length(reads)
+
+        # Pass 2: same (unrebuilt) graph, feed forward pass 1's output. A read
+        # already at streak==1 is still BELOW threshold (2) entering this pass,
+        # so it decodes again (not yet frozen); it should end this pass at
+        # streak==2 if still no improvement. No frozen-skip should have fired
+        # yet (nothing was >= threshold when this pass STARTED).
+        out2, = Mycelia.improve_read_set_likelihood(
+            out1, graph, k; common..., skip_frozen_reads = true,
+            freeze_streak_threshold = threshold, freeze_streaks = freeze_streaks,
+            diagnostics = diag)
+        Test.@test diag.frozen_reads_skipped[] == 0
+        Test.@test all(s -> s in (0, 1, 2), freeze_streaks)
+        Test.@test count(==(2), freeze_streaks) > 0
+
+        # Pass 3: reads now at streak==2 meet the threshold entering this pass,
+        # so they are frozen-skipped — the diagnostic counter must move.
+        Mycelia.improve_read_set_likelihood(
+            out2, graph, k; common..., skip_frozen_reads = true,
+            freeze_streak_threshold = threshold, freeze_streaks = freeze_streaks,
+            diagnostics = diag)
+        Test.@test diag.frozen_reads_skipped[] > 0
+
+        # RESET-ON-IMPROVE, engineered deterministically: manually seed a streak
+        # BELOW threshold for a read with an obviously-correctable single-base
+        # error and confirm it lands back at 0 after a fresh call (rather than
+        # relying on natural convergence timing, which is not deterministic
+        # read-by-read).
+        rng2 = Random.MersenneTwister(4242)
+        ref2 = join(rand(rng2, _OPT4FS_BASES, 1200))
+        reads2 = _opt4fs_reads(rng2, ref2; n_reads = 180, readlen = 80, n_err = 30)
+        graph2 = Mycelia.Rhizomorph.build_qualmer_graph(reads2, k; mode = :canonical)
+        seeded = zeros(Int, length(reads2))
+        seeded[1] = 3   # well below a high threshold, so read 1 still decodes
+        out3, = Mycelia.improve_read_set_likelihood(
+            reads2, graph2, k; common..., skip_frozen_reads = true,
+            freeze_streak_threshold = 10, freeze_streaks = seeded)
+        # read 1 (index 1, n_err=30 => the first 30 reads carry an injected
+        # error) was decoded fresh this pass; whatever the outcome, the streak
+        # reflects THIS pass's was_improved, not the stale seed of 3 — i.e. it
+        # must have moved off the seeded value of 3 in the improving direction
+        # (either reset to 0 on improvement, or advanced to 4 on no
+        # improvement — never left untouched at the stale 3).
+        Test.@test seeded[1] != 3
+    end
+
+    Test.@testset "scope: within-rung resets at k-advance vs across-rung persists" begin
+        rng = Random.MersenneTwister(606)
+        ref = join(rand(rng, _OPT4FS_BASES, 900))
+        reads = _opt4fs_reads(rng, ref; n_reads = 150, readlen = 80, n_err = 25)
+        tmp = mktempdir()
+        fq = joinpath(tmp, "in.fastq")
+        Mycelia.write_fastq(records = reads, filename = fq)
+
+        # freeze_streak_threshold=1 is maximally aggressive: any single
+        # no-improvement pass makes a read eligible for frozen-skip on the NEXT
+        # pass. Within-rung resets streaks to 0 at every k-advance, so a fresh
+        # rung starts every read unfrozen; across-rung carries streaks forward,
+        # so once a read is frozen it stays frozen (and counted) into later
+        # rungs too. The run-total frozen_reads_skipped should therefore be
+        # LARGER (or at worst equal) under across-rung than within-rung.
+        run = across -> Mycelia.mycelia_iterative_assemble(fq;
+            max_k = 17, n_k_rungs = 3, max_iterations_per_k = 3,
+            graph_mode = :canonical, skip_solid = true, cheap_correct = true,
+            hard_window = true, soft_em = false, batch_size = 50,
+            verbose = false, enable_checkpointing = false,
+            skip_frozen_reads = true, freeze_streak_threshold = 1,
+            freeze_across_rungs = across,
+            output_dir = joinpath(tmp, across ? "across" : "within"))
+
+        r_within = run(false)
+        r_across = run(true)
+
+        frozen_within = r_within[:metadata][:corrector_errors][:frozen_reads_skipped]
+        frozen_across = r_across[:metadata][:corrector_errors][:frozen_reads_skipped]
+
+        Test.@test frozen_within > 0   # positive control: freezing actually fired
+        Test.@test frozen_across >= frozen_within
+
+        # The k-ladder itself is controlled by n_k_rungs/max_k, independent of
+        # freeze scope — freezing changes WHEN a rung stops (within-k
+        # convergence), never WHICH rungs run. Both scopes must reach the same
+        # final k.
+        Test.@test r_within[:metadata][:final_k] == r_across[:metadata][:final_k]
+    end
+
+    Test.@testset "soft-EM interaction: skip_frozen_reads + soft_em don't crash" begin
+        rng = Random.MersenneTwister(808)
+        ref = join(rand(rng, _OPT4FS_BASES, 1200))
+        reads = _opt4fs_reads(rng, ref; n_reads = 150, readlen = 80, n_err = 25)
+        tmp = mktempdir()
+        fq = joinpath(tmp, "in.fastq")
+        Mycelia.write_fastq(records = reads, filename = fq)
+
+        result = Mycelia.mycelia_iterative_assemble(fq;
+            max_k = 17, n_k_rungs = 3, max_iterations_per_k = 2,
+            graph_mode = :canonical, skip_solid = true, cheap_correct = true,
+            hard_window = true, soft_em = true, batch_size = 50,
+            verbose = false, enable_checkpointing = false,
+            skip_frozen_reads = true, freeze_streak_threshold = 2,
+            output_dir = joinpath(tmp, "soft_em_frozen"))
+
+        final_fastq = result[:metadata][:final_fastq_file]
+        Test.@test isfile(final_fastq)
+        out_records = open(FASTX.FASTQ.Reader, final_fastq) do rd
+            collect(rd)
+        end
+        Test.@test length(out_records) == length(reads)
+        Test.@test all(r -> length(FASTX.sequence(String, r)) == 80, out_records)
+        Test.@test result[:metadata][:soft_em] != false
+    end
+
+    Test.@testset "stop_on_no_change interaction: no premature/stalled k-advance" begin
+        rng = Random.MersenneTwister(1717)
+        ref = join(rand(rng, _OPT4FS_BASES, 900))
+        reads = _opt4fs_reads(rng, ref; n_reads = 150, readlen = 80, n_err = 25)
+        tmp = mktempdir()
+        fq = joinpath(tmp, "in.fastq")
+        Mycelia.write_fastq(records = reads, filename = fq)
+
+        run = frozen -> Mycelia.mycelia_iterative_assemble(fq;
+            max_k = 17, n_k_rungs = 3, max_iterations_per_k = 5,
+            graph_mode = :canonical, skip_solid = true, cheap_correct = true,
+            hard_window = true, soft_em = false, batch_size = 50,
+            verbose = false, enable_checkpointing = false,
+            stop_on_no_change = true,
+            skip_frozen_reads = frozen, freeze_streak_threshold = 1,
+            output_dir = joinpath(tmp, frozen ? "frozen" : "exact"))
+
+        r_exact = run(false)
+        r_frozen = run(true)
+
+        # Both must terminate (no hang) with a positive iteration count, never
+        # exceeding the hard cap (n_k_rungs * max_iterations_per_k = 15).
+        Test.@test 0 < r_exact[:metadata][:total_iterations] <= 15
+        Test.@test 0 < r_frozen[:metadata][:total_iterations] <= 15
+
+        # Freezing never changes the k-ladder itself (only within-k pass count),
+        # so both runs reach the same final k.
+        Test.@test r_exact[:metadata][:final_k] == r_frozen[:metadata][:final_k]
+
+        # The early-stop is a zero-improvement pass; frozen-skip can only make
+        # a pass see FEWER (or equal) improvements than the exact path would
+        # (skipped reads cannot contribute genuine improvements), so it should
+        # never require MORE passes than the exact path to converge within a
+        # k-rung.
+        Test.@test r_frozen[:metadata][:total_iterations] <=
+                   r_exact[:metadata][:total_iterations]
+    end
+end

--- a/test/4_assembly/corrector_opt4_freeze_state_test.jl
+++ b/test/4_assembly/corrector_opt4_freeze_state_test.jl
@@ -196,6 +196,114 @@ Test.@testset "opt4 skip_frozen_reads freeze-state + interactions (td-jbjd pass 
         Test.@test result[:metadata][:soft_em] != false
     end
 
+    Test.@testset "scope: direct observation of reset (within) vs persist (across) at k-advance" begin
+        rng = Random.MersenneTwister(9001)
+        ref = join(rand(rng, _OPT4FS_BASES, 1200))
+        reads = _opt4fs_reads(rng, ref; n_reads = 180, readlen = 80, n_err = 30)
+        k1 = 13
+        graph1 = Mycelia.Rhizomorph.build_qualmer_graph(reads, k1; mode = :canonical)
+        threshold = 2
+
+        common = (; graph_mode = :canonical, skip_solid = false,
+            cheap_correct = false, decode_enabled = true, batch_size = 50)
+
+        # Reproduce the SAME two-pass setup as the "freeze-state" testset above
+        # (identical rng seed / fixture / k) to reliably land reads at
+        # streak >= threshold BEFORE any k-advance.
+        streaks = zeros(Int, length(reads))
+        out1, = Mycelia.improve_read_set_likelihood(
+            reads, graph1, k1; common..., skip_frozen_reads = true,
+            freeze_streak_threshold = threshold, freeze_streaks = streaks)
+        out2, = Mycelia.improve_read_set_likelihood(
+            out1, graph1, k1; common..., skip_frozen_reads = true,
+            freeze_streak_threshold = threshold, freeze_streaks = streaks)
+        Test.@test count(>=(threshold), streaks) > 0   # setup sanity
+
+        # Simulate the k-advance: build the next-rung graph.
+        k2 = 17
+        graph2 = Mycelia.Rhizomorph.build_qualmer_graph(out2, k2; mode = :canonical)
+
+        # WITHIN-RUNG (default): `mycelia_iterative_assemble` resets
+        # `freeze_streaks` to `nothing` then lazily reallocates a fresh zero
+        # vector at every k-advance (iterative-assembly.jl ~:2309/:2341) —
+        # reproduce that reset explicitly here, rather than only inferring it
+        # from the aggregate `frozen_reads_skipped` inequality in the testset
+        # above (which cannot distinguish a working reset from a broken one,
+        # since `across >= within` also holds trivially when both are equal).
+        within_streaks = zeros(Int, length(out2))
+        diag_within = Mycelia.CorrectorDiagnostics()
+        Mycelia.improve_read_set_likelihood(
+            out2, graph2, k2; common..., skip_frozen_reads = true,
+            freeze_streak_threshold = threshold, freeze_streaks = within_streaks,
+            diagnostics = diag_within)
+        # Every streak starts this pass at 0 (< threshold), so NOTHING can be
+        # frozen-skipped on the very first pass of a fresh rung — the
+        # within-rung "everyone re-decodes fresh at a new rung" guarantee.
+        Test.@test diag_within.frozen_reads_skipped[] == 0
+
+        # ACROSS-RUNG (`freeze_across_rungs=true`): the streak vector is
+        # carried forward UNRESET across the k-advance instead — reproduce by
+        # reusing the already->=-threshold `streaks` vector unmodified against
+        # the new graph.
+        diag_across = Mycelia.CorrectorDiagnostics()
+        Mycelia.improve_read_set_likelihood(
+            out2, graph2, k2; common..., skip_frozen_reads = true,
+            freeze_streak_threshold = threshold, freeze_streaks = streaks,
+            diagnostics = diag_across)
+        # Streaks that already met the bar BEFORE this pass started are
+        # frozen-skipped immediately at the new k — no additional
+        # no-improvement passes required. This is the across-rung "streak
+        # survives the k-advance" behavior, observed directly rather than
+        # inferred.
+        Test.@test diag_across.frozen_reads_skipped[] > 0
+    end
+
+    Test.@testset "composition: skip_solid gate-skip never inflates the freeze streak" begin
+        rng = Random.MersenneTwister(2026)
+        ref = join(rand(rng, _OPT4FS_BASES, 900))
+        reads = _opt4fs_reads(rng, ref; n_reads = 150, readlen = 80, n_err = 20)
+        k = 13
+        graph = Mycelia.Rhizomorph.build_qualmer_graph(reads, k; mode = :canonical)
+
+        # Independently compute which reads `skip_solid` will gate-skip EVERY
+        # pass (every k-mer classifies solid/high-coverage) so we can assert
+        # their freeze streak never moves, without reaching into
+        # `_improve_read_set_likelihood_impl`'s internal closures.
+        solid_kmers = Mycelia._solid_kmer_set(graph)
+        solid_read_idx = findall(
+            r -> Mycelia._read_is_all_solid(
+                r, k, solid_kmers; graph_mode = :canonical),
+            reads)
+        Test.@test !isempty(solid_read_idx)   # setup sanity: gate has something to skip
+
+        threshold = 2
+        streaks = zeros(Int, length(reads))
+        diag = Mycelia.CorrectorDiagnostics()
+        out = reads
+        for _pass in 1:4
+            out, = Mycelia.improve_read_set_likelihood(
+                out, graph, k; graph_mode = :canonical, skip_solid = true,
+                cheap_correct = true, decode_enabled = true, batch_size = 50,
+                skip_frozen_reads = true, freeze_streak_threshold = threshold,
+                freeze_streaks = streaks, diagnostics = diag)
+        end
+
+        # finding #5: a read gate-skipped every pass was never EVALUATED for
+        # improvement, so it must never accrue freeze streak -- conflating
+        # "not looked at" with "converged" would let skip_solid silently
+        # inflate `frozen_reads_skipped`. A streak stuck at 0 (always below
+        # threshold) also mechanically proves such a read can never itself
+        # satisfy `_frozen_read_at` and be counted as frozen-skipped.
+        Test.@test all(==(0), streaks[solid_read_idx])
+
+        # Positive control: the two skip mechanisms compose (OR) without
+        # conflict -- reads OUTSIDE the solid set are genuinely decoded and,
+        # given 4 passes at threshold=2, some converge and are frozen-skipped
+        # for real, so the counter is not permanently pinned at 0 by the
+        # composition.
+        Test.@test diag.frozen_reads_skipped[] > 0
+    end
+
     Test.@testset "stop_on_no_change interaction: no premature/stalled k-advance" begin
         rng = Random.MersenneTwister(1717)
         ref = join(rand(rng, _OPT4FS_BASES, 900))

--- a/test/4_assembly/corrector_opt4_frozen_read_skip_test.jl
+++ b/test/4_assembly/corrector_opt4_frozen_read_skip_test.jl
@@ -67,9 +67,13 @@ Test.@testset "opt4 skip_frozen_reads disabled-path identity lock (td-jbjd)" beg
         graph = Mycelia.Rhizomorph.build_qualmer_graph(reads, k; mode = :canonical)
         hard = Mycelia._hard_vertex_set(graph, k)
 
-        # batch_size < n_reads => multiple batches, exercising both the serial
-        # and (with enable_parallel) the parallel collect-results freeze-streak
-        # bookkeeping sites — all of which must be no-ops here.
+        # batch_size < n_reads => multiple batches, exercising the SERIAL
+        # freeze-streak bookkeeping sites (this test never sets
+        # enable_parallel=true, so the parallel collect-results sites are NOT
+        # exercised here — that path is locked separately by
+        # corrector_opt4_parallel_freeze_byte_identity_test.jl under real
+        # `-t4` concurrency). All of the serial sites are no-ops here since
+        # skip_frozen_reads is never true in this testset.
         common = (; graph_mode = :canonical, skip_solid = true,
             cheap_correct = true, hard_vertices = hard, decode_enabled = true,
             batch_size = 50)

--- a/test/4_assembly/corrector_opt4_frozen_read_skip_test.jl
+++ b/test/4_assembly/corrector_opt4_frozen_read_skip_test.jl
@@ -1,0 +1,120 @@
+# OPT4 FROZEN-READ SKIP — DISABLED-PATH IDENTITY LOCK (td-jbjd, pass 1)
+# =======================================================================
+#
+# opt4 is the corrector campaign's first APPROXIMATE optimization: skipping
+# re-decode of "frozen" (converged, N-consecutive-pass-stable) reads trades a
+# bounded amount of accuracy for skipped work, so it is opt-in and ships
+# default OFF (`skip_frozen_reads=false`). Unlike opt5/opt1/opt2, the shipped
+# deliverable for opt4 is an accuracy sign-off, not a byte-identity lock — but
+# the DISABLED path (the default for every existing caller) MUST remain a true
+# no-op: identical output whether the kwarg is passed explicitly as `false` or
+# omitted entirely. That disabled-path guarantee is what this test locks.
+#
+# See docs/design/2026-07-26-opt4-frozen-read-skip-design.md.
+#
+# WHAT IS ASSERTED
+#   * Unit (improve_read_set_likelihood): a run with `skip_frozen_reads=false`
+#     passed explicitly is byte-identical to a run where the kwarg (and its
+#     siblings freeze_streak_threshold/freeze_across_rungs) are omitted.
+#   * Integration (mycelia_iterative_assemble), multi-pass/multi-k so the
+#     freeze-streak state-threading machinery actually runs its bookkeeping
+#     paths (just gated off by the flag): omitted-kwarg vs explicit-false
+#     produce byte-identical final corrected FASTQ.
+#
+# Run directly:
+#   LD_LIBRARY_PATH='' julia --project=. \
+#     -e 'include("test/4_assembly/corrector_opt4_frozen_read_skip_test.jl")'
+
+import Test
+import Mycelia
+import FASTX
+import Random
+
+const _OPT4_BASES = ['A', 'C', 'G', 'T']
+
+# Reads sampled from ref, with a single substitution injected into the first
+# n_err of them, so Stage 0 + the per-read decode both have work across
+# multiple batches/passes (exercising the new freeze-streak bookkeeping sites
+# even though skip_frozen_reads stays off).
+function _opt4_reads(rng, ref; n_reads = 180, readlen = 80, n_err = 30)
+    reflen = length(ref)
+    records = FASTX.FASTQ.Record[]
+    for i in 1:n_reads
+        s = rand(rng, 1:(reflen - readlen + 1))
+        seq = collect(ref[s:(s + readlen - 1)])
+        if i <= n_err
+            p = rand(rng, 1:readlen)
+            seq[p] = rand(rng, filter(!=(seq[p]), _OPT4_BASES))
+        end
+        push!(records,
+            FASTX.FASTQ.Record("r$i", String(seq), String(fill('I', readlen))))
+    end
+    return records
+end
+
+# Full-record fingerprint (identifier, sequence, quality).
+function _opt4_recs(records)
+    [(String(FASTX.identifier(r)), FASTX.sequence(String, r),
+         String(FASTX.quality(r))) for r in records]
+end
+
+Test.@testset "opt4 skip_frozen_reads disabled-path identity lock (td-jbjd)" begin
+    Test.@testset "unit: improve_read_set_likelihood, explicit-false == omitted" begin
+        rng = Random.MersenneTwister(4242)
+        ref = join(rand(rng, _OPT4_BASES, 1200))
+        reads = _opt4_reads(rng, ref; n_reads = 180, readlen = 80, n_err = 30)
+        k = 13
+        graph = Mycelia.Rhizomorph.build_qualmer_graph(reads, k; mode = :canonical)
+        hard = Mycelia._hard_vertex_set(graph, k)
+
+        # batch_size < n_reads => multiple batches, exercising both the serial
+        # and (with enable_parallel) the parallel collect-results freeze-streak
+        # bookkeeping sites — all of which must be no-ops here.
+        common = (; graph_mode = :canonical, skip_solid = true,
+            cheap_correct = true, hard_vertices = hard, decode_enabled = true,
+            batch_size = 50)
+
+        out_omitted, = Mycelia.improve_read_set_likelihood(
+            reads, graph, k; common...)
+        out_explicit, = Mycelia.improve_read_set_likelihood(
+            reads, graph, k; common...,
+            skip_frozen_reads = false, freeze_streak_threshold = 2,
+            freeze_across_rungs = false)
+
+        Test.@test _opt4_recs(out_omitted) == _opt4_recs(out_explicit)
+    end
+
+    Test.@testset "integration: mycelia_iterative_assemble, explicit-false == omitted" begin
+        rng = Random.MersenneTwister(909)
+        ref = join(rand(rng, _OPT4_BASES, 900))
+        reads = _opt4_reads(rng, ref; n_reads = 150, readlen = 80, n_err = 25)
+        tmp = mktempdir()
+        fq = joinpath(tmp, "in.fastq")
+        Mycelia.write_fastq(records = reads, filename = fq)
+
+        # Multi-k, multi-iteration so freeze-streak allocation/reset (k-advance)
+        # and per-read update sites all execute at least once — still a no-op
+        # since skip_frozen_reads is never true.
+        run_common = out -> Mycelia.mycelia_iterative_assemble(fq;
+            max_k = 17, n_k_rungs = 3, max_iterations_per_k = 3,
+            graph_mode = :canonical, skip_solid = true, cheap_correct = true,
+            hard_window = true, soft_em = false, batch_size = 50,
+            verbose = false, enable_checkpointing = false, output_dir = out)
+
+        r_omitted = run_common(joinpath(tmp, "omitted"))
+        r_explicit = Mycelia.mycelia_iterative_assemble(fq;
+            max_k = 17, n_k_rungs = 3, max_iterations_per_k = 3,
+            graph_mode = :canonical, skip_solid = true, cheap_correct = true,
+            hard_window = true, soft_em = false, batch_size = 50,
+            verbose = false, enable_checkpointing = false,
+            output_dir = joinpath(tmp, "explicit"),
+            skip_frozen_reads = false, freeze_streak_threshold = 2,
+            freeze_across_rungs = false)
+
+        final_recs = res -> _opt4_recs(
+            open(FASTX.FASTQ.Reader, res[:metadata][:final_fastq_file]) do rd
+            collect(rd)
+        end)
+        Test.@test final_recs(r_omitted) == final_recs(r_explicit)
+    end
+end

--- a/test/4_assembly/corrector_opt4_frozen_read_skip_test.jl
+++ b/test/4_assembly/corrector_opt4_frozen_read_skip_test.jl
@@ -76,10 +76,14 @@ Test.@testset "opt4 skip_frozen_reads disabled-path identity lock (td-jbjd)" beg
 
         out_omitted, = Mycelia.improve_read_set_likelihood(
             reads, graph, k; common...)
+        # opt4 pass 2 (td-jbjd, finding #1): `freeze_across_rungs` was removed from
+        # `improve_read_set_likelihood`'s kwarg list -- it was threaded through but
+        # never consumed by `_improve_read_set_likelihood_impl` (its only real
+        # effect is the outer k-loop reset inside `mycelia_iterative_assemble`,
+        # exercised by the integration testset below). Not passed here.
         out_explicit, = Mycelia.improve_read_set_likelihood(
             reads, graph, k; common...,
-            skip_frozen_reads = false, freeze_streak_threshold = 2,
-            freeze_across_rungs = false)
+            skip_frozen_reads = false, freeze_streak_threshold = 2)
 
         Test.@test _opt4_recs(out_omitted) == _opt4_recs(out_explicit)
     end

--- a/test/4_assembly/corrector_opt4_golden_master_lock_test.jl
+++ b/test/4_assembly/corrector_opt4_golden_master_lock_test.jl
@@ -1,0 +1,106 @@
+# OPT4 FROZEN-READ SKIP — GOLDEN LOCK vs PRE-OPT4 MASTER (td-jbjd, pass 3)
+# =============================================================================
+#
+# Pass 1's disabled-path lock (corrector_opt4_frozen_read_skip_test.jl) proves
+# `skip_frozen_reads=false` (explicit) is byte-identical to the kwarg being
+# OMITTED — both on THIS branch. That is a real but strictly weaker claim than
+# "opt4 is a true no-op when off": a bug shared by both call sites on this
+# branch (e.g. a stray side effect introduced by the freeze-streak plumbing
+# that fires regardless of the flag) would not be caught by comparing the
+# branch to itself.
+#
+# This test closes that gap by comparing THIS branch's disabled-path output
+# directly against pre-opt4 MASTER (merge b032fab3, the commit
+# cp/opt4-frozen-read-design forked from) — a completely independent
+# checkout that has never seen the opt4 diff at all. If this test ever
+# diverges, that is a CRITICAL finding: it means opt4-off is not a true no-op,
+# contradicting the pass 1/2 acceptance criterion ("skip_frozen_reads=false
+# (default) is a bit-identical no-op vs pre-opt4 master (locked by test)").
+#
+# PROVENANCE OF THE HARDCODED HASH
+#   Generated 2026-07-27 by running the fixture below (verbatim) via:
+#     LD_LIBRARY_PATH='' julia --project=<checkout> \
+#       /path/to/opt4_golden_fixture.jl [--opt4-off]
+#   against THREE checkouts, all producing the IDENTICAL SHA256 below:
+#     1. pre-opt4 master, git commit b032fab3 (no opt4 kwargs — they don't
+#        exist on that commit; ran with no opt4 flags at all)
+#     2. cp/opt4-frozen-read-design (commit 62f0b3d1, this branch's pass-2
+#        HEAD at write time) with `skip_frozen_reads=false` explicit
+#     3. cp/opt4-frozen-read-design (same commit) with all opt4 kwargs OMITTED
+#   Fixture params: MersenneTwister(20260726) seed, 900bp random reference,
+#   150 reads/80bp/25 injected single-base substitution errors, max_k=17,
+#   n_k_rungs=3, max_iterations_per_k=3, graph_mode=:canonical,
+#   skip_solid=true, cheap_correct=true, hard_window=true, soft_em=false,
+#   batch_size=50, enable_checkpointing=false.
+#
+# Run directly:
+#   LD_LIBRARY_PATH='' julia --project=. \
+#     -e 'include("test/4_assembly/corrector_opt4_golden_master_lock_test.jl")'
+
+import Test
+import Mycelia
+import FASTX
+import Random
+import SHA
+
+# Hash captured from pre-opt4 master (b032fab3) — see provenance note above.
+# DO NOT update this constant to make a failing test pass; a mismatch means
+# the disabled path regressed and must be investigated, not silenced.
+const _OPT4_GOLDEN_MASTER_SHA256 = "e0c249c092399d98afb40137ef4bb07ae3d9c1d1c94b3aafc01d95a6516b6c54"
+
+const _OPT4GM_BASES = ['A', 'C', 'G', 'T']
+
+# Verbatim copy of the fixture generator used to produce the golden hash above
+# (kept identical on purpose — do not "clean up" the parameters without
+# regenerating the golden hash against master again).
+function _opt4gm_reads(rng, ref; n_reads = 150, readlen = 80, n_err = 25)
+    reflen = length(ref)
+    records = FASTX.FASTQ.Record[]
+    for i in 1:n_reads
+        s = rand(rng, 1:(reflen - readlen + 1))
+        seq = collect(ref[s:(s + readlen - 1)])
+        if i <= n_err
+            p = rand(rng, 1:readlen)
+            seq[p] = rand(rng, filter(!=(seq[p]), _OPT4GM_BASES))
+        end
+        push!(records,
+            FASTX.FASTQ.Record("r$i", String(seq), String(fill('I', readlen))))
+    end
+    return records
+end
+
+function _opt4gm_run(fq, out_dir; skip_frozen_reads_explicit::Bool)
+    common = (; max_k = 17, n_k_rungs = 3, max_iterations_per_k = 3,
+        graph_mode = :canonical, skip_solid = true, cheap_correct = true,
+        hard_window = true, soft_em = false, batch_size = 50,
+        verbose = false, enable_checkpointing = false, output_dir = out_dir)
+    if skip_frozen_reads_explicit
+        return Mycelia.mycelia_iterative_assemble(fq; common...,
+            skip_frozen_reads = false, freeze_streak_threshold = 2,
+            freeze_across_rungs = false)
+    end
+    return Mycelia.mycelia_iterative_assemble(fq; common...)
+end
+
+Test.@testset "opt4 golden lock vs pre-opt4 master (td-jbjd pass 3)" begin
+    rng = Random.MersenneTwister(20260726)
+    ref = join(rand(rng, _OPT4GM_BASES, 900))
+    reads = _opt4gm_reads(rng, ref; n_reads = 150, readlen = 80, n_err = 25)
+    tmp = mktempdir()
+    fq = joinpath(tmp, "in.fastq")
+    Mycelia.write_fastq(records = reads, filename = fq)
+
+    Test.@testset "skip_frozen_reads=false (explicit) matches golden master hash" begin
+        result = _opt4gm_run(
+            fq, joinpath(tmp, "explicit"); skip_frozen_reads_explicit = true)
+        digest = bytes2hex(SHA.sha256(read(result[:metadata][:final_fastq_file])))
+        Test.@test digest == _OPT4_GOLDEN_MASTER_SHA256
+    end
+
+    Test.@testset "opt4 kwargs omitted matches golden master hash" begin
+        result = _opt4gm_run(
+            fq, joinpath(tmp, "omitted"); skip_frozen_reads_explicit = false)
+        digest = bytes2hex(SHA.sha256(read(result[:metadata][:final_fastq_file])))
+        Test.@test digest == _OPT4_GOLDEN_MASTER_SHA256
+    end
+end

--- a/test/4_assembly/corrector_opt4_parallel_freeze_byte_identity_test.jl
+++ b/test/4_assembly/corrector_opt4_parallel_freeze_byte_identity_test.jl
@@ -1,0 +1,133 @@
+# OPT4 PARALLEL FREEZE-STREAK BYTE-IDENTITY (td-jbjd, review fix C1)
+# =======================================================================
+#
+# corrector_opt4_freeze_state_test.jl and corrector_opt4_frozen_read_skip_test.jl
+# exercise the freeze-streak bookkeeping only under SERIAL decode (no test in
+# either file passes `enable_parallel=true`), so the parallel collect-results
+# freeze-streak update sites in `_improve_read_set_likelihood_impl` (the
+# `Threads.@threads` batch loop's per-read streak/diagnostic update, guarded on
+# `skip_flags[i]` / `_frozen_read_at`) were UNTESTED under real concurrency —
+# review finding C1. CI runs single-threaded by default, so `@threads` degrades
+# to sequential execution and proves nothing; this test relaunches itself under
+# `julia --threads=4` to get genuine concurrent batch decode (mirrors
+# parallel_soft_em_byte_identity_test.jl's self-hoist harness, opt1).
+#
+# WHAT IS ASSERTED
+#   * The parallel path is ACTUALLY taken (parallel_decode_batches > 0) and
+#     freezing ACTUALLY engages (frozen_reads_skipped > 0) in both arms — two
+#     positive controls, so a silent revert to serial or a freeze mechanism
+#     that never fires cannot pass vacuously.
+#   * skip_frozen_reads=true + enable_parallel=true produces BYTE-IDENTICAL
+#     corrected FASTQ output (identifier, sequence, quality) to
+#     skip_frozen_reads=true + enable_parallel=false (serial), on a fixture
+#     with batch_size < n_reads (multiple batches per pass) and enough passes
+#     (multi-k, multi-iteration, aggressive threshold) that freezing reliably
+#     engages within the first rung.
+#
+# Run directly:
+#   LD_LIBRARY_PATH='' julia --project=. \
+#     -e 'include("test/4_assembly/corrector_opt4_parallel_freeze_byte_identity_test.jl")'
+
+import Test
+import Mycelia
+import FASTX
+import Random
+
+if Threads.nthreads() == 1 && get(ENV, "MYCELIA_OPT4_PFB_CHILD", "0") != "1"
+    # Self-hoist to real threads, same pattern as opt1's
+    # parallel_soft_em_byte_identity_test.jl.
+    proj = Base.active_project()
+    thisfile = @__FILE__
+    cmd = `$(Base.julia_cmd()) --project=$(proj) --threads=4 -e "include(\"$(thisfile)\")"`
+    Test.@testset "opt4 parallel freeze-streak byte-identity (hoisted to -t4)" begin
+        Test.@test success(pipeline(
+            setenv(cmd, "MYCELIA_OPT4_PFB_CHILD" => "1"; dir = pwd());
+            stdout = stdout, stderr = stderr))
+    end
+else
+    const _OPT4PFB_BASES = ['A', 'C', 'G', 'T']
+
+    function _opt4pfb_reads(rng, ref; n_reads = 150, readlen = 80, n_err = 25)
+        reflen = length(ref)
+        records = FASTX.FASTQ.Record[]
+        for i in 1:n_reads
+            s = rand(rng, 1:(reflen - readlen + 1))
+            seq = collect(ref[s:(s + readlen - 1)])
+            if i <= n_err
+                p = rand(rng, 1:readlen)
+                seq[p] = rand(rng, filter(!=(seq[p]), _OPT4PFB_BASES))
+            end
+            push!(records,
+                FASTX.FASTQ.Record("r$i", String(seq), String(fill('I', readlen))))
+        end
+        return records
+    end
+
+    # Full-record fingerprint (identifier, sequence, quality) — mirrors
+    # corrector_opt4_frozen_read_skip_test.jl's `_opt4_recs`.
+    function _opt4pfb_recs(records)
+        [(String(FASTX.identifier(r)), FASTX.sequence(String, r),
+             String(FASTX.quality(r))) for r in records]
+    end
+
+    function _opt4pfb_final_recs(result)
+        open(FASTX.FASTQ.Reader, result[:metadata][:final_fastq_file]) do rd
+            _opt4pfb_recs(collect(rd))
+        end
+    end
+
+    Test.@testset "opt4 parallel freeze-streak byte-identity (td-jbjd, C1)" begin
+        Test.@test Threads.nthreads() > 1     # guard: real threads
+
+        rng = Random.MersenneTwister(606)
+        ref = join(rand(rng, _OPT4PFB_BASES, 900))
+        reads = _opt4pfb_reads(rng, ref; n_reads = 150, readlen = 80, n_err = 25)
+        tmp = mktempdir()
+        fq = joinpath(tmp, "in.fastq")
+        Mycelia.write_fastq(records = reads, filename = fq)
+
+        # batch_size=50 < n_reads=150 => 3 batches/pass, exercising the
+        # parallel collect-results loop across multiple `Threads.@threads`
+        # dispatches. freeze_streak_threshold=1 is maximally aggressive (any
+        # single no-improvement pass makes a read frozen-eligible on the very
+        # next pass), and max_iterations_per_k=3 gives each of the 3 k-rungs
+        # enough passes for freezing to engage reliably — the same
+        # config shown to produce frozen_reads_skipped > 0 in
+        # corrector_opt4_freeze_state_test.jl's "scope" testset.
+        run = parallel -> Mycelia.mycelia_iterative_assemble(fq;
+            max_k = 17, n_k_rungs = 3, max_iterations_per_k = 3,
+            graph_mode = :canonical, skip_solid = true, cheap_correct = true,
+            hard_window = true, soft_em = false, batch_size = 50,
+            verbose = false, enable_checkpointing = false,
+            enable_parallel = parallel,
+            skip_frozen_reads = true, freeze_streak_threshold = 1,
+            output_dir = joinpath(tmp, parallel ? "parallel" : "serial"))
+
+        r_parallel = Base.redirect_stderr(devnull) do
+            run(true)
+        end
+        r_serial = Base.redirect_stderr(devnull) do
+            run(false)
+        end
+
+        parallel_errors = r_parallel[:metadata][:corrector_errors]
+        serial_errors = r_serial[:metadata][:corrector_errors]
+
+        # Positive control (a): the parallel path was ACTUALLY taken. A silent
+        # revert-to-serial regression would leave this at 0 even though
+        # byte-identity still (trivially) holds.
+        Test.@test parallel_errors[:parallel_decode_batches] > 0
+        Test.@test serial_errors[:parallel_decode_batches] == 0
+
+        # Positive control (b): freezing ACTUALLY engaged in BOTH arms. A
+        # config that never crosses the freeze threshold would make the
+        # byte-identity comparison below vacuous (both arms trivially equal
+        # because neither ever exercises the freeze-skip code path).
+        Test.@test parallel_errors[:frozen_reads_skipped] > 0
+        Test.@test serial_errors[:frozen_reads_skipped] > 0
+
+        # The actual lock: serial and parallel decode must agree exactly, read
+        # for read, byte for byte, under freezing.
+        Test.@test _opt4pfb_final_recs(r_parallel) == _opt4pfb_final_recs(r_serial)
+    end
+end

--- a/test/4_assembly/corrector_opt4_positive_control_test.jl
+++ b/test/4_assembly/corrector_opt4_positive_control_test.jl
@@ -1,0 +1,315 @@
+# OPT4 FROZEN-READ SKIP — POSITIVE CONTROL (td-jbjd, pass 4)
+# =============================================================================
+#
+# THE ASK (design doc "Accuracy sign-off methodology", bullet 3, and Rule-of-5
+# pass 4): build a toy fixture where freezing DEMONSTRABLY DEGRADES per-base
+# correction accuracy, so a later accuracy sign-off's "no degradation" verdict
+# on representative data is trustworthy -- the same "null needs a positive
+# control" discipline as the accuracy benchmark's Control B read-scramble null
+# (benchmarking/rhizomorph_correction_accuracy_benchmark.jl).
+#
+# THE RESULT, after extensive investigation (see the finding below): at TOY
+# fixture scale, using the wired `:scalable`-tier corrector configuration
+# (cheap_correct=true, skip_solid=true, hard_window=true -- the settings used
+# throughout the opt4 test suite and the accuracy benchmark), `skip_frozen_reads`
+# could NOT be made to measurably degrade per-base correction accuracy, even
+# under the MOST aggressive freeze configuration tested
+# (freeze_streak_threshold=1, freeze_across_rungs=true). This held across every
+# fixture design attempted:
+#   1. An engineered repeat/paralogous-SNP confounder (two near-identical repeat
+#      copies differing at one base, with a read error that mimics the OTHER
+#      copy's real allele) walked through a k-ladder from k=11 to k=39, run via
+#      the full `mycelia_iterative_assemble` pipeline.
+#   2. An ordinary random single-substitution fixture (mirrors
+#      corrector_opt4_freeze_state_test.jl's own "composition" fixture, which IS
+#      proven to converge) driven directly via `improve_read_set_likelihood`,
+#      rebuilding the graph every pass, comparing unlimited retries (exact) vs
+#      threshold=1 freezing over multiple passes at a fixed k.
+#
+# THE ROOT CAUSE (verified against src/iterative-assembly.jl, 2026-07-27):
+#   (a) Stage 0 cheap k-mer-spectrum correction (`_stage0_cheap_correct`,
+#       gated on `cheap_correct=true`) runs on `work_reads` UNCONDITIONALLY,
+#       BEFORE the skip/freeze decision (`_gate_skip`/`_frozen_read_at`), for
+#       EVERY read every pass -- including reads that are about to be
+#       frozen-skipped for that pass's decode. A frozen read's Stage 0
+#       correction (if any) still lands in `updated_reads` regardless of freeze
+#       state (iterative-assembly.jl ~4675-4692 unconditional Stage 0 call,
+#       ~4901/~4980 `read = batch_reads[i]`/`work_reads[i]` flowing into a
+#       SKIPPED read's output). opt4's freeze mechanism ONLY gates the
+#       expensive per-read Viterbi decode step downstream of Stage 0 -- it
+#       cannot touch Stage 0's output either way.
+#   (b) At toy fixture scale, Stage 0 (freeze-immune per (a)) accounts for
+#       effectively ALL correction volume: every fixture tested showed the raw
+#       per-read Viterbi decode alone (cheap_correct=false, so Stage 0 disabled)
+#       making ZERO edits at ANY k from 7 to 43, with or without
+#       skip_solid/hard_window/windowed_decode. Separately, `mycelia_iterative_
+#       assemble`'s adaptive low-k decode gate (`decode_gate_density`, default
+#       0.90, active whenever `hard_window=true`) additionally disables the
+#       whole per-read decode step at toy scale because a small/dense graph
+#       cannot achieve genuine (<90%) decode-fraction selectivity -- a SECOND,
+#       independent reason decode contributes ~nothing to toy-scale accuracy.
+#   (c) Multi-pass convergence is also observed to be "one-shot" at this scale:
+#       a read that CAN be fixed (by Stage 0 or decode) is fixed on its very
+#       first evaluation; a read that can't be fixed does not benefit from
+#       additional passes even with the graph rebuilt fresh each pass (probe
+#       investigation, not itself asserted below since it is a property of the
+#       decode/Stage-0 algorithms, not of opt4's freeze plumbing). This means
+#       there is no "read that would have converged on attempt 3" for freezing
+#       to strand at toy scale -- exactly the scenario a genuine positive
+#       control would need to exploit.
+#
+# WHAT THIS MEANS FOR THE SIGN-OFF (per the design doc: "If after reasonable
+# effort you CANNOT make freezing degrade on a toy fixture: that is itself an
+# important FINDING -- report it... Do NOT fake a passing assertion"):
+#   * This is NOT evidence that opt4 is safe on REPRESENTATIVE data. Stage 0's
+#     freeze-immunity is scale-INDEPENDENT (architectural), so it will also
+#     dominate on larger data -- meaning opt4's real accuracy exposure is
+#     concentrated in whatever residual correction volume Stage 0 and the
+#     adaptive gate leave to genuine per-read Viterbi decode, which is
+#     precisely the volume this toy scale could not exercise (findings (a)-(b)
+#     above). The pass-5 accuracy sign-off on representative data (Lambda
+#     phage scale, per rhizomorph_correction_accuracy_benchmark.jl) is where
+#     the adaptive gate stops firing (larger, sparser graphs have genuine
+#     hard-window selectivity) and decode does real work -- THAT is where a
+#     freeze-induced degradation, if any exists, would actually show up.
+#   * Rather than assert a fabricated degradation, this file locks in the
+#     ACTUAL discovered invariant as a regression guard: both fixture designs
+#     above produce BYTE-IDENTICAL corrected output whether frozen or exact, at
+#     the most aggressive freeze setting tested. If a future change makes
+#     these diverge, that is a signal worth investigating (either Stage 0's
+#     unconditional guarantee broke, the adaptive gate's behavior changed, or
+#     decode started doing real work at toy scale) -- and it would also mean a
+#     toy-scale positive control might become achievable where it currently is
+#     not.
+#
+# Run directly:
+#   LD_LIBRARY_PATH='' julia --project=. \
+#     -e 'include("test/4_assembly/corrector_opt4_positive_control_test.jl")'
+
+import Test
+import Mycelia
+import FASTX
+import Random
+
+include(joinpath(@__DIR__, "..", "..", "benchmarking",
+    "rhizomorph_correction_accuracy_metrics.jl"))
+
+const _OPT4PC_BASES = ['A', 'C', 'G', 'T']
+
+# --- Fixture 1: engineered repeat/paralogous-SNP confounder -----------------
+# Two 60bp repeat copies (copy1, copy2) embedded in unique flanking sequence,
+# identical except at ONE base (`snp_offset` into each copy). A small set of
+# "engineered" reads are copy1-derived with a substitution AT that position
+# that happens to equal copy2's real allele -- i.e. the corrupted base is not
+# noise, it is a second real (paralogous) allele elsewhere in the genome. This
+# is the design doc's Risks-section scenario: a read wrong at low k (the SNP
+# position's local k-mer window is genuinely ambiguous between the two repeat
+# copies) that should resolve once the graph sharpens at higher k (once the
+# k-mer window spans past the repeat edge into copy-specific unique flank).
+function _opt4pc_build_genome(rng; fb = 40, rl = 60, mu = 40, fa = 40, snp_offset = 30)
+    flank_before = join(rand(rng, _OPT4PC_BASES, fb))
+    repeat_body = collect(rand(rng, _OPT4PC_BASES, rl))
+    middle = join(rand(rng, _OPT4PC_BASES, mu))
+    flank_after = join(rand(rng, _OPT4PC_BASES, fa))
+    copy1 = join(repeat_body)
+    other_base = rand(rng, filter(!=(repeat_body[snp_offset]), _OPT4PC_BASES))
+    copy2_body = copy(repeat_body)
+    copy2_body[snp_offset] = other_base
+    copy2 = join(copy2_body)
+    genome = flank_before * copy1 * middle * copy2 * flank_after
+    copy1_snp_pos = fb + snp_offset
+    return genome, copy1_snp_pos, other_base
+end
+
+function _opt4pc_build_reads(rng, genome, copy1_snp_pos, mimic_allele;
+        readlen = 80, coverage = 20, n_error_reads = 8, n_plain = 8)
+    glen = length(genome)
+    n_reads = max(1, ceil(Int, coverage * glen / readlen))
+    records = FASTX.FASTQ.Record[]
+    truth_by_id = Dict{String, String}()
+    observed_by_id = Dict{String, String}()
+    qstr = repeat(string(Char(20 + 33)), readlen)
+    for i in 1:n_reads
+        s = rand(rng, 1:(glen - readlen + 1))
+        seq = genome[s:(s + readlen - 1)]
+        rid = "bg_$(i)"
+        truth_by_id[rid] = seq
+        observed_by_id[rid] = seq
+        push!(records, FASTX.FASTQ.Record(rid, seq, qstr))
+    end
+    lo = max(1, copy1_snp_pos - readlen + 1)
+    hi = min(glen - readlen + 1, copy1_snp_pos)
+    for i in 1:n_error_reads
+        s = rand(rng, lo:hi)
+        truth = genome[s:(s + readlen - 1)]
+        p = copy1_snp_pos - s + 1
+        chars = collect(truth)
+        chars[p] = mimic_allele
+        observed = join(chars)
+        rid = "err_$(i)"
+        truth_by_id[rid] = truth
+        observed_by_id[rid] = observed
+        push!(records, FASTX.FASTQ.Record(rid, observed, qstr))
+    end
+    for i in 1:n_plain
+        s = rand(rng, 1:(glen - readlen + 1))
+        truth = genome[s:(s + readlen - 1)]
+        p = rand(rng, 1:readlen)
+        chars = collect(truth)
+        chars[p] = rand(rng, filter(!=(chars[p]), _OPT4PC_BASES))
+        observed = join(chars)
+        rid = "plain_$(i)"
+        truth_by_id[rid] = truth
+        observed_by_id[rid] = observed
+        push!(records, FASTX.FASTQ.Record(rid, observed, qstr))
+    end
+    return records, truth_by_id, observed_by_id
+end
+
+function _opt4pc_run_ladder(records, tmp, label; skip_frozen, threshold, across, k_ladder)
+    fq = joinpath(tmp, "in.fastq")
+    isfile(fq) || Mycelia.write_fastq(records = records, filename = fq)
+    result = Mycelia.mycelia_iterative_assemble(fq;
+        max_k = maximum(k_ladder) + 10, k_ladder = k_ladder, graph_mode = :canonical,
+        skip_solid = true, cheap_correct = true, hard_window = true, soft_em = false,
+        batch_size = 50, max_iterations_per_k = 2, verbose = false,
+        enable_checkpointing = false, skip_frozen_reads = skip_frozen,
+        freeze_streak_threshold = threshold, freeze_across_rungs = across,
+        output_dir = joinpath(tmp, label))
+    corrected_by_id = Dict{String, String}()
+    open(FASTX.FASTQ.Reader, result[:metadata][:final_fastq_file]) do rd
+        for rec in rd
+            corrected_by_id[FASTX.identifier(rec)] = FASTX.sequence(String, rec)
+        end
+    end
+    return corrected_by_id, result
+end
+
+# --- Fixture 2: ordinary substitution fixture (mirrors freeze_state_test's
+# "composition" subtest, which IS proven to converge under skip_solid=true/
+# cheap_correct=true) -----------------------------------------------------
+function _opt4pc_plain_reads(rng, ref; n_reads = 150, readlen = 80, n_err = 20)
+    reflen = length(ref)
+    records = FASTX.FASTQ.Record[]
+    truth_by_id = Dict{String, String}()
+    observed_by_id = Dict{String, String}()
+    for i in 1:n_reads
+        s = rand(rng, 1:(reflen - readlen + 1))
+        seq = collect(ref[s:(s + readlen - 1)])
+        truth = join(seq)
+        if i <= n_err
+            p = rand(rng, 1:readlen)
+            seq[p] = rand(rng, filter(!=(seq[p]), _OPT4PC_BASES))
+        end
+        observed = join(seq)
+        rid = "r$i"
+        truth_by_id[rid] = truth
+        observed_by_id[rid] = observed
+        push!(records, FASTX.FASTQ.Record(rid, observed, String(fill('I', readlen))))
+    end
+    return records, truth_by_id, observed_by_id
+end
+
+function _opt4pc_run_multi_pass_rebuild(
+        records, k, common; skip_frozen, threshold, n_passes)
+    streaks = zeros(Int, length(records))
+    diag = Mycelia.CorrectorDiagnostics()
+    reads = records
+    for _pass in 1:n_passes
+        graph = Mycelia.Rhizomorph.build_qualmer_graph(reads, k; mode = :canonical)
+        reads, = Mycelia.improve_read_set_likelihood(reads, graph, k; common...,
+            skip_frozen_reads = skip_frozen, freeze_streak_threshold = threshold,
+            freeze_streaks = streaks, diagnostics = diag)
+    end
+    return reads, diag
+end
+
+Test.@testset "opt4 positive control -- toy-scale degradation NOT inducible (td-jbjd pass 4)" begin
+    Test.@testset "repeat/paralogous-SNP fixture: exact vs freeze byte-identical" begin
+        rng = Random.MersenneTwister(1234)
+        genome, c1pos, mimic_allele = _opt4pc_build_genome(rng)
+        rng2 = Random.MersenneTwister(5678)
+        records, truth_by_id,
+        observed_by_id = _opt4pc_build_reads(
+            rng2, genome, c1pos, mimic_allele; readlen = 80, coverage = 20,
+            n_error_reads = 8, n_plain = 8)
+
+        tmp = mktempdir()
+        k_ladder = [11, 15, 19, 23, 27, 31, 35, 39]
+        corrected_exact,
+        r_exact = _opt4pc_run_ladder(records, tmp, "exact";
+            skip_frozen = false, threshold = 2, across = false, k_ladder = k_ladder)
+        corrected_freeze,
+        r_freeze = _opt4pc_run_ladder(records, tmp, "freeze";
+            skip_frozen = true, threshold = 1, across = true, k_ladder = k_ladder)
+
+        # Setup sanity: this fixture DOES exercise real correction (some
+        # engineered reads fixed via Stage 0's unique-neighbor search once the
+        # k-mer window spans into copy-specific flank), and freeze DID skip a
+        # substantial number of decodes -- so the byte-identical result below
+        # is not simply "nothing happened in either arm".
+        err_truth = Dict(
+            rid=>truth_by_id[rid] for rid in keys(truth_by_id) if startswith(rid, "err_"))
+        err_obs = Dict(
+            rid=>observed_by_id[rid]
+        for
+        rid in keys(observed_by_id) if startswith(rid, "err_"))
+        err_corr_exact = Dict(
+            rid=>corrected_exact[rid]
+        for rid in keys(err_truth) if haskey(corrected_exact, rid))
+        m_exact = per_base_metrics(err_truth, err_obs, err_corr_exact)
+        Test.@test m_exact.tp > 0   # some engineered reads WERE fixed (by Stage 0)
+        Test.@test r_freeze[:metadata][:corrector_errors][:frozen_reads_skipped] > 0
+
+        # THE FINDING: despite real correction activity and real freeze
+        # activity, the two arms' final corrected FASTQs are byte-identical --
+        # Stage 0 (freeze-immune) accounts for every actual edit at this scale.
+        recs = res -> [(String(FASTX.identifier(r)), FASTX.sequence(String, r),
+                           String(FASTX.quality(r)))
+                       for r in
+                           open(FASTX.FASTQ.Reader, res[:metadata][:final_fastq_file]) do rd
+            collect(rd)
+        end]
+        Test.@test recs(r_exact) == recs(r_freeze)
+    end
+
+    Test.@testset "ordinary-substitution fixture, multi-pass with graph rebuild: exact vs freeze byte-identical" begin
+        rng = Random.MersenneTwister(2026)
+        ref = join(rand(rng, _OPT4PC_BASES, 900))
+        records, truth_by_id,
+        observed_by_id = _opt4pc_plain_reads(
+            rng, ref; n_reads = 150, readlen = 80, n_err = 20)
+        k = 13
+        common = (; graph_mode = :canonical, skip_solid = true, cheap_correct = true,
+            decode_enabled = true, batch_size = 50)
+
+        reads_exact,
+        diag_exact = _opt4pc_run_multi_pass_rebuild(
+            records, k, common; skip_frozen = false, threshold = 1, n_passes = 4)
+        reads_freeze,
+        diag_freeze = _opt4pc_run_multi_pass_rebuild(
+            records, k, common; skip_frozen = true, threshold = 1, n_passes = 4)
+
+        corrected_exact = Dict(
+            String(FASTX.identifier(r))=>FASTX.sequence(String, r) for r in reads_exact)
+        corrected_freeze = Dict(
+            String(FASTX.identifier(r))=>FASTX.sequence(String, r) for r in reads_freeze)
+        m_exact = per_base_metrics(truth_by_id, observed_by_id, corrected_exact)
+
+        # Setup sanity: real correction happened (recall > 0), and freeze DID
+        # fire under the maximally aggressive threshold=1 setting -- multiple
+        # extra passes were denied to whichever reads did not converge on their
+        # first attempt.
+        Test.@test m_exact.tp > 0
+        Test.@test diag_freeze.frozen_reads_skipped[] > 0
+
+        # THE FINDING (independent confirmation, bypassing mycelia_iterative_
+        # assemble's adaptive low-k gate entirely by calling
+        # improve_read_set_likelihood directly): the corrected sequences are
+        # identical whether extra passes were denied (freeze) or granted
+        # (exact) -- a read that converges here does so on its FIRST
+        # evaluation; the additional passes freezing denies never mattered.
+        recs = d -> sort(collect(d))
+        Test.@test recs(corrected_exact) == recs(corrected_freeze)
+    end
+end


### PR DESCRIPTION
## Summary

Campaign step opt4 (Rule-of-5): an **opt-in, default-off, approximate** corrector optimization that skips re-decoding "frozen" (N-consecutive-pass converged) reads across iterations. Unlike opt5/opt1/opt2 (byte-identical), opt4 trades a bounded, *measured* amount of accuracy for skipped Viterbi decode — so it ships **default off**, gated by an accuracy sign-off.

- **Mechanism** (`src/iterative-assembly.jl`, +119 lines): per-read consecutive-no-improvement streak; a read freezing at threshold is OR'd into the existing `_skip_this_read_at` path (reuses the proven `skip_solid` mechanism — its frozen correction still flows into every graph rebuild). Opt-in kwargs `skip_frozen_reads=false`, `freeze_streak_threshold=2`, `freeze_across_rungs=false`, threaded shallow (opt5 pattern). New `frozen_reads_skipped` diagnostic.
- **Byte-identical when off** — locked by a **golden-vs-pre-opt4-master** test: opt4-off reproduces `b032fab3`'s corrected output bit-for-bit (SHA `e0c249c0…`), plus an explicit-false==omitted lock.
- **Only gates the Viterbi decode** — Stage 0 cheap correction runs unconditionally regardless, so opt4's impact is bounded to the decode contribution (safer than a naive "skip the read entirely").

## Accuracy sign-off (representative scale: Lambda phage, production `:scalable` knobs)

- **Default within-rung scope is a byte-identical no-op under production `max_iterations_per_k=2`** (a threshold-2 streak can't reach the freeze point with a same-k pass left to skip; confirmed engaging at `max_iterations_per_k=4`). Harmless but delivers nothing at the current config.
- **Aggressive across-rung scope**: ~15–17% fewer Viterbi decodes for **−0.02% relative recall at 21x** (cost shrinks with scale: −0.31% at 8x → −0.02% at 21x).
- **Positive control** (threshold 1, across-rung) degrades recall −1.0% to −4.8% — confirms the metric detects degradation, so the near-zero deltas are real.
- **Assembly-level dnadiff check**: exact and freeze_across are indistinguishable — both 100.00% AvgIdentity, 99.93% reference aligned, **0 SNPs, 0 indels**; assemblies differ by 0.02% redundant bases only.

Full numbers: `benchmarking/results/opt4_frozen_read_skip_signoff.md`. Design: `docs/design/2026-07-26-opt4-frozen-read-skip-design.md`.

## Test coverage (5 files)

- `corrector_opt4_frozen_read_skip_test.jl` — disabled-path identity lock (explicit-false == omitted).
- `corrector_opt4_golden_master_lock_test.jl` — opt4-off == pre-opt4 master (byte-identical).
- `corrector_opt4_freeze_state_test.jl` — streak increment/reset, within/across-rung scope, skip_solid composition.
- `corrector_opt4_edge_cases_test.jl` — all-freeze, single-read, N=1 vs N≥2, k-boundary reset.
- `corrector_opt4_positive_control_test.jl` — documents toy-scale inertness (Stage 0 dominates) with the traced mechanism.

## Test Plan

- [ ] All 5 opt4 test files pass (locally: 168+ assertions green).
- [ ] `fieldcount` completeness test passes with `frozen_reads_skipped` added (13 fields).
- [ ] Existing corrector lock tests + full `test (lts)` suite pass (opt4-off is a no-op).
- [ ] Sign-off + dnadiff reproducible from the committed scripts.

## Ship posture

Default **off**; no production behavior change. The sign-off documents that within-rung is inert at prod knobs and across-rung is the effective (opt-in) speedup path with its measured tradeoff. Enabling by default is a separate, evidence-gated decision — not part of this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added opt-in frozen-read skipping during iterative correction, with configurable thresholds and within- or across-rung behavior.
  * Added diagnostics reporting the number of frozen reads skipped.
  * Added checkpoint validation for frozen-read settings.

* **Documentation**
  * Added design guidance and representative-scale accuracy and assembly validation results.

* **Tests**
  * Added coverage for configuration guards, edge cases, parallel consistency, regression compatibility, and correction accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->