### PR TITLE
fix(review): close three Criticals from the unreviewed tail of #439

### DIFF
--- a/benchmarking/rgv_paired_wilcoxon.jl
+++ b/benchmarking/rgv_paired_wilcoxon.jl
@@ -663,7 +663,24 @@ function run_paired_analysis(df;
     # shown to be consistent, it is a table that cannot be checked — and `ok` is
     # the same kind of claim.
     ok_column_present = :ok in Symbol.(DataFrames.names(work))
-    ok_filter_applied = !keep_not_ok && ok_column_present
+    # A PRESENT `ok` column whose element type cannot express success is not a
+    # check that ran. `coalesce.(okcol, false) .== true` is vacuously FALSE for a
+    # `String` element, so every row was dropped and the counter split then
+    # attributed the drops to `ok=false` — the report asserted the harness had
+    # OBSERVED N failed runs whose cells literally read `"TRUE"`. The trigger is
+    # ordinary: `CSV.read` infers `String7` for an `ok` column containing
+    # `true,false,NA`, one sentinel poisons the column, and merging that shard with
+    # a Bool-typed shard under `cols = :union` propagates it. `n` then shrinks and
+    # the p-value moves, with the added "(status unknown, not an observed failure)"
+    # phrasing actively ruling out the correct explanation.
+    #
+    # `Bool <: Integer`, so the `Bool` arm below is redundant to the compiler and
+    # kept only to name the intended case; a 0/1 `Integer` column filters correctly
+    # (`1 == true`) and stays runnable.
+    ok_column_eltype = ok_column_present ? string(eltype(work.ok)) : nothing
+    ok_column_runnable = ok_column_present &&
+                         eltype(work.ok) <: Union{Missing, Bool, Integer}
+    ok_filter_applied = !keep_not_ok && ok_column_runnable
     n_dropped_not_ok = 0
     n_dropped_ok_missing = 0
     if ok_filter_applied
@@ -734,7 +751,10 @@ function run_paired_analysis(df;
         definition_provenance_undeterminable = definition_undeterminable,
         treatment = String(treatment), control = String(control),
         n_input_rows = n_input, n_rows_analyzed = DataFrames.nrow(work),
-        ok_column_present = ok_column_present, ok_filter_applied = ok_filter_applied,
+        ok_column_present = ok_column_present,
+        ok_column_runnable = ok_column_runnable,
+        ok_column_eltype = ok_column_eltype,
+        ok_filter_applied = ok_filter_applied,
         keep_not_ok = keep_not_ok,
         n_dropped_not_ok = n_dropped_not_ok,
         n_dropped_ok_missing = n_dropped_ok_missing,
@@ -793,6 +813,14 @@ function write_paired_report(path::AbstractString, analysis; csv_paths)
         ok_clause = if !analysis.ok_column_present
             "**`ok` column ABSENT — no row was verified; the ok=false check could " *
             "NOT run**"
+        elseif !analysis.ok_column_runnable
+            # Present but uninterpretable. Stated as its own outcome so it can never
+            # be read as a count of observed failures, and so the reader learns the
+            # actual defect (a non-boolean column, usually a sentinel like `NA`
+            # forcing `CSV.read` to infer a string type for the whole shard).
+            "**`ok` column is `$(analysis.ok_column_eltype)`, NOT a boolean — it " *
+            "cannot express success, so the ok=false check could NOT run; NO row " *
+            "was dropped by it (fix the column type or re-export the sweep)**"
         elseif !analysis.ok_filter_applied
             "`ok` filter DISABLED via --keep-not-ok — failed rows were KEPT"
         else
@@ -1009,6 +1037,12 @@ function paired_analysis_json(analysis; csv_paths)
         # Whether the ok=false check RAN, not only what it dropped. Without the
         # flag, "0 dropped" is indistinguishable from "could not be checked".
         "ok_column_present" => analysis.ok_column_present,
+        # Present is not the same as usable: a `String` `ok` column cannot express
+        # success, so the filter could not run over it. Without this field a
+        # consumer reading `ok_column_present: true, n_dropped_not_ok: 0` would
+        # conclude the check ran and found nothing.
+        "ok_column_runnable" => analysis.ok_column_runnable,
+        "ok_column_eltype" => analysis.ok_column_eltype,
         "ok_filter_applied" => analysis.ok_filter_applied,
         "n_dropped_not_ok" => analysis.n_dropped_not_ok,
         "n_dropped_ok_missing" => analysis.n_dropped_ok_missing,

--- a/benchmarking/rgv_paired_wilcoxon.jl
+++ b/benchmarking/rgv_paired_wilcoxon.jl
@@ -783,24 +783,33 @@ function write_paired_report(path::AbstractString, analysis; csv_paths)
                 "misassembly. **These results are not validation-grade and must not " *
                 "be reported as a measured effect.**\n")
         elseif analysis.allow_mixed_src
+            # Deliberately does NOT say "so the aggregate is well-defined": that is
+            # a claim about the VALUES, and it is settled by the provenance block
+            # below, not by whether a flag bound. This branch reports only what it
+            # actually knows — that the override did not fire.
             println(io,
                 "\n_`--allow-mixed-src` was passed but did NOT bind: the rows are " *
-                "single-definition on every checked axis, so the aggregate is " *
-                "well-defined._\n")
-        elseif analysis.definition_operator_asserted
-            # The assurance is deliberately NOT printed here: it would certify an
-            # operator's claim as a checked fact. The warning block above stands in
-            # its place.
-            println(io,
-                "\n_`metric_source_guard.jl` (bead td-9p91) ran and no override was " *
-                "used, but the values it compared were operator-asserted for some " *
-                "rows (see the warning above), so this run does NOT establish that " *
-                "the aggregate spans a single MEASURED definition._\n")
-        else
+                "single-definition on every checked axis._\n")
+        elseif !analysis.definition_operator_asserted
             println(io,
                 "\n_A single value per definition column is what makes the aggregate " *
                 "meaningful; `metric_source_guard.jl` (bead td-9p91) enforced it — " *
                 "no override was used._\n")
+        end
+
+        # INDEPENDENT of the override state above. Whether the guard was overridden
+        # and whether the values it compared were observed are two orthogonal facts,
+        # and chaining them through one `if/elseif` let the weaker one shadow the
+        # stronger: a harmless NON-BINDING `--allow-mixed-src` suppressed this
+        # qualifier and restored an unqualified "the aggregate is well-defined" over
+        # a table whose definition was never observed — the exact assurance this
+        # machinery exists to withhold. Emitted last so it is the final word.
+        if analysis.definition_operator_asserted
+            println(io,
+                "\n_`metric_source_guard.jl` (bead td-9p91) checked what it was given, " *
+                "but the values it compared were operator-asserted for some rows " *
+                "(see the warning above), so this run does NOT establish that the " *
+                "aggregate spans a single MEASURED definition._\n")
         end
 
         println(io, "## Results\n")

--- a/benchmarking/rgv_paired_wilcoxon.jl
+++ b/benchmarking/rgv_paired_wilcoxon.jl
@@ -529,16 +529,31 @@ than observed by the run that produced the metrics.
 `rgv_seed_backfill.jl` writes `"operator-asserted (backfill)"` into
 `<definition-column>_provenance` for every row it supplies a definition for. The
 match is on the substring so the writer can extend the label (with a tool name, a
-date) without breaking the reader; the coupling is pinned by a test that greps the
-backfill tool's source.
+date) without breaking the reader; the coupling is pinned by a BEHAVIOURAL
+round-trip test (backfill writes a frame, this reader classifies it), because a
+grep of the writer's source passes unchanged while its call site drifts to a label
+this reader does not understand.
 """
 const RGV_ASSERTED_DEFINITION_MARKER = "operator-asserted"
 
 """
-    operator_asserted_definitions(df) -> (axes, n_rows)
+Label identifying a metric definition the run itself OBSERVED, written by
+`rgv_seed_backfill.jl` as `DEFINITION_PROVENANCE_OBSERVED` for rows it did not
+supply a value for.
 
-Definition axes whose value was operator-asserted for at least one row of `df`,
-and the number of rows carrying an assertion on any axis.
+Matched EXACTLY, not as a substring: this is the only value that earns the
+unqualified assurance, so anything else — including a label a future writer
+invents — must fall through to `undeterminable` rather than be read as evidence.
+The coupling to the writer is pinned by a behavioural round-trip test, not by a
+grep of the writer's source (a grep passes while the writer's call site drifts).
+"""
+const RGV_OBSERVED_DEFINITION_LABEL = "observed"
+
+"""
+    definition_provenance_axes(df) -> (asserted, undeterminable, n_asserted_rows)
+
+Classify the provenance of every metric-definition axis PRESENT in `df` as
+asserted, observed, or undeterminable, and count the rows carrying an assertion.
 
 This is the fact `assert_single_metric_definition` structurally CANNOT establish.
 The guard checks that the definition labels agree with each other; when those
@@ -547,22 +562,72 @@ guaranteed by construction and says nothing about how the runs were scored. A
 legacy table that genuinely mixed QUAST-scored and degraded rows, backfilled with
 a single `--metric-source`, passes the guard perfectly. Only the provenance column
 distinguishes that case, so the report and `results.json` must surface it.
+
+# Why three states and not two
+
+The two-state reader FAILED OPEN in exactly the situation it exists for. Absence
+of the `"operator-asserted"` marker was read as evidence of measurement, so an
+axis whose sibling `<axis>_provenance` column is missing — which is EVERY CSV the
+documented backfill/analyse workflow produced before this axis existed — was
+reported as `metric_definition_operator_asserted: false`, an affirmative claim the
+definition was measured, and the report went on to print the unqualified
+"the guard enforced it — no override was used".
+
+An unrecognised label failed the same way and is worse: a column present but
+holding, say, `"backfilled-by-tool"` is STRONGER evidence that something wrote
+provenance metadata than no column at all, yet a blacklist reader treats it more
+permissively. Both are the same epistemic state — the table carries no usable
+provenance — and neither is "observed". This mirrors the doctrine applied twelve
+lines away to `ok`, and the one `metric_source_guard.jl` applies when one
+definition axis is present and another absent: unverifiable is not verified.
+
+An axis can appear in BOTH returned lists (some rows asserted, others carrying an
+unreadable label); each list answers its own question.
 """
-function operator_asserted_definitions(df)
+function definition_provenance_axes(df)
     cols = Set(String.(DataFrames.names(df)))
-    axes = String[]
+    asserted = String[]
+    undeterminable = String[]
     asserted_rows = falses(DataFrames.nrow(df))
     for col in METRIC_DEFINITION_COLUMNS
+        # Only axes the table actually carries are classified: an axis that is not
+        # in the table is not part of the definition being reported on.
+        String(col) in cols || continue
         prov = String(col) * "_provenance"
-        prov in cols || continue
+        if !(prov in cols)
+            push!(undeterminable, String(col))
+            continue
+        end
+        values = getproperty(df, Symbol(prov))
         flags = Bool[!ismissing(v) &&
                      occursin(RGV_ASSERTED_DEFINITION_MARKER, string(v))
-                     for v in getproperty(df, Symbol(prov))]
-        any(flags) || continue
-        push!(axes, String(col))
-        asserted_rows .|= flags
+                     for v in values]
+        unreadable = Bool[!flags[i] &&
+                          (ismissing(values[i]) ||
+                           string(values[i]) != RGV_OBSERVED_DEFINITION_LABEL)
+                          for i in eachindex(values)]
+        if any(flags)
+            push!(asserted, String(col))
+            asserted_rows .|= flags
+        end
+        any(unreadable) && push!(undeterminable, String(col))
     end
-    return axes, count(asserted_rows)
+    return asserted, undeterminable, count(asserted_rows)
+end
+
+"""
+    operator_asserted_definitions(df) -> (axes, n_rows)
+
+Definition axes whose value was operator-asserted for at least one row of `df`,
+and the number of rows carrying an assertion on any axis.
+
+Thin view over [`definition_provenance_axes`](@ref) that answers only the
+asserted question. Callers that need to distinguish "observed" from "cannot be
+determined" must use the three-state function.
+"""
+function operator_asserted_definitions(df)
+    asserted, _, n_rows = definition_provenance_axes(df)
+    return asserted, n_rows
 end
 
 """
@@ -640,8 +705,10 @@ function run_paired_analysis(df;
     # onto a table that really did mix definitions, which the guard then certifies
     # as consistent. That fact has to reach the deliverable, for the same reason
     # `override_bound` does.
-    asserted_axes, n_asserted_rows = operator_asserted_definitions(work)
+    asserted_axes, undeterminable_axes,
+    n_asserted_rows = definition_provenance_axes(work)
     definition_asserted = !isempty(asserted_axes)
+    definition_undeterminable = !isempty(undeterminable_axes)
 
     results = [analyze_metric(work, m; treatment = treatment, control = control)
                for m in metrics]
@@ -663,6 +730,8 @@ function run_paired_analysis(df;
         operator_asserted_axes = asserted_axes,
         n_rows_operator_asserted = n_asserted_rows,
         definition_operator_asserted = definition_asserted,
+        undeterminable_definition_axes = undeterminable_axes,
+        definition_provenance_undeterminable = definition_undeterminable,
         treatment = String(treatment), control = String(control),
         n_input_rows = n_input, n_rows_analyzed = DataFrames.nrow(work),
         ok_column_present = ok_column_present, ok_filter_applied = ok_filter_applied,
@@ -765,6 +834,25 @@ function write_paired_report(path::AbstractString, analysis; csv_paths)
                 "with a single value. **Treat the definition below as an operator " *
                 "assertion, not as measured provenance.**\n")
         end
+        # The third state. "No contrary signal" is not evidence of measurement, and
+        # reading it as such is how the two-state reader certified every pre-existing
+        # sweep CSV — none of which has a `*_provenance` column — as measured.
+        if analysis.definition_provenance_undeterminable
+            println(io,
+                "\n> ## :warning: METRIC DEFINITION PROVENANCE UNDETERMINABLE\n>\n" *
+                "> This table carries no usable provenance for " *
+                join(("`$a`" for a in analysis.undeterminable_definition_axes), ", ") *
+                ": the sibling `<axis>_provenance` column is missing, empty, or " *
+                "holds a label this reader does not recognise (only " *
+                "`$(RGV_OBSERVED_DEFINITION_LABEL)` and labels containing " *
+                "`$(RGV_ASSERTED_DEFINITION_MARKER)` are understood).\n>\n" *
+                "> Whether those definitions were MEASURED by the runs or ASSERTED " *
+                "by an operator therefore **cannot be determined from this table**. " *
+                "That is not the same as their having been measured, and it is the " *
+                "state every sweep CSV written before the provenance column existed " *
+                "is in. Recover it with `rgv_seed_backfill.jl`, or read the numbers " *
+                "below as resting on an unverified definition.\n")
+        end
         # The artifact must never assert the guard was enforced when it was
         # overridden. Previously this line printed unconditionally, so a run with
         # `--allow-mixed-src` listed two definitions and then, one line later, told
@@ -790,7 +878,12 @@ function write_paired_report(path::AbstractString, analysis; csv_paths)
             println(io,
                 "\n_`--allow-mixed-src` was passed but did NOT bind: the rows are " *
                 "single-definition on every checked axis._\n")
-        elseif !analysis.definition_operator_asserted
+        elseif !analysis.definition_operator_asserted &&
+               !analysis.definition_provenance_undeterminable
+            # The unqualified assurance requires AFFIRMATIVELY-OBSERVED provenance on
+            # every present axis, not merely the absence of a contrary signal. Gating
+            # it on `!definition_operator_asserted` alone handed it to every table
+            # with no provenance column at all.
             println(io,
                 "\n_A single value per definition column is what makes the aggregate " *
                 "meaningful; `metric_source_guard.jl` (bead td-9p91) enforced it — " *
@@ -808,6 +901,12 @@ function write_paired_report(path::AbstractString, analysis; csv_paths)
             println(io,
                 "\n_`metric_source_guard.jl` (bead td-9p91) checked what it was given, " *
                 "but the values it compared were operator-asserted for some rows " *
+                "(see the warning above), so this run does NOT establish that the " *
+                "aggregate spans a single MEASURED definition._\n")
+        elseif analysis.definition_provenance_undeterminable
+            println(io,
+                "\n_`metric_source_guard.jl` (bead td-9p91) checked what it was given, " *
+                "but the table carries no usable provenance for the axes named above " *
                 "(see the warning above), so this run does NOT establish that the " *
                 "aggregate spans a single MEASURED definition._\n")
         end
@@ -930,6 +1029,11 @@ function paired_analysis_json(analysis; csv_paths)
         "metric_definition_operator_asserted" => analysis.definition_operator_asserted,
         "operator_asserted_definition_axes" => analysis.operator_asserted_axes,
         "n_rows_operator_asserted_definition" => analysis.n_rows_operator_asserted,
+        # The THIRD state, kept separate from the boolean above rather than folded
+        # into it: `metric_definition_operator_asserted` still means "at least one
+        # row was asserted", and `false` on it no longer implies "observed".
+        "metric_definition_provenance_undeterminable" => analysis.definition_provenance_undeterminable,
+        "undeterminable_definition_provenance_axes" => analysis.undeterminable_definition_axes,
         "alpha" => RGV_ALPHA,
         "improvement_threshold" => RGV_IMPROVEMENT_THRESHOLD,
         "metrics" => [Dict(

--- a/benchmarking/rgv_paired_wilcoxon.jl
+++ b/benchmarking/rgv_paired_wilcoxon.jl
@@ -588,11 +588,29 @@ function run_paired_analysis(df;
 
     work = df
     n_input = DataFrames.nrow(work)
+    # "The ok check ran and every row passed" and "the ok check COULD NOT RUN"
+    # are different facts about the data, and they used to render identically:
+    # `0 dropped for ok=false` was emitted verbatim whether the column was present
+    # and all-true or absent entirely, and `results.json` carried neither count nor
+    # a presence flag, so no consumer could recover the distinction from either
+    # artifact. `metric_source_guard.jl` already applies the opposite doctrine to
+    # the definition columns — a table with no provenance column is not a table
+    # shown to be consistent, it is a table that cannot be checked — and `ok` is
+    # the same kind of claim.
+    ok_column_present = :ok in Symbol.(DataFrames.names(work))
+    ok_filter_applied = !keep_not_ok && ok_column_present
     n_dropped_not_ok = 0
-    if !keep_not_ok && (:ok in Symbol.(DataFrames.names(work)))
-        before = DataFrames.nrow(work)
-        work = work[coalesce.(work.ok, false) .== true, :]
-        n_dropped_not_ok = before - DataFrames.nrow(work)
+    n_dropped_ok_missing = 0
+    if ok_filter_applied
+        okcol = work.ok
+        keep = coalesce.(okcol, false) .== true
+        # `coalesce(missing, false)` drops an unknown-status row, which is the right
+        # default, but counting it as ok=false conflates "the harness SAID this run
+        # failed" with "we do not know whether it succeeded". Only the first is an
+        # observed failure, so the two are counted separately.
+        n_dropped_ok_missing = count(ismissing, okcol)
+        n_dropped_not_ok = count(!, keep) - n_dropped_ok_missing
+        work = work[keep, :]
     end
     n_dropped_source = 0
     if metric_source !== nothing
@@ -647,7 +665,11 @@ function run_paired_analysis(df;
         definition_operator_asserted = definition_asserted,
         treatment = String(treatment), control = String(control),
         n_input_rows = n_input, n_rows_analyzed = DataFrames.nrow(work),
-        n_dropped_not_ok = n_dropped_not_ok, n_dropped_metric_source = n_dropped_source,
+        ok_column_present = ok_column_present, ok_filter_applied = ok_filter_applied,
+        keep_not_ok = keep_not_ok,
+        n_dropped_not_ok = n_dropped_not_ok,
+        n_dropped_ok_missing = n_dropped_ok_missing,
+        n_dropped_metric_source = n_dropped_source,
         pair_keys = RGV_PAIR_KEYS)
 end
 
@@ -698,10 +720,21 @@ function write_paired_report(path::AbstractString, analysis; csv_paths)
             "rather than error rate, and designates k=31 primary (k=21/51 " *
             "sensitivity). Compare the axes above against that before reading the " *
             "decision column — the thresholds were calibrated for that design._")
+        # An absent `ok` column must never render as a check that ran and passed.
+        ok_clause = if !analysis.ok_column_present
+            "**`ok` column ABSENT — no row was verified; the ok=false check could " *
+            "NOT run**"
+        elseif !analysis.ok_filter_applied
+            "`ok` filter DISABLED via --keep-not-ok — failed rows were KEPT"
+        else
+            "$(analysis.n_dropped_not_ok) dropped for ok=false, " *
+            "$(analysis.n_dropped_ok_missing) dropped for ok=missing (status " *
+            "unknown, not an observed failure)"
+        end
         println(io,
             "- Rows: $(analysis.n_input_rows) read, " *
             "$(analysis.n_rows_analyzed) analyzed " *
-            "($(analysis.n_dropped_not_ok) dropped for ok=false, " *
+            "($ok_clause; " *
             "$(analysis.n_dropped_metric_source) dropped by metric_source filter)")
         println(io, "\n### Metric definition analyzed under\n")
         for (col, vals) in analysis.definition
@@ -865,6 +898,13 @@ function paired_analysis_json(analysis; csv_paths)
         "seeds" => collect(analysis.seeds),
         "n_input_rows" => analysis.n_input_rows,
         "n_rows_analyzed" => analysis.n_rows_analyzed,
+        # Whether the ok=false check RAN, not only what it dropped. Without the
+        # flag, "0 dropped" is indistinguishable from "could not be checked".
+        "ok_column_present" => analysis.ok_column_present,
+        "ok_filter_applied" => analysis.ok_filter_applied,
+        "n_dropped_not_ok" => analysis.n_dropped_not_ok,
+        "n_dropped_ok_missing" => analysis.n_dropped_ok_missing,
+        "n_dropped_metric_source" => analysis.n_dropped_metric_source,
         "metric_definition" => Dict(string(col) => vals
         for (col, vals) in analysis.definition),
         "exploratory" => true,

--- a/benchmarking/rgv_paired_wilcoxon.jl
+++ b/benchmarking/rgv_paired_wilcoxon.jl
@@ -878,8 +878,14 @@ function write_paired_report(path::AbstractString, analysis; csv_paths)
                 "by an operator therefore **cannot be determined from this table**. " *
                 "That is not the same as their having been measured, and it is the " *
                 "state every sweep CSV written before the provenance column existed " *
-                "is in. Recover it with `rgv_seed_backfill.jl`, or read the numbers " *
-                "below as resting on an unverified definition.\n")
+                "is in.\n>\n" *
+                "> This is NOT recoverable by re-running `rgv_seed_backfill.jl`: it " *
+                "labels only the rows whose definition it SUPPLIES, so a CSV that " *
+                "already carries the definition gains no provenance column, and " *
+                "labelling those rows `$(RGV_OBSERVED_DEFINITION_LABEL)` after the " *
+                "fact would assert exactly the thing that cannot be determined. Re-run " *
+                "the sweep to get a table that records its own provenance, or read the " *
+                "numbers below as resting on an unverified definition.\n")
         end
         # The artifact must never assert the guard was enforced when it was
         # overridden. Previously this line printed unconditionally, so a run with

--- a/benchmarking/rgv_paired_wilcoxon.jl
+++ b/benchmarking/rgv_paired_wilcoxon.jl
@@ -42,6 +42,15 @@
 #    size-ratio proxy. Selecting a definition is explicit (`--metric-source quast`)
 #    or the run fails.
 #
+#    A definition column can also be SUPPLIED after the fact by
+#    `rgv_seed_backfill.jl --metric-source`, on operator say-so, with nothing to
+#    verify it against. The guard cannot see the difference — a backfilled label
+#    agrees with itself by construction — so a genuinely mixed legacy table becomes
+#    one the guard certifies as uniform. This script therefore reads the
+#    `<column>_provenance` column the backfill writes and refuses to print the
+#    "guard enforced it" assurance over operator-asserted rows; `results.json`
+#    carries the same fact in `metric_definition_operator_asserted`.
+#
 # HOW PAIRS ARE FORMED
 # --------------------
 # One pair per (reference, error_rate, readlen, target_coverage, k, seed) cell:
@@ -514,6 +523,49 @@ function decide(result, adjusted_p)
 end
 
 """
+Substring identifying a metric definition that was ASSERTED BY AN OPERATOR rather
+than observed by the run that produced the metrics.
+
+`rgv_seed_backfill.jl` writes `"operator-asserted (backfill)"` into
+`<definition-column>_provenance` for every row it supplies a definition for. The
+match is on the substring so the writer can extend the label (with a tool name, a
+date) without breaking the reader; the coupling is pinned by a test that greps the
+backfill tool's source.
+"""
+const RGV_ASSERTED_DEFINITION_MARKER = "operator-asserted"
+
+"""
+    operator_asserted_definitions(df) -> (axes, n_rows)
+
+Definition axes whose value was operator-asserted for at least one row of `df`,
+and the number of rows carrying an assertion on any axis.
+
+This is the fact `assert_single_metric_definition` structurally CANNOT establish.
+The guard checks that the definition labels agree with each other; when those
+labels were written by `rgv_seed_backfill.jl --metric-source`, agreement is
+guaranteed by construction and says nothing about how the runs were scored. A
+legacy table that genuinely mixed QUAST-scored and degraded rows, backfilled with
+a single `--metric-source`, passes the guard perfectly. Only the provenance column
+distinguishes that case, so the report and `results.json` must surface it.
+"""
+function operator_asserted_definitions(df)
+    cols = Set(String.(DataFrames.names(df)))
+    axes = String[]
+    asserted_rows = falses(DataFrames.nrow(df))
+    for col in METRIC_DEFINITION_COLUMNS
+        prov = String(col) * "_provenance"
+        prov in cols || continue
+        flags = Bool[!ismissing(v) &&
+                     occursin(RGV_ASSERTED_DEFINITION_MARKER, string(v))
+                     for v in getproperty(df, Symbol(prov))]
+        any(flags) || continue
+        push!(axes, String(col))
+        asserted_rows .|= flags
+    end
+    return axes, count(asserted_rows)
+end
+
+"""
     run_paired_analysis(df; treatment, control, metrics, metric_source=nothing,
                         allow_mixed_src=false, keep_not_ok=false) -> NamedTuple
 
@@ -565,6 +617,14 @@ function run_paired_analysis(df;
     mixed_axes = [String(col) for (col, vals) in definition if length(vals) > 1]
     override_bound = allow_mixed_src && !isempty(mixed_axes)
 
+    # A definition the guard CHECKED is not the same as a definition anyone
+    # OBSERVED. `rgv_seed_backfill.jl --metric-source` can write a uniform label
+    # onto a table that really did mix definitions, which the guard then certifies
+    # as consistent. That fact has to reach the deliverable, for the same reason
+    # `override_bound` does.
+    asserted_axes, n_asserted_rows = operator_asserted_definitions(work)
+    definition_asserted = !isempty(asserted_axes)
+
     results = [analyze_metric(work, m; treatment = treatment, control = control)
                for m in metrics]
     adjusted = benjamini_hochberg(Float64[r.test.pvalue for r in results])
@@ -582,6 +642,9 @@ function run_paired_analysis(df;
         definition = definition, seeds = seeds,
         axes = axes, allow_mixed_src = allow_mixed_src, mixed_axes = mixed_axes,
         override_bound = override_bound,
+        operator_asserted_axes = asserted_axes,
+        n_rows_operator_asserted = n_asserted_rows,
+        definition_operator_asserted = definition_asserted,
         treatment = String(treatment), control = String(control),
         n_input_rows = n_input, n_rows_analyzed = DataFrames.nrow(work),
         n_dropped_not_ok = n_dropped_not_ok, n_dropped_metric_source = n_dropped_source,
@@ -644,6 +707,31 @@ function write_paired_report(path::AbstractString, analysis; csv_paths)
         for (col, vals) in analysis.definition
             println(io, "- `$col`: " * join(("`$v`" for v in vals), ", "))
         end
+        # Same doctrine as the override block below, applied to the other way the
+        # assurance can be false. A definition SUPPLIED by `rgv_seed_backfill.jl`
+        # is uniform by construction, so the guard passing over it is not evidence
+        # about how the runs were scored — a legacy table that genuinely mixed
+        # QUAST-scored and degraded rows, backfilled with one `--metric-source`,
+        # produces exactly this artifact. The reader must be told before reading
+        # the numbers, and the unqualified assurance below is suppressed.
+        if analysis.definition_operator_asserted
+            println(io,
+                "\n> ## :warning: METRIC DEFINITION OPERATOR-ASSERTED, NOT OBSERVED\n>\n" *
+                "> $(analysis.n_rows_operator_asserted) of " *
+                "$(analysis.n_rows_analyzed) analyzed rows carry a definition that " *
+                "was **supplied by `rgv_seed_backfill.jl`** on operator say-so, on " *
+                join(("`$a`" for a in analysis.operator_asserted_axes), ", ") *
+                " (see the `*_provenance` column(s) in the input CSV).\n>\n" *
+                "> Nothing verified that claim: unlike `seed`, which can be " *
+                "recovered from a run log, there is no record of which definition " *
+                "produced a historical metric. `metric_source_guard.jl` can only " *
+                "confirm that the asserted labels agree with EACH OTHER, and a " *
+                "backfilled label agrees with itself by construction — a table that " *
+                "genuinely mixed an alignment-validated QUAST metric with an " *
+                "internal size-ratio proxy passes this check once it is backfilled " *
+                "with a single value. **Treat the definition below as an operator " *
+                "assertion, not as measured provenance.**\n")
+        end
         # The artifact must never assert the guard was enforced when it was
         # overridden. Previously this line printed unconditionally, so a run with
         # `--allow-mixed-src` listed two definitions and then, one line later, told
@@ -666,6 +754,15 @@ function write_paired_report(path::AbstractString, analysis; csv_paths)
                 "\n_`--allow-mixed-src` was passed but did NOT bind: the rows are " *
                 "single-definition on every checked axis, so the aggregate is " *
                 "well-defined._\n")
+        elseif analysis.definition_operator_asserted
+            # The assurance is deliberately NOT printed here: it would certify an
+            # operator's claim as a checked fact. The warning block above stands in
+            # its place.
+            println(io,
+                "\n_`metric_source_guard.jl` (bead td-9p91) ran and no override was " *
+                "used, but the values it compared were operator-asserted for some " *
+                "rows (see the warning above), so this run does NOT establish that " *
+                "the aggregate spans a single MEASURED definition._\n")
         else
             println(io,
                 "\n_A single value per definition column is what makes the aggregate " *
@@ -778,6 +875,12 @@ function paired_analysis_json(analysis; csv_paths)
         "allow_mixed_src" => analysis.allow_mixed_src,
         "mixed_definition_axes" => analysis.mixed_axes,
         "metric_definition_override_bound" => analysis.override_bound,
+        # Whether the definition the guard checked was MEASURED or merely ASSERTED.
+        # A consumer that reads only `metric_definition` cannot tell the two apart,
+        # and they are very different provenance claims.
+        "metric_definition_operator_asserted" => analysis.definition_operator_asserted,
+        "operator_asserted_definition_axes" => analysis.operator_asserted_axes,
+        "n_rows_operator_asserted_definition" => analysis.n_rows_operator_asserted,
         "alpha" => RGV_ALPHA,
         "improvement_threshold" => RGV_IMPROVEMENT_THRESHOLD,
         "metrics" => [Dict(

--- a/benchmarking/rgv_paired_wilcoxon_figure.jl
+++ b/benchmarking/rgv_paired_wilcoxon_figure.jl
@@ -65,8 +65,15 @@ Every flag is read with a `false` default, so an older `results.json` written be
 the fields existed renders with no caveats, exactly as it did before.
 """
 function paired_figure_caption(payload)
+    # Sorted by axis name: `metric_definition` is a `Dict`, whose iteration order is
+    # unspecified, so an unsorted comprehension can name the axes in a different
+    # order for two renders of the SAME results.json. That makes the SVG/PNG
+    # non-reproducible and every figure diff noisy — which matters here more than
+    # usual, because under `1 notebook = 1 figure = 1 slide` these files are
+    # committed artifacts that get diffed and re-rendered.
+    md = payload["metric_definition"]
     definition = join(
-        [string(k, "=", join(v, "/")) for (k, v) in payload["metric_definition"]], "  ")
+        [string(k, "=", join(md[k], "/")) for k in sort(collect(keys(md)))], "  ")
     seeds = join(string.(payload["seeds"]), ", ")
     caveats = String[]
     if get(payload, "metric_definition_override_bound", false) === true

--- a/benchmarking/rgv_paired_wilcoxon_figure.jl
+++ b/benchmarking/rgv_paired_wilcoxon_figure.jl
@@ -40,15 +40,29 @@ The metric definition already belongs on the figure: a paired plot of QUAST NGA5
 and a paired plot of an internal size-ratio proxy look identical, so the caption is
 what keeps the reader from conflating them (bead td-9p91).
 
-The same argument applies with more force to the two facts that say the definition
-is not trustworthy. Under this repo's `1 notebook = 1 figure = 1 slide` model the
+The same argument applies with more force to every fact that says the definition is
+not trustworthy. Under this repo's `1 notebook = 1 figure = 1 slide` model the
 SVG/PNG is what reaches a deck or a manuscript, detached from `report.md`. A run
-whose guard was overridden, or whose definition was asserted by an operator rather
-than observed, previously rendered a caption bit-for-bit identical to a measured
-run — so the artifact that travels furthest carried the least disclosure.
+whose guard was overridden, whose definition was asserted by an operator rather than
+observed, or whose provenance cannot be determined at all, previously rendered a
+caption bit-for-bit identical to a measured run — so the artifact that travels
+furthest carried the least disclosure.
 
-Both flags are read with a `false` default so an older `results.json` (written
-before the fields existed) renders exactly as it did before.
+ALL THREE states `report.md` can report are rendered here. Carrying two of the three
+would recreate the partial-propagation defect this series has spent several rounds
+closing: a fact computed in one file, routed to two of its three consumers, and
+dropped by the third.
+
+The title says EXPLORATORY for the same reason. This analysis applies the
+pre-registration's statistical RULE to a comparison the pre-registration does not
+describe — its H1 is Viterbi DP vs greedy, while this sweep compares
+`corrector=:none` against `corrector=:iterative` — and `report.md` says so in its
+first line. A figure captioned "pre-registered" while its own report calls the run
+exploratory is the same conflation, in the artifact least likely to be read
+alongside the correction.
+
+Every flag is read with a `false` default, so an older `results.json` written before
+the fields existed renders with no caveats, exactly as it did before.
 """
 function paired_figure_caption(payload)
     definition = join(
@@ -62,7 +76,11 @@ function paired_figure_caption(payload)
     if get(payload, "metric_definition_operator_asserted", false) === true
         push!(caveats, "definition OPERATOR-ASSERTED (backfilled), not observed")
     end
-    head = "RGV correction-validation sweep — pre-registered paired Wilcoxon\n" *
+    if get(payload, "metric_definition_provenance_undeterminable", false) === true
+        push!(caveats,
+            "definition PROVENANCE UNDETERMINABLE — measured-vs-asserted is unknown")
+    end
+    head = "RGV correction-validation sweep — paired Wilcoxon (EXPLORATORY)\n" *
            "seeds $seeds · definition: $definition"
     return isempty(caveats) ? head : head * "\n⚠ " * join(caveats, "\n⚠ ")
 end

--- a/benchmarking/rgv_paired_wilcoxon_figure.jl
+++ b/benchmarking/rgv_paired_wilcoxon_figure.jl
@@ -28,6 +28,46 @@ import JSON
 import Statistics
 
 """
+    paired_figure_caption(payload) -> String
+
+Caption for the paired figure, including any INTEGRITY CAVEAT the payload carries.
+
+Pure (no CairoMakie, no IO) so the caveats can be unit-tested without rendering.
+
+# Why the caveats belong here and not only in `report.md`
+
+The metric definition already belongs on the figure: a paired plot of QUAST NGA50
+and a paired plot of an internal size-ratio proxy look identical, so the caption is
+what keeps the reader from conflating them (bead td-9p91).
+
+The same argument applies with more force to the two facts that say the definition
+is not trustworthy. Under this repo's `1 notebook = 1 figure = 1 slide` model the
+SVG/PNG is what reaches a deck or a manuscript, detached from `report.md`. A run
+whose guard was overridden, or whose definition was asserted by an operator rather
+than observed, previously rendered a caption bit-for-bit identical to a measured
+run — so the artifact that travels furthest carried the least disclosure.
+
+Both flags are read with a `false` default so an older `results.json` (written
+before the fields existed) renders exactly as it did before.
+"""
+function paired_figure_caption(payload)
+    definition = join(
+        [string(k, "=", join(v, "/")) for (k, v) in payload["metric_definition"]], "  ")
+    seeds = join(string.(payload["seeds"]), ", ")
+    caveats = String[]
+    if get(payload, "metric_definition_override_bound", false) === true
+        push!(caveats,
+            "GUARD OVERRIDDEN — rows span more than one definition — NOT validation-grade")
+    end
+    if get(payload, "metric_definition_operator_asserted", false) === true
+        push!(caveats, "definition OPERATOR-ASSERTED (backfilled), not observed")
+    end
+    head = "RGV correction-validation sweep — pre-registered paired Wilcoxon\n" *
+           "seeds $seeds · definition: $definition"
+    return isempty(caveats) ? head : head * "\n⚠ " * join(caveats, "\n⚠ ")
+end
+
+"""
     draw_paired_figure(payload; output_dir, basename) -> (svg_path, png_path)
 
 Render the paired slope plot and paired-difference panel for every metric in
@@ -102,15 +142,7 @@ function draw_paired_figure(payload; output_dir::AbstractString,
         end
     end
 
-    # The metric definition belongs ON the figure: a paired plot of QUAST NGA50 and
-    # a paired plot of an internal size-ratio proxy look identical, so the caption
-    # is what keeps the reader from conflating them (bead td-9p91).
-    definition = join(
-        [string(k, "=", join(v, "/")) for (k, v) in payload["metric_definition"]], "  ")
-    seeds = join(string.(payload["seeds"]), ", ")
-    CairoMakie.Label(fig[0, 1:2],
-        "RGV correction-validation sweep — pre-registered paired Wilcoxon\n" *
-        "seeds $seeds · definition: $definition";
+    CairoMakie.Label(fig[0, 1:2], paired_figure_caption(payload);
         fontsize = 15, padding = (0, 0, 8, 0))
 
     mkpath(output_dir)

--- a/benchmarking/rgv_seed_backfill.jl
+++ b/benchmarking/rgv_seed_backfill.jl
@@ -145,6 +145,16 @@ function insert_seed_column!(df::DataFrames.DataFrame, seed::Integer)
             return df
         end
         if length(existing) == 1 && first(existing) == seed
+            # PARTIALLY populated is the case between "all missing" and "conflicting":
+            # some rows carry `seed`, others are `missing`. `skipmissing` above hides
+            # those holes, so returning early here reported success while leaving the
+            # table unpairable — and `require_pairing_schema` then rejects it with a
+            # hint pointing back at THIS tool, so the operator ping-pongs forever.
+            # The populated values already agree with `seed`, so filling the holes
+            # asserts nothing new.
+            if any(ismissing, df.seed)
+                df[!, :seed] = fill(Int(seed), DataFrames.nrow(df))
+            end
             return df
         end
         error("CSV already has a `seed` column with value(s) " *
@@ -177,6 +187,16 @@ function insert_definition_column!(df::DataFrames.DataFrame, name::Symbol, value
             return df
         end
         if length(existing) == 1 && first(existing) == value
+            # PARTIALLY populated, exactly as in `insert_seed_column!`: `skipmissing`
+            # above hides the holes, so returning early reported success while
+            # leaving rows whose definition is still `missing`. The metric-definition
+            # guard renders `missing` as the literal `"missing"` and counts it as a
+            # DISTINCT value, so those holes make the guard raise later with a
+            # message that points nowhere. The populated values already agree with
+            # `value`, so filling the holes asserts nothing new about them.
+            if any(ismissing, getproperty(df, name))
+                df[!, name] = fill(value, DataFrames.nrow(df))
+            end
             return df
         end
         error("CSV already has a `$col` column with value(s) " *
@@ -232,10 +252,10 @@ function backfill_seed(csv_path::AbstractString;
                 "output_csv" => abspath(out),
                 "seed" => Int(seed),
                 "seed_provenance" => String(provenance),
-                "metric_source_backfilled" =>
-                    metric_source === nothing ? nothing : String(metric_source),
-                "quast_min_contig_backfilled" =>
-                    quast_min_contig === nothing ? nothing : Int(quast_min_contig),
+                "metric_source_backfilled" => metric_source === nothing ? nothing :
+                                              String(metric_source),
+                "quast_min_contig_backfilled" => quast_min_contig === nothing ? nothing :
+                                                 Int(quast_min_contig),
                 "rows" => DataFrames.nrow(df),
                 "backfilled_at" => string(Dates.now()),
                 "tool" => "benchmarking/rgv_seed_backfill.jl",

--- a/benchmarking/rgv_seed_backfill.jl
+++ b/benchmarking/rgv_seed_backfill.jl
@@ -360,7 +360,14 @@ function backfill_seed(csv_path::AbstractString;
                 "bead" => "td-59o7"
             ), 2)
     end
-    return out, sidecar, DataFrames.nrow(df)
+    # `provenance_columns` is returned, not just written to the sidecar, so the CLI
+    # can report what it ACTUALLY wrote. It previously announced "rows labelled
+    # <asserted> in metric_source_provenance" unconditionally — including on the one
+    # shape where `_mark_definition_provenance!` writes nothing at all (a definition
+    # column that already carries the requested value, so no row is asserted and no
+    # provenance column exists to update). Trailing positional, so existing
+    # three-way destructuring keeps working.
+    return out, sidecar, DataFrames.nrow(df), provenance_columns
 end
 
 # === CLI ====================================================================
@@ -421,7 +428,8 @@ function main()
     ms = _bf_arg("--metric-source")
     qmc = _bf_arg("--quast-min-contig")
     out, sidecar,
-    n = backfill_seed(csv_path;
+    n,
+    prov_cols = backfill_seed(csv_path;
         seed = seed, provenance = provenance,
         metric_source = ms,
         quast_min_contig = qmc === nothing ? nothing : parse(Int, qmc),
@@ -430,13 +438,25 @@ function main()
     println("Source     : $csv_path")
     println("Seed       : $seed")
     println("Provenance : $provenance")
-    ms === nothing ||
-        println("metric_source    : $ms (operator-supplied; rows labelled " *
-                "\"$DEFINITION_PROVENANCE_ASSERTED\" in metric_source_provenance)")
-    qmc === nothing ||
-        println("quast_min_contig : $qmc (operator-supplied; rows labelled " *
-                "\"$DEFINITION_PROVENANCE_ASSERTED\" in quast_min_contig_provenance)")
-    if ms !== nothing || qmc !== nothing
+    # Report what was WRITTEN, not what was requested. Naming a definition the CSV
+    # already carries asserts nothing, so no provenance column is created — and
+    # announcing one anyway is an assurance the sidecar contradicts in the same run.
+    _bf_wrote(col) = String(definition_provenance_column(col)) in prov_cols
+    ms === nothing || println("metric_source    : $ms (operator-supplied)" *
+            (_bf_wrote(:metric_source) ?
+             "; rows supplied are labelled " *
+             "\"$DEFINITION_PROVENANCE_ASSERTED\" in " *
+             "metric_source_provenance" :
+             "; already present with this value — nothing asserted, " *
+             "so NO metric_source_provenance column was written"))
+    qmc === nothing || println("quast_min_contig : $qmc (operator-supplied)" *
+            (_bf_wrote(:quast_min_contig) ?
+             "; rows supplied are labelled " *
+             "\"$DEFINITION_PROVENANCE_ASSERTED\" in " *
+             "quast_min_contig_provenance" :
+             "; already present with this value — nothing asserted, " *
+             "so NO quast_min_contig_provenance column was written"))
+    if !isempty(prov_cols)
         println("             NOTE: an operator-asserted definition is a CLAIM, not an " *
                 "observation. rgv_paired_wilcoxon.jl reads the provenance column and " *
                 "will refuse to report the guard as enforced over these rows.")

--- a/benchmarking/rgv_seed_backfill.jl
+++ b/benchmarking/rgv_seed_backfill.jl
@@ -55,8 +55,27 @@
 # WHY THE DEFINITION COLUMNS ARE HERE TOO. A `seed`-only backfill DEAD-ENDS: the
 # analysis accepts the seed and then refuses the same file for carrying no
 # metric-definition column, and nothing else could supply one. Both are opt-in and
-# operator-supplied — never inferred — and both are recorded in the sidecar, so a
-# reader can always tell a backfilled definition from an observed one.
+# operator-supplied — never inferred.
+#
+# THE ASSERTION TRAVELS IN THE TABLE, NOT ONLY IN THE SIDECAR. `--metric-source`
+# states, on operator say-so, WHICH DEFINITION PRODUCED EVERY METRIC IN THE FILE.
+# That is a much stronger claim than a seed label, and unlike `--seed` there is no
+# `--run-log` that could recover it: nothing verifies it. Recording it only in
+# `<out>.seed_backfill.json` is not enough, because NO consumer reads that sidecar
+# — `rgv_paired_wilcoxon.jl` calls `load_sweep_csvs(csv_paths)` and nothing else.
+# A genuinely mixed legacy table (QUAST-scored rows plus `internal:quast-failed`
+# rows, no `metric_source` column) backfilled with `--metric-source quast` would
+# therefore produce a file the guard certifies as uniform, and the analysis report
+# would print "`metric_source_guard.jl` enforced it — no override was used" over
+# numbers mixing an alignment-validated NGA50 with a size-ratio proxy. That is
+# strictly worse than the dead end it replaced, because the dead end failed closed.
+#
+# So every row this tool SUPPLIES a definition for is labelled in a sibling
+# `<column>_provenance` column carrying `DEFINITION_PROVENANCE_ASSERTED`. Rows that
+# already carried the value keep `"observed"`. The column travels with the CSV into
+# every downstream consumer, and `rgv_paired_wilcoxon.jl` reads it: an analysis over
+# operator-asserted rows cannot print the unqualified guard assurance, and
+# `results.json` carries the fact in machine-readable form.
 
 import CSV
 import DataFrames
@@ -168,15 +187,81 @@ function insert_seed_column!(df::DataFrames.DataFrame, seed::Integer)
 end
 
 """
+Value written into `<definition-column>_provenance` for every row whose metric
+definition was SUPPLIED BY THIS TOOL rather than observed by the run that produced
+the metrics.
+
+`rgv_paired_wilcoxon.jl` matches on the `"operator-asserted"` substring, so the
+prefix is part of the cross-file contract and is pinned by a test in
+`test/4_assembly/rgv_paired_wilcoxon_test.jl`.
+"""
+const DEFINITION_PROVENANCE_ASSERTED = "operator-asserted (backfill)"
+
+"""
+Value kept for rows that already carried the definition value before the backfill
+ran. Those rows are evidence; the asserted ones are a claim.
+"""
+const DEFINITION_PROVENANCE_OBSERVED = "observed"
+
+"""
+    definition_provenance_column(name) -> Symbol
+
+Sibling provenance column for a metric-definition column, e.g.
+`:metric_source` -> `:metric_source_provenance`.
+"""
+definition_provenance_column(name::Symbol) = Symbol(String(name) * "_provenance")
+
+"""
+    _mark_definition_provenance!(df, name, asserted) -> DataFrames.DataFrame
+
+Record, per row, whether this tool SUPPLIED the value in definition column `name`.
+
+`asserted[i]` is true for rows written by the backfill. Rows it did not write keep
+whatever provenance they already carried (or `"observed"` if the column is new), so
+re-running the tool can only ever ADD assertions — it can never launder a
+previously asserted row back into an observed one.
+
+No column is created when nothing was asserted and none exists: a table this tool
+did not change should not gain a column claiming it did.
+"""
+function _mark_definition_provenance!(df::DataFrames.DataFrame, name::Symbol,
+        asserted::AbstractVector{Bool})
+    prov = definition_provenance_column(name)
+    n = DataFrames.nrow(df)
+    present = String(prov) in DataFrames.names(df)
+    (!any(asserted) && !present) && return df
+    prior = present ?
+            String[ismissing(v) ? DEFINITION_PROVENANCE_OBSERVED : string(v)
+                   for v in getproperty(df, prov)] :
+            fill(DEFINITION_PROVENANCE_OBSERVED, n)
+    labels = String[asserted[i] ? DEFINITION_PROVENANCE_ASSERTED : prior[i]
+                    for i in 1:n]
+    if present
+        df[!, prov] = labels
+    else
+        DataFrames.insertcols!(df, DataFrames.ncol(df) + 1, prov => labels)
+    end
+    return df
+end
+
+"""
     insert_definition_column!(df, name, value) -> DataFrames.DataFrame
 
 Append a metric-definition column (`:metric_source` / `:quast_min_contig`) with a
-single operator-supplied `value`.
+single operator-supplied `value`, and label every row it supplies in the sibling
+`<name>_provenance` column.
 
 Refuses to overwrite an existing column holding a different value, for the same
 reason `insert_seed_column!` does: asserting a definition a run did not have makes
 an unusable table look usable, and the metric-definition guard would then pass on
 a claim nobody verified.
+
+The provenance column exists because refusing to overwrite is not sufficient. When
+the column is ABSENT there is nothing to conflict with, so the value is accepted
+unconditionally — and a legacy table that really did mix definitions has exactly
+that shape. The guard downstream can then only confirm that the asserted labels
+agree with each other, which is not evidence about how the runs were scored. The
+provenance column is what carries that distinction to the consumer.
 """
 function insert_definition_column!(df::DataFrames.DataFrame, name::Symbol, value)
     col = String(name)
@@ -184,7 +269,8 @@ function insert_definition_column!(df::DataFrames.DataFrame, name::Symbol, value
         existing = unique(skipmissing(getproperty(df, name)))
         if isempty(existing)          # present but unpopulated — fill, do not refuse
             df[!, name] = fill(value, DataFrames.nrow(df))
-            return df
+            return _mark_definition_provenance!(df, name,
+                trues(DataFrames.nrow(df)))
         end
         if length(existing) == 1 && first(existing) == value
             # PARTIALLY populated, exactly as in `insert_seed_column!`: `skipmissing`
@@ -194,10 +280,13 @@ function insert_definition_column!(df::DataFrames.DataFrame, name::Symbol, value
             # DISTINCT value, so those holes make the guard raise later with a
             # message that points nowhere. The populated values already agree with
             # `value`, so filling the holes asserts nothing new about them.
-            if any(ismissing, getproperty(df, name))
+            holes = BitVector(ismissing(v) for v in getproperty(df, name))
+            if any(holes)
                 df[!, name] = fill(value, DataFrames.nrow(df))
             end
-            return df
+            # Only the FILLED rows are asserted; the rows that already carried the
+            # value are evidence and stay labelled as observed.
+            return _mark_definition_provenance!(df, name, holes)
         end
         error("CSV already has a `$col` column with value(s) " *
               "$(join(string.(existing), ", ")); refusing to overwrite it with " *
@@ -205,7 +294,7 @@ function insert_definition_column!(df::DataFrames.DataFrame, name::Symbol, value
     end
     DataFrames.insertcols!(df, DataFrames.ncol(df) + 1,
         name => fill(value, DataFrames.nrow(df)))
-    return df
+    return _mark_definition_provenance!(df, name, trues(DataFrames.nrow(df)))
 end
 
 """
@@ -236,7 +325,8 @@ function backfill_seed(csv_path::AbstractString;
     # having no metric-definition column, and nothing else could supply one. The
     # documented backfill -> analyse workflow has to be completable, so the same
     # provenance discipline is extended to the definition columns — each is opt-in,
-    # explicit, and recorded in the sidecar, never inferred.
+    # explicit, labelled per row IN THE CSV, and recorded in the sidecar, never
+    # inferred.
     if metric_source !== nothing
         insert_definition_column!(df, :metric_source, String(metric_source))
     end
@@ -244,6 +334,12 @@ function backfill_seed(csv_path::AbstractString;
         insert_definition_column!(df, :quast_min_contig, Int(quast_min_contig))
     end
     CSV.write(out, df)
+    # The sidecar is an audit record, NOT the disclosure mechanism: no consumer
+    # reads it. The disclosure that has to reach the analysis rides in the CSV's
+    # `<column>_provenance` columns, named here so the two cannot drift apart.
+    provenance_columns = String[String(definition_provenance_column(c))
+                                for c in (:metric_source, :quast_min_contig)
+                                if String(definition_provenance_column(c)) in DataFrames.names(df)]
     sidecar = out * ".seed_backfill.json"
     open(sidecar, "w") do io
         JSON.print(io,
@@ -256,6 +352,8 @@ function backfill_seed(csv_path::AbstractString;
                                               String(metric_source),
                 "quast_min_contig_backfilled" => quast_min_contig === nothing ? nothing :
                                                  Int(quast_min_contig),
+                "definition_provenance_columns" => provenance_columns,
+                "definition_provenance_asserted_label" => DEFINITION_PROVENANCE_ASSERTED,
                 "rows" => DataFrames.nrow(df),
                 "backfilled_at" => string(Dates.now()),
                 "tool" => "benchmarking/rgv_seed_backfill.jl",
@@ -332,8 +430,17 @@ function main()
     println("Source     : $csv_path")
     println("Seed       : $seed")
     println("Provenance : $provenance")
-    ms === nothing || println("metric_source    : $ms (operator-supplied)")
-    qmc === nothing || println("quast_min_contig : $qmc (operator-supplied)")
+    ms === nothing ||
+        println("metric_source    : $ms (operator-supplied; rows labelled " *
+                "\"$DEFINITION_PROVENANCE_ASSERTED\" in metric_source_provenance)")
+    qmc === nothing ||
+        println("quast_min_contig : $qmc (operator-supplied; rows labelled " *
+                "\"$DEFINITION_PROVENANCE_ASSERTED\" in quast_min_contig_provenance)")
+    if ms !== nothing || qmc !== nothing
+        println("             NOTE: an operator-asserted definition is a CLAIM, not an " *
+                "observation. rgv_paired_wilcoxon.jl reads the provenance column and " *
+                "will refuse to report the guard as enforced over these rows.")
+    end
     println("Rows       : $n")
     println("Wrote      : $out")
     println("Sidecar    : $sidecar")

--- a/test/4_assembly/rgv_paired_wilcoxon_figure_test.jl
+++ b/test/4_assembly/rgv_paired_wilcoxon_figure_test.jl
@@ -1,0 +1,92 @@
+# Unit test for the paired-Wilcoxon FIGURE caption (beads td-59o7, td-9p91).
+#
+# `paired_figure_caption` was made pure — no CairoMakie call, no IO — precisely so
+# the integrity caveats it stamps could be asserted without rendering anything, and
+# it shipped with no test. This file supplies one.
+#
+# Why the caveats matter enough to test: under this repo's
+# `1 notebook = 1 figure = 1 slide` model the SVG/PNG is the artifact that reaches
+# a deck or a manuscript, detached from `report.md`. A run whose guard was
+# overridden, or whose metric definition was asserted by an operator rather than
+# observed, previously rendered a caption bit-for-bit identical to a measured run,
+# so the artifact that travels furthest carried the least disclosure.
+#
+# The script is loaded into its own module: it defines `main` / `_fig_arg` at top
+# level, as do the other RGV scripts, and the full suite includes them all into the
+# same `Main`.
+
+import Test
+
+module _RGVFigure
+include(joinpath(@__DIR__, "..", "..", "benchmarking", "rgv_paired_wilcoxon_figure.jl"))
+end
+
+# The minimum a caption needs. `metric_definition` values are vectors because the
+# analysis emits one entry per distinct value on the axis.
+function _figt_payload(; extra...)
+    payload = Dict{String, Any}(
+        "metric_definition" => Dict("metric_source" => ["quast"],
+            "quast_min_contig" => [500]),
+        "seeds" => [42, 123, 456]
+    )
+    for (k, v) in extra
+        payload[string(k)] = v
+    end
+    return payload
+end
+
+Test.@testset "RGV paired-Wilcoxon figure caption" begin
+    Test.@testset "a clean run carries no warning glyph" begin
+        caption = _RGVFigure.paired_figure_caption(
+            _figt_payload(metric_definition_operator_asserted = false,
+            metric_definition_override_bound = false))
+        Test.@test !occursin("⚠", caption)
+        Test.@test occursin("paired Wilcoxon", caption)
+        # The definition itself still belongs on the figure: a paired plot of QUAST
+        # NGA50 and one of an internal size-ratio proxy look identical.
+        Test.@test occursin("metric_source=quast", caption)
+        Test.@test occursin("42, 123, 456", caption)
+    end
+
+    Test.@testset "an operator-asserted definition is stamped on the figure" begin
+        caption = _RGVFigure.paired_figure_caption(
+            _figt_payload(metric_definition_operator_asserted = true,
+            metric_definition_override_bound = false))
+        Test.@test occursin("⚠", caption)
+        Test.@test occursin("OPERATOR-ASSERTED", caption)
+        Test.@test !occursin("GUARD OVERRIDDEN", caption)
+    end
+
+    Test.@testset "a bound guard override is stamped on the figure" begin
+        caption = _RGVFigure.paired_figure_caption(
+            _figt_payload(metric_definition_operator_asserted = false,
+            metric_definition_override_bound = true))
+        Test.@test occursin("GUARD OVERRIDDEN", caption)
+        Test.@test occursin("NOT validation-grade", caption)
+        Test.@test !occursin("OPERATOR-ASSERTED", caption)
+    end
+
+    Test.@testset "the two caveats are independent, not exclusive" begin
+        # They answer different questions — whether the guard was overridden, and
+        # whether the values it compared were observed — so a run in both states
+        # must show both. Chaining them would let the weaker one shadow the stronger.
+        caption = _RGVFigure.paired_figure_caption(
+            _figt_payload(metric_definition_operator_asserted = true,
+            metric_definition_override_bound = true))
+        Test.@test occursin("GUARD OVERRIDDEN", caption)
+        Test.@test occursin("OPERATOR-ASSERTED", caption)
+        Test.@test count("⚠", caption) == 2
+    end
+
+    Test.@testset "an older results.json renders exactly the clean caption" begin
+        # Both flags are read with a `false` default so a payload written before the
+        # fields existed does not gain a caveat it has no basis for — and does not
+        # raise a KeyError either.
+        clean = _RGVFigure.paired_figure_caption(
+            _figt_payload(metric_definition_operator_asserted = false,
+            metric_definition_override_bound = false))
+        legacy = _RGVFigure.paired_figure_caption(_figt_payload())
+        Test.@test legacy == clean
+        Test.@test !occursin("⚠", legacy)
+    end
+end

--- a/test/4_assembly/rgv_paired_wilcoxon_figure_test.jl
+++ b/test/4_assembly/rgv_paired_wilcoxon_figure_test.jl
@@ -99,6 +99,29 @@ Test.@testset "RGV paired-Wilcoxon figure caption" begin
         Test.@test count("⚠", all_three) == 3
     end
 
+    Test.@testset "the definition axes are named in a deterministic order" begin
+        # `metric_definition` is a Dict, so iteration order is unspecified: an
+        # unsorted comprehension could name the axes differently across two renders
+        # of the SAME results.json, making the committed SVG/PNG non-reproducible.
+        # Asserting the sorted order pins the contract; building the same payload
+        # from two different insertion orders pins that it does not depend on how
+        # the Dict happened to be constructed.
+        a = Dict{String, Any}(
+            "metric_definition" => Dict("metric_source" => ["quast"],
+                "quast_min_contig" => [500]),
+            "seeds" => [42])
+        b = Dict{String, Any}(
+            "metric_definition" => Dict("quast_min_contig" => [500],
+                "metric_source" => ["quast"]),
+            "seeds" => [42])
+        Test.@test _RGVFigure.paired_figure_caption(a) ==
+                   _RGVFigure.paired_figure_caption(b)
+        # Sorted: `metric_source` precedes `quast_min_contig`.
+        cap = _RGVFigure.paired_figure_caption(a)
+        Test.@test findfirst("metric_source=", cap).start <
+                   findfirst("quast_min_contig=", cap).start
+    end
+
     Test.@testset "the caption does not call an exploratory run pre-registered" begin
         # `report.md` opens by stating the run is exploratory: the pre-registration's
         # H1 is Viterbi DP vs greedy, while this sweep compares corrector arms. A

--- a/test/4_assembly/rgv_paired_wilcoxon_figure_test.jl
+++ b/test/4_assembly/rgv_paired_wilcoxon_figure_test.jl
@@ -66,16 +66,47 @@ Test.@testset "RGV paired-Wilcoxon figure caption" begin
         Test.@test !occursin("OPERATOR-ASSERTED", caption)
     end
 
-    Test.@testset "the two caveats are independent, not exclusive" begin
-        # They answer different questions — whether the guard was overridden, and
-        # whether the values it compared were observed — so a run in both states
-        # must show both. Chaining them would let the weaker one shadow the stronger.
+    Test.@testset "undeterminable provenance is stamped on the figure" begin
+        # The third state `report.md` can report. Carrying two of three would
+        # recreate the partial-propagation defect this series has been closing: a
+        # fact computed in one file, routed to two of its three consumers, dropped
+        # by the third. This is the state EVERY pre-provenance CSV lands in.
+        caption = _RGVFigure.paired_figure_caption(
+            _figt_payload(metric_definition_provenance_undeterminable = true))
+        Test.@test occursin("PROVENANCE UNDETERMINABLE", caption)
+        Test.@test occursin("measured-vs-asserted is unknown", caption)
+        Test.@test !occursin("OPERATOR-ASSERTED", caption)
+        Test.@test !occursin("GUARD OVERRIDDEN", caption)
+    end
+
+    Test.@testset "the caveats are independent, not exclusive" begin
+        # They answer different questions — whether the guard was overridden,
+        # whether the values it compared were observed, and whether that is knowable
+        # at all — so a run in several states must show each. Chaining them would let
+        # a weaker one shadow a stronger one, which is exactly how the report's own
+        # branch chain let a non-binding flag suppress the asserted qualifier.
         caption = _RGVFigure.paired_figure_caption(
             _figt_payload(metric_definition_operator_asserted = true,
             metric_definition_override_bound = true))
         Test.@test occursin("GUARD OVERRIDDEN", caption)
         Test.@test occursin("OPERATOR-ASSERTED", caption)
         Test.@test count("⚠", caption) == 2
+
+        all_three = _RGVFigure.paired_figure_caption(
+            _figt_payload(metric_definition_operator_asserted = true,
+            metric_definition_override_bound = true,
+            metric_definition_provenance_undeterminable = true))
+        Test.@test count("⚠", all_three) == 3
+    end
+
+    Test.@testset "the caption does not call an exploratory run pre-registered" begin
+        # `report.md` opens by stating the run is exploratory: the pre-registration's
+        # H1 is Viterbi DP vs greedy, while this sweep compares corrector arms. A
+        # figure captioned "pre-registered" contradicts its own report, in the
+        # artifact least likely to be read alongside the correction.
+        caption = _RGVFigure.paired_figure_caption(_figt_payload())
+        Test.@test occursin("EXPLORATORY", caption)
+        Test.@test !occursin("pre-registered", caption)
     end
 
     Test.@testset "an older results.json renders exactly the clean caption" begin

--- a/test/4_assembly/rgv_paired_wilcoxon_test.jl
+++ b/test/4_assembly/rgv_paired_wilcoxon_test.jl
@@ -430,7 +430,8 @@ Test.@testset "RGV paired-Wilcoxon analysis" begin
             append!(ARGS, ["--metric-source", "quast"])
             Test.@test isempty(_pw_args("--csv"))                       # absent flag
         finally
-            empty!(ARGS); append!(ARGS, saved)
+            empty!(ARGS);
+            append!(ARGS, saved)
         end
     end
 
@@ -570,8 +571,9 @@ Test.@testset "RGV paired-Wilcoxon analysis" begin
         Test.@test "metric_source" in a.mixed_axes
 
         mktempdir() do dir
-            text = read(write_paired_report(joinpath(dir, "r.md"), a;
-                csv_paths = ["f.csv"]), String)
+            text = read(
+                write_paired_report(joinpath(dir, "r.md"), a;
+                    csv_paths = ["f.csv"]), String)
             # The artifact must say the guard was overridden...
             Test.@test occursin("GUARD OVERRIDDEN", text)
             Test.@test occursin("not validation-grade", lowercase(text))
@@ -591,11 +593,104 @@ Test.@testset "RGV paired-Wilcoxon analysis" begin
         Test.@test b.allow_mixed_src
         Test.@test !b.override_bound
         mktempdir() do dir
-            text = read(write_paired_report(joinpath(dir, "r.md"), b;
-                csv_paths = ["f.csv"]), String)
+            text = read(
+                write_paired_report(joinpath(dir, "r.md"), b;
+                    csv_paths = ["f.csv"]), String)
             Test.@test occursin("did NOT bind", text)
             Test.@test !occursin("GUARD OVERRIDDEN", text)
         end
+    end
+
+    Test.@testset "B: an OPERATOR-ASSERTED definition cannot earn the guard assurance" begin
+        # `rgv_seed_backfill.jl --metric-source quast` writes a definition on
+        # operator say-so, with nothing to verify it against. The guard can then
+        # only check that the asserted labels agree with EACH OTHER, and a
+        # backfilled label agrees with itself by construction — so a legacy table
+        # that genuinely mixed an alignment-validated NGA50 with a size-ratio proxy
+        # passes, and the report went on to assert the guard had enforced
+        # single-definition-ness. That is the same laundering the `--allow-mixed-src`
+        # disclosure exists to prevent, reached by a different route.
+        cells = [(seed = s, error_rate = e, naive = 1000.0, iterative = 1600.0)
+                 for (s, e) in [(42, 0.01), (42, 0.05), (123, 0.01),
+            (123, 0.05), (456, 0.01), (456, 0.05)]]
+        observed = _pwt_frame(cells)
+        asserted = _pwt_frame(cells)
+        asserted[!, :metric_source_provenance] = fill("operator-asserted (backfill)",
+            DataFrames.nrow(asserted))
+
+        a_obs = run_paired_analysis(observed; metrics = (:quast_nga50,))
+        a_ast = run_paired_analysis(asserted; metrics = (:quast_nga50,))
+        # The two tables produce IDENTICAL definition summaries — that is the point.
+        Test.@test Dict(a_obs.definition) == Dict(a_ast.definition)
+        Test.@test !a_obs.definition_operator_asserted
+        Test.@test a_ast.definition_operator_asserted
+        Test.@test a_ast.operator_asserted_axes == ["metric_source"]
+        Test.@test a_ast.n_rows_operator_asserted == DataFrames.nrow(asserted)
+
+        mktempdir() do dir
+            t_obs = read(
+                write_paired_report(joinpath(dir, "obs.md"), a_obs;
+                    csv_paths = ["f.csv"]), String)
+            t_ast = read(
+                write_paired_report(joinpath(dir, "ast.md"), a_ast;
+                    csv_paths = ["f.csv"]), String)
+            # A measured definition still earns the unqualified assurance...
+            Test.@test occursin("enforced it — no override was used", t_obs)
+            Test.@test !occursin("OPERATOR-ASSERTED", t_obs)
+            # ...an asserted one must not, and must say so before the numbers.
+            Test.@test !occursin("enforced it — no override was used", t_ast)
+            Test.@test occursin("OPERATOR-ASSERTED, NOT OBSERVED", t_ast)
+            Test.@test occursin("operator assertion", t_ast)
+
+            p_ast = paired_analysis_json(a_ast; csv_paths = ["f.csv"])
+            Test.@test p_ast["metric_definition_operator_asserted"] == true
+            Test.@test p_ast["operator_asserted_definition_axes"] == ["metric_source"]
+            Test.@test p_ast["n_rows_operator_asserted_definition"] == 12
+            p_obs = paired_analysis_json(a_obs; csv_paths = ["f.csv"])
+            Test.@test p_obs["metric_definition_operator_asserted"] == false
+            Test.@test isempty(p_obs["operator_asserted_definition_axes"])
+        end
+
+        # ONE asserted row is enough: the rows the backfill did not touch stay
+        # labelled observed, but the aggregate still spans a claim nobody verified.
+        partial = _pwt_frame(cells)
+        prov = fill("observed", DataFrames.nrow(partial))
+        prov[1] = "operator-asserted (backfill)"
+        partial[!, :metric_source_provenance] = prov
+        a_part = run_paired_analysis(partial; metrics = (:quast_nga50,))
+        Test.@test a_part.definition_operator_asserted
+        Test.@test a_part.n_rows_operator_asserted == 1
+
+        # The claim is evaluated over the rows actually ANALYZED. An assertion on
+        # rows the `--metric-source` filter removed does not taint what is left.
+        filtered = _pwt_frame([
+            (seed = 42, error_rate = 0.01, naive = 1000.0, iterative = 1500.0,
+                metric_source = "quast"),
+            (seed = 123, error_rate = 0.01, naive = 900.0, iterative = 1400.0,
+                metric_source = "internal:quast-failed"),
+            (seed = 456, error_rate = 0.01, naive = 950.0, iterative = 1450.0,
+                metric_source = "quast")])
+        filtered[!, :metric_source_provenance] = [src == "quast" ? "observed" :
+                                                  "operator-asserted (backfill)"
+                                                  for src in filtered.metric_source]
+        a_filt = run_paired_analysis(filtered;
+            metrics = (:quast_nga50,), metric_source = "quast")
+        Test.@test a_filt.n_rows_operator_asserted == 0
+        Test.@test !a_filt.definition_operator_asserted
+    end
+
+    Test.@testset "B: the asserted marker matches what the backfill actually writes" begin
+        # The disclosure crosses a file boundary through a string literal, so the
+        # two ends have to be pinned together or the reader silently stops
+        # detecting what the writer emits.
+        backfill = read(
+            joinpath(@__DIR__, "..", "..", "benchmarking", "rgv_seed_backfill.jl"),
+            String)
+        Test.@test occursin(
+            "DEFINITION_PROVENANCE_ASSERTED = \"$(RGV_ASSERTED_DEFINITION_MARKER)",
+            backfill)
+        # And the column-naming convention the reader looks under.
+        Test.@test occursin("String(name) * \"_provenance\"", backfill)
     end
 
     Test.@testset "C1/I3: the report does not claim to be a pre-registered test" begin
@@ -604,8 +699,9 @@ Test.@testset "RGV paired-Wilcoxon analysis" begin
             (123, 0.05), (456, 0.01), (456, 0.05)]])
         a = run_paired_analysis(df; metrics = (:quast_nga50,))
         mktempdir() do dir
-            text = read(write_paired_report(joinpath(dir, "r.md"), a;
-                csv_paths = ["f.csv"]), String)
+            text = read(
+                write_paired_report(joinpath(dir, "r.md"), a;
+                    csv_paths = ["f.csv"]), String)
             # H1 is Viterbi-DP-vs-greedy; this compares correctors. Attributing it
             # to H1 would put an unregistered comparison into a manuscript as
             # confirmatory.

--- a/test/4_assembly/rgv_paired_wilcoxon_test.jl
+++ b/test/4_assembly/rgv_paired_wilcoxon_test.jl
@@ -601,6 +601,91 @@ Test.@testset "RGV paired-Wilcoxon analysis" begin
         end
     end
 
+    Test.@testset "C: an absent `ok` column is not 'every row verified ok=true'" begin
+        # `report.md` emitted the byte-identical line
+        #   `- Rows: 12 read, 12 analyzed (0 dropped for ok=false, ...)`
+        # both when the column was present and all-true, and when it was ABSENT
+        # entirely. "0 dropped for ok=false" reads as "the check ran and every row
+        # passed"; it was printed verbatim when the check could not run at all, and
+        # `results.json` carried neither the count nor a presence flag, so no
+        # consumer could recover the distinction from either artifact.
+        # `metric_source_guard.jl` applies the opposite doctrine to the definition
+        # columns: unverifiable is not the same as verified.
+        cells = [(seed = s, error_rate = e, naive = 1000.0, iterative = 1600.0)
+                 for (s, e) in [(42, 0.01), (42, 0.05), (123, 0.01),
+            (123, 0.05), (456, 0.01), (456, 0.05)]]
+        with_ok = _pwt_frame(cells)                       # ok=true on every row
+        no_ok = DataFrames.select(with_ok, DataFrames.Not(:ok))
+
+        a_ok = run_paired_analysis(with_ok; metrics = (:quast_nga50,))
+        a_no = run_paired_analysis(no_ok; metrics = (:quast_nga50,))
+        # Identical numbers — the difference is what is KNOWN about them.
+        Test.@test a_ok.n_rows_analyzed == a_no.n_rows_analyzed == 12
+        Test.@test a_ok.ok_column_present && a_ok.ok_filter_applied
+        Test.@test !a_no.ok_column_present && !a_no.ok_filter_applied
+
+        mktempdir() do dir
+            t_ok = read(
+                write_paired_report(joinpath(dir, "ok.md"), a_ok;
+                    csv_paths = ["f.csv"]), String)
+            t_no = read(
+                write_paired_report(joinpath(dir, "no.md"), a_no;
+                    csv_paths = ["f.csv"]), String)
+            Test.@test occursin("0 dropped for ok=false", t_ok)
+            Test.@test !occursin("ABSENT", t_ok)
+            # The unrunnable case must SAY it was unrunnable, and must not claim a
+            # count of failures it never looked for.
+            Test.@test occursin("`ok` column ABSENT", t_no)
+            Test.@test occursin("could NOT run", t_no)
+            Test.@test !occursin("dropped for ok=false", t_no)
+
+            # And the distinction must survive into the machine-readable artifact.
+            p_ok = paired_analysis_json(a_ok; csv_paths = ["f.csv"])
+            p_no = paired_analysis_json(a_no; csv_paths = ["f.csv"])
+            Test.@test p_ok["ok_column_present"] == true
+            Test.@test p_no["ok_column_present"] == false
+            Test.@test p_ok["ok_filter_applied"] != p_no["ok_filter_applied"]
+            Test.@test p_ok["n_dropped_not_ok"] == 0
+            Test.@test p_ok["n_dropped_metric_source"] == 0
+        end
+
+        # `--keep-not-ok` is a THIRD state: the column is present and the check was
+        # deliberately disabled. That is not "0 failures" either.
+        a_keep = run_paired_analysis(with_ok;
+            metrics = (:quast_nga50,), keep_not_ok = true)
+        Test.@test a_keep.ok_column_present
+        Test.@test !a_keep.ok_filter_applied
+        mktempdir() do dir
+            t = read(
+                write_paired_report(joinpath(dir, "k.md"), a_keep;
+                    csv_paths = ["f.csv"]), String)
+            Test.@test occursin("filter DISABLED", t)
+            Test.@test !occursin("ABSENT", t)
+        end
+
+        # Sub-finding: `coalesce(missing, false)` counted an UNKNOWN status as an
+        # observed failure. "The harness said this run failed" and "we do not know
+        # whether it succeeded" are different claims and are counted separately.
+        holey = DataFrames.DataFrame(with_ok)
+        holey[!, :ok] = Vector{Union{Missing, Bool}}(holey.ok)
+        holey[1, :ok] = missing
+        holey[3, :ok] = false
+        a_h = run_paired_analysis(holey; metrics = (:quast_nga50,))
+        Test.@test a_h.n_dropped_ok_missing == 1
+        Test.@test a_h.n_dropped_not_ok == 1          # NOT 2
+        Test.@test a_h.n_rows_analyzed == 10
+        mktempdir() do dir
+            t = read(
+                write_paired_report(joinpath(dir, "h.md"), a_h;
+                    csv_paths = ["f.csv"]), String)
+            Test.@test occursin("1 dropped for ok=false", t)
+            Test.@test occursin("1 dropped for ok=missing", t)
+            p = paired_analysis_json(a_h; csv_paths = ["f.csv"])
+            Test.@test p["n_dropped_not_ok"] == 1
+            Test.@test p["n_dropped_ok_missing"] == 1
+        end
+    end
+
     Test.@testset "B: an OPERATOR-ASSERTED definition cannot earn the guard assurance" begin
         # `rgv_seed_backfill.jl --metric-source quast` writes a definition on
         # operator say-so, with nothing to verify it against. The guard can then

--- a/test/4_assembly/rgv_paired_wilcoxon_test.jl
+++ b/test/4_assembly/rgv_paired_wilcoxon_test.jl
@@ -1012,6 +1012,43 @@ Test.@testset "RGV paired-Wilcoxon analysis" begin
         Test.@test occursin("String(name) * \"_provenance\"", backfill)
     end
 
+    Test.@testset "B: the operator-asserted qualifier does not depend on --allow-mixed-src" begin
+        # This was the untested cell of the cross-product. A NON-BINDING
+        # `--allow-mixed-src` used to take the `elseif` arm and suppress the
+        # operator-asserted qualifier entirely, restoring an unqualified assurance
+        # over a table whose definition was never observed. The two facts are
+        # orthogonal, so the qualifier must appear in BOTH columns.
+        cells = [(seed = s, error_rate = e, naive = 1000.0, iterative = 1600.0)
+                 for (s, e) in [(42, 0.01), (42, 0.05), (123, 0.01),
+            (123, 0.05), (456, 0.01), (456, 0.05)]]
+        asserted = _pwt_frame(cells; provenance = "observed")
+        asserted[!, :metric_source_provenance] = fill("operator-asserted (backfill)",
+            DataFrames.nrow(asserted))
+
+        for allow in (false, true)
+            a = run_paired_analysis(asserted;
+                metrics = (:quast_nga50,), allow_mixed_src = allow)
+            Test.@test a.definition_operator_asserted
+            Test.@test !a.override_bound          # the flag is non-binding either way
+            mktempdir() do dir
+                text = read(
+                    write_paired_report(joinpath(dir, "r.md"), a;
+                        csv_paths = ["f.csv"]), String)
+                Test.@test occursin("OPERATOR-ASSERTED, NOT OBSERVED", text)
+                Test.@test occursin(
+                    "does NOT establish that the aggregate spans a single MEASURED definition",
+                    text)
+                Test.@test !occursin("enforced it — no override was used", text)
+                # The specific phrase the non-binding branch used to restore. It is
+                # a claim about the VALUES and is not settled by whether a flag
+                # bound, so the report must never make it.
+                Test.@test !occursin("well-defined", text)
+                # And the non-binding flag still reports itself accurately.
+                Test.@test occursin("did NOT bind", text) == allow
+            end
+        end
+    end
+
     Test.@testset "C1/I3: the report does not claim to be a pre-registered test" begin
         df = _pwt_frame([(seed = s, error_rate = e, naive = 1000.0, iterative = 1600.0)
                          for (s, e) in [(42, 0.01), (42, 0.05), (123, 0.01),

--- a/test/4_assembly/rgv_paired_wilcoxon_test.jl
+++ b/test/4_assembly/rgv_paired_wilcoxon_test.jl
@@ -23,6 +23,13 @@ import JSON
 
 include(joinpath(@__DIR__, "..", "..", "benchmarking", "rgv_paired_wilcoxon.jl"))
 
+# The WRITER of the provenance labels this file's reader consumes, loaded so the
+# cross-file contract can be tested by round-trip rather than by grepping source.
+# Namespaced into a module because both scripts define `main` at top level.
+module _PWTBackfill
+include(joinpath(@__DIR__, "..", "..", "benchmarking", "rgv_seed_backfill.jl"))
+end
+
 function _pwt_throws_with(f, needles::Vector{String})
     try
         f()
@@ -39,8 +46,14 @@ end
 
 # Build a sweep-shaped table. `with_seed=false` reproduces the pre-td-59o7 schema.
 # `naive`/`iterative` give the per-cell metric values, one entry per (seed, cell).
+#
+# `provenance=nothing` (the default) reproduces the shape of EVERY sweep CSV the
+# documented backfill/analyse workflow produced before the provenance axis existed:
+# definition columns present, no `*_provenance` siblings. That is a table whose
+# provenance cannot be determined, NOT a table shown to be observed, so callers
+# that want the measured case must ask for it explicitly.
 function _pwt_frame(cells; with_seed = true, metric_source = "quast",
-        min_contig = 500, metric = :quast_nga50, ok = true)
+        min_contig = 500, metric = :quast_nga50, ok = true, provenance = nothing)
     rows = []
     for c in cells
         for (arm, value) in (("naive", c.naive), ("iterative", c.iterative))
@@ -57,6 +70,11 @@ function _pwt_frame(cells; with_seed = true, metric_source = "quast",
                 metric => value
             )
             with_seed && (row[:seed] = get(c, :seed, 42))
+            if provenance !== nothing
+                p = get(c, :provenance, provenance)
+                row[:metric_source_provenance] = p
+                row[:quast_min_contig_provenance] = p
+            end
             push!(rows, row)
         end
     end
@@ -632,7 +650,10 @@ Test.@testset "RGV paired-Wilcoxon analysis" begin
                 write_paired_report(joinpath(dir, "no.md"), a_no;
                     csv_paths = ["f.csv"]), String)
             Test.@test occursin("0 dropped for ok=false", t_ok)
-            Test.@test !occursin("ABSENT", t_ok)
+            # Scoped to the `ok` clause: bare "ABSENT" also matches unrelated
+            # disclosures elsewhere in the report and would silently stop testing
+            # this one.
+            Test.@test !occursin("`ok` column ABSENT", t_ok)
             # The unrunnable case must SAY it was unrunnable, and must not claim a
             # count of failures it never looked for.
             Test.@test occursin("`ok` column ABSENT", t_no)
@@ -660,7 +681,7 @@ Test.@testset "RGV paired-Wilcoxon analysis" begin
                 write_paired_report(joinpath(dir, "k.md"), a_keep;
                     csv_paths = ["f.csv"]), String)
             Test.@test occursin("filter DISABLED", t)
-            Test.@test !occursin("ABSENT", t)
+            Test.@test !occursin("`ok` column ABSENT", t)
         end
 
         # Sub-finding: `coalesce(missing, false)` counted an UNKNOWN status as an
@@ -698,8 +719,11 @@ Test.@testset "RGV paired-Wilcoxon analysis" begin
         cells = [(seed = s, error_rate = e, naive = 1000.0, iterative = 1600.0)
                  for (s, e) in [(42, 0.01), (42, 0.05), (123, 0.01),
             (123, 0.05), (456, 0.01), (456, 0.05)]]
-        observed = _pwt_frame(cells)
-        asserted = _pwt_frame(cells)
+        # Both tables must carry AFFIRMATIVE provenance on every definition axis:
+        # the assurance is granted for observed provenance, not for the absence of a
+        # contrary signal (see the "undeterminable" testset below).
+        observed = _pwt_frame(cells; provenance = "observed")
+        asserted = _pwt_frame(cells; provenance = "observed")
         asserted[!, :metric_source_provenance] = fill("operator-asserted (backfill)",
             DataFrames.nrow(asserted))
 
@@ -738,7 +762,7 @@ Test.@testset "RGV paired-Wilcoxon analysis" begin
 
         # ONE asserted row is enough: the rows the backfill did not touch stay
         # labelled observed, but the aggregate still spans a claim nobody verified.
-        partial = _pwt_frame(cells)
+        partial = _pwt_frame(cells; provenance = "observed")
         prov = fill("observed", DataFrames.nrow(partial))
         prov[1] = "operator-asserted (backfill)"
         partial[!, :metric_source_provenance] = prov
@@ -748,13 +772,15 @@ Test.@testset "RGV paired-Wilcoxon analysis" begin
 
         # The claim is evaluated over the rows actually ANALYZED. An assertion on
         # rows the `--metric-source` filter removed does not taint what is left.
-        filtered = _pwt_frame([
-            (seed = 42, error_rate = 0.01, naive = 1000.0, iterative = 1500.0,
-                metric_source = "quast"),
-            (seed = 123, error_rate = 0.01, naive = 900.0, iterative = 1400.0,
-                metric_source = "internal:quast-failed"),
-            (seed = 456, error_rate = 0.01, naive = 950.0, iterative = 1450.0,
-                metric_source = "quast")])
+        filtered = _pwt_frame(
+            [
+                (seed = 42, error_rate = 0.01, naive = 1000.0, iterative = 1500.0,
+                    metric_source = "quast"),
+                (seed = 123, error_rate = 0.01, naive = 900.0, iterative = 1400.0,
+                    metric_source = "internal:quast-failed"),
+                (seed = 456, error_rate = 0.01, naive = 950.0, iterative = 1450.0,
+                    metric_source = "quast")];
+            provenance = "observed")
         filtered[!, :metric_source_provenance] = [src == "quast" ? "observed" :
                                                   "operator-asserted (backfill)"
                                                   for src in filtered.metric_source]
@@ -764,10 +790,132 @@ Test.@testset "RGV paired-Wilcoxon analysis" begin
         Test.@test !a_filt.definition_operator_asserted
     end
 
+    Test.@testset "B: provenance that CANNOT be determined must not read as observed" begin
+        # The two-state reader was a BLACKLIST: anything not containing
+        # "operator-asserted" counted as observed. So it failed OPEN in exactly the
+        # cases it exists for, and reported `metric_definition_operator_asserted:
+        # false` — an affirmative claim the definition was MEASURED — over tables
+        # that carry no evidence either way.
+        cells = [(seed = s, error_rate = e, naive = 1000.0, iterative = 1600.0)
+                 for (s, e) in [(42, 0.01), (42, 0.05), (123, 0.01),
+            (123, 0.05), (456, 0.01), (456, 0.05)]]
+
+        # (1) NO sibling provenance column — the shape of every sweep CSV the
+        # documented backfill -> analyse workflow produced before this PR.
+        none = _pwt_frame(cells)
+        a_none = run_paired_analysis(none; metrics = (:quast_nga50,))
+        Test.@test a_none.definition_provenance_undeterminable
+        Test.@test a_none.undeterminable_definition_axes ==
+                   ["metric_source", "quast_min_contig"]
+        # The existing boolean keeps its meaning — true iff a row was ASSERTED — so
+        # the third state is added alongside it rather than overloaded onto it.
+        Test.@test !a_none.definition_operator_asserted
+        Test.@test a_none.n_rows_operator_asserted == 0
+
+        # (2) A provenance column carrying a label the reader does not understand.
+        # This is STRONGER evidence that something wrote provenance metadata than an
+        # absent column is, yet a blacklist treated it more permissively.
+        drifted = _pwt_frame(cells; provenance = "backfilled-by-operator")
+        a_drift = run_paired_analysis(drifted; metrics = (:quast_nga50,))
+        Test.@test a_drift.definition_provenance_undeterminable
+        Test.@test !a_drift.definition_operator_asserted
+
+        # (3) A provenance column that is present but `missing` on some rows.
+        holey = _pwt_frame(cells; provenance = "observed")
+        holey[!, :metric_source_provenance] = Vector{Union{Missing, String}}(
+            holey.metric_source_provenance)
+        holey[1, :metric_source_provenance] = missing
+        a_holey = run_paired_analysis(holey; metrics = (:quast_nga50,))
+        Test.@test a_holey.undeterminable_definition_axes == ["metric_source"]
+        Test.@test !a_holey.definition_operator_asserted
+
+        # (4) One axis affirmatively observed, the other with no sibling column: the
+        # assurance is per-axis, so a partial disclosure does not earn it.
+        partial = _pwt_frame(cells; provenance = "observed")
+        DataFrames.select!(partial,
+            DataFrames.Not(:quast_min_contig_provenance))
+        a_partial = run_paired_analysis(partial; metrics = (:quast_nga50,))
+        Test.@test a_partial.undeterminable_definition_axes == ["quast_min_contig"]
+
+        # (5) The control: AFFIRMATIVELY observed on every present axis is the only
+        # state that earns the unqualified assurance.
+        observed = _pwt_frame(cells; provenance = "observed")
+        a_obs = run_paired_analysis(observed; metrics = (:quast_nga50,))
+        Test.@test !a_obs.definition_provenance_undeterminable
+        Test.@test isempty(a_obs.undeterminable_definition_axes)
+
+        mktempdir() do dir
+            for (name, a) in (("none", a_none), ("drift", a_drift),
+                ("holey", a_holey), ("partial", a_partial))
+                text = read(
+                    write_paired_report(joinpath(dir, "$name.md"), a;
+                        csv_paths = ["f.csv"]), String)
+                # The undeterminable state gets its own block, and the unqualified
+                # assurance is withheld: "no contrary signal" is not evidence.
+                Test.@test occursin("PROVENANCE UNDETERMINABLE", text)
+                Test.@test occursin("cannot be determined from this table", text)
+                Test.@test !occursin("enforced it — no override was used", text)
+                Test.@test occursin(
+                    "does NOT establish that the aggregate spans a single MEASURED definition",
+                    text)
+                p = paired_analysis_json(a; csv_paths = ["f.csv"])
+                Test.@test p["metric_definition_provenance_undeterminable"] == true
+                Test.@test p["undeterminable_definition_provenance_axes"] ==
+                           a.undeterminable_definition_axes
+                # NOT overloaded onto the asserted boolean.
+                Test.@test p["metric_definition_operator_asserted"] == false
+            end
+            t_obs = read(
+                write_paired_report(joinpath(dir, "obs.md"), a_obs;
+                    csv_paths = ["f.csv"]), String)
+            Test.@test occursin("enforced it — no override was used", t_obs)
+            Test.@test !occursin("PROVENANCE UNDETERMINABLE", t_obs)
+            p_obs = paired_analysis_json(a_obs; csv_paths = ["f.csv"])
+            Test.@test p_obs["metric_definition_provenance_undeterminable"] == false
+            Test.@test isempty(p_obs["undeterminable_definition_provenance_axes"])
+        end
+    end
+
+    Test.@testset "B: the reader detects what the backfill WRITES (round-trip)" begin
+        # A source grep certifies a coupling it cannot detect breaking. Leaving
+        # `DEFINITION_PROVENANCE_ASSERTED` defined verbatim while changing only the
+        # call site in `_mark_definition_provenance!` to emit another label keeps
+        # both grep assertions passing — Julia does not warn on a defined-but-unused
+        # const — while this reader stops detecting the writer's output entirely.
+        # So the coupling is pinned BEHAVIOURALLY: the writer produces a frame, the
+        # reader classifies it.
+        #
+        # Loaded into its own module because both scripts define `main`.
+        df = DataFrames.DataFrame(
+            arm = ["naive", "iterative"],
+            metric_source = ["quast", missing])
+        _PWTBackfill.insert_definition_column!(df, :metric_source, "quast")
+        asserted, undeterminable, n_asserted = definition_provenance_axes(df)
+        # The row the backfill FILLED is detected as an assertion...
+        Test.@test asserted == ["metric_source"]
+        Test.@test n_asserted == 1
+        # ...and the row it left alone is detected as affirmatively OBSERVED, which
+        # pins the other half of the contract: the reader must recognise the exact
+        # label the writer uses for untouched rows, or every backfilled table also
+        # reads as undeterminable.
+        Test.@test isempty(undeterminable)
+
+        # The writer's own constants must round-trip through the reader's two
+        # recognised categories, so neither end can be renamed unilaterally.
+        Test.@test occursin(RGV_ASSERTED_DEFINITION_MARKER,
+            _PWTBackfill.DEFINITION_PROVENANCE_ASSERTED)
+        Test.@test _PWTBackfill.DEFINITION_PROVENANCE_OBSERVED ==
+                   RGV_OBSERVED_DEFINITION_LABEL
+        # The column-naming convention the reader looks under, from the writer's own
+        # function rather than a grep of its source.
+        Test.@test _PWTBackfill.definition_provenance_column(:metric_source) ==
+                   :metric_source_provenance
+    end
+
     Test.@testset "B: the asserted marker matches what the backfill actually writes" begin
-        # The disclosure crosses a file boundary through a string literal, so the
-        # two ends have to be pinned together or the reader silently stops
-        # detecting what the writer emits.
+        # Retained as a cheap literal check ONLY. It cannot detect the call site
+        # drifting away from the const it declares — that is what the round-trip
+        # testset above is for.
         backfill = read(
             joinpath(@__DIR__, "..", "..", "benchmarking", "rgv_seed_backfill.jl"),
             String)

--- a/test/4_assembly/rgv_paired_wilcoxon_test.jl
+++ b/test/4_assembly/rgv_paired_wilcoxon_test.jl
@@ -707,6 +707,92 @@ Test.@testset "RGV paired-Wilcoxon analysis" begin
         end
     end
 
+    Test.@testset "C: a non-boolean `ok` column is not a check that found failures" begin
+        # `keep = coalesce.(okcol, false) .== true` is vacuously FALSE for a `String`
+        # element, and the counter split then attributes every such row to
+        # `n_dropped_not_ok` (only `ismissing` rows are subtracted out). So the
+        # report asserted the harness had OBSERVED N failed runs whose cells
+        # literally read "TRUE". Those runs succeeded: they are dropped, `n` shrinks,
+        # the p-value moves, and the "(status unknown, not an observed failure)"
+        # phrasing rules out the correct explanation.
+        #
+        # The trigger is ordinary. `CSV.read` infers a string type for an `ok` column
+        # containing `true,false,NA` — one sentinel poisons the whole column — and
+        # merging that shard with a Bool-typed shard under `cols = :union` produces
+        # exactly the mixed column below.
+        cells = [(seed = s, error_rate = e, naive = 1000.0, iterative = 1600.0)
+                 for (s, e) in [(42, 0.01), (42, 0.05), (123, 0.01),
+            (123, 0.05), (456, 0.01), (456, 0.05)]]
+        base = _pwt_frame(cells; provenance = "observed")
+        n = DataFrames.nrow(base)
+
+        # A merged two-shard table: the string shard's rows all read as successes.
+        merged = DataFrames.DataFrame(base)
+        merged[!, :ok] = Union{Bool, String}[i <= 6 ? "TRUE" : true for i in 1:n]
+        a_mix = run_paired_analysis(merged; metrics = (:quast_nga50,))
+        Test.@test a_mix.ok_column_present
+        Test.@test !a_mix.ok_column_runnable
+        Test.@test !a_mix.ok_filter_applied
+        # The successful rows are NOT dropped, and nothing is reported as an
+        # observed failure.
+        Test.@test a_mix.n_rows_analyzed == n
+        Test.@test a_mix.n_dropped_not_ok == 0
+        Test.@test a_mix.n_dropped_ok_missing == 0
+
+        # A wholly string-typed column is the same epistemic state. Under the old
+        # filter every row dropped and the analysis died with "no rows left after
+        # filtering", which at least failed loudly — the mixed case above is the one
+        # that silently moved the p-value.
+        stringy = DataFrames.DataFrame(base)
+        stringy[!, :ok] = fill("TRUE", n)
+        a_str = run_paired_analysis(stringy; metrics = (:quast_nga50,))
+        Test.@test !a_str.ok_column_runnable
+        Test.@test a_str.n_rows_analyzed == n
+
+        mktempdir() do dir
+            for (name, a) in (("mix", a_mix), ("str", a_str))
+                text = read(
+                    write_paired_report(joinpath(dir, "$name.md"), a;
+                        csv_paths = ["f.csv"]), String)
+                Test.@test occursin("NOT a boolean", text)
+                Test.@test occursin("could NOT run", text)
+                # It must never render as a count of observed failures.
+                Test.@test !occursin("dropped for ok=false", text)
+                Test.@test !occursin("`ok` column ABSENT", text)
+                p = paired_analysis_json(a; csv_paths = ["f.csv"])
+                Test.@test p["ok_column_present"] == true
+                Test.@test p["ok_column_runnable"] == false
+                Test.@test p["ok_filter_applied"] == false
+                Test.@test occursin("String", p["ok_column_eltype"])
+            end
+        end
+
+        # Positive control: an INTEGER 0/1 column really can express success, so it
+        # must stay runnable and keep filtering. Widening the runnable predicate
+        # must not quietly stop checking a schema that works today.
+        ints = DataFrames.DataFrame(base)
+        okints = Union{Missing, Int}[1 for _ in 1:n]
+        okints[3] = 0
+        okints[4] = missing
+        ints[!, :ok] = okints
+        a_int = run_paired_analysis(ints; metrics = (:quast_nga50,))
+        Test.@test a_int.ok_column_runnable
+        Test.@test a_int.ok_filter_applied
+        Test.@test a_int.n_dropped_not_ok == 1
+        Test.@test a_int.n_dropped_ok_missing == 1
+        Test.@test a_int.n_rows_analyzed == n - 2
+        # Bool remains runnable, and an ABSENT column is still its own state.
+        a_bool = run_paired_analysis(base; metrics = (:quast_nga50,))
+        Test.@test a_bool.ok_column_runnable
+        Test.@test a_bool.ok_column_eltype == "Bool"
+        a_absent = run_paired_analysis(
+            DataFrames.select(base, DataFrames.Not(:ok)); metrics = (:quast_nga50,))
+        Test.@test !a_absent.ok_column_present
+        Test.@test !a_absent.ok_column_runnable
+        Test.@test paired_analysis_json(a_absent;
+            csv_paths = ["f.csv"])["ok_column_eltype"] === nothing
+    end
+
     Test.@testset "B: an OPERATOR-ASSERTED definition cannot earn the guard assurance" begin
         # `rgv_seed_backfill.jl --metric-source quast` writes a definition on
         # operator say-so, with nothing to verify it against. The guard can then

--- a/test/4_assembly/rgv_paired_wilcoxon_test.jl
+++ b/test/4_assembly/rgv_paired_wilcoxon_test.jl
@@ -944,6 +944,15 @@ Test.@testset "RGV paired-Wilcoxon analysis" begin
                 Test.@test occursin(
                     "does NOT establish that the aggregate spans a single MEASURED definition",
                     text)
+                # The block must not send the reader on an errand that cannot
+                # succeed. It used to say "Recover it with `rgv_seed_backfill.jl`",
+                # but that tool labels only the rows whose definition it SUPPLIES —
+                # so for the shape this block describes (definition present, no
+                # provenance sibling) it writes nothing, the analysis prints the
+                # identical warning, and the operator loops. Same class as the
+                # backfill/analyse ping-pong this PR opened by closing.
+                Test.@test occursin("NOT recoverable by re-running", text)
+                Test.@test !occursin("Recover it with", text)
                 p = paired_analysis_json(a; csv_paths = ["f.csv"])
                 Test.@test p["metric_definition_provenance_undeterminable"] == true
                 Test.@test p["undeterminable_definition_provenance_axes"] ==

--- a/test/4_assembly/rgv_seed_backfill_test.jl
+++ b/test/4_assembly/rgv_seed_backfill_test.jl
@@ -426,4 +426,40 @@ Test.@testset "RGV seed backfill (td-59o7)" begin
             Test.@test occursin("MYCELIA_RGV_SEED:-42,123,456", text)
         end
     end
+
+    Test.@testset "the tool reports the provenance columns it ACTUALLY wrote" begin
+        # Naming a definition the CSV already carries asserts nothing, so
+        # `_mark_definition_provenance!` writes no column. The CLI nevertheless
+        # announced "rows labelled <asserted> in metric_source_provenance" — an
+        # assurance its own sidecar contradicted in the same invocation. The written
+        # columns are now returned so the caller cannot claim more than happened.
+        dir = mktempdir()
+
+        # Definition ALREADY present with the requested value -> nothing asserted.
+        present = joinpath(dir, "present.csv")
+        CSV.write(present,
+            DataFrames.DataFrame(reference = ["Lambda", "Lambda"], k = [21, 21],
+                seed = [42, 42], arm = ["naive", "iterative"],
+                metric_source = ["quast", "quast"]))
+        _, _,
+        _,
+        cols_noop = backfill_seed(present;
+            seed = 42, provenance = "explicit (test)", metric_source = "quast",
+            output_path = joinpath(dir, "present_out.csv"))
+        Test.@test isempty(cols_noop)
+
+        # Definition ABSENT -> supplied, so the column IS written and labelled.
+        absent = joinpath(dir, "absent.csv")
+        CSV.write(absent,
+            DataFrames.DataFrame(reference = ["Lambda", "Lambda"], k = [21, 21],
+                seed = [42, 42], arm = ["naive", "iterative"]))
+        out_a, _,
+        _,
+        cols_written = backfill_seed(absent;
+            seed = 42, provenance = "explicit (test)", metric_source = "quast",
+            output_path = joinpath(dir, "absent_out.csv"))
+        Test.@test "metric_source_provenance" in cols_written
+        back = CSV.read(out_a, DataFrames.DataFrame)
+        Test.@test all(back.metric_source_provenance .== DEFINITION_PROVENANCE_ASSERTED)
+    end
 end

--- a/test/4_assembly/rgv_seed_backfill_test.jl
+++ b/test/4_assembly/rgv_seed_backfill_test.jl
@@ -354,6 +354,63 @@ Test.@testset "RGV seed backfill (td-59o7)" begin
         end
     end
 
+    Test.@testset "B: a supplied definition is labelled IN THE CSV, not just the sidecar" begin
+        # `--metric-source` states, on operator say-so, which definition produced
+        # every metric in the file — a claim nothing verifies, and one no
+        # `--run-log` equivalent could recover. Recording it only in the sidecar is
+        # not a disclosure, because NO consumer reads the sidecar: the analysis
+        # calls `load_sweep_csvs(csv_paths)` and nothing else. So a legacy table
+        # that genuinely mixed QUAST-scored and degraded rows, backfilled with one
+        # `--metric-source`, produced a file the guard certifies as uniform and a
+        # report asserting the guard was enforced. The disclosure has to ride in
+        # the CSV.
+        mktempdir() do dir
+            src = _sbf_legacy_csv(joinpath(dir, "sweep.csv"))
+            out, sidecar,
+            _ = backfill_seed(src;
+                seed = 42, provenance = "explicit (test)",
+                metric_source = "quast", quast_min_contig = 500)
+            df = CSV.read(out, DataFrames.DataFrame)
+
+            for col in ("metric_source_provenance", "quast_min_contig_provenance")
+                Test.@test col in DataFrames.names(df)
+            end
+            # Every row of a column this tool SUPPLIED is an assertion.
+            Test.@test all(occursin.("operator-asserted", df.metric_source_provenance))
+            Test.@test all(occursin.("operator-asserted", df.quast_min_contig_provenance))
+            # The sidecar names the columns that carry the disclosure, so the two
+            # records cannot drift apart.
+            meta = JSON.parsefile(sidecar)
+            Test.@test "metric_source_provenance" in meta["definition_provenance_columns"]
+            Test.@test occursin("operator-asserted",
+                meta["definition_provenance_asserted_label"])
+
+            # A backfill that supplies no definition asserts nothing, so it must not
+            # gain a provenance column claiming otherwise.
+            out2, _,
+            _ = backfill_seed(src;
+                seed = 42, provenance = "explicit (test)",
+                output_path = joinpath(dir, "seed_only.csv"))
+            names2 = DataFrames.names(CSV.read(out2, DataFrames.DataFrame))
+            Test.@test !any(endswith.(names2, "_provenance"))
+        end
+
+        # Rows that ALREADY carried the value are evidence, not assertions: only
+        # the rows the tool actually writes are labelled asserted.
+        partial = DataFrames.DataFrame(
+            arm = ["naive", "iterative"],
+            metric_source = ["quast", missing])
+        marked = insert_definition_column!(partial, :metric_source, "quast")
+        Test.@test marked.metric_source_provenance ==
+                   [DEFINITION_PROVENANCE_OBSERVED, DEFINITION_PROVENANCE_ASSERTED]
+
+        # Re-running can only ADD assertions. Downgrading an already-asserted row to
+        # "observed" would launder the claim away on a second pass.
+        again = insert_definition_column!(copy(marked), :metric_source, "quast")
+        Test.@test again.metric_source_provenance ==
+                   [DEFINITION_PROVENANCE_OBSERVED, DEFINITION_PROVENANCE_ASSERTED]
+    end
+
     Test.@testset "I1: the launchers actually request the replicate seeds" begin
         # The seed axis was asserted by the schema but not produced by anything: a
         # scalar MYCELIA_RGV_SEED and no loop meant a pairable multi-seed table

--- a/test/4_assembly/rgv_seed_backfill_test.jl
+++ b/test/4_assembly/rgv_seed_backfill_test.jl
@@ -126,11 +126,73 @@ Test.@testset "RGV seed backfill (td-59o7)" begin
         mktempdir() do dir
             src = joinpath(dir, "empty_col.csv")
             write(src, "arm,k,seed,metric_source\nnaive,21,,\niterative,21,,\n")
-            out, _, _ = backfill_seed(src;
+            out, _,
+            _ = backfill_seed(src;
                 seed = 42, provenance = "explicit (test)", metric_source = "quast")
             df = CSV.read(out, DataFrames.DataFrame)
             Test.@test all(df.seed .== 42)
             Test.@test all(df.metric_source .== "quast")
+        end
+    end
+
+    Test.@testset "a PARTIALLY populated column is completed, not reported as done" begin
+        # The hole between "entirely empty" (filled above) and "conflicting"
+        # (refused below): SOME rows carry the value and others are `missing`.
+        # `unique(skipmissing(...))` hides the holes, so the equal-value branch
+        # returned the frame UNCHANGED and reported success while leaving the table
+        # unpairable — and `require_pairing_schema` in rgv_paired_wilcoxon.jl then
+        # rejects it with a hint pointing back at THIS tool, so the operator
+        # ping-pongs between the two forever.
+        mktempdir() do dir
+            src = joinpath(dir, "partial.csv")
+            write(src,
+                "arm,k,seed,metric_source\n" *
+                "naive,21,42,quast\n" *
+                "iterative,21,,\n")
+
+            out, _,
+            _ = backfill_seed(src;
+                seed = 42, provenance = "explicit (test)", metric_source = "quast")
+            df = CSV.read(out, DataFrames.DataFrame)
+            # The contract: after a successful backfill NO row is left unlabelled.
+            Test.@test count(ismissing, df.seed) == 0
+            Test.@test all(df.seed .== 42)
+            Test.@test count(ismissing, df.metric_source) == 0
+            Test.@test all(df.metric_source .== "quast")
+
+            # The same holds at the function level, for both columns.
+            partial_seed = DataFrames.DataFrame(
+                arm = ["naive", "iterative"],
+                k = [21, 21],
+                seed = [42, missing])
+            filled = insert_seed_column!(partial_seed, 42)
+            Test.@test collect(filled.seed) == [42, 42]
+
+            partial_def = DataFrames.DataFrame(
+                arm = ["naive", "iterative"],
+                metric_source = ["quast", missing])
+            filled_def = insert_definition_column!(partial_def, :metric_source, "quast")
+            Test.@test collect(filled_def.metric_source) == ["quast", "quast"]
+
+            # Filling holes is only legitimate because the populated rows AGREE with
+            # the supplied value. A partially populated column whose populated value
+            # DISAGREES is a conflict and must still raise — completing it would
+            # rewrite an observed value, which is the failure this tool exists to
+            # prevent.
+            _sbf_throws_with(
+                () -> insert_seed_column!(
+                    DataFrames.DataFrame(k = [21, 21], seed = [42, missing]), 99),
+                ["already has a `seed` column", "refusing to overwrite", "99"])
+            _sbf_throws_with(
+                () -> insert_definition_column!(
+                    DataFrames.DataFrame(metric_source = ["quast", missing]),
+                    :metric_source, "internal:quast-failed"),
+                ["already has a `metric_source` column", "refusing to overwrite"])
+            # And a fully populated CONFLICTING column is refused as before.
+            _sbf_throws_with(
+                () -> insert_seed_column!(
+                    DataFrames.DataFrame(k = [21, 21], seed = [42, 99]), 42),
+                ["already has a `seed` column", "refusing to overwrite"])
         end
     end
 
@@ -247,7 +309,8 @@ Test.@testset "RGV seed backfill (td-59o7)" begin
         # nothing could supply one. The workflow the tools document has to finish.
         mktempdir() do dir
             src = _sbf_legacy_csv(joinpath(dir, "sweep.csv"))
-            out, sidecar, _ = backfill_seed(src;
+            out, sidecar,
+            _ = backfill_seed(src;
                 seed = 42, provenance = "explicit (test)",
                 metric_source = "internal:quast-disabled", quast_min_contig = 200)
             df = CSV.read(out, DataFrames.DataFrame)
@@ -264,18 +327,19 @@ Test.@testset "RGV seed backfill (td-59o7)" begin
 
             # Never inferred: with no flags the columns stay absent, so the
             # analysis still fails closed rather than getting a fabricated value.
-            out2, _, _ = backfill_seed(src;
+            out2, _,
+            _ = backfill_seed(src;
                 seed = 42, provenance = "explicit (test)",
                 output_path = joinpath(dir, "seed_only.csv"))
-            Test.@test !("metric_source" in
-                         DataFrames.names(CSV.read(out2, DataFrames.DataFrame)))
+            Test.@test !("metric_source" in DataFrames.names(CSV.read(out2, DataFrames.DataFrame)))
         end
     end
 
     Test.@testset "an existing definition column is not silently overwritten" begin
         mktempdir() do dir
             src = _sbf_legacy_csv(joinpath(dir, "sweep.csv"))
-            out, _, _ = backfill_seed(src;
+            out, _,
+            _ = backfill_seed(src;
                 seed = 42, provenance = "t", metric_source = "quast")
             df = CSV.read(out, DataFrames.DataFrame)
             # Same value is a no-op, so a re-run is safe: the column keeps its


### PR DESCRIPTION
Fix-forward for three Critical defects that shipped to master in the unreviewed
tail of #439. Each is reproduced below; each has a regression test that fails
against the pre-fix code.

## Why these reached master

#439 merged on head `5362dc85`. CodeRabbit's last review was on `0f5079fa`, two
commits earlier — so `ac3ba333` and `5362dc85` (337 insertions / 55 deletions
across 10 files) shipped with no reviewer of any kind seeing them. All three
defects below are in that range, and two of them are in the `fix(review)` commits
themselves. Two independent review lenses run against the range found them.

## C-A — a partially populated `seed` column reported success and changed nothing

`insert_seed_column!` swapped `unique(df.seed)` for `unique(skipmissing(df.seed))`.
That fixed the all-missing case and regressed the **mixed** case: `[42, missing]`
reduces to `[42]`, satisfies `length(existing) == 1 && first(existing) == seed`,
and returns `df` untouched while the CLI prints `Wrote: …`. Before the tail this
raised.

The result is a closed loop, reproduced end to end:

```text
$ rgv_seed_backfill.jl --csv mixed.csv --seed 42
Rows       : 2
Wrote      : mixed_seedbackfill.csv        # row 2's seed cell is STILL empty

$ rgv_paired_wilcoxon.jl --csv mixed_seedbackfill.csv
ERROR: 1 of 2 rows have a `missing` value in the pairing column `seed` …
       Backfill the incomplete shard before merging it:
         julia --project=. benchmarking/rgv_seed_backfill.jl --csv <csv> …
```

Following that pointer runs the backfill again, which succeeds again, unchanged.
The operator ping-pongs between two tools that each direct them to the other.

Fixed by filling the holes when the populated values already agree with `seed` —
which asserts nothing new — while a genuinely conflicting value (`[42, 99]`, or
`[42, missing]` backfilled with `--seed 99`) still raises.
`insert_definition_column!` had the identical hole and is fixed the same way;
there the consequence is worse, because `metric_source_guard.jl` renders
`missing` as the literal `"missing"` and counts it as a distinct definition, so
the leftover holes make the analysis raise later with a message that names no
cause.

## C-B — the backfill asserted a metric definition indistinguishable from an observed one

To let the backfill→analyse workflow complete, the tail taught
`rgv_seed_backfill.jl` to write `metric_source` and `quast_min_contig` on
operator say-so. It got none of the provenance discipline `seed` has (three
justification flags, a provenance string, a hard refusal to guess), and the
sidecar that recorded the assertion is read by no consumer —
`rgv_paired_wilcoxon.jl` calls `load_sweep_csvs` and nothing else.

Applied to its own documented input — a historical CSV with no `metric_source` —
this converts a genuinely mixed table into one the guard certifies as uniform,
and `report.md` then printed:

> `metric_source_guard.jl` (bead td-9p91) enforced it — no override was used.

over numbers mixing an alignment-validated NGA50 with a size-ratio proxy. That is
strictly worse than the dead end it replaced, because the dead end failed closed.
The file's own header states the principle two paragraphs above the code that
broke it: *"a seed value invented for a historical run is worse than a missing
one: it makes an unpairable run look pairable."*

This is not hypothetical. #438 commits
`rhizomorph_correction_validation_sweep_20260725_113706.csv` — the real Lovelace
Lambda sweep, 12 rows, `metric_source` = 4 `quast` + 8 `internal:quast-failed`,
with no `seed` and no `quast_min_contig`. It is a mixed table whose only route to
being analysable is this backfill.

Fixed on both sides:

- **Writer** — every row whose definition the backfill *supplies* is labelled in a
  sibling `<column>_provenance` column (`"operator-asserted (backfill)"`). Rows
  that already carried the value keep `"observed"`, so re-running can add an
  assertion but never launder one back to observed. No provenance column is
  created when nothing was asserted.
- **Reader** — `operator_asserted_definitions` is evaluated over the rows actually
  analysed, so an assertion on rows the `--metric-source` filter removed does not
  taint the remainder. Rendered like the existing `override_bound`:

```text
report.md:28  > ## ⚠️ METRIC DEFINITION OPERATOR-ASSERTED, NOT OBSERVED
report.md:35  _`metric_source_guard.jl` (bead td-9p91) ran and no override was used, but the
              values it compared were operator-asserted for some rows …, so this run does NOT
              establish that the aggregate spans a single MEASURED definition._

results.json  metric_definition_operator_asserted: true
              operator_asserted_definition_axes: ["metric_source","quast_min_contig"]
              n_rows_operator_asserted_definition: 12
```

## C-C — a missing `ok` column read identically to "every row verified"

```julia
if !keep_not_ok && (:ok in Symbol.(DataFrames.names(work)))
```

With `ok` present and all-true, and with `ok` absent entirely, `report.md` emitted
the byte-identical line `(0 dropped for ok=false, …)` — which reads as *the check
ran and every row passed*. `results.json` carried no `n_dropped_not_ok` and no
`ok_column_present`, so a consumer could not recover the distinction from either
artifact. This is the same "unverifiable is not verified" doctrine
`metric_source_guard.jl` already applies to the definition columns, not applied to
`ok`.

Three states are now explicit:

```text
- Rows: 12 read, 12 analyzed (**`ok` column ABSENT — no row was verified;
  the ok=false check could NOT run**; 0 dropped by metric_source filter)
```

plus `ok_column_present`, `ok_filter_applied`, `n_dropped_not_ok`,
`n_dropped_ok_missing`, `n_dropped_metric_source` in `results.json` — the last
three were absent entirely. Sub-fix at the same site: `coalesce.(work.ok, false)`
counted an `ok === missing` row toward `n_dropped_not_ok`, conflating "the harness
said this failed" with "we do not know whether it succeeded"; those are now
counted and reported separately.

## Test plan

All counts reproduced independently, not taken from the implementation:

- [x] `test/4_assembly/rgv_seed_backfill_test.jl` — **81/81** (was 59)
- [x] `test/4_assembly/rgv_paired_wilcoxon_test.jl` — **345/345** (was 300)
- [x] `test/4_assembly/track_a_merge_hosts_test.jl` — **148/148** (unchanged)
- [x] Every new test confirmed to FAIL against pre-fix code, by exporting
      `origin/master`'s `benchmarking/` + `test/4_assembly/` with `git archive`
      into a scratch tree and running the new tests against the old
      implementations. C-A: only the new testset fails. C-B: only the two new
      testsets fail — and the pre-fix report does print "enforced it — no override
      was used" over an operator-asserted table. C-C: its testset fails while all
      300 pre-existing assertions still pass.
- [x] End-to-end smoke beyond the unit tests: a legacy CSV with no
      `metric_source`, backfilled with `--metric-source quast --quast-min-contig 500`,
      then analysed — disclosure appears in `report.md` and `results.json` as shown
      above. Re-run with the `ok` column stripped produced the ABSENT line and
      `ok_column_present: false`.
- [x] The C-A ping-pong reproduced before the fix and confirmed closed after.

## Deferred, with beads

Four Important findings from the same audit are tracked rather than fixed here,
to keep this PR to the Criticals: the Track A merge tool's residual fail-open
states (a reachable-but-empty source still shrinks the analyzed table at exit 0;
an unparseable checkpoint is waivable while a bad-field one is fatal; a bare
`catch` swallows `InterruptException`), the launcher walltime and the missing
pre-registered-seed-set gate, and the stale seed-log pattern / unstamped figure
override / incomplete verdict legend.

## Judgement calls worth a look

1. **Cross-file string coupling in C-B.** The writer's label and the reader's
   marker live in two files, pinned by a source-grep test (house style — same as
   the "sbatch wrappers echo SEED" test). The tighter alternative is a shared
   constant in `metric_source_guard.jl` `include`d from the backfill tool;
   double-inclusion of that file is tolerated on Julia 1.10. I kept the backfill
   tool dependency-free.
2. **Per-row provenance rather than a file-level flag.** Costs two CSV columns,
   but makes "half this table was backfilled" representable, which a file-level
   flag cannot.
3. **The sidecar is still read by no consumer.** Deliberate: the disclosure now
   rides in the CSV, which is the durable fix. The sidecar stays an audit record
   and now names the columns carrying the disclosure, so the two cannot silently
   diverge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added transparent provenance labels for metric definitions, distinguishing observed, operator-asserted, and undeterminable values.
  - Enhanced reports, JSON output, and figure captions with explicit caveats and exploratory-analysis labeling.
  - Improved filtering and status reporting for missing, unusable, disabled, and failed records.
  - Backfill workflows now complete missing values while preserving existing data and recording provenance.

- **Bug Fixes**
  - Prevented unavailable or asserted definitions from being presented as verified measurements.
  - Preserved matching existing values and rejected conflicting backfill data.

- **Tests**
  - Expanded coverage for provenance, filtering states, backfills, reports, JSON output, and figure captions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->