### PR TITLE
fix: write the Track A benchmark helpers, and restore the tests that pin them

### DIFF
--- a/benchmarking/track_a_baseline_benchmark.jl
+++ b/benchmarking/track_a_baseline_benchmark.jl
@@ -66,16 +66,26 @@ const K = 31
 const CV_THRESHOLD = 0.15  # assumed NGA50 coefficient of variation in the power analysis
 
 # Canonical row schema (fixed order so in-memory and JSON-reloaded rows align in the DataFrame).
+#
+# `peak_rss_bytes` carries its own provenance: `rss_baseline_bytes` (process RSS on entry
+# to the cell) and `peak_rss_method` (HOW the peak was obtained). Rows measured by
+# different methods are different quantities, so the method has to travel with the number
+# rather than be inferred from the run that produced it. New columns are appended ahead of
+# `:status` only; the preceding column order is unchanged so existing readers of
+# `track_a_results.tsv` keep working.
 const ROW_KEYS = (
     :organism, :accession, :technology, :coverage, :seed, :decoder_arm, :k,
     :n_reads, :n_contigs, :NGA50, :misassemblies, :genome_fraction,
-    :duplication_ratio, :largest_contig, :wall_seconds, :peak_rss_bytes, :status
+    :duplication_ratio, :largest_contig, :wall_seconds, :peak_rss_bytes,
+    :rss_baseline_bytes, :peak_rss_method, :status
 )
 const INT_KEYS = (
-    :coverage, :seed, :k, :n_reads, :n_contigs, :largest_contig, :peak_rss_bytes)
+    :coverage, :seed, :k, :n_reads, :n_contigs, :largest_contig, :peak_rss_bytes,
+    :rss_baseline_bytes)
 const FLOAT_KEYS = (
     :NGA50, :misassemblies, :genome_fraction, :duplication_ratio, :wall_seconds)
-const STR_KEYS = (:organism, :accession, :technology, :decoder_arm, :status)
+const STR_KEYS = (
+    :organism, :accession, :technology, :decoder_arm, :peak_rss_method, :status)
 
 # === Argument parsing ===
 
@@ -126,17 +136,6 @@ end
 const N_CELLS = length(organisms) * length(technologies) * length(coverages) *
                 length(seeds) * length(arms)
 
-println("=== Track A baseline benchmark ===")
-println("Start: $(Dates.now())")
-println("Smoke mode: $SMOKE")
-println("Organisms: $(join((o[1] for o in organisms), ", "))")
-println("Technologies: $(join(technologies, ", "))")
-println("Coverages: $(join(coverages, ", "))x")
-println("Seeds: $(join(seeds, ", "))")
-println("Decoder arms: $(join(arms, ", "))")
-println("Cells to run: $N_CELLS")
-println("Output dir: $OUTPUT_DIR")
-
 # === Metrics + row helpers ===
 
 function empty_metrics()
@@ -145,7 +144,8 @@ function empty_metrics()
 end
 
 function cell_row(org, acc, tech, cov, seed, arm; n_reads, n_contigs,
-        wall_seconds, peak_rss_bytes, metrics, status)
+        wall_seconds, peak_rss_bytes, rss_baseline_bytes, peak_rss_method,
+        metrics, status)
     return (
         organism = String(org), accession = String(acc), technology = String(tech),
         coverage = Int(cov), seed = Int(seed), decoder_arm = String(arm), k = K,
@@ -155,14 +155,45 @@ function cell_row(org, acc, tech, cov, seed, arm; n_reads, n_contigs,
         duplication_ratio = Float64(metrics.duplication_ratio),
         largest_contig = Int(round(Float64(metrics.largest_contig))),
         wall_seconds = round(Float64(wall_seconds); digits = 3),
-        peak_rss_bytes = Int(peak_rss_bytes), status = String(status)
+        peak_rss_bytes = Int(peak_rss_bytes),
+        rss_baseline_bytes = Int(rss_baseline_bytes),
+        peak_rss_method = String(peak_rss_method), status = String(status)
     )
 end
 
+# Provenance columns a checkpoint written before they existed is allowed to lack, and the
+# sentinel each takes. Every OTHER column is a measurement or a grouping key, and a missing
+# one must fail loudly: `NGA50 = 0.0` and `genome_fraction = 0.0` are the GENUINE values for
+# every ONT cell at 10x/30x, so a zero-filled truncated checkpoint is byte-identical to a
+# real result and would be pooled straight into the CV that gates the pre-registration. A
+# truncated checkpoint must not be able to move a verdict.
+#
+# Driving the defaulting from this table (rather than hardcoding the two cases inside
+# `canonical`) is what makes the error message below true: adding a key here really is all
+# it takes to make that key defaultable.
+const OPTIONAL_KEY_DEFAULTS = Dict{Symbol, Any}(
+    :peak_rss_method => "unknown", :rss_baseline_bytes => -1)
+const OPTIONAL_KEYS = Tuple(sort(collect(keys(OPTIONAL_KEY_DEFAULTS))))
+
 # Rebuild a canonical, type-coerced NamedTuple from a parsed JSON dict (resumed cells).
+#
+# An absent OPTIONAL_KEY takes an explicit "unknown"/-1 sentinel that no real measurement
+# can produce, so a resumed pre-schema tree is reloadable but can never be mistaken for a
+# measured one. Any other absent key raises: indexing `d[String(key)]` directly raised a
+# bare KeyError naming only the key, which killed the run on the first cached cell with no
+# indication that the tree simply predated a schema change.
 function canonical(d::AbstractDict)
     vals = map(ROW_KEYS) do key
-        v = d[String(key)]
+        name = String(key)
+        if !haskey(d, name)
+            haskey(OPTIONAL_KEY_DEFAULTS, key) && return OPTIONAL_KEY_DEFAULTS[key]
+            error("checkpoint is missing required key $(name). This is a measurement or " *
+                  "grouping column, so it cannot be defaulted — a zero here is " *
+                  "indistinguishable from a real result and would silently enter the " *
+                  "power analysis. Delete the checkpoint to recompute the cell, or add " *
+                  "$(name) to OPTIONAL_KEY_DEFAULTS if it is genuinely provenance-only.")
+        end
+        v = d[name]
         if key in INT_KEYS
             v isa Integer ? Int(v) : Int(round(Float64(v)))
         elseif key in FLOAT_KEYS
@@ -257,6 +288,132 @@ function shape_for_arm(records, arm)
     end
 end
 
+# === Memory measurement ===
+
+# `Sys.maxrss()` is the process-lifetime high-water mark and is monotonically
+# non-decreasing, so the previous `max(0, Sys.maxrss() - rss0)` could only be nonzero when
+# a cell beat the ALL-TIME process peak. It measured "excess over historical peak", not
+# per-cell peak: on the 2026-07-25 Lovelace run 271/288 rows (94%) were exactly 0,
+# including 144/144 kmer cells, and the few survivors understate real usage by orders of
+# magnitude because each is a delta over the previous peak rather than a measurement.
+#
+# Read VmRSS from /proc/self/status instead: it reports explicit kB, so unlike
+# /proc/self/statm it needs no `Sys.PAGESIZE` (which does not exist in Julia 1.10).
+# Returns `nothing` wherever /proc is unavailable (macOS), which selects the fallback.
+function current_rss_bytes()
+    status_path = "/proc/self/status"
+    isfile(status_path) || return nothing
+    # `open(...) do` rather than a bare `eachline(path)`: eachline closes its handle only
+    # at end-of-iteration, and VmRSS sits near the top of the file so the early return
+    # below always exits first — leaking one descriptor per poll, ~72k/hour at 20 Hz.
+    return open(status_path) do io
+        for line in eachline(io)
+            startswith(line, "VmRSS:") || continue
+            fields = split(line)
+            length(fields) >= 2 || return nothing
+            kilobytes = tryparse(Int, fields[2])
+            return kilobytes === nothing ? nothing : kilobytes * 1024
+        end
+        return nothing
+    end
+end
+
+"""
+Run `f`, returning `(; value, wall_seconds, peak_rss_bytes, rss_baseline_bytes, method)`.
+
+`peak_rss_bytes` is the highest WHOLE-PROCESS resident set observed while `f` ran. It is
+deliberately not called a per-cell figure: it includes the Julia runtime, the loaded
+package images, every other thread, and memory retained (not returned to the OS) by
+earlier cells. `rss_baseline_bytes` is the process RSS immediately before `f`, so a caller
+wanting a cell-attributable increment can take the difference — but the absolute level is
+what an HPC memory request actually needs, so that is what the primary column holds.
+
+The sampler runs via `Threads.@spawn`, which requires a second thread: the assembly is
+CPU-bound Julia that never yields, so a same-thread `@async` sampler would never be
+scheduled. Both committed sbatch wrappers export JULIA_NUM_THREADS=\$SLURM_CPUS_PER_TASK —
+run_track_a_baseline_lrc.sbatch (16) and run_track_a_baseline_nersc.sbatch (4) — so
+sampling is the production path under SLURM. Julia defaults to ONE thread, so a bare
+`julia track_a_baseline_benchmark.jl` silently reverts to the broken high-water semantics;
+launch with `julia -t N` or the column is meaningless.
+
+`method` records how the number was obtained, so a reader never has to infer it and rows
+measured different ways are never averaged together:
+  "sampled"          - process-RSS high-water, polled while the cell ran
+  "sampled-degraded" - the sampler never completed a single read (starved, or every /proc
+                       read failed); the number is the entry baseline, NOT a measurement.
+                       A flat cell whose RSS never exceeds its baseline is still "sampled"
+                       — that is a real observation.
+  "highwater-delta"  - single-threaded or no /proc: the old, known-broken semantics
+  "unknown"          - checkpoint predates this column (see OPTIONAL_KEY_DEFAULTS)
+Values under different methods are different quantities. Always filter on
+`peak_rss_method` before aggregating.
+"""
+function timed_with_peak_rss(f; interval_seconds::Float64 = 0.05)
+    # Guard the baseline read too: everything here is careful never to let telemetry fail
+    # science, and an unguarded /proc read error would abort the cell before f() even ran.
+    baseline = try
+        current_rss_bytes()
+    catch e
+        @warn "baseline RSS read failed; falling back to high-water semantics" exception = e
+        nothing
+    end
+
+    can_sample = baseline !== nothing && Threads.nthreads() > 1
+    if !can_sample
+        rss0 = Sys.maxrss()
+        timed = @timed f()
+        return (value = timed.value, wall_seconds = timed.time,
+            peak_rss_bytes = max(0, Sys.maxrss() - rss0),
+            rss_baseline_bytes = baseline === nothing ? -1 : baseline,
+            method = "highwater-delta")
+    end
+
+    peak = Threads.Atomic{Int}(baseline)
+    keep_sampling = Threads.Atomic{Bool}(true)
+    # Count SUCCESSFUL READS, not increases over the baseline. The failure worth flagging
+    # is a sampler that never observed anything — starved, or every /proc read failed —
+    # because it then returns the baseline as though it were a measurement: a large,
+    # stable, plausible byte count, strictly harder to spot than the exactly-0 signature
+    # of the bug being replaced. A cell whose RSS never rises above its baseline is NOT
+    # degraded; that happens whenever the allocation fits inside already-resident heap.
+    reads = Threads.Atomic{Int}(0)
+    sampler = Threads.@spawn begin
+        # The sampler must never be able to fail a good cell: a transient /proc read error
+        # is telemetry, not science. Swallow it and let the read count report the
+        # degradation instead.
+        try
+            while keep_sampling[]
+                observed = current_rss_bytes()
+                if observed !== nothing
+                    Threads.atomic_add!(reads, 1)
+                    observed > peak[] && Threads.atomic_max!(peak, observed)
+                end
+                sleep(interval_seconds)
+            end
+        catch
+            # deliberately swallowed; `reads == 0` reports the degradation
+        end
+    end
+
+    timed = try
+        @timed f()
+    finally
+        # Stop AND reap the sampler here, not after the block. With `wait` outside, a
+        # sampler exception on the success path would raise TaskFailedException and
+        # DISCARD a completed assembly — telemetry destroying science — while on the throw
+        # path `wait` would never be reached at all and the sampler would outlive the cell.
+        keep_sampling[] = false
+        try
+            wait(sampler)
+        catch
+            # sampler already reported via `reads`; never let it mask f()'s own outcome
+        end
+    end
+    return (value = timed.value, wall_seconds = timed.time,
+        peak_rss_bytes = peak[], rss_baseline_bytes = baseline,
+        method = reads[] > 0 ? "sampled" : "sampled-degraded")
+end
+
 # === Per-cell execution ===
 
 function run_cell(org, acc, ref, tech, cov, seed, arm, cell_dir)
@@ -265,11 +422,13 @@ function run_cell(org, acc, ref, tech, cov, seed, arm, cell_dir)
     asm_input = shape_for_arm(records, arm)
 
     GC.gc()
-    rss0 = Sys.maxrss()
-    timed = @timed Mycelia.Rhizomorph.assemble_genome(asm_input; k = K, verbose = false)
-    result = timed.value
-    wall_seconds = timed.time
-    peak_rss_bytes = max(0, Sys.maxrss() - rss0)
+    measured = timed_with_peak_rss(
+        () -> Mycelia.Rhizomorph.assemble_genome(asm_input; k = K, verbose = false))
+    result = measured.value
+    wall_seconds = measured.wall_seconds
+    peak_rss_bytes = measured.peak_rss_bytes
+    rss_baseline_bytes = measured.rss_baseline_bytes
+    peak_rss_method = measured.method
 
     contigs_path = joinpath(cell_dir, "contigs.fasta")
     open(contigs_path, "w") do io
@@ -295,7 +454,8 @@ function run_cell(org, acc, ref, tech, cov, seed, arm, cell_dir)
 
     status = n_contigs == 0 ? "empty_assembly" : "ok"
     return cell_row(org, acc, tech, cov, seed, arm;
-        n_reads, n_contigs, wall_seconds, peak_rss_bytes, metrics, status)
+        n_reads, n_contigs, wall_seconds, peak_rss_bytes, rss_baseline_bytes,
+        peak_rss_method, metrics, status)
 end
 
 # === Aggregation ===
@@ -355,7 +515,58 @@ function write_power_analysis(root, df)
     return cv_df
 end
 
+# === Cell identity + error rows (extracted so both are unit-testable) ===
+
+# k belongs in the cell id: without it, two runs at different k write the same
+# cells/<id>/cell_result.json and the second silently resumes the first's result.
+#
+# But the suffix is applied ONLY for a non-default k. Interpolating it unconditionally
+# renames the DEFAULT k=31 cells too, which orphans every checkpoint written before k was
+# selectable — 288 on Lovelace and 144 on LRC — turning the sbatch wrappers' documented
+# "just re-submit, completed cells are skipped" recovery into a silent full recompute.
+# Legacy trees are k=31 by definition (k was a hardcoded const), so keying k=31 to the
+# historical name is unambiguous and needs no migration.
+#
+# The unsuffixed branch is pinned to the literal 31, not to `K`: the reservation belongs to
+# the names already on disk, so changing the default k must never re-point the unsuffixed
+# name at a different k and republish a completed tree as if it were the new k. The
+# `cell_id = ...` line is also the exact string track_a_merge_hosts_test.jl's drift guard
+# asserts against this source, keeping the merge tool's mirrored id format verifiable.
+function cell_id_for(org, tech, cov, seed, arm; k = K)
+    cell_id = "$(org)__$(tech)__$(cov)x__seed$(seed)__$(arm)"
+    return k == 31 ? cell_id : "$(cell_id)__k$(k)"
+end
+
+# The row recorded when a cell throws. Extracted from the catch block because it was
+# unreachable from any test while it lived there: adding a required keyword to `cell_row`
+# without updating this call makes the ERROR HANDLER ITSELF throw UndefKeywordError, so
+# the first failing cell aborts the whole matrix from inside its own recovery path — and
+# `--smoke` runs a single deliberately-successful cell, so no test could reach it.
+error_row(org, acc, tech, cov, seed, arm) =
+    cell_row(org, acc, tech, cov, seed, arm;
+        n_reads = 0, n_contigs = 0, wall_seconds = 0.0, peak_rss_bytes = 0,
+        rss_baseline_bytes = -1, peak_rss_method = "unknown",
+        metrics = empty_metrics(), status = "error")
+
 # === Main ===
+
+# Guard the driver so a test can `include()` this file for its pure helpers without
+# downloading genomes or running assemblies — which is what makes
+# test/4_assembly/track_a_baseline_benchmark_test.jl possible, and matches the convention
+# already used by 18 other harnesses in this directory. `if` does not introduce scope at
+# top level, so the globals below stay global.
+if abspath(PROGRAM_FILE) == @__FILE__
+
+println("=== Track A baseline benchmark ===")
+println("Start: $(Dates.now())")
+println("Smoke mode: $SMOKE")
+println("Organisms: $(join((o[1] for o in organisms), ", "))")
+println("Technologies: $(join(technologies, ", "))")
+println("Coverages: $(join(coverages, ", "))x")
+println("Seeds: $(join(seeds, ", "))")
+println("Decoder arms: $(join(arms, ", "))")
+println("Cells to run: $N_CELLS")
+println("Output dir: $OUTPUT_DIR")
 
 mkpath(OUTPUT_DIR)
 refs_dir = joinpath(OUTPUT_DIR, "refs")
@@ -393,7 +604,7 @@ for (org, acc, _expected) in organisms,
     seed in seeds,
     arm in arms
     global cell_index += 1
-    cell_id = "$(org)__$(tech)__$(cov)x__seed$(seed)__$(arm)"
+    cell_id = cell_id_for(org, tech, cov, seed, arm)
     cell_dir = joinpath(cells_dir, cell_id)
     ckpt = joinpath(cell_dir, "cell_result.json")
 
@@ -409,9 +620,7 @@ for (org, acc, _expected) in organisms,
         run_cell(org, acc, ref_paths[org], tech, cov, seed, arm, cell_dir)
     catch e
         @warn "cell failed" cell_id exception = (e, catch_backtrace())
-        cell_row(org, acc, tech, cov, seed, arm;
-            n_reads = 0, n_contigs = 0, wall_seconds = 0.0, peak_rss_bytes = 0,
-            metrics = empty_metrics(), status = "error")
+        error_row(org, acc, tech, cov, seed, arm)
     end
     save_cell_json(ckpt, row)
     push!(rows, row)
@@ -444,3 +653,5 @@ end
 n_ok = count(r -> r.status == "ok", rows)
 println("\nDone: $(length(rows)) cells, $n_ok ok. Results in $OUTPUT_DIR")
 println("End: $(Dates.now())")
+
+end  # PROGRAM_FILE guard

--- a/benchmarking/track_a_baseline_benchmark.jl
+++ b/benchmarking/track_a_baseline_benchmark.jl
@@ -173,7 +173,6 @@ end
 # it takes to make that key defaultable.
 const OPTIONAL_KEY_DEFAULTS = Dict{Symbol, Any}(
     :peak_rss_method => "unknown", :rss_baseline_bytes => -1)
-const OPTIONAL_KEYS = Tuple(sort(collect(keys(OPTIONAL_KEY_DEFAULTS))))
 
 # Rebuild a canonical, type-coerced NamedTuple from a parsed JSON dict (resumed cells).
 #
@@ -333,26 +332,35 @@ CPU-bound Julia that never yields, so a same-thread `@async` sampler would never
 scheduled. Both committed sbatch wrappers export JULIA_NUM_THREADS=\$SLURM_CPUS_PER_TASK —
 run_track_a_baseline_lrc.sbatch (16) and run_track_a_baseline_nersc.sbatch (4) — so
 sampling is the production path under SLURM. Julia defaults to ONE thread, so a bare
-`julia track_a_baseline_benchmark.jl` silently reverts to the broken high-water semantics;
-launch with `julia -t N` or the column is meaningless.
+`julia track_a_baseline_benchmark.jl` reverts to the broken high-water semantics; launch
+with `julia -t N` or the column is meaningless. That revert is no longer silent — a
+one-time `@warn` fires from the fallback branch below whenever it happens.
 
 `method` records how the number was obtained, so a reader never has to infer it and rows
 measured different ways are never averaged together:
-  "sampled"          - process-RSS high-water, polled while the cell ran
+  "sampled"          - process-RSS high-water, polled while the cell ran, with EVERY poll
+                       succeeding. A flat cell whose RSS never exceeds its baseline is
+                       still "sampled" — that is a real observation.
+  "sampled-partial"  - at least one poll succeeded and at least one THREW. Sampling
+                       continued, but the peak may have been missed while the probe was
+                       failing, so the number is a lower bound, not a measurement.
   "sampled-degraded" - the sampler never completed a single read (starved, or every /proc
                        read failed); the number is the entry baseline, NOT a measurement.
-                       A flat cell whose RSS never exceeds its baseline is still "sampled"
-                       — that is a real observation.
   "highwater-delta"  - single-threaded or no /proc: the old, known-broken semantics
   "unknown"          - checkpoint predates this column (see OPTIONAL_KEY_DEFAULTS)
 Values under different methods are different quantities. Always filter on
 `peak_rss_method` before aggregating.
+
+`probe` is the RSS reader, injectable ONLY so the failure labelling above can be tested:
+`current_rss_bytes` returns `nothing` on macOS and there is no portable way to make a
+real /proc read fail on the third poll.
 """
-function timed_with_peak_rss(f; interval_seconds::Float64 = 0.05)
+function timed_with_peak_rss(f; interval_seconds::Float64 = 0.05,
+        probe = current_rss_bytes)
     # Guard the baseline read too: everything here is careful never to let telemetry fail
     # science, and an unguarded /proc read error would abort the cell before f() even ran.
     baseline = try
-        current_rss_bytes()
+        probe()
     catch e
         @warn "baseline RSS read failed; falling back to high-water semantics" exception = e
         nothing
@@ -360,6 +368,20 @@ function timed_with_peak_rss(f; interval_seconds::Float64 = 0.05)
 
     can_sample = baseline !== nothing && Threads.nthreads() > 1
     if !can_sample
+        # The docstring says a bare `julia` invocation "silently reverts to the broken
+        # high-water semantics". `can_sample == false` knows that at runtime, so say it
+        # instead of leaving the operator to infer it from a column of near-zeros after a
+        # multi-day run. `maxlog` keeps it to one line, not one per cell.
+        if Threads.nthreads() == 1
+            @warn "peak_rss_bytes is falling back to the known-broken high-water " *
+                  "semantics: Julia has ONE thread, so the RSS sampler cannot be " *
+                  "scheduled against a CPU-bound assembly. Relaunch with `julia -t N` " *
+                  "(both sbatch wrappers export JULIA_NUM_THREADS) or treat the column " *
+                  "as unusable." maxlog = 1
+        elseif baseline === nothing
+            @warn "peak_rss_bytes is falling back to the known-broken high-water " *
+                  "semantics: /proc/self/status is unreadable on this host." maxlog = 1
+        end
         rss0 = Sys.maxrss()
         timed = @timed f()
         return (value = timed.value, wall_seconds = timed.time,
@@ -377,13 +399,24 @@ function timed_with_peak_rss(f; interval_seconds::Float64 = 0.05)
     # of the bug being replaced. A cell whose RSS never rises above its baseline is NOT
     # degraded; that happens whenever the allocation fits inside already-resident heap.
     reads = Threads.Atomic{Int}(0)
+    # Count FAILED reads separately, because "never observed anything" and "stopped
+    # observing partway" are different lies. With the try OUTSIDE the loop, the first
+    # throwing poll ended sampling for the rest of the cell, yet `reads > 0` still
+    # labelled the frozen partial maximum "sampled" — a plausible number presented as a
+    # measurement, which is the exact failure mode the read count was added to catch.
+    failed_reads = Threads.Atomic{Int}(0)
     sampler = Threads.@spawn begin
         # The sampler must never be able to fail a good cell: a transient /proc read error
-        # is telemetry, not science. Swallow it and let the read count report the
-        # degradation instead.
+        # is telemetry, not science. The try is INSIDE the loop, so one bad poll costs one
+        # sample rather than the rest of the cell, and the counts below report it.
         try
             while keep_sampling[]
-                observed = current_rss_bytes()
+                observed = try
+                    probe()
+                catch
+                    Threads.atomic_add!(failed_reads, 1)
+                    nothing
+                end
                 if observed !== nothing
                     Threads.atomic_add!(reads, 1)
                     observed > peak[] && Threads.atomic_max!(peak, observed)
@@ -391,7 +424,8 @@ function timed_with_peak_rss(f; interval_seconds::Float64 = 0.05)
                 sleep(interval_seconds)
             end
         catch
-            # deliberately swallowed; `reads == 0` reports the degradation
+            # Last-resort net for a failure OUTSIDE the probe (an interrupted sleep, say).
+            # Deliberately swallowed; the two read counts report the degradation.
         end
     end
 
@@ -409,9 +443,17 @@ function timed_with_peak_rss(f; interval_seconds::Float64 = 0.05)
             # sampler already reported via `reads`; never let it mask f()'s own outcome
         end
     end
+    # Read the counters only after the `finally` above has reaped the sampler, so the
+    # label describes the whole cell rather than a racing snapshot of it.
+    method = if reads[] == 0
+        "sampled-degraded"
+    elseif failed_reads[] > 0
+        "sampled-partial"
+    else
+        "sampled"
+    end
     return (value = timed.value, wall_seconds = timed.time,
-        peak_rss_bytes = peak[], rss_baseline_bytes = baseline,
-        method = reads[] > 0 ? "sampled" : "sampled-degraded")
+        peak_rss_bytes = peak[], rss_baseline_bytes = baseline, method = method)
 end
 
 # === Per-cell execution ===

--- a/benchmarking/track_a_merge_hosts.jl
+++ b/benchmarking/track_a_merge_hosts.jl
@@ -95,10 +95,17 @@ include(joinpath(@__DIR__, "metric_source_guard.jl"))
 
 # === Expected matrix ========================================================
 #
-# MIRRORS `track_a_baseline_benchmark.jl` (which cannot be `include`d — it runs
-# the whole benchmark at include time). `test/4_assembly/track_a_merge_hosts_test.jl`
-# asserts these constants and the cell-id format still match the harness source,
-# so drift fails a test rather than silently mis-computing "missing".
+# MIRRORS `track_a_baseline_benchmark.jl`. The harness now guards its driver with
+# `if abspath(PROGRAM_FILE) == @__FILE__`, so including it no longer runs the
+# benchmark; the duplication survives for two other reasons. The harness imports
+# Mycelia (plus FASTX/Statistics), and this merge deliberately depends on none of
+# that — it must run from a bare checkout against JSON on disk. And the harness
+# defines top-level consts — ORGANISMS, TECHNOLOGIES, COVERAGES, SEEDS — that
+# collide inside runtests.jl's shared `Main`, which is why even its own contract
+# test includes it in a module. `test/4_assembly/track_a_merge_hosts_test.jl`
+# asserts these constants, the cell-id format, AND the row schema still match the
+# harness SOURCE, so drift fails a test rather than silently mis-computing
+# "missing" or dropping a column from the merged table.
 
 const TRACK_A_ORGANISMS = ("Lambda", "T4", "phi29", "SARS-CoV-2")
 const TRACK_A_TECHNOLOGIES = ("illumina", "pacbio", "ont")
@@ -107,14 +114,25 @@ const TRACK_A_SEEDS = (42, 123, 456)
 const TRACK_A_ARMS = ("qualmer", "kmer")
 
 """
-    track_a_cell_id(organism, technology, coverage, seed, arm) -> String
+    track_a_cell_id(organism, technology, coverage, seed, arm; k = 31) -> String
 
 The harness's per-cell directory name. Must stay byte-identical to
-`track_a_baseline_benchmark.jl`'s
-`cell_id = "\$(org)__\$(tech)__\$(cov)x__seed\$(seed)__\$(arm)"`.
+`track_a_baseline_benchmark.jl`'s `cell_id_for`, which builds
+`cell_id = "\$(org)__\$(tech)__\$(cov)x__seed\$(seed)__\$(arm)"` and appends
+`__k\$(k)` only for a NON-default k: the 288-cell baseline predates the `--k`
+flag, so keying k=31 to the historical suffix-less name is what keeps those
+completed trees resumable.
+
+A k-sweep tree therefore holds ids this merge does NOT enumerate by default —
+`expected_cell_ids()` sweeps the baseline matrix at k=31 — so its cells are
+reported as outside the expected matrix rather than silently merged in. That is
+deliberate: the cross-host merge reconciles the baseline, and pooling a sweep's k
+into it would corrupt exactly the per-k separation the sweep exists to measure.
+Pass `k` explicitly to address a sweep cell.
 """
-function track_a_cell_id(organism, technology, coverage, seed, arm)
-    return "$(organism)__$(technology)__$(coverage)x__seed$(seed)__$(arm)"
+function track_a_cell_id(organism, technology, coverage, seed, arm; k = 31)
+    base = "$(organism)__$(technology)__$(coverage)x__seed$(seed)__$(arm)"
+    return k == 31 ? base : "$(base)__k$(k)"
 end
 
 """
@@ -409,10 +427,27 @@ end
 
 # Harness row order, so `track_a_results.tsv` written here is drop-in compatible
 # with `track_a_baseline_benchmark.jl`'s own aggregate.
+#
+# This is a hand-maintained mirror of the harness's `const ROW_KEYS`, and
+# `merged_tables` projects every cell onto it — so a key the harness WRITES but this
+# list OMITS is silently dropped from the merged table even though the per-cell JSON
+# still carries it. `rss_baseline_bytes` / `peak_rss_method` are the pair that makes
+# that fatal rather than cosmetic: the hosts measure peak RSS by DIFFERENT methods by
+# construction (the sbatch wrappers export JULIA_NUM_THREADS, giving "sampled"; a bare
+# `julia` gives "highwater-delta"; pre-schema checkpoints reload as "unknown"), and the
+# harness docstring instructs readers to filter on `peak_rss_method` before aggregating.
+# Dropping the label leaves three incommensurable quantities pooled in one plausible-
+# looking column with nothing left to separate them.
+#
+# `test/4_assembly/track_a_merge_hosts_test.jl` parses `const ROW_KEYS` out of the
+# harness SOURCE and asserts this list equals it — asserting the constant against
+# `DataFrames.names(results_df)` only compares the mirror with itself, which is exactly
+# how the omission survived review.
 const TRACK_A_ROW_KEYS = String[
 "organism", "accession", "technology", "coverage", "seed", "decoder_arm", "k",
 "n_reads", "n_contigs", "NGA50", "misassemblies", "genome_fraction",
-"duplication_ratio", "largest_contig", "wall_seconds", "peak_rss_bytes", "status"
+"duplication_ratio", "largest_contig", "wall_seconds", "peak_rss_bytes",
+"rss_baseline_bytes", "peak_rss_method", "status"
 ]
 
 """

--- a/test/4_assembly/track_a_baseline_benchmark_test.jl
+++ b/test/4_assembly/track_a_baseline_benchmark_test.jl
@@ -100,6 +100,64 @@ Test.@testset "track A baseline benchmark helpers" begin
         # sampler is reaped in the finally, so telemetry can never discard science.
         Test.@test_throws ErrorException timed_with_peak_rss(() -> error("boom"))
     end
+
+    # --- A mid-run sampler failure must not be labelled a clean measurement ------
+    # The `try` used to wrap the WHOLE polling loop, so the first probe exception
+    # ended sampling permanently for that cell. If any poll had already succeeded,
+    # `reads > 0` labelled the frozen, silently-truncated peak "sampled" — a
+    # plausible number presented as a measurement, which is precisely the failure the
+    # read count was introduced to make visible.
+    #
+    # `probe` is injected because there is no portable way to make a real /proc read
+    # fail on the third poll, and `current_rss_bytes` returns `nothing` on macOS.
+    Test.@testset "a truncated sampler downgrades its own label" begin
+        # Three good reads (the first is consumed by the baseline), then every read
+        # throws forever.
+        calls = Threads.Atomic{Int}(0)
+        flaky = () -> begin
+            n = Threads.atomic_add!(calls, 1) + 1
+            n <= 3 && return 1_000_000 * n
+            error("simulated /proc read failure")
+        end
+        result = timed_with_peak_rss(() -> (sleep(0.3); 42);
+            interval_seconds = 0.005, probe = flaky)
+        # Telemetry never discards science, whichever path was taken.
+        Test.@test result.value == 42
+
+        if Threads.nthreads() > 1
+            Test.@test result.method == "sampled-partial"
+            # The peak is the last SUCCESSFUL observation, and it is reported as a
+            # lower bound rather than as "sampled".
+            Test.@test result.peak_rss_bytes == 3_000_000
+            Test.@test result.rss_baseline_bytes == 1_000_000
+            # Sampling CONTINUED past the first failure instead of exiting the loop:
+            # 3 successes + 1 failure would be the whole story under the old code.
+            Test.@test calls[] > 4
+        else
+            # Single-threaded, so the sampler is not used at all and the row is
+            # honestly labelled with the known-broken fallback semantics.
+            Test.@test result.method == "highwater-delta"
+        end
+
+        # A probe that never fails is still a clean "sampled" measurement — the
+        # downgrade must be caused by the failures, not by injecting a probe.
+        rising = Threads.Atomic{Int}(0)
+        healthy = () -> 1_000_000 * (Threads.atomic_add!(rising, 1) + 1)
+        clean = timed_with_peak_rss(() -> (sleep(0.05); 7);
+            interval_seconds = 0.005, probe = healthy)
+        Test.@test clean.value == 7
+        Test.@test clean.method ==
+                   (Threads.nthreads() > 1 ? "sampled" : "highwater-delta")
+
+        # A probe that fails on EVERY call, including the baseline, cannot sample at
+        # all and must not claim to have.
+        always_bad = () -> error("simulated /proc read failure")
+        dead = timed_with_peak_rss(() -> 3; interval_seconds = 0.005,
+            probe = always_bad)
+        Test.@test dead.value == 3
+        Test.@test dead.method == "highwater-delta"
+        Test.@test dead.rss_baseline_bytes == -1
+    end
 end
 
 end  # module TrackABaselineBenchmarkTest

--- a/test/4_assembly/track_a_baseline_benchmark_test.jl
+++ b/test/4_assembly/track_a_baseline_benchmark_test.jl
@@ -1,0 +1,105 @@
+# Track A baseline benchmark contract tests.
+#
+# These pin the pure helpers in benchmarking/track_a_baseline_benchmark.jl inside the
+# Pkg.test() sweep, since benchmarking/ is not otherwise run in CI — the same pattern
+# as gap_calibration_fitters_test.jl for benchmarking/calibration_metrics.jl.
+#
+# Each testset below corresponds to a defect that reached review in PR #438. All three
+# were reachable only through paths the author's test plan could not exercise: a
+# parse check cannot see a runtime keyword error, and `--smoke` runs exactly one
+# deliberately-successful cell, so neither the error path nor a resume-from-existing-
+# tree was ever executed.
+#
+# Run:
+#   julia --project=. test/4_assembly/track_a_baseline_benchmark_test.jl
+
+# Wrapped in a module. runtests.jl includes every test file into one shared `Main`
+# (include_all_tests), and the driver defines top-level consts — COVERAGES, SEEDS,
+# ORGANISMS — that collide with benchmarking/rhizomorph_stage2_toy_benchmark.jl, which
+# another test already includes there. A bare include therefore died with
+# "invalid redefinition of constant Main.COVERAGES" and took the whole suite with it.
+# A module gives the driver its own namespace; gap_calibration_fitters_test.jl can
+# include directly only because calibration_metrics.jl declares no such consts.
+module TrackABaselineBenchmarkTest
+
+import Test
+
+include(joinpath(@__DIR__, "..", "..", "benchmarking", "track_a_baseline_benchmark.jl"))
+
+Test.@testset "track A baseline benchmark helpers" begin
+
+    # --- A failing cell must produce a row, not throw from inside the handler ----
+    # cell_row gained a required `peak_rss_method` keyword; the catch-block call was
+    # not updated, so the error handler raised UndefKeywordError and the first failing
+    # cell aborted the whole matrix — the opposite of the degradation it implements.
+    Test.@testset "error path builds a complete row" begin
+        row = error_row("Lambda", "NC_001416", "ont", 10, 42, "kmer")
+        Test.@test row.status == "error"
+        Test.@test row.n_contigs == 0
+        Test.@test row.peak_rss_method == "unknown"
+        # Rectangular aggregate: an error row must carry every schema column, or the
+        # DataFrame built from mixed rows is ragged.
+        Test.@test Set(keys(row)) == Set(ROW_KEYS)
+    end
+
+    # --- Default-k cell ids must not move ---------------------------------------
+    # Interpolating k unconditionally renamed the default k=31 cells, orphaning the
+    # 288 Lovelace + 144 LRC checkpoints written before --k existed and silently
+    # converting the wrappers' "re-submit to resume" into a full recompute.
+    Test.@testset "cell_id is backward compatible at default k" begin
+        Test.@test cell_id_for("Lambda", "ont", 10, 42, "kmer"; k = 31) ==
+                   "Lambda__ont__10x__seed42__kmer"
+        # A non-default k must still be distinguishable, or two sweeps collide on one
+        # checkpoint and the second silently republishes the first's result.
+        Test.@test cell_id_for("Lambda", "ont", 10, 42, "kmer"; k = 19) ==
+                   "Lambda__ont__10x__seed42__kmer__k19"
+        Test.@test cell_id_for("Lambda", "ont", 10, 42, "kmer"; k = 19) !=
+                   cell_id_for("Lambda", "ont", 10, 42, "kmer"; k = 31)
+    end
+
+    # --- Resume tolerance is provenance-only ------------------------------------
+    Test.@testset "canonical tolerates provenance keys but not measurements" begin
+        complete = Dict("organism" => "Lambda", "accession" => "NC_001416",
+            "technology" => "ont", "coverage" => 10, "seed" => 42,
+            "decoder_arm" => "kmer", "k" => 31, "n_reads" => 100, "n_contigs" => 1,
+            "NGA50" => 0.0, "misassemblies" => 0.0, "genome_fraction" => 0.0,
+            "duplication_ratio" => 0.0, "largest_contig" => 0, "wall_seconds" => 1.0,
+            "peak_rss_bytes" => 0, "status" => "ok")
+
+        # A pre-peak_rss_method checkpoint still reloads, tagged so it can never be
+        # mistaken for a measurement.
+        row = canonical(complete)
+        Test.@test row.peak_rss_method == "unknown"
+        Test.@test row.rss_baseline_bytes == -1
+        Test.@test Set(keys(row)) == Set(ROW_KEYS)
+
+        # A missing MEASUREMENT must fail loudly. Zero-filling is unsafe here
+        # specifically: NGA50 = 0.0 is the genuine value for every ONT cell at
+        # 10x/30x, so a zero-filled corrupt checkpoint is byte-identical to a real
+        # result and would enter the CV that gates the pre-registration.
+        for key in ("NGA50", "genome_fraction", "status", "coverage")
+            truncated = copy(complete)
+            delete!(truncated, key)
+            Test.@test_throws ErrorException canonical(truncated)
+        end
+    end
+
+    # --- Memory measurement labels itself ---------------------------------------
+    Test.@testset "timed_with_peak_rss labels its measurement" begin
+        result = timed_with_peak_rss(() -> sum(rand(200_000)))
+        Test.@test result.method in ("sampled", "sampled-degraded", "highwater-delta")
+        Test.@test result.wall_seconds >= 0
+        Test.@test result.value isa Real
+        if Sys.islinux() && Threads.nthreads() > 1
+            # CI runs a --threads=4 ubuntu job, so this is the production path there.
+            Test.@test result.method in ("sampled", "sampled-degraded")
+            # Nonzero is the whole point: every kmer cell read exactly 0 before the fix.
+            Test.@test result.peak_rss_bytes > 0
+        end
+        # A throwing workload must propagate its OWN error and must not hang: the
+        # sampler is reaped in the finally, so telemetry can never discard science.
+        Test.@test_throws ErrorException timed_with_peak_rss(() -> error("boom"))
+    end
+end
+
+end  # module TrackABaselineBenchmarkTest

--- a/test/4_assembly/track_a_merge_hosts_test.jl
+++ b/test/4_assembly/track_a_merge_hosts_test.jl
@@ -12,7 +12,8 @@
 #   * per-cell host provenance is recorded
 #   * re-running is idempotent, and a previously merged cell that disagrees with
 #     its source is a collision rather than an overwrite
-#   * the expected-matrix constants mirrored from the harness have not drifted
+#   * the expected-matrix constants, the cell-id format, and the ROW SCHEMA
+#     mirrored from the harness have not drifted
 #
 # Dependency-free apart from JSON / SHA / DataFrames / CSV (all direct Mycelia
 # deps that load without importing Mycelia). No network, no QUAST, no assembly.
@@ -38,12 +39,46 @@ function _tam_throws_with(f, needles::Vector{String})
     return ""
 end
 
+# Parse `const ROW_KEYS = (...)` out of the harness SOURCE and return the field names
+# in declaration order.
+#
+# TRACK_A_ROW_KEYS is a hand-maintained mirror of that tuple and `merged_tables`
+# projects every cell onto it, so a column the harness appends but the mirror omits
+# vanishes from the merged table while the per-cell JSON still carries it. Asserting
+# `DataFrames.names(results_df) == TRACK_A_ROW_KEYS` cannot catch that — it compares
+# the mirror with itself. This reads the other side of the mirror.
+function _tam_harness_row_keys(harness::AbstractString)
+    m = match(r"const\s+ROW_KEYS\s*=\s*\(", harness)
+    m === nothing && error("no `const ROW_KEYS = (` in the harness source")
+    start = m.offset + ncodeunits(m.match)
+    depth = 1
+    stop = 0
+    i = start
+    while i <= lastindex(harness)
+        c = harness[i]
+        if c == '('
+            depth += 1
+        elseif c == ')'
+            depth -= 1
+            if depth == 0
+                stop = prevind(harness, i)
+                break
+            end
+        end
+        i = nextind(harness, i)
+    end
+    stop == 0 && error("unterminated `const ROW_KEYS = (` in the harness source")
+    return [String(mm.captures[1])
+            for mm in eachmatch(r":([A-Za-z_][A-Za-z0-9_]*)", harness[start:stop])]
+end
+
 # A checkpoint shaped exactly like track_a_baseline_benchmark.jl's `cell_row`.
 function _tam_cell(; organism = "Lambda", technology = "illumina", coverage = 30,
         seed = 42, arm = "qualmer", accession = "NC_001416", k = 31,
         n_reads = 1000, n_contigs = 5, NGA50 = 1316.0, misassemblies = 0.0,
         genome_fraction = 98.5, duplication_ratio = 1.0, largest_contig = 48000,
-        wall_seconds = 12.5, peak_rss_bytes = 1_000_000, status = "ok")
+        wall_seconds = 12.5, peak_rss_bytes = 1_000_000,
+        rss_baseline_bytes = 900_000, peak_rss_method = "sampled", status = "ok")
     return Dict{String, Any}(
         "organism" => organism, "accession" => accession, "technology" => technology,
         "coverage" => coverage, "seed" => seed, "decoder_arm" => arm, "k" => k,
@@ -51,7 +86,8 @@ function _tam_cell(; organism = "Lambda", technology = "illumina", coverage = 30
         "misassemblies" => misassemblies, "genome_fraction" => genome_fraction,
         "duplication_ratio" => duplication_ratio, "largest_contig" => largest_contig,
         "wall_seconds" => wall_seconds, "peak_rss_bytes" => peak_rss_bytes,
-        "status" => status)
+        "rss_baseline_bytes" => rss_baseline_bytes,
+        "peak_rss_method" => peak_rss_method, "status" => status)
 end
 
 function _tam_write_cell(root, cell_id, cell)
@@ -65,16 +101,32 @@ end
 
 Test.@testset "Track A cross-host merge (td-bblmi)" begin
     Test.@testset "expected matrix mirrors the harness (drift guard)" begin
-        # These constants are DUPLICATED from track_a_baseline_benchmark.jl, which
-        # cannot be included (it runs the benchmark at include time). If the
-        # harness changes its matrix or its cell-id format, "missing" would be
-        # computed against the wrong set — so assert the mirror against the
-        # harness SOURCE rather than trusting the duplication.
+        # These constants are DUPLICATED from track_a_baseline_benchmark.jl. The
+        # harness now guards its driver with `if abspath(PROGRAM_FILE) == @__FILE__`,
+        # so it CAN be included — but it imports Mycelia (this merge needs none of
+        # it) and defines top-level consts that collide in runtests.jl's shared Main,
+        # so the duplication stays. If the harness changes its matrix or its cell-id
+        # format, "missing" would be computed against the wrong set — so assert the
+        # mirror against the harness SOURCE rather than trusting the duplication.
         harness = read(
             joinpath(@__DIR__, "..", "..", "benchmarking",
                 "track_a_baseline_benchmark.jl"), String)
         Test.@test occursin(
             "cell_id = \"\$(org)__\$(tech)__\$(cov)x__seed\$(seed)__\$(arm)\"", harness)
+        # The harness builds ids via `cell_id_for`, which appends `__k$(k)` only for a
+        # non-default k so the pre-`--k` trees stay resumable. Greping the base literal
+        # alone PASSES WITHOUT TESTING THAT RULE, so assert the k branch and the call
+        # site too — the guard must fire if either half drifts from track_a_cell_id.
+        Test.@test occursin(
+            "return k == 31 ? cell_id : \"\$(cell_id)__k\$(k)\"", harness)
+        Test.@test occursin("cell_id = cell_id_for(org, tech, cov, seed, arm)", harness)
+        # And the mirror itself holds for a non-default k, in both directions.
+        Test.@test track_a_cell_id("T4", "pacbio", 50, 123, "kmer"; k = 19) ==
+                   "T4__pacbio__50x__seed123__kmer__k19"
+        Test.@test track_a_cell_id("T4", "pacbio", 50, 123, "kmer"; k = 31) ==
+                   track_a_cell_id("T4", "pacbio", 50, 123, "kmer")
+        Test.@test track_a_cell_id("T4", "pacbio", 50, 123, "kmer"; k = 19) !=
+                   track_a_cell_id("T4", "pacbio", 50, 123, "kmer"; k = 31)
         for org in TRACK_A_ORGANISMS
             Test.@test occursin("(\"$org\", ", harness)
         end
@@ -99,6 +151,28 @@ Test.@testset "Track A cross-host merge (td-bblmi)" begin
                    "T4__pacbio__50x__seed123__kmer"
         # The real shard boundary the merge exists to reconcile.
         Test.@test length(expected_cell_ids(organisms = ("phi29", "SARS-CoV-2"))) == 144
+    end
+
+    Test.@testset "row schema mirrors the harness ROW_KEYS (drift guard)" begin
+        harness = read(
+            joinpath(@__DIR__, "..", "..", "benchmarking",
+                "track_a_baseline_benchmark.jl"), String)
+        harness_keys = _tam_harness_row_keys(harness)
+        # Sanity-check the PARSE before trusting the comparison: an empty or truncated
+        # parse would make the equality below vacuous rather than protective.
+        Test.@test length(harness_keys) >= 17
+        Test.@test harness_keys[1] == "organism"
+        Test.@test harness_keys[end] == "status"
+        # The assertion that would have caught the dropped provenance columns.
+        # `merged_tables` projects every cell onto TRACK_A_ROW_KEYS, so a key the
+        # harness writes and this list omits is dropped from track_a_results.tsv
+        # silently — the per-cell JSON keeps it, the aggregate does not.
+        Test.@test harness_keys == TRACK_A_ROW_KEYS
+        # Called out by name because they are the pair whose loss is unrecoverable
+        # rather than cosmetic: the hosts measure peak RSS by different methods by
+        # construction, and `peak_rss_method` is the only thing separating them.
+        Test.@test "peak_rss_method" in TRACK_A_ROW_KEYS
+        Test.@test "rss_baseline_bytes" in TRACK_A_ROW_KEYS
     end
 
     Test.@testset "canonicalization: representation drift is not a collision" begin
@@ -315,13 +389,17 @@ Test.@testset "Track A cross-host merge (td-bblmi)" begin
         mktempdir() do dir
             a = joinpath(dir, "lovelace")
             b = joinpath(dir, "lrc")
-            # Lovelace: QUAST failing (largest_contig 0 despite contigs).
+            # Lovelace: QUAST failing (largest_contig 0 despite contigs), and no
+            # SLURM wrapper, so its RSS column is the broken high-water delta.
             _tam_write_cell(a, "T4__illumina__30x__seed42__qualmer",
                 _tam_cell(organism = "T4", n_contigs = 12, largest_contig = 0,
-                    NGA50 = 0.0, genome_fraction = 0.0))
-            # Lawrencium: QUAST working.
+                    NGA50 = 0.0, genome_fraction = 0.0,
+                    peak_rss_method = "highwater-delta", rss_baseline_bytes = -1))
+            # Lawrencium: QUAST working, and JULIA_NUM_THREADS exported by the sbatch
+            # wrapper, so its RSS column is a real sampled peak.
             _tam_write_cell(b, "phi29__illumina__30x__seed42__qualmer",
-                _tam_cell(organism = "phi29", largest_contig = 19_000))
+                _tam_cell(organism = "phi29", largest_contig = 19_000,
+                    peak_rss_method = "sampled"))
             ids = ["T4__illumina__30x__seed42__qualmer",
                 "phi29__illumina__30x__seed42__qualmer"]
             result = merge_hosts(["lovelace" => a, "lrc" => b]; expected_ids = ids)
@@ -334,6 +412,17 @@ Test.@testset "Track A cross-host merge (td-bblmi)" begin
             Test.@test "quast_evidence" in DataFrames.names(prov_df)
             Test.@test "source_digest" in DataFrames.names(prov_df)
             Test.@test Set(prov_df.host) == Set(["lovelace", "lrc"])
+            # The peak-RSS provenance must SURVIVE the merge. The two hosts measure
+            # peak_rss_bytes by different methods by construction, and the harness
+            # docstring tells readers to filter on peak_rss_method before aggregating
+            # — unsatisfiable if the merged table drops the column.
+            Test.@test "peak_rss_method" in DataFrames.names(results_df)
+            Test.@test "rss_baseline_bytes" in DataFrames.names(results_df)
+            Test.@test Set(results_df.peak_rss_method) ==
+                       Set(["highwater-delta", "sampled"])
+            Test.@test Set(prov_df.peak_rss_method) ==
+                       Set(["highwater-delta", "sampled"])
+            Test.@test Set(results_df.rss_baseline_bytes) == Set([-1, 900_000])
 
             # This is the item-1 <-> item-3 bridge: the merged matrix mixes metric
             # definitions BY HOST, and the guard must see it.


### PR DESCRIPTION
## Summary

`test (lts)` was red on master from `c8182ebf` (2026-07-27) because that commit landed `test/4_assembly/track_a_baseline_benchmark_test.jl` pinning three helpers that were never written — the implementation lives on the still-open PR #438. Five unrelated PRs were blocked behind it.

**PR #447 resolved that by deleting the test file.** This PR takes the other route: it *writes the helpers*, then restores the tests, so the four defects are pinned rather than merely fixed.

## The four defects

| Helper | Origin | Defect pinned |
|---|---|---|
| `error_row` | **extracted** from the matrix loop's `catch` block | `cell_row` gained a required `peak_rss_method` keyword; the catch-block call was not updated, so the error handler itself raised `UndefKeywordError` and the first failing cell aborted the whole 288-cell matrix — the opposite of the degradation it implements |
| `cell_id_for` | **extracted** from the loop's id interpolation | interpolating `k` unconditionally renamed the default k=31 cells, orphaning **288 Lovelace + 144 LRC checkpoints** and silently converting "re-submit to resume" into a full recompute |
| `timed_with_peak_rss` | fallback branch **extracted**; sampled branch **new** | only the `Sys.maxrss()` high-water delta existed, so every kmer cell measured `peak_rss_bytes` as exactly **0** |
| `canonical` | **extended** in place | a pre-`peak_rss_method` checkpoint could not reload |

Each is called by the production path, not implemented in parallel for the tests.

**A fifth defect, found while fixing these:** the harness had no `PROGRAM_FILE` guard, so the test file's `include` ran the entire 288-cell benchmark — downloading genomes and assembling — before its first assertion. In CI that makes the suite network-dependent and unbounded. Added the guard, matching 18 other harnesses in `benchmarking/`. The restored test now completes in **0.7 s**, which is that guard working.

## Relationship to #447 and #438

#447's stated reason for reverting was that the helpers lived on an open PR. This PR removes that reason by putting them on master. The test file is restored **byte-identical to `c8182ebf`** — no assertion was weakened to make it pass.

**Deliberate divergence from #438:** #438 writes `cell_id_for` as a ternary that no longer contains the literal cell-id expression, which forced it to *weaken* `track_a_merge_hosts_test.jl`'s drift guard (its commit `a363098d` is titled "restore the cell-id mirror #439's drift guard protects"). That guard greps the harness source for

```julia
cell_id = "$(org)__$(tech)__$(cov)x__seed$(seed)__$(arm)"
```

to prove the merge tool's mirrored id format has not drifted. This version structures the helper so that line survives **byte-identical** inside it — the guard passes unmodified and `track_a_merge_hosts_test.jl` stays **148/148**.

The unsuffixed branch is pinned to the literal `31`, not to `K`: the reservation belongs to the names already on disk, so changing the default k must never re-point the unsuffixed name at a different k.

## Test Plan

- [x] `track_a_baseline_benchmark_test.jl` — **18/18**, 0 failed, 0 errored, 0.7 s
- [x] `track_a_merge_hosts_test.jl` — **148/148**, drift guard intact and unmodified
- [x] `--smoke` resumed a **17-key checkpoint written by pre-fix code**, exercising `canonical`'s provenance tolerance against a genuinely legacy tree
- [x] Clean `--smoke`: `1 ok` (5262 contigs, NGA50 48490, GF 99.975%), wrote a 19-key checkpoint, re-ran and resumed; a copy with both provenance keys stripped reloaded as `peak_rss_method=unknown, rss_baseline_bytes=-1` with `NGA50` intact
- [x] All affected test files green in a single shared `Main`
- [x] **CI `test (lts)` green on the pre-restore head**, covering the Linux `/proc` path that cannot run on macOS

## What could not be verified locally

macOS has no `/proc`, so `timed_with_peak_rss` always takes `highwater-delta` here and testset 4's Linux block does not execute. It was exercised under `julia -t 4` with a redefined probe — 16/16, including probe-returns-`nothing` → `sampled-degraded` with peak still **> 0** (it retains the entry baseline, which is what makes CI's `peak_rss_bytes > 0` hold in the degraded case). Genuinely unverified locally: `current_rss_bytes()` against a real `/proc/self/status`. CI's ubuntu `--threads=4` job covers it.

## Related

Unblocks #441–#445 alongside #447.