### PR TITLE
fix: thread sequencing_tech into the RGV sweep's corrector + close the cross-seed guard hole

### DIFF
--- a/benchmarking/rhizomorph_correction_validation_sweep.jl
+++ b/benchmarking/rhizomorph_correction_validation_sweep.jl
@@ -21,6 +21,22 @@
 #       readlen <= 500  -> "short-low-error"  regime, Illumina error model
 #       readlen  > 500  -> "long-high-error"  regime, Nanopore error model
 #
+# TECHNOLOGY WIRING. The regime technology drives BOTH halves of a cell:
+#   1. READ SIMULATION — `Mycelia.observe(...; tech=tech)` picks the error-TYPE
+#      mix (substitution- vs indel-dominated) and the quality model.
+#   2. CORRECTOR ERROR PROFILE — `assemble_genome(...; sequencing_tech=tech)`
+#      selects the indel-aware decode profile (`Mycelia.indel_error_profile`).
+#      :nanopore / :pacbio_clr enable the pair-HMM gap moves; :illumina stays on
+#      the substitution-only path.
+# The second half was NOT wired before the `corrector_sequencing_tech` column
+# existed: `run_arm` called `assemble_genome` without `sequencing_tech`, so
+# `AssemblyConfig` fell back to its `:illumina` default even on
+# nanopore-simulated long reads. Every readlen > 500 row from such a run is a
+# SUBSTITUTION-ONLY result labeled "nanopore" and is NOT comparable to a row
+# from a run that has this wiring. Absence of the `corrector_sequencing_tech`
+# column identifies those CSVs; they are retained under benchmarking/results/
+# for provenance. Compare only across rows whose corrector profile agrees.
+#
 # SCALE-ASSERTION GUARD (rhizomorph_scale_guard.jl): a VERDICT is only printed
 # when effective coverage x effective genome length exceeds a floor. Below the
 # floor the harness emits a SMOKE-ONLY notice, so a toy run can never be quoted
@@ -65,6 +81,14 @@
 #                       42/123/456: once shards are merged, replicate rows are
 #                       indistinguishable without it, so pairs cannot be formed.
 #                       See bead td-59o7 and `rgv_paired_wilcoxon.jl`.
+#   corrector_sequencing_tech
+#                     — the error profile the CORRECTOR actually ran, read BACK
+#                       from the assembler's own `assembly_stats["sequencing_tech"]`
+#                       stamp rather than echoed from the input argument. An
+#                       echoed column would read green even with the wiring
+#                       broken, which is the whole failure mode it exists to
+#                       make non-recurring. "n/a" on the naive arm, whose route
+#                       does not stamp the field.
 #   metric_source     — WHICH metric definition produced this row: "quast"
 #                       (alignment-validated) vs "internal*" (size-ratio proxy).
 #   quast_min_contig  — the --min-contig threshold QUAST was run at. Part of the
@@ -117,7 +141,11 @@ end
 Map a read length to a (label, technology) read-regime pair. Short reads model
 low-error Illumina chemistry; long reads model high-error Nanopore chemistry.
 The per-base error is still overridden by the swept error rate — the technology
-selects the error-TYPE mix (substitution- vs indel-dominated) and quality model.
+selects the error-TYPE mix (substitution- vs indel-dominated) and quality model
+for READ SIMULATION, and it is ALSO passed to `assemble_genome` as
+`sequencing_tech`, where it selects the CORRECTOR's indel-aware error profile.
+One symbol therefore governs both the simulated chemistry and the correction
+model that must match it.
 """
 function regime_for_readlen(readlen::Int)
     return readlen <= 500 ? ("short-low-error", :illumina) : ("long-high-error", :nanopore)
@@ -199,26 +227,50 @@ end
 Run one assembly ARM (`corrector` = :none or :iterative) on `reads`, both pinned
 to DoubleStrand, write contigs to FASTA, and return a metrics NamedTuple. On
 failure the arm is recorded with `ok=false` rather than aborting the whole sweep.
+
+`sequencing_tech` is REQUIRED (no default) so a caller cannot silently fall back
+to the assembler's `:illumina` default on nanopore-simulated reads — that silent
+fallback is exactly the defect this keyword fixes. It is passed to BOTH arms: on
+`corrector=:none` with the sweep's `layout=:native` it is inert (`AssemblyConfig`
+only consults it in the `:olc` layout branch and in the iterative corrector's
+error-profile lookup), and
+`rhizomorph_correction_validation_sweep_wiring_test.jl` asserts that inertness
+byte-for-byte on the contig FASTA rather than assuming it.
+
+`assembler` is dependency injection for that wiring test ONLY; it defaults to the
+production `Mycelia.Rhizomorph.assemble_genome`, so runtime behavior is unchanged.
+
+The returned `corrector_sequencing_tech` is read back from the assembler's own
+`assembly_stats["sequencing_tech"]` stamp — never echoed from the argument — so a
+future re-break of the wiring shows up in the CSV instead of reading green.
 """
-function run_arm(reads, corrector::Symbol, k::Int, glen::Int, outdir::String, tag::String)
+function run_arm(reads, corrector::Symbol, k::Int, glen::Int, outdir::String,
+        tag::String; sequencing_tech::Symbol,
+        assembler = Mycelia.Rhizomorph.assemble_genome)
     contigs_path = joinpath(outdir, "$(tag)_$(corrector)_contigs.fasta")
     t0 = time()
     local result
     try
-        result = Mycelia.Rhizomorph.assemble_genome(
+        result = assembler(
             reads;
             k = k,
             graph_mode = Mycelia.Rhizomorph.DoubleStrand,
             corrector = corrector,
+            sequencing_tech = sequencing_tech,
             verbose = false
         )
     catch e
-        @warn "Assembly arm failed" corrector tag exception = (e, catch_backtrace())
+        @warn "Assembly arm failed" corrector tag sequencing_tech exception = (
+            e, catch_backtrace())
         return (ok = false, corrector = corrector, n_contigs = 0, total_length = 0,
             largest_contig = 0, n50 = 0, genome_fraction = 0.0, runtime_s = time() - t0,
-            contigs_path = "")
+            contigs_path = "", corrector_sequencing_tech = "n/a")
     end
     runtime = time() - t0
+    # Read BACK from the assembler's own stamp (assembly.jl stamps this on the
+    # iterative and hybrid-OLC routes). The naive route does not stamp it, so
+    # "n/a" is the expected value there.
+    corrector_tech = string(get(result.assembly_stats, "sequencing_tech", "n/a"))
 
     open(contigs_path, "w") do io
         for (i, contig) in enumerate(result.contigs)
@@ -247,7 +299,7 @@ function run_arm(reads, corrector::Symbol, k::Int, glen::Int, outdir::String, ta
     return (ok = true, corrector = corrector, n_contigs = n_contigs,
         total_length = total_length, largest_contig = largest_contig, n50 = n50,
         genome_fraction = genome_fraction, runtime_s = round(runtime; digits = 3),
-        contigs_path = contigs_path)
+        contigs_path = contigs_path, corrector_sequencing_tech = corrector_tech)
 end
 
 # === Main sweep ============================================================
@@ -325,6 +377,11 @@ function run_sweep()
         arm = String[], ok = Bool[],
         n_contigs = Int[], total_length = Int[], largest_contig = Int[], n50 = Int[],
         genome_fraction = Float64[], runtime_s = Float64[],
+        # The error profile the CORRECTOR actually ran, read BACK from the
+        # assembler's assembly_stats stamp and NOT echoed from the input
+        # argument — an echoed column would read green even if the wiring
+        # regressed. "n/a" on the naive arm, which does not stamp the field.
+        corrector_sequencing_tech = String[],
         # Alignment-validated QUAST metrics (populated per arm when QUAST ran);
         # `genome_fraction` above stays the INTERNAL total_length/glen size ratio.
         quast_genome_fraction = Union{Missing, Float64}[],
@@ -361,7 +418,11 @@ function run_sweep()
             for corrector in (:none, :iterative)
                 tag = "$(ref_label)_seed$(seed)_err$(err)_len$(readlen)"
                 arm_name = corrector == :none ? "naive" : "iterative"
-                res = run_arm(reads, corrector, k, glen, cell_dir, tag)
+                # `tech` from regime_for_readlen drives BOTH read simulation
+                # (above) and the corrector's error profile (here). Passing it is
+                # what makes a "nanopore" row actually indel-aware.
+                res = run_arm(reads, corrector, k, glen, cell_dir, tag;
+                    sequencing_tech = tech)
 
                 # Optional QUAST validation for THIS arm (per-arm attribution:
                 # one assembly per invocation so the alignment-based metrics land
@@ -426,6 +487,7 @@ function run_sweep()
                         total_length = res.total_length, largest_contig = res.largest_contig,
                         n50 = res.n50, genome_fraction = res.genome_fraction,
                         runtime_s = res.runtime_s,
+                        corrector_sequencing_tech = res.corrector_sequencing_tech,
                         quast_genome_fraction = quast.quast_genome_fraction,
                         quast_nga50 = quast.quast_nga50,
                         quast_num_misassemblies = quast.quast_num_misassemblies,
@@ -435,6 +497,7 @@ function run_sweep()
                 println("    $(rpad(arm_name, 9)) -> ok=$(res.ok) contigs=$(res.n_contigs) " *
                         "total=$(res.total_length)bp largest=$(res.largest_contig) " *
                         "n50=$(res.n50) frac=$(res.genome_fraction)% " *
+                        "corr_tech=$(res.corrector_sequencing_tech) " *
                         "src=$(quast.metric_source) $(res.runtime_s)s")
             end
         end

--- a/benchmarking/rhizomorph_correction_validation_sweep.jl
+++ b/benchmarking/rhizomorph_correction_validation_sweep.jl
@@ -88,7 +88,20 @@
 #                       echoed column would read green even with the wiring
 #                       broken, which is the whole failure mode it exists to
 #                       make non-recurring. "n/a" on the naive arm, whose route
-#                       does not stamp the field.
+#                       does not stamp the field; "error" when the arm itself
+#                       threw, so an exception is distinguishable from a healthy
+#                       naive arm (ok=false alone did not disambiguate them).
+#   corrector_indel_engaged
+#                     — read BACK from `assembly_stats["indel_engaged"]`: the
+#                       runtime count of reads on which the pair-HMM gap moves
+#                       actually FIRED. `corrector_sequencing_tech` proves only
+#                       that the tech reached `AssemblyConfig`; assembly.jl
+#                       deliberately separates `indel_moves` (profile INTENT)
+#                       from `indel_engaged` (runtime OUTCOME), so a "nanopore"
+#                       row with corrector_indel_engaged==0 is an indel-aware
+#                       profile that never engaged — the residual the tech column
+#                       cannot see. `missing` where the route stamps no corrector
+#                       telemetry (the naive arm) or where the arm threw.
 #   metric_source     — WHICH metric definition produced this row: "quast"
 #                       (alignment-validated) vs "internal*" (size-ratio proxy).
 #   quast_min_contig  — the --min-contig threshold QUAST was run at. Part of the
@@ -224,16 +237,36 @@ end
 # === One assembly arm ======================================================
 
 """
+Read an integer telemetry counter back out of an assembler's `assembly_stats`.
+Returns `missing` when the key is absent — the naive route stamps no corrector
+telemetry — or when the value is not interpretable as an integer, so an UNSTAMPED
+route can never be confused with a stamped zero (the two mean opposite things for
+`indel_engaged`).
+"""
+function _stat_int(stats, key::AbstractString)
+    v = get(stats, key, missing)
+    v === missing && return missing
+    v isa Integer && return Int(v)
+    v isa Real && return round(Int, v)
+    parsed = tryparse(Int, string(v))
+    return parsed === nothing ? missing : parsed
+end
+
+"""
 Run one assembly ARM (`corrector` = :none or :iterative) on `reads`, both pinned
 to DoubleStrand, write contigs to FASTA, and return a metrics NamedTuple. On
 failure the arm is recorded with `ok=false` rather than aborting the whole sweep.
 
 `sequencing_tech` is REQUIRED (no default) so a caller cannot silently fall back
 to the assembler's `:illumina` default on nanopore-simulated reads — that silent
-fallback is exactly the defect this keyword fixes. It is passed to BOTH arms: on
-`corrector=:none` with the sweep's `layout=:native` it is inert (`AssemblyConfig`
-only consults it in the `:olc` layout branch and in the iterative corrector's
-error-profile lookup), and
+fallback is exactly the defect this keyword fixes. It is passed to BOTH arms.
+`AssemblyConfig` consults it in THREE places, not two: unconditionally at
+construction to VALIDATE the symbol against `_correction_profile_technologies()`
+(src/rhizomorph/assembly.jl), in the `:olc` layout branch, and in the iterative
+corrector's error-profile lookup. Only the latter two can change output, and the
+sweep pins `layout=:native`, so on `corrector=:none` the tech is inert for the
+RESULT — it is merely validated on an arm that previously never saw it. Both
+symbols `regime_for_readlen` emits are valid, and
 `rhizomorph_correction_validation_sweep_wiring_test.jl` asserts that inertness
 byte-for-byte on the contig FASTA rather than assuming it.
 
@@ -243,6 +276,11 @@ production `Mycelia.Rhizomorph.assemble_genome`, so runtime behavior is unchange
 The returned `corrector_sequencing_tech` is read back from the assembler's own
 `assembly_stats["sequencing_tech"]` stamp — never echoed from the argument — so a
 future re-break of the wiring shows up in the CSV instead of reading green.
+`corrector_indel_engaged` is read back the same way from
+`assembly_stats["indel_engaged"]` and answers what the tech column cannot: not
+that the indel-aware profile was SELECTED, but that its gap moves actually FIRED.
+On the exception path the tech is recorded as `"error"` — a sentinel distinct
+from the healthy naive arm's `"n/a"`.
 """
 function run_arm(reads, corrector::Symbol, k::Int, glen::Int, outdir::String,
         tag::String; sequencing_tech::Symbol,
@@ -264,13 +302,20 @@ function run_arm(reads, corrector::Symbol, k::Int, glen::Int, outdir::String,
             e, catch_backtrace())
         return (ok = false, corrector = corrector, n_contigs = 0, total_length = 0,
             largest_contig = 0, n50 = 0, genome_fraction = 0.0, runtime_s = time() - t0,
-            contigs_path = "", corrector_sequencing_tech = "n/a")
+            contigs_path = "", corrector_sequencing_tech = "error",
+            corrector_indel_engaged = missing)
     end
     runtime = time() - t0
     # Read BACK from the assembler's own stamp (assembly.jl stamps this on the
     # iterative and hybrid-OLC routes). The naive route does not stamp it, so
     # "n/a" is the expected value there.
     corrector_tech = string(get(result.assembly_stats, "sequencing_tech", "n/a"))
+    # Runtime OUTCOME of the indel-aware profile, as distinct from the profile
+    # INTENT that `corrector_tech` records. assembly.jl separates `indel_moves`
+    # (the profile requested gap moves) from `indel_engaged` (a gap move actually
+    # fired), so a "nanopore" row with 0 engagements is a selected-but-never-used
+    # profile — invisible to the tech column alone.
+    corrector_indel = _stat_int(result.assembly_stats, "indel_engaged")
 
     open(contigs_path, "w") do io
         for (i, contig) in enumerate(result.contigs)
@@ -299,7 +344,8 @@ function run_arm(reads, corrector::Symbol, k::Int, glen::Int, outdir::String,
     return (ok = true, corrector = corrector, n_contigs = n_contigs,
         total_length = total_length, largest_contig = largest_contig, n50 = n50,
         genome_fraction = genome_fraction, runtime_s = round(runtime; digits = 3),
-        contigs_path = contigs_path, corrector_sequencing_tech = corrector_tech)
+        contigs_path = contigs_path, corrector_sequencing_tech = corrector_tech,
+        corrector_indel_engaged = corrector_indel)
 end
 
 # === Main sweep ============================================================
@@ -382,6 +428,11 @@ function run_sweep()
         # argument — an echoed column would read green even if the wiring
         # regressed. "n/a" on the naive arm, which does not stamp the field.
         corrector_sequencing_tech = String[],
+        # Whether the indel-aware pair-HMM moves actually FIRED at runtime, read
+        # back from assembly_stats["indel_engaged"]. The tech column proves only
+        # that the profile was SELECTED; this proves it was USED. `missing` on
+        # the naive arm, which stamps no corrector telemetry.
+        corrector_indel_engaged = Union{Missing, Int}[],
         # Alignment-validated QUAST metrics (populated per arm when QUAST ran);
         # `genome_fraction` above stays the INTERNAL total_length/glen size ratio.
         quast_genome_fraction = Union{Missing, Float64}[],
@@ -488,6 +539,7 @@ function run_sweep()
                         n50 = res.n50, genome_fraction = res.genome_fraction,
                         runtime_s = res.runtime_s,
                         corrector_sequencing_tech = res.corrector_sequencing_tech,
+                        corrector_indel_engaged = res.corrector_indel_engaged,
                         quast_genome_fraction = quast.quast_genome_fraction,
                         quast_nga50 = quast.quast_nga50,
                         quast_num_misassemblies = quast.quast_num_misassemblies,
@@ -498,6 +550,7 @@ function run_sweep()
                         "total=$(res.total_length)bp largest=$(res.largest_contig) " *
                         "n50=$(res.n50) frac=$(res.genome_fraction)% " *
                         "corr_tech=$(res.corrector_sequencing_tech) " *
+                        "indel_engaged=$(res.corrector_indel_engaged) " *
                         "src=$(quast.metric_source) $(res.runtime_s)s")
             end
         end

--- a/benchmarking/rhizomorph_correction_validation_sweep_test.jl
+++ b/benchmarking/rhizomorph_correction_validation_sweep_test.jl
@@ -21,6 +21,73 @@ include(joinpath(@__DIR__, "rhizomorph_scale_guard.jl"))
 # includes), so the parse/wiring logic is exercised without running QUAST.
 include(joinpath(@__DIR__, "quast_report_parsing.jl"))
 
+# --- Dependency-free access to ONE production function ----------------------
+# `regime_for_readlen` lives in the sweep script, which starts with
+# `import Mycelia`. `include`-ing that script here would break this file's
+# dependency-free contract (Mycelia load time, network/QUAST-capable deps), and
+# copy-pasting the function body would test a COPY that silently drifts from
+# production. Instead: parse the real source (parsing never executes it) and
+# evaluate only the one definition into a throwaway module.
+module SweepDefs
+
+const SOURCE_PATH = joinpath(@__DIR__, "rhizomorph_correction_validation_sweep.jl")
+
+"""
+Recursively locate a `function <name>(...)` definition inside a parsed
+expression. Handles the docstring case, where the definition is nested inside a
+`@doc` macrocall rather than appearing at top level.
+"""
+function _find_function_expr(expr, name::Symbol)
+    expr isa Expr || return nothing
+    if expr.head === :function && expr.args[1] isa Expr &&
+       expr.args[1].head === :call && expr.args[1].args[1] === name
+        return expr
+    end
+    for arg in expr.args
+        found = _find_function_expr(arg, name)
+        found === nothing || return found
+    end
+    return nothing
+end
+
+function _load_function(name::Symbol)
+    src = read(SOURCE_PATH, String)
+    pos = 1
+    while pos <= lastindex(src)
+        expr, pos = Meta.parse(src, pos; raise = false)
+        expr === nothing && break
+        found = _find_function_expr(expr, name)
+        if found !== nothing
+            Core.eval(SweepDefs, found)
+            return nothing
+        end
+    end
+    error("could not locate `function $(name)` in $(SOURCE_PATH)")
+end
+
+_load_function(:regime_for_readlen)
+
+end  # module SweepDefs
+
+Test.@testset "regime_for_readlen selects the read-regime technology" begin
+    # This mapping is the ONLY thing that decides which technology reaches BOTH
+    # `Mycelia.observe` (read simulation) and `assemble_genome`'s
+    # `sequencing_tech` (corrector error profile). Silent drift here would
+    # re-open the defect where nanopore-labeled long reads were corrected with
+    # the substitution-only :illumina profile. Pin it explicitly.
+    Test.@test SweepDefs.regime_for_readlen(150) == ("short-low-error", :illumina)
+    Test.@test SweepDefs.regime_for_readlen(5000) == ("long-high-error", :nanopore)
+
+    # Threshold boundary: <=500 is short/illumina, >500 is long/nanopore.
+    Test.@test SweepDefs.regime_for_readlen(500)[2] == :illumina
+    Test.@test SweepDefs.regime_for_readlen(501)[2] == :nanopore
+
+    # The sbatch wrappers default MYCELIA_RGV_READLEN to "150,5000", so those two
+    # lengths are what a default HPC submission actually sweeps.
+    Test.@test SweepDefs.regime_for_readlen(150)[2] in (:illumina, :nanopore)
+    Test.@test SweepDefs.regime_for_readlen(5000)[2] in (:illumina, :nanopore)
+end
+
 Test.@testset "rhizomorph correction validation scale guard" begin
     # --- Toy-scale config triggers SMOKE-ONLY --------------------------------
     # Synthetic 2 kb genome at 10x effective coverage = 20,000 sequenced bases,
@@ -108,6 +175,7 @@ Test.@testset "DataFrame schema push! guards column-name drift" begin
         effective_coverage = Float64[], k = Int[], arm = String[], ok = Bool[],
         n_contigs = Int[], total_length = Int[], largest_contig = Int[], n50 = Int[],
         genome_fraction = Float64[], runtime_s = Float64[],
+        corrector_sequencing_tech = String[],
         quast_genome_fraction = Union{Missing, Float64}[],
         quast_nga50 = Union{Missing, Float64}[],
         quast_num_misassemblies = Union{Missing, Float64}[],
@@ -121,7 +189,11 @@ Test.@testset "DataFrame schema push! guards column-name drift" begin
         regime = "short-low-error", readlen = 150, tech = "illumina",
         target_coverage = 30.0, effective_coverage = 29.5, k = 21, arm = "naive",
         ok = true, n_contigs = 5, total_length = 1_980, largest_contig = 620,
-        n50 = 410, genome_fraction = 99.0, runtime_s = 1.234
+        n50 = 410, genome_fraction = 99.0, runtime_s = 1.234,
+        # `corrector_sequencing_tech` is asserted in BOTH the DataFrame above and
+        # this NamedTuple: a column added to only one side is exactly the drift
+        # this testset exists to catch.
+        corrector_sequencing_tech = "n/a"
     )
 
     mktempdir() do dir
@@ -150,4 +222,7 @@ Test.@testset "DataFrame schema push! guards column-name drift" begin
     Test.@test df.metric_source == ["quast", "internal:quast-disabled"]
     Test.@test df.quast_nga50[1] == 8421.0
     Test.@test df.quast_genome_fraction[2] === missing
+    # The corrector-profile column landed with its declared element type.
+    Test.@test df.corrector_sequencing_tech == ["n/a", "n/a"]
+    Test.@test eltype(df.corrector_sequencing_tech) == String
 end

--- a/benchmarking/rhizomorph_correction_validation_sweep_test.jl
+++ b/benchmarking/rhizomorph_correction_validation_sweep_test.jl
@@ -172,28 +172,42 @@ Test.@testset "DataFrame schema push! guards column-name drift" begin
     df = DataFrames.DataFrame(
         reference = String[], genome_len = Int[], error_rate = Float64[],
         regime = String[], readlen = Int[], tech = String[], target_coverage = Float64[],
-        effective_coverage = Float64[], k = Int[], arm = String[], ok = Bool[],
+        effective_coverage = Float64[], k = Int[],
+        # `seed` and `quast_min_contig` are production columns this testset used
+        # to omit, which is precisely the drift it exists to catch — a schema
+        # guard that lags the schema guards nothing. Keep this DataFrame a
+        # complete mirror of run_sweep's `rows` (the three columns appended AFTER
+        # the loop — mode / scale_metric_bases / scale_floor_bases — are not part
+        # of the push! contract and stay out).
+        seed = Int[],
+        arm = String[], ok = Bool[],
         n_contigs = Int[], total_length = Int[], largest_contig = Int[], n50 = Int[],
         genome_fraction = Float64[], runtime_s = Float64[],
         corrector_sequencing_tech = String[],
+        corrector_indel_engaged = Union{Missing, Int}[],
         quast_genome_fraction = Union{Missing, Float64}[],
         quast_nga50 = Union{Missing, Float64}[],
         quast_num_misassemblies = Union{Missing, Float64}[],
         quast_duplication_ratio = Union{Missing, Float64}[],
-        metric_source = String[]
+        metric_source = String[],
+        quast_min_contig = Int[]
     )
 
     # Non-QUAST columns for a row (mirrors what run_arm + the loop supply).
     base = (
         reference = "synthetic_2000bp", genome_len = 2_000, error_rate = 0.01,
         regime = "short-low-error", readlen = 150, tech = "illumina",
-        target_coverage = 30.0, effective_coverage = 29.5, k = 21, arm = "naive",
+        target_coverage = 30.0, effective_coverage = 29.5, k = 21, seed = 42,
+        arm = "naive",
         ok = true, n_contigs = 5, total_length = 1_980, largest_contig = 620,
         n50 = 410, genome_fraction = 99.0, runtime_s = 1.234,
         # `corrector_sequencing_tech` is asserted in BOTH the DataFrame above and
         # this NamedTuple: a column added to only one side is exactly the drift
-        # this testset exists to catch.
-        corrector_sequencing_tech = "n/a"
+        # this testset exists to catch. Same for `corrector_indel_engaged`, which
+        # is `missing` here because the naive arm stamps no corrector telemetry.
+        corrector_sequencing_tech = "n/a",
+        corrector_indel_engaged = missing,
+        quast_min_contig = 500
     )
 
     mktempdir() do dir
@@ -214,15 +228,35 @@ Test.@testset "DataFrame schema push! guards column-name drift" begin
         # Row 2: an internal-fallback arm via the shared helper.
         e = empty_quast_metrics("internal:quast-disabled")
         Test.@test_nowarn push!(df, merge(base, e))
+
+        # Row 3: an ITERATIVE arm. The corrector stamps both provenance fields,
+        # so this row carries a concrete tech AND a concrete engagement count —
+        # proving the Union{Missing,Int} column accepts the stamped case, not
+        # only the naive arm's `missing`.
+        iter_row = merge(base,
+            (arm = "iterative", corrector_sequencing_tech = "nanopore",
+                corrector_indel_engaged = 4))
+        Test.@test_nowarn push!(df, merge(iter_row, e))
     end
 
     # Both pushes succeeded with no field-name mismatch, and provenance labels
     # landed in the metric_source column exactly as the helpers set them.
-    Test.@test DataFrames.nrow(df) == 2
-    Test.@test df.metric_source == ["quast", "internal:quast-disabled"]
+    Test.@test DataFrames.nrow(df) == 3
+    Test.@test df.metric_source ==
+               ["quast", "internal:quast-disabled", "internal:quast-disabled"]
     Test.@test df.quast_nga50[1] == 8421.0
     Test.@test df.quast_genome_fraction[2] === missing
     # The corrector-profile column landed with its declared element type.
-    Test.@test df.corrector_sequencing_tech == ["n/a", "n/a"]
+    Test.@test df.corrector_sequencing_tech == ["n/a", "n/a", "nanopore"]
     Test.@test eltype(df.corrector_sequencing_tech) == String
+    # The runtime-engagement column keeps `missing` (unstamped) and a stamped
+    # count distinguishable — collapsing an unstamped arm to 0 would read as
+    # "the gap moves were available and never fired", the opposite claim.
+    Test.@test eltype(df.corrector_indel_engaged) == Union{Missing, Int}
+    Test.@test df.corrector_indel_engaged[1] === missing
+    Test.@test df.corrector_indel_engaged[2] === missing
+    Test.@test df.corrector_indel_engaged[3] == 4
+    # The two columns PR #439 added to production and not to this fixture.
+    Test.@test df.seed == [42, 42, 42]
+    Test.@test df.quast_min_contig == [500, 500, 500]
 end

--- a/benchmarking/rhizomorph_correction_validation_sweep_wiring_test.jl
+++ b/benchmarking/rhizomorph_correction_validation_sweep_wiring_test.jl
@@ -17,10 +17,13 @@
 #        the read-back (an echo would report the input and pass regardless).
 #
 #   T5 — passing `sequencing_tech` to the NAIVE arm (corrector=:none) is inert.
-#        `run_arm` passes the tech to BOTH arms; `AssemblyConfig` only consults
-#        it in the `:olc` layout branch and in the iterative corrector's error
-#        profile, and the sweep pins `layout=:native`. That reasoning is
-#        VERIFIED here byte-for-byte on the emitted contig FASTA, not assumed.
+#        `run_arm` passes the tech to BOTH arms. `AssemblyConfig` consults it in
+#        THREE places: unconditionally at construction to VALIDATE the symbol,
+#        in the `:olc` layout branch, and in the iterative corrector's error
+#        profile. Only the last two can change output and the sweep pins
+#        `layout=:native`, so the naive arm now merely VALIDATES a tech it
+#        previously never saw. That reasoning is VERIFIED here byte-for-byte on
+#        the emitted contig FASTA, not assumed.
 #
 # This file loads Mycelia (unlike the fast test file, which must stay
 # dependency-free). Run:
@@ -47,7 +50,8 @@ Test.@testset "run_arm forwards sequencing_tech and reads the stamp back" begin
             recorded[] = Dict(kwargs)
             return (contigs = String[], contig_names = String[],
                 assembly_stats = Dict{String, Any}(
-                    "sequencing_tech" => String(kwargs[:sequencing_tech])))
+                    "sequencing_tech" => String(kwargs[:sequencing_tech]),
+                    "indel_engaged" => 7))
         end
 
         # --- Long-read cell: the regime maps to :nanopore, which must reach the
@@ -64,6 +68,8 @@ Test.@testset "run_arm forwards sequencing_tech and reads the stamp back" begin
         Test.@test recorded[][:graph_mode] === Mycelia.Rhizomorph.DoubleStrand
         Test.@test res_iter.ok
         Test.@test res_iter.corrector_sequencing_tech == "nanopore"
+        # The runtime-engagement counter is read back from the same stats dict.
+        Test.@test res_iter.corrector_indel_engaged == 7
 
         # --- Short-read cell: the naive arm gets the tech too (see T5 for the
         # inertness proof) and reports the assembler's stamp.
@@ -99,6 +105,26 @@ Test.@testset "corrector_sequencing_tech is read back, never echoed" begin
         res_silent = run_arm(FASTX.FASTQ.Record[], :none, 21, 1_000, dir, "silent";
             sequencing_tech = :nanopore, assembler = silent)
         Test.@test res_silent.corrector_sequencing_tech == "n/a"
+        # An UNSTAMPED route must stay `missing`, not collapse to 0 — 0 would
+        # assert "the gap moves were available and never fired", which is a
+        # different (and false) claim about a route that has no gap moves.
+        Test.@test res_silent.corrector_indel_engaged === missing
+    end
+end
+
+Test.@testset "a failed arm records the distinct \"error\" sentinel" begin
+    # An arm that THREW and a healthy naive arm both used to report "n/a",
+    # disambiguated only by ok=false. Give the exception path its own sentinel so
+    # the CSV distinguishes "this route does not stamp the field" from "this arm
+    # never got far enough to stamp anything".
+    mktempdir() do dir
+        boom = (reads; kwargs...) -> error("assembler exploded")
+        res = Test.@test_logs (:warn,) run_arm(
+            FASTX.FASTQ.Record[], :iterative, 21, 1_000, dir, "boom";
+            sequencing_tech = :nanopore, assembler = boom)
+        Test.@test !res.ok
+        Test.@test res.corrector_sequencing_tech == "error"
+        Test.@test res.corrector_indel_engaged === missing
     end
 end
 
@@ -148,5 +174,9 @@ Test.@testset "naive arm is inert to sequencing_tech (T5)" begin
         # the "n/a" sentinel on both — NOT the tech that was passed in.
         Test.@test res_with.corrector_sequencing_tech == "n/a"
         Test.@test res_without.corrector_sequencing_tech == "n/a"
+        # Likewise the runtime-engagement counter: the naive route stamps no
+        # corrector telemetry at all, so both arms report `missing`.
+        Test.@test res_with.corrector_indel_engaged === missing
+        Test.@test res_without.corrector_indel_engaged === missing
     end
 end

--- a/benchmarking/rhizomorph_correction_validation_sweep_wiring_test.jl
+++ b/benchmarking/rhizomorph_correction_validation_sweep_wiring_test.jl
@@ -1,0 +1,152 @@
+# Wiring test for the Rhizomorph correction-validation sweep's technology path.
+#
+# This is the PROOF that the corrector actually receives the technology the
+# sweep simulated with. The sweep simulates long reads with the :nanopore error
+# model, but before this fix it never told the CORRECTOR that: `assemble_genome`
+# was called without `sequencing_tech`, so it fell back to the :illumina
+# substitution-only profile and every "nanopore" long-read row was silently
+# substitution-only.
+#
+# Two properties are asserted here that the fast, dependency-free
+# `rhizomorph_correction_validation_sweep_test.jl` cannot cover:
+#
+#   T3 — `run_arm` actually forwards `sequencing_tech` to the assembler, and the
+#        `corrector_sequencing_tech` it reports is READ BACK from the assembler's
+#        own `assembly_stats` stamp rather than echoed from the input argument.
+#        A stub assembler that stamps a DIFFERENT value than it received proves
+#        the read-back (an echo would report the input and pass regardless).
+#
+#   T5 — passing `sequencing_tech` to the NAIVE arm (corrector=:none) is inert.
+#        `run_arm` passes the tech to BOTH arms; `AssemblyConfig` only consults
+#        it in the `:olc` layout branch and in the iterative corrector's error
+#        profile, and the sweep pins `layout=:native`. That reasoning is
+#        VERIFIED here byte-for-byte on the emitted contig FASTA, not assumed.
+#
+# This file loads Mycelia (unlike the fast test file, which must stay
+# dependency-free). Run:
+#   LD_LIBRARY_PATH='' julia --project=. \
+#     benchmarking/rhizomorph_correction_validation_sweep_wiring_test.jl
+
+import Test
+import Random
+import FASTX
+import BioSequences
+
+# Defines run_arm / simulate_regime_reads / regime_for_readlen without executing
+# the sweep (the script's `abspath(PROGRAM_FILE) == @__FILE__` guard).
+include(joinpath(@__DIR__, "rhizomorph_correction_validation_sweep.jl"))
+
+Test.@testset "run_arm forwards sequencing_tech and reads the stamp back" begin
+    mktempdir() do dir
+        # --- Stub assembler: records the kwargs it was handed, and stamps the
+        # tech it RECEIVED into assembly_stats (the same key assemble_genome
+        # stamps at src/rhizomorph/assembly.jl).
+        recorded = Ref{Any}(nothing)
+        stub = (reads;
+            kwargs...) -> begin
+            recorded[] = Dict(kwargs)
+            return (contigs = String[], contig_names = String[],
+                assembly_stats = Dict{String, Any}(
+                    "sequencing_tech" => String(kwargs[:sequencing_tech])))
+        end
+
+        # --- Long-read cell: the regime maps to :nanopore, which must reach the
+        # assembler AND come back out on the row.
+        regime, tech = regime_for_readlen(5000)
+        Test.@test tech === :nanopore
+
+        res_iter = run_arm(FASTX.FASTQ.Record[], :iterative, 21, 1_000, dir, "iter";
+            sequencing_tech = tech, assembler = stub)
+        Test.@test recorded[] !== nothing
+        Test.@test recorded[][:sequencing_tech] === :nanopore
+        Test.@test recorded[][:corrector] === :iterative
+        Test.@test recorded[][:k] == 21
+        Test.@test recorded[][:graph_mode] === Mycelia.Rhizomorph.DoubleStrand
+        Test.@test res_iter.ok
+        Test.@test res_iter.corrector_sequencing_tech == "nanopore"
+
+        # --- Short-read cell: the naive arm gets the tech too (see T5 for the
+        # inertness proof) and reports the assembler's stamp.
+        regime_short, tech_short = regime_for_readlen(150)
+        Test.@test tech_short === :illumina
+
+        res_none = run_arm(FASTX.FASTQ.Record[], :none, 21, 1_000, dir, "none";
+            sequencing_tech = tech_short, assembler = stub)
+        Test.@test recorded[][:sequencing_tech] === :illumina
+        Test.@test recorded[][:corrector] === :none
+        Test.@test res_none.corrector_sequencing_tech == "illumina"
+    end
+end
+
+Test.@testset "corrector_sequencing_tech is read back, never echoed" begin
+    mktempdir() do dir
+        # The column's whole purpose is to be structurally incapable of reading
+        # green while the wiring is broken. Prove that by stamping a value that
+        # DISAGREES with the input: an echoed column would report "nanopore"
+        # (the argument); a read-back column reports the stamp.
+        liar = (reads;
+            kwargs...) -> (contigs = String[], contig_names = String[],
+            assembly_stats = Dict{String, Any}("sequencing_tech" => "illumina"))
+        res = run_arm(FASTX.FASTQ.Record[], :iterative, 21, 1_000, dir, "liar";
+            sequencing_tech = :nanopore, assembler = liar)
+        Test.@test res.corrector_sequencing_tech == "illumina"
+
+        # An assembler that stamps NOTHING (the real naive route's behavior)
+        # reports the "n/a" sentinel rather than inventing the input value.
+        silent = (reads;
+            kwargs...) -> (contigs = String[], contig_names = String[],
+            assembly_stats = Dict{String, Any}())
+        res_silent = run_arm(FASTX.FASTQ.Record[], :none, 21, 1_000, dir, "silent";
+            sequencing_tech = :nanopore, assembler = silent)
+        Test.@test res_silent.corrector_sequencing_tech == "n/a"
+    end
+end
+
+Test.@testset "naive arm is inert to sequencing_tech (T5)" begin
+    # `run_arm` passes sequencing_tech to BOTH arms. On corrector=:none with the
+    # sweep's layout=:native that should change nothing at all. Assert it on the
+    # produced bytes rather than trusting the code reading.
+    rng = Random.MersenneTwister(20260726)
+    rec = Mycelia.random_fasta_record(moltype = :DNA, seed = 7, L = 600)
+    refseq = FASTX.sequence(BioSequences.LongDNA{4}, rec)
+    reads, _ = simulate_regime_reads(refseq, 120, 20, 0.01, :illumina, rng)
+    Test.@test !isempty(reads)
+
+    mktempdir() do dir
+        with_dir = joinpath(dir, "with_tech")
+        without_dir = joinpath(dir, "without_tech")
+        mkpath(with_dir)
+        mkpath(without_dir)
+
+        # Arm A: the production assembler, tech explicitly :nanopore.
+        res_with = run_arm(reads, :none, 21, length(refseq), with_dir, "naive";
+            sequencing_tech = :nanopore)
+
+        # Arm B: literally OMIT the kwarg, so the assembler takes its own
+        # :illumina default — the pre-fix call shape.
+        omitting = (r; kwargs...) -> begin
+            kw = Dict{Symbol, Any}(kwargs)
+            delete!(kw, :sequencing_tech)
+            return Mycelia.Rhizomorph.assemble_genome(r; kw...)
+        end
+        res_without = run_arm(reads, :none, 21, length(refseq), without_dir, "naive";
+            sequencing_tech = :nanopore, assembler = omitting)
+
+        Test.@test res_with.ok
+        Test.@test res_without.ok
+        Test.@test res_with.n_contigs > 0
+
+        # The decisive assertion: identical contig FASTA bytes.
+        Test.@test read(res_with.contigs_path) == read(res_without.contigs_path)
+
+        # And the derived metrics agree, so nothing downstream shifted either.
+        Test.@test res_with.n_contigs == res_without.n_contigs
+        Test.@test res_with.total_length == res_without.total_length
+        Test.@test res_with.n50 == res_without.n50
+
+        # The naive route does not stamp sequencing_tech, so the column records
+        # the "n/a" sentinel on both — NOT the tech that was passed in.
+        Test.@test res_with.corrector_sequencing_tech == "n/a"
+        Test.@test res_without.corrector_sequencing_tech == "n/a"
+    end
+end

--- a/benchmarking/run_rgv_sweep_lrc.sbatch
+++ b/benchmarking/run_rgv_sweep_lrc.sbatch
@@ -106,6 +106,22 @@ echo ""
 # ever produced a comparable pair. The seed column is OPTIONAL (its absence is
 # NOT an exit-2 header error) so this guard still validates CSVs written before
 # the seed column existed; those degrade correctly to the old single-seed key.
+#
+# The guard ALSO asserts, for every ok=true `iterative` row, that
+# `corrector_sequencing_tech` (read back from the assembler's own stamp) equals
+# the `tech` the reads were simulated with. That column exists to make a re-break
+# of the corrector wiring visible, but a column nothing reads is provenance, not
+# a detector — this post-check is its automated consumer. Both columns are
+# OPTIONAL: `corrector_sequencing_tech` is absent from pre-wiring CSVs, and that
+# absence is precisely what identifies them, so a missing column skips the check
+# rather than failing it.
+#
+# The awk status is CAPTURED into `guard_rc`, never consumed by `! awk ...`:
+# `!` is true for ANY non-zero status, so exit 1 (green-but-empty), exit 2 (bad
+# header) and exit 3 (tech mismatch) all took the same branch and printed the
+# same green-but-empty message. sacct showing FAILED is only half the point —
+# the job .out has to say WHY, and the awk-level exit codes have no other
+# consumer.
 if [[ "${rc}" -eq 0 ]]; then
   # Bind to THIS job's CSV via the path the .jl printed; fail loud if absent.
   csv_line="$(grep '^CSV written: ' "${runlog}" 2>/dev/null | tail -1)"
@@ -114,10 +130,12 @@ if [[ "${rc}" -eq 0 ]]; then
     echo ">>> FAIL: sweep exited 0 but printed no 'CSV written:' path" >&2; rc=1
   elif [[ ! -f "${csv}" ]]; then
     echo ">>> FAIL: printed CSV path does not exist: ${csv}" >&2; rc=1
-  # awk guard assumes comma-free CSV fields: CSV.jl quotes any embedded comma,
-  # which would shift these -F, column positions. Safe for the current schema
-  # (only numeric + bare-word columns: reference/regime/tech/arm/mode).
-  elif ! awk -F, '
+  else
+    # awk guard assumes comma-free CSV fields: CSV.jl quotes any embedded comma,
+    # which would shift these -F, column positions. Safe for the current schema
+    # (only numeric + bare-word columns: reference/regime/tech/arm/mode).
+    guard_rc=0
+    awk -F, '
       NR==1 {
         for (i=1;i<=NF;i++) {
           if ($i=="arm")        a=i
@@ -127,12 +145,15 @@ if [[ "${rc}" -eq 0 ]]; then
           if ($i=="mode")       m=i
           if ($i=="n_contigs")  nc=i
           if ($i=="seed")       sd=i
+          if ($i=="tech")       t=i
+          if ($i=="corrector_sequencing_tech") ct=i
         }
         # `hdr_bad` is re-checked in END: awk runs END even after `exit`, and an
         # END-block `exit` OVERRIDES an earlier one — so a bare `exit 2` here was
         # unreachable and a malformed header got reported with the exit-1
-        # "green-but-empty" reason. Both codes fail the job either way; the flag
-        # keeps the REASON honest.
+        # "green-but-empty" reason. The caller branches on the captured status,
+        # so the distinction now reaches the operator instead of dying at the
+        # awk layer.
         if (!a || !er || !rl || !ok || !m || !nc) { hdr_bad=1; exit 2 }
         next
       }
@@ -141,15 +162,38 @@ if [[ "${rc}" -eq 0 ]]; then
         if ($a=="naive")          naive[key]=1
         else if ($a=="iterative") iter[key]=1
       }
+      t && ct && ($ok=="true") && ($a=="iterative") {
+        checked++
+        if ($ct != $t) {
+          tech_bad=1
+          if (!tech_shown) {
+            print "GUARD-DETAIL: line " NR ": iterative row simulated tech=" $t " but corrector ran corrector_sequencing_tech=" $ct
+            tech_shown=1
+          }
+        }
+      }
       END {
-        if (hdr_bad) exit 2
+        if (hdr_bad)  exit 2
+        # Say out loud whether the corrector-profile check actually RAN. A
+        # summary that silently covered zero rows is the same overclaim this
+        # post-check exists to prevent, one level up.
+        if (!ct)      print "GUARD-NOTE: no corrector_sequencing_tech column (pre-wiring CSV) — corrector-profile consistency NOT checked"
+        else if (!t)  print "GUARD-NOTE: no tech column — corrector-profile consistency NOT checked"
+        else          print "GUARD-NOTE: corrector-profile consistency checked on " checked+0 " ok=true iterative row(s)"
+        if (tech_bad) exit 3
         for (key in naive) if (key in iter) found=1
         exit found ? 0 : 1
       }
-    ' "${csv}"; then
-    echo ">>> FAIL: ${csv} has no (error_rate, readlen, seed) cell with BOTH naive and iterative ok=true VERDICT arms (n_contigs>0) — green-but-empty" >&2; rc=1
-  else
-    echo ">>> OK: verified >=1 (error_rate, readlen, seed) cell with BOTH naive+iterative ok=true VERDICT n_contigs>0 arms in ${csv}"
+    ' "${csv}" || guard_rc=$?
+    if [[ "${guard_rc}" -eq 2 ]]; then
+      echo ">>> FAIL: ${csv} is missing a required column (need arm/error_rate/readlen/ok/mode/n_contigs) — SCHEMA error, the table was never checked; this is NOT green-but-empty" >&2; rc=1
+    elif [[ "${guard_rc}" -eq 3 ]]; then
+      echo ">>> FAIL: ${csv} has an ok=true iterative row whose corrector_sequencing_tech disagrees with the simulated tech — the CORRECTOR ran a different error profile than the reads (see GUARD-DETAIL above); results are not comparable" >&2; rc=1
+    elif [[ "${guard_rc}" -ne 0 ]]; then
+      echo ">>> FAIL: ${csv} has no (error_rate, readlen, seed) cell with BOTH naive and iterative ok=true VERDICT arms (n_contigs>0) — green-but-empty" >&2; rc=1
+    else
+      echo ">>> OK: verified >=1 (error_rate, readlen, seed) cell with BOTH naive+iterative ok=true VERDICT n_contigs>0 arms in ${csv} — see the GUARD-NOTE line above for how many iterative rows the corrector-profile check actually covered"
+    fi
   fi
 fi
 

--- a/benchmarking/run_rgv_sweep_lrc.sbatch
+++ b/benchmarking/run_rgv_sweep_lrc.sbatch
@@ -93,11 +93,19 @@ fi
 
 echo ""
 # Post-check: a green exit is a silent failure UNLESS at least one
-# (error_rate, readlen) cell has BOTH the naive AND the iterative arm passing —
-# ok=true, mode=VERDICT, and n_contigs>0. The .jl records a failed/empty arm as
-# ok=false (or n_contigs=0) and still writes the CSV + exits 0; and the sweep's
-# whole purpose IS the naive-vs-iterative comparison, so one lone naive arm is
-# NOT a result. Fail loud so sacct shows FAILED rather than green-but-empty.
+# (error_rate, readlen, seed) cell has BOTH the naive AND the iterative arm
+# passing — ok=true, mode=VERDICT, and n_contigs>0. The .jl records a
+# failed/empty arm as ok=false (or n_contigs=0) and still writes the CSV + exits
+# 0; and the sweep's whole purpose IS the naive-vs-iterative comparison, so one
+# lone naive arm is NOT a result. Fail loud so sacct shows FAILED rather than
+# green-but-empty.
+#
+# The cell key includes `seed`. MYCELIA_RGV_SEED now defaults to THREE seeds, so
+# an (error_rate, readlen)-only key can be satisfied by a naive arm from seed 42
+# paired with an iterative arm from seed 123 — green, yet no single replicate
+# ever produced a comparable pair. The seed column is OPTIONAL (its absence is
+# NOT an exit-2 header error) so this guard still validates CSVs written before
+# the seed column existed; those degrade correctly to the old single-seed key.
 if [[ "${rc}" -eq 0 ]]; then
   # Bind to THIS job's CSV via the path the .jl printed; fail loud if absent.
   csv_line="$(grep '^CSV written: ' "${runlog}" 2>/dev/null | tail -1)"
@@ -118,20 +126,30 @@ if [[ "${rc}" -eq 0 ]]; then
           if ($i=="ok")         ok=i
           if ($i=="mode")       m=i
           if ($i=="n_contigs")  nc=i
+          if ($i=="seed")       sd=i
         }
-        if (!a || !er || !rl || !ok || !m || !nc) exit 2
+        # `hdr_bad` is re-checked in END: awk runs END even after `exit`, and an
+        # END-block `exit` OVERRIDES an earlier one — so a bare `exit 2` here was
+        # unreachable and a malformed header got reported with the exit-1
+        # "green-but-empty" reason. Both codes fail the job either way; the flag
+        # keeps the REASON honest.
+        if (!a || !er || !rl || !ok || !m || !nc) { hdr_bad=1; exit 2 }
         next
       }
       ($ok=="true") && ($m=="VERDICT") && (($nc+0)>0) {
-        key = $er SUBSEP $rl
+        key = $er SUBSEP $rl SUBSEP (sd ? $sd : "-")
         if ($a=="naive")          naive[key]=1
         else if ($a=="iterative") iter[key]=1
       }
-      END { for (key in naive) if (key in iter) found=1; exit found ? 0 : 1 }
+      END {
+        if (hdr_bad) exit 2
+        for (key in naive) if (key in iter) found=1
+        exit found ? 0 : 1
+      }
     ' "${csv}"; then
-    echo ">>> FAIL: ${csv} has no cell with BOTH naive and iterative ok=true VERDICT arms (n_contigs>0) — green-but-empty" >&2; rc=1
+    echo ">>> FAIL: ${csv} has no (error_rate, readlen, seed) cell with BOTH naive and iterative ok=true VERDICT arms (n_contigs>0) — green-but-empty" >&2; rc=1
   else
-    echo ">>> OK: verified >=1 cell with BOTH naive+iterative ok=true VERDICT n_contigs>0 arms in ${csv}"
+    echo ">>> OK: verified >=1 (error_rate, readlen, seed) cell with BOTH naive+iterative ok=true VERDICT n_contigs>0 arms in ${csv}"
   fi
 fi
 

--- a/benchmarking/run_rgv_sweep_nersc.sbatch
+++ b/benchmarking/run_rgv_sweep_nersc.sbatch
@@ -98,6 +98,22 @@ echo ""
 # ever produced a comparable pair. The seed column is OPTIONAL (its absence is
 # NOT an exit-2 header error) so this guard still validates CSVs written before
 # the seed column existed; those degrade correctly to the old single-seed key.
+#
+# The guard ALSO asserts, for every ok=true `iterative` row, that
+# `corrector_sequencing_tech` (read back from the assembler's own stamp) equals
+# the `tech` the reads were simulated with. That column exists to make a re-break
+# of the corrector wiring visible, but a column nothing reads is provenance, not
+# a detector — this post-check is its automated consumer. Both columns are
+# OPTIONAL: `corrector_sequencing_tech` is absent from pre-wiring CSVs, and that
+# absence is precisely what identifies them, so a missing column skips the check
+# rather than failing it.
+#
+# The awk status is CAPTURED into `guard_rc`, never consumed by `! awk ...`:
+# `!` is true for ANY non-zero status, so exit 1 (green-but-empty), exit 2 (bad
+# header) and exit 3 (tech mismatch) all took the same branch and printed the
+# same green-but-empty message. sacct showing FAILED is only half the point —
+# the job .out has to say WHY, and the awk-level exit codes have no other
+# consumer.
 if [[ "${rc}" -eq 0 ]]; then
   # Bind to THIS job's CSV via the path the .jl printed; fail loud if absent.
   csv_line="$(grep '^CSV written: ' "${runlog}" 2>/dev/null | tail -1)"
@@ -106,10 +122,12 @@ if [[ "${rc}" -eq 0 ]]; then
     echo ">>> FAIL: sweep exited 0 but printed no 'CSV written:' path" >&2; rc=1
   elif [[ ! -f "${csv}" ]]; then
     echo ">>> FAIL: printed CSV path does not exist: ${csv}" >&2; rc=1
-  # awk guard assumes comma-free CSV fields: CSV.jl quotes any embedded comma,
-  # which would shift these -F, column positions. Safe for the current schema
-  # (only numeric + bare-word columns: reference/regime/tech/arm/mode).
-  elif ! awk -F, '
+  else
+    # awk guard assumes comma-free CSV fields: CSV.jl quotes any embedded comma,
+    # which would shift these -F, column positions. Safe for the current schema
+    # (only numeric + bare-word columns: reference/regime/tech/arm/mode).
+    guard_rc=0
+    awk -F, '
       NR==1 {
         for (i=1;i<=NF;i++) {
           if ($i=="arm")        a=i
@@ -119,12 +137,15 @@ if [[ "${rc}" -eq 0 ]]; then
           if ($i=="mode")       m=i
           if ($i=="n_contigs")  nc=i
           if ($i=="seed")       sd=i
+          if ($i=="tech")       t=i
+          if ($i=="corrector_sequencing_tech") ct=i
         }
         # `hdr_bad` is re-checked in END: awk runs END even after `exit`, and an
         # END-block `exit` OVERRIDES an earlier one — so a bare `exit 2` here was
         # unreachable and a malformed header got reported with the exit-1
-        # "green-but-empty" reason. Both codes fail the job either way; the flag
-        # keeps the REASON honest.
+        # "green-but-empty" reason. The caller branches on the captured status,
+        # so the distinction now reaches the operator instead of dying at the
+        # awk layer.
         if (!a || !er || !rl || !ok || !m || !nc) { hdr_bad=1; exit 2 }
         next
       }
@@ -133,15 +154,38 @@ if [[ "${rc}" -eq 0 ]]; then
         if ($a=="naive")          naive[key]=1
         else if ($a=="iterative") iter[key]=1
       }
+      t && ct && ($ok=="true") && ($a=="iterative") {
+        checked++
+        if ($ct != $t) {
+          tech_bad=1
+          if (!tech_shown) {
+            print "GUARD-DETAIL: line " NR ": iterative row simulated tech=" $t " but corrector ran corrector_sequencing_tech=" $ct
+            tech_shown=1
+          }
+        }
+      }
       END {
-        if (hdr_bad) exit 2
+        if (hdr_bad)  exit 2
+        # Say out loud whether the corrector-profile check actually RAN. A
+        # summary that silently covered zero rows is the same overclaim this
+        # post-check exists to prevent, one level up.
+        if (!ct)      print "GUARD-NOTE: no corrector_sequencing_tech column (pre-wiring CSV) — corrector-profile consistency NOT checked"
+        else if (!t)  print "GUARD-NOTE: no tech column — corrector-profile consistency NOT checked"
+        else          print "GUARD-NOTE: corrector-profile consistency checked on " checked+0 " ok=true iterative row(s)"
+        if (tech_bad) exit 3
         for (key in naive) if (key in iter) found=1
         exit found ? 0 : 1
       }
-    ' "${csv}"; then
-    echo ">>> FAIL: ${csv} has no (error_rate, readlen, seed) cell with BOTH naive and iterative ok=true VERDICT arms (n_contigs>0) — green-but-empty" >&2; rc=1
-  else
-    echo ">>> OK: verified >=1 (error_rate, readlen, seed) cell with BOTH naive+iterative ok=true VERDICT n_contigs>0 arms in ${csv}"
+    ' "${csv}" || guard_rc=$?
+    if [[ "${guard_rc}" -eq 2 ]]; then
+      echo ">>> FAIL: ${csv} is missing a required column (need arm/error_rate/readlen/ok/mode/n_contigs) — SCHEMA error, the table was never checked; this is NOT green-but-empty" >&2; rc=1
+    elif [[ "${guard_rc}" -eq 3 ]]; then
+      echo ">>> FAIL: ${csv} has an ok=true iterative row whose corrector_sequencing_tech disagrees with the simulated tech — the CORRECTOR ran a different error profile than the reads (see GUARD-DETAIL above); results are not comparable" >&2; rc=1
+    elif [[ "${guard_rc}" -ne 0 ]]; then
+      echo ">>> FAIL: ${csv} has no (error_rate, readlen, seed) cell with BOTH naive and iterative ok=true VERDICT arms (n_contigs>0) — green-but-empty" >&2; rc=1
+    else
+      echo ">>> OK: verified >=1 (error_rate, readlen, seed) cell with BOTH naive+iterative ok=true VERDICT n_contigs>0 arms in ${csv} — see the GUARD-NOTE line above for how many iterative rows the corrector-profile check actually covered"
+    fi
   fi
 fi
 

--- a/benchmarking/run_rgv_sweep_nersc.sbatch
+++ b/benchmarking/run_rgv_sweep_nersc.sbatch
@@ -85,11 +85,19 @@ fi
 
 echo ""
 # Post-check: a green exit is a silent failure UNLESS at least one
-# (error_rate, readlen) cell has BOTH the naive AND the iterative arm passing —
-# ok=true, mode=VERDICT, and n_contigs>0. The .jl records a failed/empty arm as
-# ok=false (or n_contigs=0) and still writes the CSV + exits 0; and the sweep's
-# whole purpose IS the naive-vs-iterative comparison, so one lone naive arm is
-# NOT a result. Fail loud so sacct shows FAILED rather than green-but-empty.
+# (error_rate, readlen, seed) cell has BOTH the naive AND the iterative arm
+# passing — ok=true, mode=VERDICT, and n_contigs>0. The .jl records a
+# failed/empty arm as ok=false (or n_contigs=0) and still writes the CSV + exits
+# 0; and the sweep's whole purpose IS the naive-vs-iterative comparison, so one
+# lone naive arm is NOT a result. Fail loud so sacct shows FAILED rather than
+# green-but-empty.
+#
+# The cell key includes `seed`. MYCELIA_RGV_SEED now defaults to THREE seeds, so
+# an (error_rate, readlen)-only key can be satisfied by a naive arm from seed 42
+# paired with an iterative arm from seed 123 — green, yet no single replicate
+# ever produced a comparable pair. The seed column is OPTIONAL (its absence is
+# NOT an exit-2 header error) so this guard still validates CSVs written before
+# the seed column existed; those degrade correctly to the old single-seed key.
 if [[ "${rc}" -eq 0 ]]; then
   # Bind to THIS job's CSV via the path the .jl printed; fail loud if absent.
   csv_line="$(grep '^CSV written: ' "${runlog}" 2>/dev/null | tail -1)"
@@ -110,20 +118,30 @@ if [[ "${rc}" -eq 0 ]]; then
           if ($i=="ok")         ok=i
           if ($i=="mode")       m=i
           if ($i=="n_contigs")  nc=i
+          if ($i=="seed")       sd=i
         }
-        if (!a || !er || !rl || !ok || !m || !nc) exit 2
+        # `hdr_bad` is re-checked in END: awk runs END even after `exit`, and an
+        # END-block `exit` OVERRIDES an earlier one — so a bare `exit 2` here was
+        # unreachable and a malformed header got reported with the exit-1
+        # "green-but-empty" reason. Both codes fail the job either way; the flag
+        # keeps the REASON honest.
+        if (!a || !er || !rl || !ok || !m || !nc) { hdr_bad=1; exit 2 }
         next
       }
       ($ok=="true") && ($m=="VERDICT") && (($nc+0)>0) {
-        key = $er SUBSEP $rl
+        key = $er SUBSEP $rl SUBSEP (sd ? $sd : "-")
         if ($a=="naive")          naive[key]=1
         else if ($a=="iterative") iter[key]=1
       }
-      END { for (key in naive) if (key in iter) found=1; exit found ? 0 : 1 }
+      END {
+        if (hdr_bad) exit 2
+        for (key in naive) if (key in iter) found=1
+        exit found ? 0 : 1
+      }
     ' "${csv}"; then
-    echo ">>> FAIL: ${csv} has no cell with BOTH naive and iterative ok=true VERDICT arms (n_contigs>0) — green-but-empty" >&2; rc=1
+    echo ">>> FAIL: ${csv} has no (error_rate, readlen, seed) cell with BOTH naive and iterative ok=true VERDICT arms (n_contigs>0) — green-but-empty" >&2; rc=1
   else
-    echo ">>> OK: verified >=1 cell with BOTH naive+iterative ok=true VERDICT n_contigs>0 arms in ${csv}"
+    echo ">>> OK: verified >=1 (error_rate, readlen, seed) cell with BOTH naive+iterative ok=true VERDICT n_contigs>0 arms in ${csv}"
   fi
 fi
 


### PR DESCRIPTION
## Summary

Two defects, both verified still live on current master (`c8182ebf`).

### 1. The corrector never receives the read technology

`regime_for_readlen` maps `readlen > 500 -> :nanopore`, and that tech **is** passed to read simulation. But `run_arm` (`:203`) calls `assemble_genome` with only `k`, `graph_mode`, `corrector`, `verbose` — no `sequencing_tech`. `AssemblyConfig` defaults to `:illumina`, so the corrector runs the **substitution-only** profile on nanopore-simulated, indel-bearing reads. Both sbatch wrappers default `READLEN=150,5000`.

Net effect: running the sweep today produces a substitution-only result labeled "nanopore."

Fix: `run_arm` gains a **required, no-default** `sequencing_tech::Symbol` (a caller must not be able to silently fall back) plus an injectable `assembler` for testing. The new `corrector_sequencing_tech` column is **read back from the assembler's own `assembly_stats` stamp**, never echoed from the input — an echoed column would have read green even with the original bug present.

### 2. The awk guard's cross-seed pairing hole — widened by #439

The green-but-empty guard keys cells as `key = $er SUBSEP $rl`, with no seed field. `#439` changed `MYCELIA_RGV_SEED` to default to **three** seeds. So a naive arm from seed 42 can satisfy the guard alongside an iterative arm from seed 123, and it passes on a table containing no complete cell.

Fix: an **optional** `seed` index (so pre-seed-column CSVs still validate) extending the key to `$er SUBSEP $rl SUBSEP (sd ? $sd : "-")`. Also repairs an unreachable `exit 2` — awk runs `END` even after `exit`, so `END { exit found ? 0 : 1 }` overrode the header-error code, and a malformed schema was misreported as "green-but-empty."

## Positive control — both guards run against the same fixtures

| fixture | old guard | new guard |
|---|---|---|
| cross-seed-only (no complete cell) | **exit 0** — the bug | **exit 1** — fixed |
| new CSV as emitted (SMOKE-ONLY) | — | exit 1 (correctly requires VERDICT) |
| same rows forced to VERDICT | — | exit 0 |
| pre-change committed CSV (no seed column) | exit 1 | exit 1 — identical |
| header missing `arm` | exit 1 (misreported) | **exit 2** (honest schema error) |

The guard program was extracted from the committed sbatch by line markers rather than retyped; the lrc guard was verified byte-identical to the nersc one.

## Deliberately NOT included

`#439` independently landed the seed axis (comma-separated `MYCELIA_RGV_SEED`, the `seed` column, per-seed RNG). All of that was dropped from this branch as superseded — master's implementation is authoritative. `MYCELIA_RGV_REF_SEED` was dropped too, since master handles the reference seed as `seed = first(seeds)`.

No `harness_version` column: `#439` established a per-row metric-definition convention (`metric_source`, `quast_min_contig`, enforced by `metric_source_guard.jl`), and `corrector_sequencing_tech` **is** such a stamp — its absence identifies a pre-fix CSV by construction. A hand-maintained integer would be a second, weaker, drift-prone generation signal the guard does not know about.

## Test Plan

- [x] Fast schema/regime tests — 39 pass, 0 fail
- [x] Wiring test (new file) — 24 pass, 0 fail, incl. a stub that stamps a *different* value than it receives, so an echoed column would fail
- [x] **T5 naive-arm inertness — PASSED**: contig FASTA bytes identical between `sequencing_tech=:nanopore` and the kwarg genuinely omitted, so passing it to both arms introduces no asymmetry
- [x] `bash -n` clean on both wrappers
- [x] Smoke sweep (`SEED=42,43`, `READLEN=150,1200`): every `readlen=1200` iterative row stamps `nanopore`, every `readlen=150` iterative row stamps `illumina`, naive rows stamp `n/a`
- [x] No regression to `#439`: `rgv_seed_backfill_test.jl` 59/59, `rgv_paired_wilcoxon_test.jl` 300/300

Pre-fix long-read rows were substitution-only despite the `nanopore` label and are **not comparable** to post-fix rows.

## Follow-ups (not in this PR)

- Master's schema testset is missing `seed` and `quast_min_contig`, which `#439` added to the production schema — pre-existing drift.
- `corrector_sequencing_tech` is a natural `METRIC_DEFINITION_COLUMNS` member: two rows scored under different corrector profiles are not comparable, exactly the hazard `metric_source_guard.jl` exists to trip on.

## Related

Part of the td-jt7r indel-decoder workstream. Unblocks the HPC Lambda sweep, which would otherwise produce a mislabeled result.