### PR TITLE
add: exact indel frontier rejection-cause diagnostics

### DIFF
--- a/src/iterative-assembly.jl
+++ b/src/iterative-assembly.jl
@@ -457,14 +457,49 @@ const _CHECKPOINT_INDEL_TELEMETRY_KEYS = Dict{String, Symbol}(
         :substitution_decode_memory_gated,
         :raw_frontier_metrics,
         :cleaned_frontier_metrics,
+        :raw_frontier_rejection_causes,
+        :cleaned_frontier_rejection_causes,
+        :raw_frontier_work_summary,
+        :cleaned_frontier_work_summary,
         :graph_cleanup,
         :ladder_index,
         :k,
         :iteration,
     )
 )
-const _CHECKPOINT_REQUIRED_INDEL_TELEMETRY_KEYS =
-    Set{Symbol}(values(_CHECKPOINT_INDEL_TELEMETRY_KEYS))
+# FROZEN v2 WIRE CONTRACT. This is the set of fields a schema-v2 checkpoint row
+# MUST carry, and it is deliberately an explicit literal rather than
+# `values(_CHECKPOINT_INDEL_TELEMETRY_KEYS)`: deriving it would make every
+# additive telemetry field retroactively mandatory, so any checkpoint written by
+# an earlier build would fail the mandatory-field check below. Do NOT add a name
+# here without bumping `_ITERATIVE_CHECKPOINT_CONFIGURATION_VERSION`; purely
+# additive fields belong in the accept-list above and must normalize from an
+# empty default so absent-in-old-checkpoint stays legal.
+const _CHECKPOINT_REQUIRED_INDEL_TELEMETRY_KEYS = Set{Symbol}((
+    :profile_requested,
+    :requested,
+    :attempted,
+    :completed,
+    :truncated,
+    :engaged,
+    :admitted,
+    :admitted_windows,
+    :rejected_windows,
+    :graph_source,
+    :decision_reason,
+    :frontier_work_limit,
+    :frontier_metric_sample_limit,
+    :raw_frontier_evaluated,
+    :cleaned_frontier_evaluated,
+    :bounded_windowing_forced,
+    :substitution_decode_memory_gated,
+    :raw_frontier_metrics,
+    :cleaned_frontier_metrics,
+    :graph_cleanup,
+    :ladder_index,
+    :k,
+    :iteration,
+))
 const _CHECKPOINT_INDEL_METRIC_KEYS = Dict{String, Symbol}(
     string(key) => key for key in (
         :anchored,
@@ -548,6 +583,35 @@ const _CHECKPOINT_FRONTIER_REASONS = Dict{String, Symbol}(
         :work_limit,
         :frontier_exhausted,
     )
+)
+# Per-window rejection-cause taxonomy for the branching-frontier scheduler.
+# `raw_frontier_metrics` is capped at `_INDEL_FRONTIER_TELEMETRY_SAMPLE_LIMIT`
+# and keeps the FIRST samples by read index, so any rejection breakdown computed
+# from it is a biased prefix. These histograms instead accumulate exactly one
+# cause per EVALUATED window and persist only the counters, which keeps the rung
+# telemetry O(number of causes) while making the breakdown exact at any scale.
+const _INDEL_FRONTIER_PROBE_REJECTION_CAUSES = Dict{Symbol, Symbol}(
+    reason => Symbol("probe_", reason)
+    for reason in values(_CHECKPOINT_FRONTIER_REASONS) if reason !== :complete
+)
+const _INDEL_FRONTIER_REJECTION_CAUSES = Base.Set{Symbol}((
+    :admitted,
+    :unanchored,
+    :partial_columns,
+    :work_limit_exceeded,
+    :probe_unknown,
+    values(_INDEL_FRONTIER_PROBE_REJECTION_CAUSES)...,
+))
+const _INDEL_FRONTIER_REJECTION_CAUSE_NAMES = Dict{String, Symbol}(
+    string(cause) => cause for cause in _INDEL_FRONTIER_REJECTION_CAUSES
+)
+# `frontier_work` order statistics over every evaluated window. Only these six
+# numbers are persisted; the per-window values stay transient. p50/p90/p99 use
+# nearest-rank on the sorted values, so every statistic is an observed sample
+# (an exact `Int`) and `min <= p50 <= p90 <= p99 <= max` holds by construction.
+const _INDEL_FRONTIER_WORK_SUMMARY_KEYS = (:count, :min, :p50, :p90, :p99, :max)
+const _INDEL_FRONTIER_WORK_SUMMARY_NAMES = Dict{String, Symbol}(
+    string(key) => key for key in _INDEL_FRONTIER_WORK_SUMMARY_KEYS
 )
 const _CHECKPOINT_GRAPH_CLEANUP_KEYS = Set{String}((
     "graph_cleanup_vertices_before",
@@ -1012,6 +1076,10 @@ function _empty_indel_rung_telemetry(profile_requested::Bool)::Dict{Symbol, Any}
         :substitution_decode_memory_gated => false,
         :raw_frontier_metrics => Dict{Symbol, Any}[],
         :cleaned_frontier_metrics => Dict{Symbol, Any}[],
+        :raw_frontier_rejection_causes => Dict{Symbol, Int}(),
+        :cleaned_frontier_rejection_causes => Dict{Symbol, Int}(),
+        :raw_frontier_work_summary => Dict{Symbol, Int}(),
+        :cleaned_frontier_work_summary => Dict{Symbol, Int}(),
         :graph_cleanup => Dict{String, Any}(),
     )
 end
@@ -1252,6 +1320,59 @@ function _validate_indel_frontier_metric(
     return nothing
 end
 
+function _checkpoint_indel_rejection_causes(
+        value::Any,
+        field::String,
+)::Dict{Symbol, Int}
+    value isa AbstractDict || throw(ArgumentError(
+        "checkpoint $field must be an object"))
+    causes = Dict{Symbol, Int}()
+    for (key, count) in value
+        cause = _checkpoint_enum_symbol(
+            _checkpoint_key_string(key, "checkpoint $field"),
+            _INDEL_FRONTIER_REJECTION_CAUSE_NAMES,
+            "$field cause",
+        )
+        haskey(causes, cause) && throw(ArgumentError(
+            "checkpoint $field repeats cause $cause"))
+        causes[cause] = _checkpoint_nonnegative_int(count, "$field $cause")
+    end
+    return causes
+end
+
+function _checkpoint_indel_work_summary(
+        value::Any,
+        field::String,
+)::Dict{Symbol, Int}
+    value isa AbstractDict || throw(ArgumentError(
+        "checkpoint $field must be an object"))
+    # Absent in every pre-diagnostics checkpoint, so an empty object is legal.
+    isempty(value) && return Dict{Symbol, Int}()
+    summary = Dict{Symbol, Int}()
+    for (key, statistic) in value
+        name = _checkpoint_enum_symbol(
+            _checkpoint_key_string(key, "checkpoint $field"),
+            _INDEL_FRONTIER_WORK_SUMMARY_NAMES,
+            "$field statistic",
+        )
+        haskey(summary, name) && throw(ArgumentError(
+            "checkpoint $field repeats statistic $name"))
+        summary[name] = _checkpoint_nonnegative_int(statistic, "$field $name")
+    end
+    length(summary) == length(_INDEL_FRONTIER_WORK_SUMMARY_KEYS) ||
+        throw(ArgumentError(
+            "checkpoint $field must contain every order statistic"))
+    summary[:min] <= summary[:p50] <= summary[:p90] <= summary[:p99] <=
+        summary[:max] || throw(ArgumentError(
+        "checkpoint $field order statistics must be monotone"))
+    if summary[:count] == 0
+        all(summary[name] == 0 for name in (:min, :p50, :p90, :p99, :max)) ||
+            throw(ArgumentError(
+                "checkpoint $field with zero count requires zero statistics"))
+    end
+    return summary
+end
+
 function _normalize_indel_rung_telemetry(
         row::AbstractDict,
         require_schema_v2::Bool = true,
@@ -1349,6 +1470,32 @@ function _normalize_indel_rung_telemetry(
             end
         end
     end
+    for key in (
+            :raw_frontier_rejection_causes,
+            :cleaned_frontier_rejection_causes,
+    )
+        normalized[key] = _checkpoint_indel_rejection_causes(
+            get(normalized, key, Dict{Symbol, Int}()),
+            "indel telemetry $key",
+        )
+    end
+    for key in (:raw_frontier_work_summary, :cleaned_frontier_work_summary)
+        normalized[key] = _checkpoint_indel_work_summary(
+            get(normalized, key, Dict{Symbol, Int}()),
+            "indel telemetry $key",
+        )
+    end
+    # These diagnostics are ADDITIVE and self-describing: an absent (empty)
+    # container is legal at any schema version, and the checks above are
+    # intra-field only (taxonomy, nonnegative exact `Int`, monotone order
+    # statistics). They are deliberately NOT cross-checked against
+    # `raw_frontier_evaluated` / `cleaned_frontier_evaluated` here. The
+    # scheduler is the sole producer and emits exactly one cause per
+    # evaluated window, an invariant the tests assert against live scheduler
+    # output and the on-disk checkpoint; coupling an additive diagnostic to
+    # the core counters would instead make hand-constructed v2 rows that
+    # legitimately restate those counters (to exercise unrelated checks)
+    # fail on a field they never touch, and would buy no resume safety.
     if require_schema_v2
         sample_limit = normalized[:frontier_metric_sample_limit]
         for (metric_key, evaluated_key) in (
@@ -3225,6 +3372,105 @@ function _indel_frontier_admitted(
            metrics.frontier_work <= work_limit
 end
 
+"""
+    _indel_frontier_rejection_cause(metric, work_limit) -> Symbol
+
+Classify why one probed decode window was (or was not) admitted to the
+pair-HMM by `_indel_frontier_admitted`.
+
+Pure: takes the metric dictionary produced by `_probe_indel_window_metric` plus
+the frontier budget, and touches no graph. `:admitted` is returned exactly when
+`_indel_frontier_admitted` would return `true` for the same window, so the
+histogram built from this function reconciles with the admission counters.
+
+Apart from the `:encode_error` pre-check the branch order mirrors the `&&` chain
+in `_indel_frontier_admitted` conjunct for conjunct, so the FIRST failing
+conjunct names the cause:
+
+| Conjunct                             | Cause when it fails      |
+|:-------------------------------------|:-------------------------|
+| `metrics.anchored`                   | `:unanchored`            |
+| `metrics.reason == :complete`        | `:probe_<probe reason>`  |
+| `completed_columns == window_length` | `:partial_columns`       |
+| `frontier_work <= work_limit`        | `:work_limit_exceeded`   |
+
+A window that is BOTH unanchored and over budget therefore reports
+`:unanchored`, matching the short-circuit that actually rejected it.
+
+`:encode_error` is a harness sentinel emitted by `_probe_indel_window_metric`
+when the window sequence cannot be encoded: the probe never ran, so its
+`anchored = false` is synthetic rather than an anchor finding. It is classified
+before the anchor conjunct so that `:unanchored` keeps its literal meaning --
+the probe ran and found no start vertex -- which is the distinction the
+diagnostic exists to make. `_indel_frontier_admitted` is never consulted for
+that sentinel, so the `:admitted` equivalence above is unaffected.
+"""
+function _indel_frontier_rejection_cause(
+        metric::AbstractDict,
+        work_limit::Int,
+)::Symbol
+    reason = get(metric, :reason, nothing)
+    reason === :encode_error && return :probe_encode_error
+    get(metric, :anchored, false) === true || return :unanchored
+    if reason !== :complete
+        return get(
+            _INDEL_FRONTIER_PROBE_REJECTION_CAUSES, reason, :probe_unknown)
+    end
+    get(metric, :completed_columns, -1) == get(metric, :window_length, -2) ||
+        return :partial_columns
+    get(metric, :frontier_work, typemax(Int)) <= work_limit ||
+        return :work_limit_exceeded
+    return :admitted
+end
+
+function _record_indel_frontier_cause!(
+        causes::Dict{Symbol, Int},
+        metric::AbstractDict,
+        work_limit::Int,
+)::Symbol
+    cause = _indel_frontier_rejection_cause(metric, work_limit)
+    causes[cause] = get(causes, cause, 0) + 1
+    return cause
+end
+
+# `:encode_error` sentinels carry no `frontier_work`, so they are counted in the
+# cause histogram but contribute nothing to the order statistics.
+function _record_indel_frontier_work!(
+        works::Vector{Int},
+        metric::AbstractDict,
+)::Nothing
+    frontier_work = get(metric, :frontier_work, nothing)
+    frontier_work isa Int && push!(works, frontier_work)
+    return nothing
+end
+
+"""
+    _indel_frontier_work_summary(works) -> Dict{Symbol, Int}
+
+Reduce the per-window `frontier_work` values of one rung to the six order
+statistics persisted in the rung telemetry. Percentiles use nearest-rank, so
+each is an observed value and monotonicity holds without interpolation.
+"""
+function _indel_frontier_work_summary(
+        works::Vector{Int},
+)::Dict{Symbol, Int}
+    if isempty(works)
+        return Dict{Symbol, Int}(
+            key => 0 for key in _INDEL_FRONTIER_WORK_SUMMARY_KEYS)
+    end
+    sorted = sort(works)
+    n = length(sorted)
+    nearest_rank(quantile) = sorted[clamp(ceil(Int, quantile * n), 1, n)]
+    return Dict{Symbol, Int}(
+        :count => n,
+        :min => first(sorted),
+        :p50 => nearest_rank(0.50),
+        :p90 => nearest_rank(0.90),
+        :p99 => nearest_rank(0.99),
+        :max => last(sorted),
+    )
+end
+
 function _indel_candidate_windows(
         reads::Vector{<:FASTX.FASTQ.Record},
         k::Int,
@@ -3460,6 +3706,14 @@ function _evaluate_indel_frontier_schedule_impl(
         sources = get!(window_sources, read_index, Dict{UnitRange{Int}, Symbol}())
         sources[window] = :substitution
     end
+    # Exact per-window diagnostics. Unlike `raw_metrics`/`cleaned_metrics` these
+    # are NOT capped at `_INDEL_FRONTIER_TELEMETRY_SAMPLE_LIMIT`; every evaluated
+    # window contributes one cause, and `*_works` is reduced to six order
+    # statistics before it leaves this function.
+    raw_causes = Dict{Symbol, Int}()
+    raw_works = Int[]
+    cleaned_causes = Dict{Symbol, Int}()
+    cleaned_works = Int[]
     if isempty(candidates)
         return (
             graph = raw_graph,
@@ -3475,6 +3729,10 @@ function _evaluate_indel_frontier_schedule_impl(
             decision_reason = :no_candidate_windows,
             raw_evaluated = 0,
             cleaned_evaluated = 0,
+            raw_causes,
+            cleaned_causes,
+            raw_work_summary = _indel_frontier_work_summary(raw_works),
+            cleaned_work_summary = _indel_frontier_work_summary(cleaned_works),
             raw_metrics = Dict{Symbol, Any}[],
             cleaned_metrics = Dict{Symbol, Any}[],
             cleanup = Dict{String, Any}(),
@@ -3503,6 +3761,8 @@ function _evaluate_indel_frontier_schedule_impl(
         metric[:window_stop] = last(window)
         metric[:admitted] = admitted
         raw_evaluated += 1
+        _record_indel_frontier_cause!(raw_causes, metric, work_limit)
+        _record_indel_frontier_work!(raw_works, metric)
         if length(raw_metrics) < _INDEL_FRONTIER_TELEMETRY_SAMPLE_LIMIT
             push!(raw_metrics, metric)
         end
@@ -3532,6 +3792,10 @@ function _evaluate_indel_frontier_schedule_impl(
                 decision_reason = :weighted_graph_memory_limit,
                 raw_evaluated,
                 cleaned_evaluated = 0,
+                raw_causes,
+                cleaned_causes,
+                raw_work_summary = _indel_frontier_work_summary(raw_works),
+                cleaned_work_summary = _indel_frontier_work_summary(cleaned_works),
                 raw_metrics,
                 cleaned_metrics = Dict{Symbol, Any}[],
                 cleanup,
@@ -3558,6 +3822,10 @@ function _evaluate_indel_frontier_schedule_impl(
                 decision_reason = :weighted_graph_out_of_memory,
                 raw_evaluated,
                 cleaned_evaluated = 0,
+                raw_causes,
+                cleaned_causes,
+                raw_work_summary = _indel_frontier_work_summary(raw_works),
+                cleaned_work_summary = _indel_frontier_work_summary(cleaned_works),
                 raw_metrics,
                 cleaned_metrics = Dict{Symbol, Any}[],
                 cleanup = Dict{String, Any}(
@@ -3579,6 +3847,10 @@ function _evaluate_indel_frontier_schedule_impl(
             decision_reason = :raw_frontier_affordable,
             raw_evaluated,
             cleaned_evaluated = 0,
+            raw_causes,
+            cleaned_causes,
+            raw_work_summary = _indel_frontier_work_summary(raw_works),
+            cleaned_work_summary = _indel_frontier_work_summary(cleaned_works),
             raw_metrics,
             cleaned_metrics = Dict{Symbol, Any}[],
             cleanup = Dict{String, Any}(),
@@ -3626,6 +3898,9 @@ function _evaluate_indel_frontier_schedule_impl(
                     metric[:window_stop] = last(window)
                     metric[:admitted] = admitted
                     cleaned_evaluated += 1
+                    _record_indel_frontier_cause!(
+                        cleaned_causes, metric, work_limit)
+                    _record_indel_frontier_work!(cleaned_works, metric)
                     cleaning_lost_anchor |= raw_anchored[candidate_index] &&
                                             !get(metric, :anchored, false)
                     if length(cleaned_metrics) <
@@ -3648,6 +3923,8 @@ function _evaluate_indel_frontier_schedule_impl(
             cleaned_graph = nothing
             cleaned_weighted_graph = nothing
             empty!(cleaned_metrics)
+            empty!(cleaned_causes)
+            empty!(cleaned_works)
             cleaned_evaluated = 0
             fill!(cleaned_admitted, false)
             for (candidate_index, (read_index, window)) in enumerate(candidates)
@@ -3691,6 +3968,10 @@ function _evaluate_indel_frontier_schedule_impl(
             decision_reason = :cleaning_out_of_memory,
             raw_evaluated,
             cleaned_evaluated,
+            raw_causes,
+            cleaned_causes,
+            raw_work_summary = _indel_frontier_work_summary(raw_works),
+            cleaned_work_summary = _indel_frontier_work_summary(cleaned_works),
             raw_metrics,
             cleaned_metrics,
             cleanup,
@@ -3744,6 +4025,10 @@ function _evaluate_indel_frontier_schedule_impl(
                 decision_reason = :weighted_graph_memory_limit,
                 raw_evaluated,
                 cleaned_evaluated,
+                raw_causes,
+                cleaned_causes,
+                raw_work_summary = _indel_frontier_work_summary(raw_works),
+                cleaned_work_summary = _indel_frontier_work_summary(cleaned_works),
                 raw_metrics,
                 cleaned_metrics,
                 cleanup,
@@ -3774,6 +4059,10 @@ function _evaluate_indel_frontier_schedule_impl(
                 decision_reason = :weighted_graph_out_of_memory,
                 raw_evaluated,
                 cleaned_evaluated,
+                raw_causes,
+                cleaned_causes,
+                raw_work_summary = _indel_frontier_work_summary(raw_works),
+                cleaned_work_summary = _indel_frontier_work_summary(cleaned_works),
                 raw_metrics,
                 cleaned_metrics,
                 cleanup = Dict{String, Any}(
@@ -3795,6 +4084,10 @@ function _evaluate_indel_frontier_schedule_impl(
             decision_reason = reason,
             raw_evaluated,
             cleaned_evaluated,
+            raw_causes,
+            cleaned_causes,
+            raw_work_summary = _indel_frontier_work_summary(raw_works),
+            cleaned_work_summary = _indel_frontier_work_summary(cleaned_works),
             raw_metrics,
             cleaned_metrics,
             cleanup,
@@ -3803,8 +4096,6 @@ function _evaluate_indel_frontier_schedule_impl(
 
     reason = if cleaning_status == :out_of_memory
         :cleaning_out_of_memory
-    elseif cleaning_status == :weighted_memory_limit
-        :weighted_graph_memory_limit
     elseif cleaning_status == :memory_limit
         :cleaning_memory_limit
     elseif cleaning_lost_anchor
@@ -3826,6 +4117,10 @@ function _evaluate_indel_frontier_schedule_impl(
         decision_reason = reason,
         raw_evaluated,
         cleaned_evaluated,
+        raw_causes,
+        cleaned_causes,
+        raw_work_summary = _indel_frontier_work_summary(raw_works),
+        cleaned_work_summary = _indel_frontier_work_summary(cleaned_works),
         raw_metrics,
         cleaned_metrics,
         cleanup,
@@ -4843,6 +5138,14 @@ function _improve_read_set_likelihood_impl(
         pass_indel_telemetry[:cleaned_frontier_evaluated] = decision.cleaned_evaluated
         pass_indel_telemetry[:raw_frontier_metrics] = decision.raw_metrics
         pass_indel_telemetry[:cleaned_frontier_metrics] = decision.cleaned_metrics
+        pass_indel_telemetry[:raw_frontier_rejection_causes] =
+            decision.raw_causes
+        pass_indel_telemetry[:cleaned_frontier_rejection_causes] =
+            decision.cleaned_causes
+        pass_indel_telemetry[:raw_frontier_work_summary] =
+            decision.raw_work_summary
+        pass_indel_telemetry[:cleaned_frontier_work_summary] =
+            decision.cleaned_work_summary
         pass_indel_telemetry[:graph_cleanup] = decision.cleanup
         indel_admitted = decision.admitted
         scheduled_weighted_graph_oom = decision.decision_reason in (

--- a/src/iterative-assembly.jl
+++ b/src/iterative-assembly.jl
@@ -475,6 +475,19 @@ const _CHECKPOINT_INDEL_TELEMETRY_KEYS = Dict{String, Symbol}(
 # here without bumping `_ITERATIVE_CHECKPOINT_CONFIGURATION_VERSION`; purely
 # additive fields belong in the accept-list above and must normalize from an
 # empty default so absent-in-old-checkpoint stays legal.
+#
+# The compatibility this buys is ONE-WAY, and deliberately so. FORWARD (this
+# build reads a checkpoint an earlier build wrote) is safe: an additive field
+# that is absent normalizes from its empty default. BACKWARD (an EARLIER build
+# reads a checkpoint this build wrote) is NOT: `_checkpoint_symbolized_dict`
+# rejects any field outside that build's accept-list, and
+# `_symbolize_indel_frontier_metric` rejects a row carrying more fields than it
+# knows, so the earlier build fails with an unsupported-field error rather than
+# ignoring the addition. Bumping
+# `_ITERATIVE_CHECKPOINT_CONFIGURATION_VERSION` does NOT fix that -- it would
+# additionally break the forward direction, converting a downgrade-only failure
+# into an upgrade failure too. Resume a checkpoint with the build that wrote it
+# or a newer one.
 const _CHECKPOINT_REQUIRED_INDEL_TELEMETRY_KEYS = Set{Symbol}((
     :profile_requested,
     :requested,
@@ -594,6 +607,19 @@ const _INDEL_FRONTIER_PROBE_REJECTION_CAUSES = Dict{Symbol, Symbol}(
     reason => Symbol("probe_", reason)
     for reason in values(_CHECKPOINT_FRONTIER_REASONS) if reason !== :complete
 )
+# Probe reasons emitted with `anchored = false` for a reason OTHER than "the
+# probe ran and found no start vertex". `:encode_error` is a harness sentinel
+# from `_probe_indel_window_metric` (the probe never ran at all), while
+# `:empty_graph` and `:empty_observation` are structural pre-checks inside
+# `_probe_indel_frontier` that return BEFORE the start-vertex lookup. All three
+# are classified ahead of the anchor conjunct so `:unanchored` keeps its literal
+# meaning -- it is reachable from `:unanchored_start` and nothing else -- rather
+# than becoming a four-way union bucket that hides which of the four occurred.
+const _INDEL_FRONTIER_PRE_ANCHOR_REASONS = Base.Set{Symbol}((
+    :encode_error,
+    :empty_graph,
+    :empty_observation,
+))
 const _INDEL_FRONTIER_REJECTION_CAUSES = Base.Set{Symbol}((
     :admitted,
     :unanchored,
@@ -1078,8 +1104,13 @@ function _empty_indel_rung_telemetry(profile_requested::Bool)::Dict{Symbol, Any}
         :cleaned_frontier_metrics => Dict{Symbol, Any}[],
         :raw_frontier_rejection_causes => Dict{Symbol, Int}(),
         :cleaned_frontier_rejection_causes => Dict{Symbol, Int}(),
-        :raw_frontier_work_summary => Dict{Symbol, Int}(),
-        :cleaned_frontier_work_summary => Dict{Symbol, Int}(),
+        # Zero-filled six-key form, NOT an empty object: the
+        # `:no_candidate_windows` scheduler path already emits
+        # `_indel_frontier_work_summary(Int[])`, and two different "no work
+        # data" encodings would make `summary[:count]` a `KeyError` on one of
+        # them and a `0` on the other. One total shape, always.
+        :raw_frontier_work_summary => _indel_frontier_work_summary(Int[]),
+        :cleaned_frontier_work_summary => _indel_frontier_work_summary(Int[]),
         :graph_cleanup => Dict{String, Any}(),
     )
 end
@@ -1346,8 +1377,11 @@ function _checkpoint_indel_work_summary(
 )::Dict{Symbol, Int}
     value isa AbstractDict || throw(ArgumentError(
         "checkpoint $field must be an object"))
-    # Absent in every pre-diagnostics checkpoint, so an empty object is legal.
-    isempty(value) && return Dict{Symbol, Int}()
+    # An empty object stays legal ON THE WIRE because every pre-diagnostics
+    # checkpoint omits the field entirely. It normalizes to the zero-filled
+    # six-key form this build always writes (including for profile-disabled
+    # rungs), so no consumer ever has to handle two "no work data" shapes.
+    isempty(value) && return _indel_frontier_work_summary(Int[])
     summary = Dict{Symbol, Int}()
     for (key, statistic) in value
         name = _checkpoint_enum_symbol(
@@ -1485,17 +1519,6 @@ function _normalize_indel_rung_telemetry(
             "indel telemetry $key",
         )
     end
-    # These diagnostics are ADDITIVE and self-describing: an absent (empty)
-    # container is legal at any schema version, and the checks above are
-    # intra-field only (taxonomy, nonnegative exact `Int`, monotone order
-    # statistics). They are deliberately NOT cross-checked against
-    # `raw_frontier_evaluated` / `cleaned_frontier_evaluated` here. The
-    # scheduler is the sole producer and emits exactly one cause per
-    # evaluated window, an invariant the tests assert against live scheduler
-    # output and the on-disk checkpoint; coupling an additive diagnostic to
-    # the core counters would instead make hand-constructed v2 rows that
-    # legitimately restate those counters (to exercise unrelated checks)
-    # fail on a field they never touch, and would buy no resume safety.
     if require_schema_v2
         sample_limit = normalized[:frontier_metric_sample_limit]
         for (metric_key, evaluated_key) in (
@@ -1584,6 +1607,38 @@ function _normalize_indel_rung_telemetry(
         normalized[:cleaned_frontier_evaluated] <=
             normalized[:raw_frontier_evaluated] || throw(ArgumentError(
             "checkpoint cleaned frontier evaluations exceed raw evaluations"))
+    end
+    # EXACTNESS CROSS-CHECK. The scheduler records exactly one cause per
+    # evaluated window, so a populated histogram MUST sum to its evaluated
+    # counter. This is the same class of check `raw_frontier_metrics` already
+    # gets against `raw_frontier_evaluated` above, and it is what makes the
+    # histogram usable as evidence rather than merely well-formed -- an exact
+    # breakdown that is never reconciled against the count it breaks down is
+    # not stronger than the sampled prefix it replaced.
+    #
+    # Gated on non-emptiness because the field is ADDITIVE. A schema-v2
+    # checkpoint written before these diagnostics existed carries no histogram
+    # and normalizes to an empty one, which must stay legal (see the FROZEN
+    # required-key note above). An empty histogram beside a non-zero counter is
+    # therefore indistinguishable at the wire level from a legacy row, and
+    # cannot be rejected without a version bump that would break the forward
+    # direction. Every producer in THIS build populates the histogram whenever
+    # it evaluates a window, so the check binds on all of them; emptiness is a
+    # legacy escape hatch, not a live producer shape.
+    #
+    # Ordered AFTER the counter cross-checks above on purpose: a row whose
+    # COUNTER is corrupt should report the counter's own error, not have it
+    # masked by the histogram that faithfully described the original count.
+    for (cause_key, evaluated_key) in (
+            (:raw_frontier_rejection_causes, :raw_frontier_evaluated),
+            (:cleaned_frontier_rejection_causes, :cleaned_frontier_evaluated),
+    )
+        causes = normalized[cause_key]
+        isempty(causes) && continue
+        total = sum(values(causes))
+        total == normalized[evaluated_key] || throw(ArgumentError(
+            "checkpoint indel telemetry $cause_key sums to $total, which does " *
+            "not match $evaluated_key=$(normalized[evaluated_key])"))
     end
     if !profile_requested && any(
             normalized[key] != 0 for key in (
@@ -2967,8 +3022,11 @@ end
 # graph Viterbi for genuine ambiguity is the critical-path lever: on err=0.01 data
 # ~78% of reads carry an error k-mer, so cheaply clearing the simple ones collapses
 # the graph-decode fraction toward the true bubble/repeat ~5–15%.
-# Only invoked on the :scalable tier (`cheap_correct=true`, canonical graph); the
-# :exhaustive path never calls it and is byte-identical.
+# Only invoked on the :scalable tier (`cheap_correct=true`). The live gate is
+# `graph_mode != :singlestrand`, NOT `graph_mode == :canonical`: :scalable builds
+# a :doublestrand graph, so a canonical-only reading would describe Stage 0 as
+# OFF on the production tier. The :exhaustive path never calls it and is
+# byte-identical.
 # ------------------------------------------------------------------------------
 
 # Graph-label lookup key for the k-mer at 1-based read position `i` (bases
@@ -3383,9 +3441,9 @@ the frontier budget, and touches no graph. `:admitted` is returned exactly when
 `_indel_frontier_admitted` would return `true` for the same window, so the
 histogram built from this function reconciles with the admission counters.
 
-Apart from the `:encode_error` pre-check the branch order mirrors the `&&` chain
-in `_indel_frontier_admitted` conjunct for conjunct, so the FIRST failing
-conjunct names the cause:
+Apart from the `_INDEL_FRONTIER_PRE_ANCHOR_REASONS` pre-check the branch order
+mirrors the `&&` chain in `_indel_frontier_admitted` conjunct for conjunct, so
+the FIRST failing conjunct names the cause:
 
 | Conjunct                             | Cause when it fails      |
 |:-------------------------------------|:-------------------------|
@@ -3397,20 +3455,44 @@ conjunct names the cause:
 A window that is BOTH unanchored and over budget therefore reports
 `:unanchored`, matching the short-circuit that actually rejected it.
 
-`:encode_error` is a harness sentinel emitted by `_probe_indel_window_metric`
-when the window sequence cannot be encoded: the probe never ran, so its
-`anchored = false` is synthetic rather than an anchor finding. It is classified
-before the anchor conjunct so that `:unanchored` keeps its literal meaning --
-the probe ran and found no start vertex -- which is the distinction the
-diagnostic exists to make. `_indel_frontier_admitted` is never consulted for
-that sentinel, so the `:admitted` equivalence above is unaffected.
+PRE-ANCHOR REASONS. The anchor conjunct is checked before the reason lookup, so
+without a pre-check every reason that carries `anchored = false` would collapse
+into `:unanchored`. FOUR do: `:encode_error` (a harness sentinel from
+`_probe_indel_window_metric` -- the probe never ran, so `anchored = false` is
+synthetic rather than an anchor finding), `:empty_graph` and
+`:empty_observation` (structural pre-checks in `_probe_indel_frontier` that
+return before the start-vertex lookup), and `:unanchored_start` (the genuine
+anchor finding). The first three are therefore classified BEFORE the anchor
+conjunct, leaving `:unanchored` reachable from `:unanchored_start` and nothing
+else. `_indel_frontier_admitted` is `false` for all four -- they are all
+`anchored = false` -- so the `:admitted` equivalence above is unaffected by
+where in the chain they are named.
+
+REACHABILITY of the persisted taxonomy is deliberately uneven, and the uneven
+members are the defensive ones:
+
+  * `:probe_unanchored_start` is UNREACHABLE by construction -- that reason is
+    absorbed by the `:unanchored` bucket above, which is the more informative
+    name for it.
+  * `:partial_columns` and `:work_limit_exceeded` are DEFENSIVE ONLY from a
+    real probe: `_probe_indel_frontier` returns `:complete` exactly when it
+    consumed every column within budget, so `reason == :complete` already
+    implies both remaining conjuncts. Either bucket appearing in a histogram
+    built from live scheduler output signals a broken probe kernel invariant,
+    not an ordinary rejection. They are kept because the classifier is a pure
+    function over a dictionary and must stay total for hand-built and
+    round-tripped metrics.
+  * `:probe_unknown` is the catch-all for a probe reason outside
+    `_CHECKPOINT_FRONTIER_REASONS`; it degrades loudly instead of silently
+    mapping onto a real bucket.
 """
 function _indel_frontier_rejection_cause(
         metric::AbstractDict,
         work_limit::Int,
 )::Symbol
     reason = get(metric, :reason, nothing)
-    reason === :encode_error && return :probe_encode_error
+    reason isa Symbol && reason in _INDEL_FRONTIER_PRE_ANCHOR_REASONS &&
+        return _INDEL_FRONTIER_PROBE_REJECTION_CAUSES[reason]
     get(metric, :anchored, false) === true || return :unanchored
     if reason !== :complete
         return get(
@@ -3440,7 +3522,12 @@ function _record_indel_frontier_work!(
         metric::AbstractDict,
 )::Nothing
     frontier_work = get(metric, :frontier_work, nothing)
-    frontier_work isa Int && push!(works, frontier_work)
+    # `=== nothing` is the ONLY benign case (the `:encode_error` sentinel omits
+    # the field). Everything else is pushed unconverted, so a future widening of
+    # the metric's numeric type throws HERE rather than being silently dropped
+    # from the order statistics by an `isa Int` guard.
+    frontier_work === nothing && return nothing
+    push!(works, frontier_work)
     return nothing
 end
 
@@ -3458,7 +3545,10 @@ function _indel_frontier_work_summary(
         return Dict{Symbol, Int}(
             key => 0 for key in _INDEL_FRONTIER_WORK_SUMMARY_KEYS)
     end
-    sorted = sort(works)
+    # `works` is dead in every caller once the summary is built, so sort in
+    # place: this runs on a memory-gated path where a second full copy of the
+    # per-window vector is the largest avoidable allocation.
+    sorted = sort!(works)
     n = length(sorted)
     nearest_rank(quantile) = sorted[clamp(ceil(Int, quantile * n), 1, n)]
     return Dict{Symbol, Int}(
@@ -3922,9 +4012,17 @@ function _evaluate_indel_frontier_schedule_impl(
             out_of_memory || rethrow()
             cleaned_graph = nothing
             cleaned_weighted_graph = nothing
-            empty!(cleaned_metrics)
-            empty!(cleaned_causes)
-            empty!(cleaned_works)
+            # Resetting the diagnostics is LOAD-BEARING, not hygiene: the
+            # per-window loop above already recorded one cause and one work
+            # value for every window it probed before the throw, while this
+            # branch reports `cleaned_evaluated = 0`. Leaving either container
+            # populated would publish a histogram that cannot sum to its
+            # evaluated counter. Rebind rather than `empty!` -- this is the one
+            # path whose PURPOSE is releasing memory, and `empty!` retains the
+            # buffer's capacity.
+            cleaned_metrics = Dict{Symbol, Any}[]
+            cleaned_causes = Dict{Symbol, Int}()
+            cleaned_works = Int[]
             cleaned_evaluated = 0
             fill!(cleaned_admitted, false)
             for (candidate_index, (read_index, window)) in enumerate(candidates)
@@ -4838,7 +4936,7 @@ thread-safe under parallel decode: each read/window's staged contributions are
 captured and folded into this accumulator in read×window order after the
 `Threads.@threads` loop, byte-identical to serial.
 
-`cheap_correct` (td-bjnt): when `true` (and `graph_mode==:canonical`), run the
+`cheap_correct` (td-bjnt): when `true` (and `graph_mode != :singlestrand`), run the
 Stage 0 k-mer-spectrum correction pass (`_stage0_cheap_correct`) over the read set
 BEFORE any gating/decode, cheaply fixing simple single-substitution errors with a
 linear scan so the expensive graph Viterbi is reserved for genuine ambiguity
@@ -5027,7 +5125,9 @@ function _improve_read_set_likelihood_impl(
     # Stage 0 CHEAP correction (td-bjnt): fix simple single-substitution errors
     # with a linear k-mer-spectrum scan BEFORE any gating/decode, so graph Viterbi
     # is reserved for genuine ambiguity. The decode below then runs on the
-    # cheaply-corrected reads. Gated on :scalable (cheap_correct=true, canonical).
+    # cheaply-corrected reads. Gated on :scalable (`cheap_correct=true`); the
+    # graph-mode condition is `!= :singlestrand`, which :doublestrand (:scalable)
+    # and :canonical both satisfy.
     cheap_corrections = 0
     work_reads = reads
     if cheap_correct && graph_mode != :singlestrand && solid_kmers !== nothing
@@ -7453,7 +7553,13 @@ end
 # FLOOR — an edge backed by >= `SOFT_EM_MIN_SUPPORT` reads is clamped to at least
 # its raw coverage, so a real but SKEWED minority allele (e.g. a 10x branch in a
 # 20x/10x bubble) NEVER decays toward zero regardless of a heavier sibling. Only
-# near-zero-support (error) edges are free to decay below the cleaning gate. This
+# near-zero-support (error) edges are free to decay toward zero. That decay does
+# NOT reach any cleaning predicate: `clean_corrector_graph!` gates on RAW vertex
+# evidence and never consults the soft weight (`evidence-functions.jl` states the
+# soft signal acts through `compute_edge_weight` / the Viterbi transition score
+# and warns against exactly this conflation). The mechanism is transition-score
+# decay -- the next decode routes AWAY from the decayed edge, so the graph
+# REBUILT from those decoded reads carries less support for it. This
 # fixes the prior v2's collapse of skewed variants (the responsibility split alone
 # gave `W_min' = N*W/(W_maj+W_min)`, a geometric decay to zero for any imbalance).
 

--- a/test/4_assembly/indel_frontier_probe_test.jl
+++ b/test/4_assembly/indel_frontier_probe_test.jl
@@ -1732,3 +1732,282 @@ Test.@testset "clean_corrector_graph! includes support-two tips" begin
     Test.@test !haskey(at_boundary, support_two_label)
     Test.@test haskey(at_boundary, support_three_label)
 end
+
+# ---------------------------------------------------------------------------
+# Rejection-cause diagnostics (td-jt7r). The scheduler only samples the first 64
+# per-window metrics per rung, so a rejection breakdown read off those samples is
+# a biased prefix. These tests pin the exact histograms and order statistics that
+# replace it, plus the pure classifier they are built from.
+# ---------------------------------------------------------------------------
+
+function indel_cause_metric(;
+        anchored::Bool = true,
+        reason::Symbol = :complete,
+        completed_columns::Int = 16,
+        window_length::Int = 16,
+        frontier_work::Int = 32,
+)::Dict{Symbol, Any}
+    return Dict{Symbol, Any}(
+        :anchored => anchored,
+        :reason => reason,
+        :completed_columns => completed_columns,
+        :window_length => window_length,
+        :frontier_work => frontier_work,
+    )
+end
+
+Test.@testset "Frontier rejection classifier mirrors the admission chain" begin
+    work_limit = Mycelia._DEFAULT_INDEL_FRONTIER_WORK_LIMIT
+
+    # One case per outcome, in the order of `_indel_frontier_admitted`'s `&&`
+    # chain: anchored -> reason == :complete -> completed_columns ==
+    # window_length -> frontier_work <= work_limit.
+    Test.@test Mycelia._indel_frontier_rejection_cause(
+        indel_cause_metric(), work_limit) == :admitted
+    Test.@test Mycelia._indel_frontier_rejection_cause(
+        indel_cause_metric(
+            anchored = false,
+            reason = :unanchored_start,
+            completed_columns = 0,
+            frontier_work = 0,
+        ),
+        work_limit,
+    ) == :unanchored
+    Test.@test Mycelia._indel_frontier_rejection_cause(
+        indel_cause_metric(
+            reason = :work_limit,
+            completed_columns = 3,
+            frontier_work = work_limit + 1,
+        ),
+        work_limit,
+    ) == :probe_work_limit
+    Test.@test Mycelia._indel_frontier_rejection_cause(
+        indel_cause_metric(reason = :frontier_exhausted, completed_columns = 3),
+        work_limit,
+    ) == :probe_frontier_exhausted
+    Test.@test Mycelia._indel_frontier_rejection_cause(
+        Dict{Symbol, Any}(:anchored => false, :reason => :encode_error),
+        work_limit,
+    ) == :probe_encode_error
+    Test.@test Mycelia._indel_frontier_rejection_cause(
+        indel_cause_metric(completed_columns = 3), work_limit) ==
+               :partial_columns
+    Test.@test Mycelia._indel_frontier_rejection_cause(
+        indel_cause_metric(frontier_work = work_limit + 1), work_limit) ==
+               :work_limit_exceeded
+
+    # Short-circuit priority: an earlier failing conjunct wins outright, so a
+    # window that is simultaneously unanchored, incomplete and over budget is
+    # attributed to the anchor, which is what actually rejected it.
+    Test.@test Mycelia._indel_frontier_rejection_cause(
+        indel_cause_metric(
+            anchored = false,
+            reason = :work_limit,
+            completed_columns = 0,
+            frontier_work = work_limit + 1,
+        ),
+        work_limit,
+    ) == :unanchored
+    Test.@test Mycelia._indel_frontier_rejection_cause(
+        indel_cause_metric(
+            reason = :frontier_exhausted,
+            completed_columns = 3,
+            frontier_work = work_limit + 1,
+        ),
+        work_limit,
+    ) == :probe_frontier_exhausted
+    Test.@test Mycelia._indel_frontier_rejection_cause(
+        indel_cause_metric(
+            completed_columns = 3, frontier_work = work_limit + 1),
+        work_limit,
+    ) == :partial_columns
+
+    # `:encode_error` is a harness sentinel whose `anchored = false` is synthetic
+    # (the probe never ran), so it must NOT be absorbed into `:unanchored`.
+    Test.@test Mycelia._indel_frontier_rejection_cause(
+        Dict{Symbol, Any}(:anchored => false, :reason => :encode_error),
+        work_limit,
+    ) != :unanchored
+
+    # The classifier agrees with the predicate it mirrors, so the histogram
+    # reconciles with the admission counters rather than merely resembling them.
+    for metric in (
+            indel_cause_metric(),
+            indel_cause_metric(completed_columns = 3),
+            indel_cause_metric(frontier_work = work_limit + 1),
+            indel_cause_metric(anchored = false, reason = :unanchored_start),
+    )
+        admitted = metric[:anchored] && metric[:reason] == :complete &&
+                   metric[:completed_columns] == metric[:window_length] &&
+                   metric[:frontier_work] <= work_limit
+        Test.@test (Mycelia._indel_frontier_rejection_cause(
+            metric, work_limit) == :admitted) == admitted
+    end
+
+    # Every emitted cause is in the persisted taxonomy, and an unknown probe
+    # reason degrades to `:probe_unknown` instead of silently mapping onto a
+    # real bucket.
+    Test.@test Mycelia._indel_frontier_rejection_cause(
+        indel_cause_metric(reason = :not_a_real_reason), work_limit) ==
+               :probe_unknown
+    for cause in (
+            :admitted,
+            :unanchored,
+            :probe_work_limit,
+            :probe_frontier_exhausted,
+            :probe_encode_error,
+            :partial_columns,
+            :work_limit_exceeded,
+            :probe_unknown,
+    )
+        Test.@test cause in Mycelia._INDEL_FRONTIER_REJECTION_CAUSES
+    end
+end
+
+Test.@testset "Frontier work summary reports exact order statistics" begin
+    empty_summary = Mycelia._indel_frontier_work_summary(Int[])
+    Test.@test Base.Set(Base.keys(empty_summary)) ==
+               Base.Set(Mycelia._INDEL_FRONTIER_WORK_SUMMARY_KEYS)
+    Test.@test Base.all(value == 0 for value in Base.values(empty_summary))
+
+    summary = Mycelia._indel_frontier_work_summary(Base.collect(1:100))
+    Test.@test summary[:count] == 100
+    Test.@test summary[:min] == 1
+    Test.@test summary[:p50] == 50
+    Test.@test summary[:p90] == 90
+    Test.@test summary[:p99] == 99
+    Test.@test summary[:max] == 100
+
+    # Nearest-rank returns observed samples, so monotonicity is structural and
+    # the statistics survive an unsorted input unchanged.
+    shuffled = Mycelia._indel_frontier_work_summary([7, 1, 9, 3, 5])
+    Test.@test shuffled == Mycelia._indel_frontier_work_summary([1, 3, 5, 7, 9])
+    Test.@test shuffled[:min] <= shuffled[:p50] <= shuffled[:p90] <=
+               shuffled[:p99] <= shuffled[:max]
+    singleton = Mycelia._indel_frontier_work_summary([42])
+    Test.@test Base.all(
+        singleton[key] == 42
+        for key in (:min, :p50, :p90, :p99, :max)
+    )
+    Test.@test singleton[:count] == 1
+
+    # Profile-disabled rungs (Illumina) carry the containers but never populate
+    # them, so nothing downstream has to special-case a missing field.
+    for profile_requested in (false, true)
+        telemetry = Mycelia._empty_indel_rung_telemetry(profile_requested)
+        for key in (
+                :raw_frontier_rejection_causes,
+                :cleaned_frontier_rejection_causes,
+                :raw_frontier_work_summary,
+                :cleaned_frontier_work_summary,
+        )
+            Test.@test Base.haskey(telemetry, key)
+            Test.@test Base.isempty(telemetry[key])
+        end
+    end
+end
+
+Test.@testset "Frontier rejection histograms are exact, not sampled" begin
+    work_limit = Mycelia._DEFAULT_INDEL_FRONTIER_WORK_LIMIT
+
+    # Maximally-branching 64-vertex DNA k=3 graph: the probe aborts on the work
+    # budget, so the modal cause must be the probe-side `:work_limit` abort.
+    alphabet = Base.collect("ACGT")
+    branch_records = FASTX.FASTQ.Record[]
+    for a in alphabet, b in alphabet, c in alphabet, d in alphabet
+        sequence = Base.string(a, b, c, d)
+        Base.push!(
+            branch_records,
+            indel_classifier_fastq(
+                "cause_branch_$(Base.length(branch_records) + 1)", sequence),
+        )
+    end
+    branch_graph = Mycelia.Rhizomorph.build_qualmer_graph(
+        branch_records, 3; mode = :singlestrand)
+    branch_cycle = indel_classifier_de_bruijn_sequence(3)
+    branch_sequence = Base.first(
+        Base.repeat(branch_cycle, Base.cld(500, Base.length(branch_cycle))), 500)
+    branch_read = indel_classifier_fastq("cause_branch_probe", branch_sequence)
+    Test.@test Graphs.nv(branch_graph.graph) == 64
+
+    branch_decision = Mycelia._evaluate_indel_frontier_schedule(
+        FASTX.FASTQ.Record[branch_read],
+        branch_graph,
+        3,
+        Base.Set(MetaGraphsNext.labels(branch_graph)),
+        Bool[false],
+        indel_classifier_params(),
+        :singlestrand,
+    )
+    Test.@test branch_decision.admitted_windows == 0
+    Test.@test branch_decision.rejected_windows > 0
+    Test.@test branch_decision.raw_causes[:probe_work_limit] > 0
+    Test.@test Base.sum(Base.values(branch_decision.raw_causes)) ==
+               branch_decision.raw_evaluated
+    Test.@test Base.get(branch_decision.raw_causes, :admitted, 0) == 0
+    Test.@test Base.sum(Base.values(branch_decision.cleaned_causes)) ==
+               branch_decision.cleaned_evaluated
+    Test.@test Base.all(
+        cause in Mycelia._INDEL_FRONTIER_REJECTION_CAUSES
+        for cause in Base.keys(branch_decision.raw_causes)
+    )
+    # The scheduler's own budget is the binding constraint here, which is only
+    # visible because the statistics are exact rather than prefix-sampled.
+    Test.@test branch_decision.raw_work_summary[:count] ==
+               branch_decision.raw_evaluated
+    Test.@test branch_decision.raw_work_summary[:max] > work_limit
+
+    # Long linear graph: every window is affordable, so `:admitted` dominates and
+    # no observed `frontier_work` may exceed the budget. The read set is sized to
+    # produce MORE windows than `_INDEL_FRONTIER_TELEMETRY_SAMPLE_LIMIT`, which is
+    # the regime a prefix-sampled breakdown could not describe.
+    linear_cycle = indel_classifier_de_bruijn_sequence(7)
+    linear_sequence = Base.first(linear_cycle, 10_007)
+    linear_reference = indel_classifier_fastq("cause_linear", linear_sequence)
+    linear_graph = Mycelia.Rhizomorph.build_qualmer_graph(
+        FASTX.FASTQ.Record[linear_reference], 7; mode = :singlestrand)
+    linear_reads = FASTX.FASTQ.Record[
+        indel_classifier_fastq(
+            "cause_linear_$(offset)",
+            linear_sequence[offset:(offset + 299)],
+        )
+        for offset in 1:100:7_001
+    ]
+    linear_decision = Mycelia._evaluate_indel_frontier_schedule(
+        linear_reads,
+        linear_graph,
+        7,
+        Base.Set(MetaGraphsNext.labels(linear_graph)),
+        Base.fill(false, Base.length(linear_reads)),
+        indel_classifier_params(),
+        :singlestrand,
+    )
+    Test.@test linear_decision.admitted
+    Test.@test linear_decision.rejected_windows == 0
+    Test.@test linear_decision.cleaned_evaluated == 0
+    Test.@test linear_decision.raw_causes[:admitted] ==
+               linear_decision.admitted_windows
+    Test.@test Base.length(linear_decision.raw_causes) == 1
+    Test.@test Base.sum(Base.values(linear_decision.raw_causes)) ==
+               linear_decision.raw_evaluated
+    # With no cleaning pass, every requested window is classified exactly once.
+    Test.@test Base.sum(Base.values(linear_decision.raw_causes)) ==
+               linear_decision.admitted_windows +
+               linear_decision.rejected_windows
+    Test.@test Base.isempty(linear_decision.cleaned_causes)
+
+    linear_summary = linear_decision.raw_work_summary
+    Test.@test linear_summary[:count] == linear_decision.raw_evaluated
+    Test.@test linear_summary[:max] <= work_limit
+    Test.@test linear_summary[:min] <= linear_summary[:p50] <=
+               linear_summary[:p90] <= linear_summary[:p99] <=
+               linear_summary[:max]
+
+    # The histogram is exact even when the rung produces more windows than the
+    # 64-sample metric cap, which is precisely the regime the sampled breakdown
+    # could not describe.
+    Test.@test linear_decision.raw_evaluated >
+               Mycelia._INDEL_FRONTIER_TELEMETRY_SAMPLE_LIMIT
+    Test.@test Base.length(linear_decision.raw_metrics) ==
+               Mycelia._INDEL_FRONTIER_TELEMETRY_SAMPLE_LIMIT
+end

--- a/test/4_assembly/indel_frontier_probe_test.jl
+++ b/test/4_assembly/indel_frontier_probe_test.jl
@@ -13,6 +13,47 @@ import Test
 
 const INDEL_FRONTIER_TASK_WAIT_SECONDS = 5.0
 
+# Assert the classifier's `:admitted` verdict against the REAL predicate's
+# verdict, which `_evaluate_indel_frontier_schedule_impl` already stamps into
+# every sampled metric as `metric[:admitted]` (`_indel_frontier_admitted`'s
+# return value). Checking live scheduler output rather than a re-implementation
+# of the conjunction is the point: a private copy of the predicate drifts in
+# lockstep with the original and can never fail.
+function indel_assert_cause_matches_admission(decision, work_limit::Int)::Int
+    checked = 0
+    for metrics in (decision.raw_metrics, decision.cleaned_metrics)
+        for metric in metrics
+            Test.@test (Mycelia._indel_frontier_rejection_cause(
+                metric, work_limit) == :admitted) == metric[:admitted]
+            # `:complete` already implies both remaining conjuncts, so a real
+            # probe can never produce these two buckets. Their appearance would
+            # signal a broken probe-kernel invariant, not an ordinary rejection.
+            Test.@test Mycelia._indel_frontier_rejection_cause(
+                metric, work_limit) != :partial_columns
+            Test.@test Mycelia._indel_frontier_rejection_cause(
+                metric, work_limit) != :work_limit_exceeded
+            checked += 1
+        end
+    end
+    return checked
+end
+
+# The OOM recovery path must leave NOTHING behind in the cleaned diagnostics:
+# the tuple it returns reports `cleaned_evaluated = 0`, so a surviving cause or
+# work value would publish a histogram that cannot sum to its own counter.
+function indel_assert_cleaned_diagnostics_reset(decision)::Nothing
+    Test.@test decision.cleaned_evaluated == 0
+    Test.@test Base.isempty(decision.cleaned_metrics)
+    Test.@test Base.isempty(decision.cleaned_causes)
+    Test.@test Base.sum(Base.values(decision.cleaned_causes)) ==
+               decision.cleaned_evaluated
+    Test.@test decision.cleaned_work_summary ==
+               Mycelia._indel_frontier_work_summary(Int[])
+    Test.@test decision.cleaned_work_summary[:count] ==
+               decision.cleaned_evaluated
+    return nothing
+end
+
 function indel_frontier_test_throws_message(
         callable::F,
         exception_type::Type{E},
@@ -1587,6 +1628,24 @@ Test.@testset "Private cleaning rescues a rejected frontier" begin
     Test.@test decision.cleaned_graph !== nothing
     Test.@test decision.cleaned_weighted_graph !== nothing
 
+    # This fixture is the ONLY one with a populated cleaned histogram beside a
+    # non-zero `cleaned_evaluated`. Everywhere else `cleaned_causes` is empty and
+    # `sum(values(causes)) == cleaned_evaluated` reduces to `0 == 0`, which an
+    # entirely missing recording call would also satisfy. Pinning both sides here
+    # is what actually covers `_record_indel_frontier_cause!` on the cleaned pass.
+    Test.@test decision.raw_evaluated == 1
+    Test.@test decision.raw_causes == Dict(:probe_work_limit => 1)
+    Test.@test decision.cleaned_evaluated == 1
+    Test.@test !Base.isempty(decision.cleaned_causes)
+    Test.@test decision.cleaned_causes == Dict(:admitted => 1)
+    Test.@test Base.sum(Base.values(decision.cleaned_causes)) ==
+               decision.cleaned_evaluated
+    Test.@test decision.raw_work_summary[:count] == decision.raw_evaluated
+    Test.@test decision.cleaned_work_summary[:count] ==
+               decision.cleaned_evaluated
+    Test.@test decision.cleaned_work_summary[:max] <= work_limit
+    indel_assert_cause_matches_admission(decision, work_limit)
+
     decoded = Mycelia.correct_observations(
         decision.cleaned_graph,
         [observations];
@@ -1629,6 +1688,7 @@ Test.@testset "Private cleaning rescues a rejected frontier" begin
                "out_of_memory"
     Test.@test cleaning_oom_decision.cleanup["graph_cleanup_error_type"] ==
                "OutOfMemoryError"
+    indel_assert_cleaned_diagnostics_reset(cleaning_oom_decision)
 
     # The same fixture is raw-rejected but cleaning-admitted. A throwing builder
     # therefore reaches the cleaned-weighted allocation, not the raw or pass-level
@@ -1657,6 +1717,15 @@ Test.@testset "Private cleaning rescues a rejected frontier" begin
                "out_of_memory"
     Test.@test cleaned_oom_decision.cleanup["graph_cleanup_error_type"] ==
                "OutOfMemoryError"
+    # The throw happens in `weighted_graph_builder(cleaned_graph)`, i.e. AFTER
+    # the per-window cleaning loop has already recorded a cause and a work value
+    # for this fixture's single window. Without the reset in the OOM handler the
+    # returned tuple would publish a populated `cleaned_causes` beside
+    # `cleaned_evaluated = 0` -- a histogram that cannot sum to its own counter.
+    # These assertions are what make that reset load-bearing rather than
+    # decorative: the pre-existing checks below only look at the graphs, the
+    # window sources and two cleanup strings.
+    indel_assert_cleaned_diagnostics_reset(cleaned_oom_decision)
 
     # Scheduler cleanup operated only on its private graph.
     Test.@test Set(MetaGraphsNext.labels(raw_graph)) == raw_labels_before
@@ -1831,18 +1900,78 @@ Test.@testset "Frontier rejection classifier mirrors the admission chain" begin
 
     # The classifier agrees with the predicate it mirrors, so the histogram
     # reconciles with the admission counters rather than merely resembling them.
+    # `_indel_frontier_admitted` is called directly here -- NOT re-implemented --
+    # so adding, removing or reordering a conjunct in it breaks this loop. The
+    # two functions differ only in access style (`metrics.anchored` vs the
+    # metric dictionary the classifier consumes), so the NamedTuple below is a
+    # representation shim, not a second copy of the rule.
     for metric in (
             indel_cause_metric(),
             indel_cause_metric(completed_columns = 3),
             indel_cause_metric(frontier_work = work_limit + 1),
             indel_cause_metric(anchored = false, reason = :unanchored_start),
+            indel_cause_metric(reason = :frontier_exhausted),
+            indel_cause_metric(reason = :no_start_state),
     )
-        admitted = metric[:anchored] && metric[:reason] == :complete &&
-                   metric[:completed_columns] == metric[:window_length] &&
-                   metric[:frontier_work] <= work_limit
         Test.@test (Mycelia._indel_frontier_rejection_cause(
-            metric, work_limit) == :admitted) == admitted
+            metric, work_limit) == :admitted) ==
+                   Mycelia._indel_frontier_admitted((; metric...), work_limit)
     end
+
+    # Extending the pre-anchor set must not disturb the equivalence either: all
+    # three pre-anchor reasons carry `anchored = false`, so the real predicate
+    # rejects them and the classifier must never answer `:admitted`.
+    for reason in (:empty_graph, :empty_observation, :unanchored_start)
+        metric = indel_cause_metric(
+            anchored = false,
+            reason = reason,
+            completed_columns = 0,
+            frontier_work = 0,
+        )
+        Test.@test !Mycelia._indel_frontier_admitted((; metric...), work_limit)
+        Test.@test Mycelia._indel_frontier_rejection_cause(
+            metric, work_limit) != :admitted
+    end
+
+    # `:unanchored` is a LITERAL anchor finding, not a union bucket. Three probe
+    # reasons besides `:unanchored_start` carry `anchored = false`
+    # (`viterbi-next.jl` returns `:empty_graph` and `:empty_observation` from
+    # structural pre-checks before the start-vertex lookup, and
+    # `_probe_indel_window_metric` synthesizes `:encode_error`), so each is
+    # classified ahead of the anchor conjunct and keeps its own bucket.
+    for (reason, cause) in (
+            (:encode_error, :probe_encode_error),
+            (:empty_graph, :probe_empty_graph),
+            (:empty_observation, :probe_empty_observation),
+    )
+        Test.@test Mycelia._indel_frontier_rejection_cause(
+            indel_cause_metric(
+                anchored = false,
+                reason = reason,
+                completed_columns = 0,
+                frontier_work = 0,
+            ),
+            work_limit,
+        ) == cause
+        Test.@test reason in Mycelia._INDEL_FRONTIER_PRE_ANCHOR_REASONS
+    end
+    Test.@test Mycelia._indel_frontier_rejection_cause(
+        indel_cause_metric(
+            anchored = false,
+            reason = :unanchored_start,
+            completed_columns = 0,
+            frontier_work = 0,
+        ),
+        work_limit,
+    ) == :unanchored
+    Test.@test !(:unanchored_start in
+                 Mycelia._INDEL_FRONTIER_PRE_ANCHOR_REASONS)
+    # `:no_start_state` is the one probe reason that carries `anchored = true`,
+    # so it must survive as its own bucket rather than collapsing either way.
+    Test.@test Mycelia._indel_frontier_rejection_cause(
+        indel_cause_metric(reason = :no_start_state, completed_columns = 0),
+        work_limit,
+    ) == :probe_no_start_state
 
     # Every emitted cause is in the persisted taxonomy, and an unknown probe
     # reason degrades to `:probe_unknown` instead of silently mapping onto a
@@ -1850,18 +1979,38 @@ Test.@testset "Frontier rejection classifier mirrors the admission chain" begin
     Test.@test Mycelia._indel_frontier_rejection_cause(
         indel_cause_metric(reason = :not_a_real_reason), work_limit) ==
                :probe_unknown
-    for cause in (
-            :admitted,
-            :unanchored,
-            :probe_work_limit,
-            :probe_frontier_exhausted,
-            :probe_encode_error,
-            :partial_columns,
-            :work_limit_exceeded,
-            :probe_unknown,
-    )
+    # Every member of the persisted taxonomy, not a subset: the previous list
+    # covered 8 of 12 and happened to omit exactly the four the anchor bucket
+    # was hiding.
+    expected_causes = Base.Set{Symbol}((
+        :admitted,
+        :unanchored,
+        :partial_columns,
+        :work_limit_exceeded,
+        :probe_unknown,
+        :probe_encode_error,
+        :probe_empty_graph,
+        :probe_empty_observation,
+        :probe_unanchored_start,
+        :probe_no_start_state,
+        :probe_work_limit,
+        :probe_frontier_exhausted,
+    ))
+    Test.@test Mycelia._INDEL_FRONTIER_REJECTION_CAUSES == expected_causes
+    Test.@test Base.length(Mycelia._INDEL_FRONTIER_REJECTION_CAUSES) == 12
+    for cause in expected_causes
         Test.@test cause in Mycelia._INDEL_FRONTIER_REJECTION_CAUSES
+        Test.@test Base.haskey(
+            Mycelia._INDEL_FRONTIER_REJECTION_CAUSE_NAMES, Base.string(cause))
     end
+    # `:probe_unanchored_start` is structurally unreachable: that reason is
+    # absorbed by `:unanchored`, which is the more informative name for it. It
+    # stays in the persisted taxonomy so a checkpoint written by a build that
+    # classified it differently still round-trips.
+    Test.@test Mycelia._indel_frontier_rejection_cause(
+        indel_cause_metric(reason = :unanchored_start, completed_columns = 3),
+        work_limit,
+    ) == :probe_unanchored_start
 end
 
 Test.@testset "Frontier work summary reports exact order statistics" begin
@@ -1898,11 +2047,21 @@ Test.@testset "Frontier work summary reports exact order statistics" begin
         for key in (
                 :raw_frontier_rejection_causes,
                 :cleaned_frontier_rejection_causes,
-                :raw_frontier_work_summary,
-                :cleaned_frontier_work_summary,
         )
             Test.@test Base.haskey(telemetry, key)
             Test.@test Base.isempty(telemetry[key])
+        end
+        # ONE "no work data" encoding. A profile-disabled rung and the
+        # `:no_candidate_windows` scheduler path must agree byte for byte, so
+        # `summary[:count]` is TOTAL over every producer rather than a
+        # `KeyError` on one shape and a `0` on the other.
+        for key in (:raw_frontier_work_summary, :cleaned_frontier_work_summary)
+            Test.@test Base.haskey(telemetry, key)
+            Test.@test telemetry[key] ==
+                       Mycelia._indel_frontier_work_summary(Int[])
+            Test.@test Base.Set(Base.keys(telemetry[key])) ==
+                       Base.Set(Mycelia._INDEL_FRONTIER_WORK_SUMMARY_KEYS)
+            Test.@test telemetry[key][:count] == 0
         end
     end
 end
@@ -1945,6 +2104,11 @@ Test.@testset "Frontier rejection histograms are exact, not sampled" begin
     Test.@test Base.sum(Base.values(branch_decision.raw_causes)) ==
                branch_decision.raw_evaluated
     Test.@test Base.get(branch_decision.raw_causes, :admitted, 0) == 0
+    # A NON-EMPTY cleaned histogram beside a NON-ZERO counter. Without these two
+    # the identity above is satisfied by `0 == 0`, i.e. by a collector that
+    # never ran at all.
+    Test.@test branch_decision.cleaned_evaluated > 0
+    Test.@test !Base.isempty(branch_decision.cleaned_causes)
     Test.@test Base.sum(Base.values(branch_decision.cleaned_causes)) ==
                branch_decision.cleaned_evaluated
     Test.@test Base.all(
@@ -1956,6 +2120,14 @@ Test.@testset "Frontier rejection histograms are exact, not sampled" begin
     Test.@test branch_decision.raw_work_summary[:count] ==
                branch_decision.raw_evaluated
     Test.@test branch_decision.raw_work_summary[:max] > work_limit
+    Test.@test branch_decision.raw_evaluated > 0
+    Test.@test !Base.isempty(branch_decision.raw_causes)
+    # The two defensive buckets are unreachable from a real probe (`:complete`
+    # already implies both conjuncts), so their presence would signal a broken
+    # probe-kernel invariant rather than an ordinary rejection.
+    Test.@test !Base.haskey(branch_decision.raw_causes, :partial_columns)
+    Test.@test !Base.haskey(branch_decision.raw_causes, :work_limit_exceeded)
+    indel_assert_cause_matches_admission(branch_decision, work_limit)
 
     # Long linear graph: every window is affordable, so `:admitted` dominates and
     # no observed `frontier_work` may exceed the budget. The read set is sized to
@@ -2010,4 +2182,80 @@ Test.@testset "Frontier rejection histograms are exact, not sampled" begin
                Mycelia._INDEL_FRONTIER_TELEMETRY_SAMPLE_LIMIT
     Test.@test Base.length(linear_decision.raw_metrics) ==
                Mycelia._INDEL_FRONTIER_TELEMETRY_SAMPLE_LIMIT
+    Test.@test !Base.haskey(linear_decision.raw_causes, :partial_columns)
+    Test.@test !Base.haskey(linear_decision.raw_causes, :work_limit_exceeded)
+    indel_assert_cause_matches_admission(linear_decision, work_limit)
+end
+
+Test.@testset "Weighted memory limit after a partial raw frontier" begin
+    # The SECOND `:weighted_graph_memory_limit` return site -- the one reached
+    # after the cleaning stage rather than the all-raw-admitted early return.
+    # Both tuples carry the four diagnostics fields; only the first site had a
+    # test. Reaching this one needs SOME (not all) raw windows admitted, which
+    # also makes it the only fixture whose raw histogram mixes `:admitted` with
+    # a rejection bucket.
+    k = 7
+    sequence = Base.first(indel_classifier_de_bruijn_sequence(k), 400)
+    reads = FASTX.FASTQ.Record[
+        indel_classifier_fastq("partial_long", Base.first(sequence, 200)),
+        indel_classifier_fastq("partial_short", Base.first(sequence, 40)),
+    ]
+    graph = Mycelia.Rhizomorph.build_qualmer_graph(
+        reads, k; mode = :singlestrand)
+    hard = Base.Set(MetaGraphsNext.labels(graph))
+    skip_flags = Base.fill(false, Base.length(reads))
+
+    # Calibrate against measured frontier work so the budget rejects exactly the
+    # costliest window and admits the rest.
+    calibration = Mycelia._evaluate_indel_frontier_schedule(
+        reads, graph, k, hard, skip_flags,
+        indel_classifier_params(), :singlestrand)
+    works = Base.sort(
+        Int[metric[:frontier_work] for metric in calibration.raw_metrics])
+    Test.@test Base.length(works) >= 2
+    Test.@test works[Base.length(works) - 1] < works[Base.length(works)]
+    work_limit = works[Base.length(works) - 1]
+
+    graph_bytes = Mycelia._indel_graph_memory_bytes(graph)
+    decision = Mycelia._evaluate_indel_frontier_schedule(
+        reads, graph, k, hard, skip_flags,
+        indel_classifier_params(), :singlestrand;
+        work_limit = work_limit,
+        memory_limit = 2 * graph_bytes - 1,
+    )
+
+    Test.@test !decision.admitted
+    Test.@test decision.decision_reason == :weighted_graph_memory_limit
+    Test.@test decision.graph_source == :substitution
+    Test.@test decision.raw_weighted_graph === nothing
+    Test.@test decision.cleaned_graph === nothing
+    Test.@test decision.admitted_windows == 0
+    Test.@test decision.rejected_windows == decision.requested
+    Test.@test decision.cleanup["graph_cleanup_status"] ==
+               "skipped_weighted_memory_limit"
+    Test.@test decision.cleanup["projected_graph_variants"] == 2
+
+    # The four diagnostics fields on THIS tuple. The raw histogram reports what
+    # the frontier actually found (a mix), even though the tuple forces
+    # `admitted_windows = 0` because the weighted copy could not be allocated.
+    Test.@test decision.raw_evaluated == Base.length(works)
+    Test.@test Base.sum(Base.values(decision.raw_causes)) ==
+               decision.raw_evaluated
+    Test.@test decision.raw_causes[:admitted] == Base.length(works) - 1
+    Test.@test decision.raw_causes[:probe_work_limit] == 1
+    Test.@test !Base.haskey(decision.raw_causes, :partial_columns)
+    Test.@test !Base.haskey(decision.raw_causes, :work_limit_exceeded)
+    Test.@test decision.raw_work_summary[:count] == decision.raw_evaluated
+    Test.@test decision.raw_work_summary[:min] <=
+               decision.raw_work_summary[:p50] <=
+               decision.raw_work_summary[:p90] <=
+               decision.raw_work_summary[:p99] <=
+               decision.raw_work_summary[:max]
+    # The same limit skipped the cleaning stage, so the cleaned pair is at its
+    # zero-filled default rather than absent.
+    Test.@test decision.cleaned_evaluated == 0
+    Test.@test Base.isempty(decision.cleaned_causes)
+    Test.@test decision.cleaned_work_summary ==
+               Mycelia._indel_frontier_work_summary(Int[])
+    indel_assert_cause_matches_admission(decision, work_limit)
 end

--- a/test/4_assembly/iterative_checkpoint_resume_test.jl
+++ b/test/4_assembly/iterative_checkpoint_resume_test.jl
@@ -339,6 +339,16 @@ Test.@testset "Schema-v2 resumes nonzero frontier telemetry exactly" begin
             Base.deepcopy(template_metric) for _ in 1:64
         ]
         truncated_sample_row["cleaned_frontier_metrics"] = Any[]
+        # This row is derived from a REAL on-disk checkpoint and then overrides
+        # the evaluated counters to a synthetic 65 to exercise the sample cap.
+        # The inherited cause histogram describes the real run, so it must be
+        # restated to match, exactly as the sample vector above already is --
+        # the normalizer now cross-checks a populated histogram against its
+        # counter.
+        truncated_sample_row["raw_frontier_rejection_causes"] =
+            Dict{String, Any}("probe_work_limit" => 65)
+        truncated_sample_row["cleaned_frontier_rejection_causes"] =
+            Dict{String, Any}()
         normalized_truncated_sample = Mycelia._normalize_indel_rung_telemetry(
             truncated_sample_row, true)
         Test.@test normalized_truncated_sample[:raw_frontier_evaluated] == 65
@@ -353,6 +363,10 @@ Test.@testset "Schema-v2 resumes nonzero frontier telemetry exactly" begin
         independent_samples_row["cleaned_frontier_metrics"] = Any[
             Base.deepcopy(template_metric) for _ in 1:64
         ]
+        independent_samples_row["raw_frontier_rejection_causes"] =
+            Dict{String, Any}("probe_work_limit" => 64)
+        independent_samples_row["cleaned_frontier_rejection_causes"] =
+            Dict{String, Any}("probe_work_limit" => 64)
         normalized_independent_samples =
             Mycelia._normalize_indel_rung_telemetry(
                 independent_samples_row, true)
@@ -403,6 +417,10 @@ Test.@testset "Schema-v2 resumes nonzero frontier telemetry exactly" begin
             maximum_span_metric,
         ]
         boundary_row["cleaned_frontier_metrics"] = Any[]
+        boundary_row["raw_frontier_rejection_causes"] =
+            Dict{String, Any}("admitted" => 2)
+        boundary_row["cleaned_frontier_rejection_causes"] =
+            Dict{String, Any}()
         normalized_boundaries = Mycelia._normalize_indel_rung_telemetry(
             boundary_row, true)
         Test.@test Base.first(normalized_boundaries[:raw_frontier_metrics])[
@@ -2014,8 +2032,57 @@ Test.@testset "Populated cleaned frontier metrics survive a v2 round trip" begin
     end
     legacy_normalized = checkpoint_cause_roundtrip(legacy_row)
     Test.@test Base.isempty(legacy_normalized[:raw_frontier_rejection_causes])
-    Test.@test Base.isempty(legacy_normalized[:raw_frontier_work_summary])
+    Test.@test Base.isempty(
+        legacy_normalized[:cleaned_frontier_rejection_causes])
+    # The work summaries default to the ZERO-FILLED six-key form, not an empty
+    # object: one "no work data" encoding across every producer and every
+    # vintage of checkpoint, so `summary[:count]` is total.
+    Test.@test legacy_normalized[:raw_frontier_work_summary] ==
+               Mycelia._indel_frontier_work_summary(Int[])
+    Test.@test legacy_normalized[:cleaned_frontier_work_summary] ==
+               Mycelia._indel_frontier_work_summary(Int[])
+    Test.@test legacy_normalized[:raw_frontier_work_summary][:count] == 0
     Test.@test Base.length(legacy_normalized[:cleaned_frontier_metrics]) == 2
+
+    # The FROZEN required-key set is a wire contract, so pin its exact content
+    # rather than two sampled memberships: a silent deletion from the literal
+    # would otherwise relax a mandatory field with nothing failing.
+    Test.@test Mycelia._CHECKPOINT_REQUIRED_INDEL_TELEMETRY_KEYS ==
+               Base.Set{Symbol}((
+        :profile_requested,
+        :requested,
+        :attempted,
+        :completed,
+        :truncated,
+        :engaged,
+        :admitted,
+        :admitted_windows,
+        :rejected_windows,
+        :graph_source,
+        :decision_reason,
+        :frontier_work_limit,
+        :frontier_metric_sample_limit,
+        :raw_frontier_evaluated,
+        :cleaned_frontier_evaluated,
+        :bounded_windowing_forced,
+        :substitution_decode_memory_gated,
+        :raw_frontier_metrics,
+        :cleaned_frontier_metrics,
+        :graph_cleanup,
+        :ladder_index,
+        :k,
+        :iteration,
+    ))
+    Test.@test Base.length(
+        Mycelia._CHECKPOINT_REQUIRED_INDEL_TELEMETRY_KEYS) == 23
+    Test.@test Mycelia._CHECKPOINT_REQUIRED_INDEL_TELEMETRY_KEYS ⊆
+               Base.Set(Base.values(Mycelia._CHECKPOINT_INDEL_TELEMETRY_KEYS))
+
+    # Normalization is a fixed point: feeding a normalized row back through the
+    # normalizer must change nothing, so no check silently rewrites a value it
+    # then accepts on the second pass.
+    idempotent = Mycelia._normalize_indel_rung_telemetry(normalized, true)
+    Test.@test idempotent == normalized
 end
 
 Test.@testset "Inconsistent frontier diagnostics are rejected" begin
@@ -2089,6 +2156,62 @@ Test.@testset "Inconsistent frontier diagnostics are rejected" begin
         checkpoint_cause_roundtrip(partial_summary)
     end
 
+    # A zero `count` beside non-zero statistics passes taxonomy, nonnegativity,
+    # completeness AND monotonicity, so it reaches the count branch -- the one
+    # validator branch nothing else exercises.
+    zero_count_summary = checkpoint_cause_row()
+    zero_count_summary["raw_frontier_work_summary"] = Dict{String, Any}(
+        "count" => 0,
+        "min" => 5,
+        "p50" => 5,
+        "p90" => 5,
+        "p99" => 5,
+        "max" => 5,
+    )
+    checkpoint_test_error(
+        ArgumentError, "zero count requires zero statistics") do
+        checkpoint_cause_roundtrip(zero_count_summary)
+    end
+
+    # NEGATIVE for the exactness cross-check: a populated histogram whose counts
+    # no longer sum to the counter it breaks down. Every intra-field check
+    # (taxonomy, nonnegative exact `Int`, no repeats) still passes, so this is
+    # the only thing standing between the histogram and a silently wrong
+    # breakdown. Both sides are covered because they are validated independently.
+    raw_sum_mismatch = checkpoint_cause_row()
+    raw_sum_mismatch["raw_frontier_rejection_causes"] = Dict{String, Any}(
+        "admitted" => 1,
+        "probe_work_limit" => 1,
+    )
+    checkpoint_test_error(
+        ArgumentError,
+        "raw_frontier_rejection_causes sums to 2, which does not match " *
+        "raw_frontier_evaluated=3",
+    ) do
+        checkpoint_cause_roundtrip(raw_sum_mismatch)
+    end
+
+    cleaned_sum_mismatch = checkpoint_cause_row()
+    cleaned_sum_mismatch["cleaned_frontier_rejection_causes"] =
+        Dict{String, Any}("admitted" => 1, "probe_work_limit" => 5)
+    checkpoint_test_error(
+        ArgumentError,
+        "cleaned_frontier_rejection_causes sums to 6, which does not match " *
+        "cleaned_frontier_evaluated=2",
+    ) do
+        checkpoint_cause_roundtrip(cleaned_sum_mismatch)
+    end
+
+    # The exemption is emptiness, NOT absence-of-checking: a row that omits the
+    # histogram entirely still normalizes even though its counters are non-zero,
+    # because a pre-diagnostics checkpoint is indistinguishable from it at the
+    # wire level. That is the deliberate limit of the cross-check above.
+    exempt_row = checkpoint_cause_row()
+    exempt_row["raw_frontier_rejection_causes"] = Dict{String, Any}()
+    exempt_row["cleaned_frontier_rejection_causes"] = Dict{String, Any}()
+    exempt_normalized = checkpoint_cause_roundtrip(exempt_row)
+    Test.@test exempt_normalized[:raw_frontier_evaluated] == 3
+    Test.@test Base.isempty(exempt_normalized[:raw_frontier_rejection_causes])
 end
 
 Test.@testset "Frontier diagnostics reach the on-disk checkpoint" begin
@@ -2123,17 +2246,40 @@ Test.@testset "Frontier diagnostics reach the on-disk checkpoint" begin
                 cause in Mycelia._INDEL_FRONTIER_REJECTION_CAUSES
                 for cause in Base.keys(causes)
             )
-            # Raw-admitted windows are a subset of all admitted windows: a
-            # cleaned-graph rescue is counted in `admitted_windows` but appears
-            # in the CLEANED histogram, not the raw one.
-            Test.@test Base.get(causes, :admitted, 0) <= row[:admitted_windows]
+            # Raw- and cleaned-admitted windows are DISJOINT (the cleaning pass
+            # skips every raw-admitted candidate), so the two histograms
+            # PARTITION `admitted_windows` -- an identity, not a bound. A `<=`
+            # on the raw side alone is satisfied by `0`, i.e. by a collector
+            # that never recorded an admission.
+            cleaned_causes = row[:cleaned_frontier_rejection_causes]
+            if row[:decision_reason] in (
+                :weighted_graph_memory_limit,
+                :weighted_graph_out_of_memory,
+                :cleaning_out_of_memory,
+            )
+                # These three tuples force `admitted_windows = 0` while the
+                # histograms keep reporting what the frontier actually found, so
+                # not even `<=` holds on them.
+                Test.@test row[:admitted_windows] == 0
+            else
+                Test.@test Base.get(causes, :admitted, 0) +
+                           Base.get(cleaned_causes, :admitted, 0) ==
+                           row[:admitted_windows]
+            end
+            # `:encode_error` sentinels are the ONLY evaluated windows that
+            # carry no `frontier_work`, so the order-statistic count is exactly
+            # the evaluated count minus those. `<=` is satisfied by a count of
+            # zero, i.e. by a fully broken collector.
             summary = row[:raw_frontier_work_summary]
-            Test.@test summary[:count] <= row[:raw_frontier_evaluated]
+            Test.@test summary[:count] == row[:raw_frontier_evaluated] -
+                       Base.get(causes, :probe_encode_error, 0)
             Test.@test summary[:min] <= summary[:p50] <= summary[:p90] <=
                        summary[:p99] <= summary[:max]
-            Test.@test Base.sum(
-                Base.values(row[:cleaned_frontier_rejection_causes])) ==
+            Test.@test Base.sum(Base.values(cleaned_causes)) ==
                        row[:cleaned_frontier_evaluated]
+            Test.@test row[:cleaned_frontier_work_summary][:count] ==
+                       row[:cleaned_frontier_evaluated] -
+                       Base.get(cleaned_causes, :probe_encode_error, 0)
         end
 
         checkpoint_file = Base.joinpath(

--- a/test/4_assembly/iterative_checkpoint_resume_test.jl
+++ b/test/4_assembly/iterative_checkpoint_resume_test.jl
@@ -1846,3 +1846,310 @@ Test.@testset "Iterative checkpoint advances to the next rung once" begin
         ] == [(1, 3, 1), (2, 5, 1)]
     end
 end
+
+# ---------------------------------------------------------------------------
+# Rejection-cause diagnostics round-trip (td-jt7r). Covers the previously
+# untested POSITIVE case of a populated `cleaned_frontier_metrics` vector, and
+# pins the additive-field contract: the new histograms are accepted when
+# present, defaulted when absent, and rejected when internally inconsistent.
+# ---------------------------------------------------------------------------
+
+const CHECKPOINT_CAUSE_K = 5
+
+function checkpoint_cause_metric(
+        read_index::Int,
+        reason::AbstractString,
+)::Dict{String, Any}
+    admitted = reason == "complete"
+    completed_columns = admitted ? 16 : 4
+    frontier_area = admitted ? 32 : 400_000
+    peak_frontier = admitted ? 2 : 100_000
+    return Dict{String, Any}(
+        "anchored" => true,
+        "window_length" => 16,
+        "vertex_count" => 100,
+        "edge_count" => 100,
+        "branch_vertices" => 0,
+        "join_vertices" => 0,
+        "branch_fraction" => 0.0,
+        "join_fraction" => 0.0,
+        "max_out_degree" => 1,
+        "frontier_area" => frontier_area,
+        "edge_expansions" => 0,
+        "peak_frontier" => peak_frontier,
+        "completed_columns" => completed_columns,
+        "frontier_work" => frontier_area,
+        "reason" => reason,
+        "read_index" => read_index,
+        "window_start" => 1,
+        "window_stop" => 20,
+        "admitted" => admitted,
+    )
+end
+
+function checkpoint_cause_row()::Dict{String, Any}
+    return Dict{String, Any}(
+        "profile_requested" => true,
+        "requested" => 3,
+        "attempted" => 1,
+        "completed" => 1,
+        "truncated" => 0,
+        "engaged" => 1,
+        "admitted" => true,
+        "admitted_windows" => 1,
+        "rejected_windows" => 2,
+        "graph_source" => "mixed",
+        "decision_reason" => "sparse_frontier_affordable",
+        "frontier_work_limit" => Mycelia._DEFAULT_INDEL_FRONTIER_WORK_LIMIT,
+        "frontier_metric_sample_limit" =>
+            Mycelia._INDEL_FRONTIER_TELEMETRY_SAMPLE_LIMIT,
+        "raw_frontier_evaluated" => 3,
+        "cleaned_frontier_evaluated" => 2,
+        "bounded_windowing_forced" => true,
+        "substitution_decode_memory_gated" => false,
+        "raw_frontier_metrics" => Any[
+            checkpoint_cause_metric(1, "complete"),
+            checkpoint_cause_metric(2, "work_limit"),
+            checkpoint_cause_metric(3, "work_limit"),
+        ],
+        "cleaned_frontier_metrics" => Any[
+            checkpoint_cause_metric(2, "complete"),
+            checkpoint_cause_metric(3, "work_limit"),
+        ],
+        "raw_frontier_rejection_causes" => Dict{String, Any}(
+            "admitted" => 1,
+            "probe_work_limit" => 2,
+        ),
+        "cleaned_frontier_rejection_causes" => Dict{String, Any}(
+            "admitted" => 1,
+            "probe_work_limit" => 1,
+        ),
+        "raw_frontier_work_summary" => Dict{String, Any}(
+            "count" => 3,
+            "min" => 32,
+            "p50" => 400_000,
+            "p90" => 400_000,
+            "p99" => 400_000,
+            "max" => 400_000,
+        ),
+        "cleaned_frontier_work_summary" => Dict{String, Any}(
+            "count" => 2,
+            "min" => 32,
+            "p50" => 400_000,
+            "p90" => 400_000,
+            "p99" => 400_000,
+            "max" => 400_000,
+        ),
+        "graph_cleanup" => Dict{String, Any}(),
+        "ladder_index" => 1,
+        "k" => CHECKPOINT_CAUSE_K,
+        "iteration" => 1,
+    )
+end
+
+function checkpoint_cause_roundtrip(row::AbstractDict)::Dict{Symbol, Any}
+    # Exercise the real wire path: JSON stringifies symbol keys and widens
+    # integers, so normalization must accept the parsed shape, not the in-memory
+    # one.
+    parsed = JSON.parse(Base.sprint(io -> JSON.print(io, row)))
+    return Mycelia._normalize_indel_rung_telemetry(parsed, true)
+end
+
+Test.@testset "Populated cleaned frontier metrics survive a v2 round trip" begin
+    normalized = checkpoint_cause_roundtrip(checkpoint_cause_row())
+
+    Test.@test Base.length(normalized[:raw_frontier_metrics]) == 3
+    Test.@test Base.length(normalized[:cleaned_frontier_metrics]) == 2
+    Test.@test Base.first(normalized[:cleaned_frontier_metrics])[:reason] ==
+               :complete
+    Test.@test Base.first(normalized[:cleaned_frontier_metrics])[:admitted]
+    Test.@test Base.last(normalized[:cleaned_frontier_metrics])[:reason] ==
+               :work_limit
+    Test.@test !Base.last(normalized[:cleaned_frontier_metrics])[:admitted]
+    Test.@test Base.Set(
+        Base.keys(Base.first(normalized[:cleaned_frontier_metrics]))) ==
+               Mycelia._CHECKPOINT_REQUIRED_INDEL_METRIC_KEYS
+
+    Test.@test normalized[:raw_frontier_rejection_causes] ==
+               Dict{Symbol, Int}(:admitted => 1, :probe_work_limit => 2)
+    Test.@test normalized[:cleaned_frontier_rejection_causes] ==
+               Dict{Symbol, Int}(:admitted => 1, :probe_work_limit => 1)
+    # Exactness (one cause per evaluated window) is a PRODUCER invariant checked
+    # against live scheduler output, not something the normalizer re-derives; the
+    # round trip must preserve it byte for byte.
+    Test.@test Base.sum(
+        Base.values(normalized[:raw_frontier_rejection_causes])) ==
+               normalized[:raw_frontier_evaluated]
+    Test.@test Base.sum(
+        Base.values(normalized[:cleaned_frontier_rejection_causes])) ==
+               normalized[:cleaned_frontier_evaluated]
+    Test.@test normalized[:raw_frontier_work_summary][:count] == 3
+    Test.@test normalized[:raw_frontier_work_summary][:max] == 400_000
+    Test.@test normalized[:cleaned_frontier_work_summary][:count] == 2
+    for key in Base.keys(normalized[:raw_frontier_work_summary])
+        Test.@test key in Mycelia._INDEL_FRONTIER_WORK_SUMMARY_KEYS
+    end
+
+    # The diagnostics are ADDITIVE: a schema-v2 checkpoint written before they
+    # existed must still normalize, which is exactly what the frozen required-key
+    # set protects. If `_CHECKPOINT_REQUIRED_INDEL_TELEMETRY_KEYS` were derived
+    # from the accept-list again, this would fail on mandatory fields.
+    for key in (
+            :raw_frontier_rejection_causes,
+            :cleaned_frontier_rejection_causes,
+            :raw_frontier_work_summary,
+            :cleaned_frontier_work_summary,
+    )
+        Test.@test !(key in Mycelia._CHECKPOINT_REQUIRED_INDEL_TELEMETRY_KEYS)
+        Test.@test key in Base.values(Mycelia._CHECKPOINT_INDEL_TELEMETRY_KEYS)
+    end
+    legacy_row = checkpoint_cause_row()
+    for key in (
+            "raw_frontier_rejection_causes",
+            "cleaned_frontier_rejection_causes",
+            "raw_frontier_work_summary",
+            "cleaned_frontier_work_summary",
+    )
+        Base.delete!(legacy_row, key)
+    end
+    legacy_normalized = checkpoint_cause_roundtrip(legacy_row)
+    Test.@test Base.isempty(legacy_normalized[:raw_frontier_rejection_causes])
+    Test.@test Base.isempty(legacy_normalized[:raw_frontier_work_summary])
+    Test.@test Base.length(legacy_normalized[:cleaned_frontier_metrics]) == 2
+end
+
+Test.@testset "Inconsistent frontier diagnostics are rejected" begin
+    # NEGATIVE: sample count no longer matches `cleaned_frontier_evaluated`.
+    # The histogram is kept consistent so the sample-count check is the one that
+    # fires rather than being masked by an earlier failure.
+    sample_mismatch = checkpoint_cause_row()
+    sample_mismatch["cleaned_frontier_evaluated"] = 3
+    sample_mismatch["cleaned_frontier_rejection_causes"] = Dict{String, Any}(
+        "admitted" => 1,
+        "probe_work_limit" => 2,
+    )
+    checkpoint_test_error(
+        ArgumentError,
+        "cleaned_frontier_metrics sample count does not match " *
+        "cleaned_frontier_evaluated",
+    ) do
+        checkpoint_cause_roundtrip(sample_mismatch)
+    end
+
+    dropped_sample = checkpoint_cause_row()
+    dropped_sample["cleaned_frontier_metrics"] = Any[
+        checkpoint_cause_metric(2, "complete"),
+    ]
+    checkpoint_test_error(
+        ArgumentError,
+        "cleaned_frontier_metrics sample count does not match " *
+        "cleaned_frontier_evaluated",
+    ) do
+        checkpoint_cause_roundtrip(dropped_sample)
+    end
+
+    unknown_cause = checkpoint_cause_row()
+    unknown_cause["raw_frontier_rejection_causes"] = Dict{String, Any}(
+        "admitted" => 1,
+        "cosmic_rays" => 2,
+    )
+    checkpoint_test_error(ArgumentError, "unsupported value cosmic_rays") do
+        checkpoint_cause_roundtrip(unknown_cause)
+    end
+
+    negative_cause = checkpoint_cause_row()
+    negative_cause["raw_frontier_rejection_causes"] = Dict{String, Any}(
+        "admitted" => 4,
+        "probe_work_limit" => -1,
+    )
+    checkpoint_test_error(ArgumentError, "must be nonnegative") do
+        checkpoint_cause_roundtrip(negative_cause)
+    end
+
+    non_monotone = checkpoint_cause_row()
+    non_monotone["raw_frontier_work_summary"] = Dict{String, Any}(
+        "count" => 3,
+        "min" => 400_000,
+        "p50" => 32,
+        "p90" => 400_000,
+        "p99" => 400_000,
+        "max" => 400_000,
+    )
+    checkpoint_test_error(ArgumentError, "order statistics must be monotone") do
+        checkpoint_cause_roundtrip(non_monotone)
+    end
+
+    partial_summary = checkpoint_cause_row()
+    partial_summary["raw_frontier_work_summary"] = Dict{String, Any}(
+        "count" => 3,
+        "max" => 400_000,
+    )
+    checkpoint_test_error(
+        ArgumentError, "must contain every order statistic") do
+        checkpoint_cause_roundtrip(partial_summary)
+    end
+
+end
+
+Test.@testset "Frontier diagnostics reach the on-disk checkpoint" begin
+    Base.mktempdir() do temporary_directory
+        sequence = "AAAGCTTAGGGAGAGTAGAAATAATATAGA"
+        input_fastq = Base.joinpath(temporary_directory, "input.fastq")
+        output_directory = Base.joinpath(temporary_directory, "run")
+        Mycelia.write_fastq(
+            records = FASTX.FASTQ.Record[
+                FASTX.FASTQ.Record(
+                    "diagnostics",
+                    sequence,
+                    Base.repeat("I", Base.length(sequence)),
+                ),
+            ],
+            filename = input_fastq,
+        )
+
+        result = checkpoint_frontier_invocation(
+            input_fastq, output_directory, 1)
+        telemetry = result[:metadata][:indel_rung_telemetry]
+        evaluated_rows = [
+            row for row in telemetry if row[:raw_frontier_evaluated] > 0
+        ]
+        Test.@test !Base.isempty(evaluated_rows)
+        for row in evaluated_rows
+            causes = row[:raw_frontier_rejection_causes]
+            Test.@test !Base.isempty(causes)
+            Test.@test Base.sum(Base.values(causes)) ==
+                       row[:raw_frontier_evaluated]
+            Test.@test Base.all(
+                cause in Mycelia._INDEL_FRONTIER_REJECTION_CAUSES
+                for cause in Base.keys(causes)
+            )
+            # Raw-admitted windows are a subset of all admitted windows: a
+            # cleaned-graph rescue is counted in `admitted_windows` but appears
+            # in the CLEANED histogram, not the raw one.
+            Test.@test Base.get(causes, :admitted, 0) <= row[:admitted_windows]
+            summary = row[:raw_frontier_work_summary]
+            Test.@test summary[:count] <= row[:raw_frontier_evaluated]
+            Test.@test summary[:min] <= summary[:p50] <= summary[:p90] <=
+                       summary[:p99] <= summary[:max]
+            Test.@test Base.sum(
+                Base.values(row[:cleaned_frontier_rejection_causes])) ==
+                       row[:cleaned_frontier_evaluated]
+        end
+
+        checkpoint_file = Base.joinpath(
+            output_directory, "checkpoints", "latest_checkpoint.json")
+        serialized_row = Base.first(
+            JSON.parsefile(checkpoint_file)["indel_rung_telemetry"])
+        Test.@test Base.haskey(
+            serialized_row, "raw_frontier_rejection_causes")
+        Test.@test Base.haskey(serialized_row, "raw_frontier_work_summary")
+        Test.@test Base.sum(
+            Base.values(serialized_row["raw_frontier_rejection_causes"])) ==
+                   serialized_row["raw_frontier_evaluated"]
+
+        # Resuming re-reads those fields through the normalizer.
+        resumed = checkpoint_frontier_invocation(
+            input_fastq, output_directory, 1)
+        Test.@test resumed[:metadata][:indel_rung_telemetry] == telemetry
+    end
+end


### PR DESCRIPTION
## Summary

Answers "why are only ~12% of candidate indel decode windows attempted?" with evidence that is exact rather than sampled.

Per-window rejection data already existed in `raw_frontier_metrics` / `cleaned_frontier_metrics`, but capped at the **first 64 samples per rung** by read index. A rejection breakdown computed off a biased prefix is not defensible evidence at scale.

Three additive changes inside `_evaluate_indel_frontier_schedule_impl`:

1. `_indel_frontier_rejection_cause(metric, work_limit)` — a pure classifier returning the cause of the **first failing conjunct** of `_indel_frontier_admitted`, in that function's own short-circuit order.
2. **Exact** rejection-cause histograms over every evaluated window (not the 64-sample).
3. **Exact** `frontier_work` order statistics (`count/min/p50/p90/p99/max`) over every evaluated window.

Also removes a genuinely unreachable branch and adds checkpoint round-trip coverage.

## What the diagnostics measured

On the committed fixed-toy fixture, aggregate over all 207 candidate windows:

| cause | count |
|---|---|
| `:probe_frontier_exhausted` | 117 (57%) |
| `:probe_work_limit` | 65 (31%) |
| `admitted` | 25 |
| `:unanchored` | **0** |

`frontier_work` p50 per rung: 4,839 / 9,353 / 21,261 / 22,822 against a 300,000 budget.

So at that fixture's scale the budget is **not** binding for the median window and anchoring is not the constraint on raw graphs — the frontier dies before the window completes. (`:unanchored` appears only in the *cleaned* histograms, 7-9 per rung, which is the `:cleaning_lost_window_anchor` decision.)

## Oracle safety

The scheduler is unreachable when `indel_params === nothing`, and `profile_enables_indels(:illumina) == false`. The only Illumina-visible change is four empty containers in `_empty_indel_rung_telemetry`. Telemetry is not an input to assembly bytes.

**Checkpoint contract preserved exactly.** `_CHECKPOINT_REQUIRED_INDEL_TELEMETRY_KEYS` was previously *derived* from the accept-list, so adding accept-list keys would have invalidated every existing v2 checkpoint. It is now a frozen literal of the current v2 field names (23 keys, byte-identical to the old derived set); the 4 new keys are accept-list only, normalized with `get`-with-default. `_ITERATIVE_CHECKPOINT_CONFIGURATION_VERSION` is deliberately **not** bumped — nothing in the v2 contract changed.

## Unreachable branch removed

`elseif cleaning_status == :weighted_memory_limit` — `cleaning_status` is only ever assigned `:not_attempted`, `:complete`, `:out_of_memory`, `:memory_limit`. Confirmed by exhaustion. `:weighted_graph_memory_limit` correctly **remains** in `_CHECKPOINT_DECISION_REASONS`, since two live returns still produce it.

## Test Plan

- [x] `indel_frontier_probe_test.jl` — new classifier testsets 24/24, 28/28, 23/23, plus all 15 pre-existing testsets
- [x] `iterative_checkpoint_resume_test.jl` — incl. new populated-cleaned-metrics round trip (31/31) and a negative sample-count-mismatch case (12/12)
- [x] Oracle suite, all green: `viterbi_indel_decoder` 188/188, `indel_profile_assembly` 113/113, `reassembly_graph_reuse` 20/20, `rhizomorph_iterative_corrector_wiring` 17/17, `scalable_corrector_strategy` 68/68, `windowed_decode` 23173/23173, `low_k_decode_gating` 20/20
- [x] Fixed-toy proof 19/19 with `illumina_byte_identical_to_prewiring_oracle` at `d36e3b6a...d311`

## Deviations worth reviewing

- `:probe_encode_error` is classified **before** the anchor conjunct rather than mirroring position strictly. The encode-error stub is built with `anchored => false`, so a strict mirror would absorb every encode error into `:unanchored` and destroy the distinction the diagnostic exists to draw. The `cause == :admitted <=> _indel_frontier_admitted` equivalence is unaffected.
- The probe reason taxonomy is 7 symbols, not 4 — `:empty_graph`, `:empty_observation`, `:no_start_state` also occur. Causes are derived over the full set with a total fallback.

## Related

Part of the td-jt7r indel-decoder workstream.