### PR TITLE
fix: reclaim minimap2 split-index temps on the abort path

### DIFF
--- a/src/alignments-and-mapping.jl
+++ b/src/alignments-and-mapping.jl
@@ -2258,11 +2258,23 @@ function minimap_merge_map_and_split(;
         # Swept BEFORE the run, not only after. A `finally` cannot cover the
         # abort that actually caused the 2026-07 incident: SLURM sends the job
         # step SIGTERM then SIGKILL at walltime, and Julia runs no `finally` on
-        # either (verified on 1.10.10) -- it dies in the signal handler. The
-        # next attempt is therefore the only moment a live Julia process exists
-        # after a job-level kill, which makes this the load-bearing half of the
-        # fix. Safe to do unconditionally: minimap2 cannot resume from these
-        # chunks, so any that exist now are orphans from a previous attempt.
+        # either -- it dies in the signal handler.
+        #
+        # It DOES run `atexit` on SIGTERM, though, and SLURM waits KillWait --
+        # 30s by default -- before escalating. Measured on 1.10.10:
+        #     SIGTERM -> atexit ran, finally did not
+        #     SIGKILL -> neither ran
+        # So the hook registered below reclaims in-job during that grace
+        # window, and this pre-run sweep covers the remaining SIGKILL/OOM-kill
+        # case on the next attempt. Both are needed: a one-shot benchmark that
+        # is never rerun has no next attempt, which is exactly the case an
+        # earlier version of this comment wrongly assumed away.
+        #
+        # Safe to do unconditionally HERE specifically: `merged_bam` is either
+        # a caller override or SHA1-fingerprinted over the input FASTQ list,
+        # and the default tmpdir comes from `mktempdir()`, so two concurrent
+        # runs cannot share a split prefix. That reasoning does NOT transfer to
+        # every caller -- see the note in `merge_and_map_single_end_samples`.
         #
         # This also covers the resume branch below, which returns the cached
         # BAM without ever entering the try/finally -- so a run killed after
@@ -2273,6 +2285,12 @@ function minimap_merge_map_and_split(;
         if nonempty_file(merged_bam) && !force
             # resume/caching: keep existing merged BAM
         else
+            # Registered before the run so a SIGTERM at walltime reclaims
+            # in-job, inside SLURM's KillWait grace window, instead of
+            # deferring to a next attempt that may never happen. Idempotent
+            # with the pre-run sweep and the `finally` below: a second call on
+            # an already-swept prefix removes nothing.
+            atexit(() -> cleanup_minimap_split_temps(split_prefix; verbose = false))
             try
                 run(minimap_cmd)
             catch err
@@ -2309,11 +2327,11 @@ function minimap_merge_map_and_split(;
                 # to survive. Previously this ran inside the `try` after a
                 # successful `run`, i.e. only on the path that needed no help;
                 # a 2026-07 CAMI_I_LOW abort stranded 783 GiB as a result.
-                try
-                    cleanup_minimap_split_temps(split_prefix)
-                catch cleanup_err
-                    @warn "minimap2 split-temp cleanup failed" split_prefix exception = cleanup_err
-                end
+                # No wrapper here: cleanup_minimap_split_temps guards every
+                # throwing operation internally and documents that it cannot
+                # throw. Wrapping it at one of three call sites would imply the
+                # opposite and invite someone to weaken those internal guards.
+                cleanup_minimap_split_temps(split_prefix)
             end
         end
     end

--- a/src/alignments-and-mapping.jl
+++ b/src/alignments-and-mapping.jl
@@ -1294,28 +1294,6 @@ function minimap_split_prefix(outfile::AbstractString)
     return outfile * ".tmp"
 end
 
-"""
-$(DocStringExtensions.TYPEDSIGNATURES)
-
-Remove the `PREFIX.NNNN.tmp` chunk files minimap2 leaves behind when a
-multi-part-index run is interrupted.
-
-`split_prefix` is the exact value passed to minimap2's `--split-prefix` (see
-[`minimap_split_prefix`](@ref)). Only files in `dirname(split_prefix)` whose
-names begin with `basename(split_prefix)` are considered; the search is not
-recursive, so it cannot escape the output directory.
-
-Returns `(; removed, bytes)` — the number of files removed and the total bytes
-reclaimed — so callers can log the reclaim rather than deleting silently.
-
-Safe against the sibling artifacts that share a stem: the output BAM
-`X.sorted.bam` does not start with `X.sorted.bam.tmp`, and samtools' own sort
-temps (`X.sorted.bam.sort.tmp.NNNN.bam`) do not either.
-
-# Arguments
-- `split_prefix`: the `--split-prefix` value used for the run.
-- `verbose::Bool=true`: emit an `@info` summarising what was reclaimed.
-"""
 # Split prefixes with a minimap2 run currently in flight, plus the one-time exit
 # hook that sweeps them.
 #
@@ -1391,6 +1369,33 @@ function untrack_minimap_split_prefix(split_prefix::AbstractString)
     return nothing
 end
 
+"""
+$(DocStringExtensions.TYPEDSIGNATURES)
+
+Remove the `PREFIX.NNNN.tmp` chunk files minimap2 leaves behind when a
+multi-part-index run is interrupted.
+
+`split_prefix` is the exact value passed to minimap2's `--split-prefix` (see
+[`minimap_split_prefix`](@ref)). Only files in `dirname(split_prefix)` whose
+names begin with `basename(split_prefix)` are considered; the search is not
+recursive, so it cannot escape the output directory.
+
+Returns `(; removed, bytes)` — the number of files removed and the total bytes
+reclaimed — so callers can log the reclaim rather than deleting silently.
+
+Safe against the sibling artifacts that share a stem: the output BAM
+`X.sorted.bam` does not start with `X.sorted.bam.tmp`, and samtools' own sort
+temps (`X.sorted.bam.sort.tmp.NNNN.bam`) do not either.
+
+# Arguments
+- `split_prefix`: the `--split-prefix` value used for the run.
+- `verbose::Bool=true`: emit an `@info` summarising what was reclaimed.
+
+This function does not throw. Every operation that can fail -- `readdir`,
+`filesize`, `rm` -- is caught individually and downgraded to an `@warn`, so it
+is safe to call from a `finally` block, where a raised exception would REPLACE
+the one that got you there and hide the real cause of the failure.
+"""
 function cleanup_minimap_split_temps(
         split_prefix::AbstractString; verbose::Bool = true)
     dir = dirname(split_prefix)
@@ -2029,6 +2034,10 @@ function minimap_merge_map_and_split(;
     if !isempty(minimap_index)
         @assert isfile(minimap_index) "minimap_index supplied but not found: $minimap_index"
     end
+    # Captured BEFORE tmpdir/merged_bam are resolved: once they are concrete
+    # paths there is no way to tell an auto-derived one from a caller override,
+    # and that distinction is what makes the pre-run sweep safe.
+    owns_output_paths = isnothing(tmpdir) && isnothing(merged_bam)
     tmpdir = isnothing(tmpdir) ? mktempdir() : tmpdir
     mkpath(tmpdir)
     @assert read_id_strategy in (:uuid, :prefix)
@@ -2345,17 +2354,33 @@ function minimap_merge_map_and_split(;
         # is never rerun has no next attempt, which is exactly the case an
         # earlier version of this comment wrongly assumed away.
         #
-        # Safe to do unconditionally HERE specifically: `merged_bam` is either
-        # a caller override or SHA1-fingerprinted over the input FASTQ list,
-        # and the default tmpdir comes from `mktempdir()`, so two concurrent
-        # runs cannot share a split prefix. That reasoning does NOT transfer to
-        # every caller -- see the note in `merge_and_map_single_end_samples`.
+        # Gated on OWNING the output paths, not done unconditionally.
+        #
+        # The SHA1 in the default `merged_bam` is a CONTENT hash over the input
+        # FASTQ list, not a uniqueness token: identical arguments produce an
+        # identical path, and `split_prefix` is a pure function of it. The only
+        # thing that actually separates two concurrent runs is `tmpdir`
+        # defaulting to `mktempdir()` -- and a caller can override it.
+        # benchmarking/15_round_trip_benchmark.jl does exactly that at two call
+        # sites, passing a deterministic `map_tmpdir` under `readset_dir`.
+        #
+        # Hoisting the sweep above the branch created a NEW harm for that case:
+        # a run that would previously have been a total no-op (cached
+        # `merged_bam`, `force` unset -> straight to the resume branch) now
+        # unlinks a peer's live chunks first. minimap2 reopens every chunk BY
+        # NAME at merge time and aborts if one is missing, so the victim dies
+        # rather than silently degrading.
+        #
+        # Same class as the binning sweep's corrected premise: orphan-ness is
+        # not the safety condition, NON-COLLISION is.
         #
         # This also covers the resume branch below, which returns the cached
         # BAM without ever entering the try/finally -- so a run killed after
         # writing a nonempty merged_bam would otherwise strand its chunks
         # permanently, with no code path left that would ever reclaim them.
-        cleanup_minimap_split_temps(split_prefix)
+        if owns_output_paths
+            cleanup_minimap_split_temps(split_prefix)
+        end
 
         if nonempty_file(merged_bam) && !force
             # resume/caching: keep existing merged BAM

--- a/src/alignments-and-mapping.jl
+++ b/src/alignments-and-mapping.jl
@@ -1326,13 +1326,22 @@ function cleanup_minimap_split_temps(
     Base.isdir(dir) || return (; removed, bytes)
     for path in readdir(dir; join = true)
         name = basename(path)
-        # TODO(human): decide which files this cleanup is willing to delete.
-        # `name` is a candidate basename in the output directory; `base` is
-        # basename(split_prefix). Set `should_remove::Bool`. See the note in the
-        # PR description for the trade-off between an exact `PREFIX.NNNN.tmp`
-        # match and a looser `startswith(name, base)` sweep.
-        should_remove = false
-        should_remove || continue
+        # Anchored on BOTH ends: the split prefix on the left, minimap2's own
+        # `.<n>.tmp` chunk naming on the right. The right-hand anchor is what
+        # makes this safe to run while a SIBLING job is mid-flight -- callers
+        # like the CAMI2 driver run samples as a SLURM array sharing one output
+        # directory, so a bare prefix sweep could delete another task's live
+        # chunks. It also spares the artifacts that share the stem: the output
+        # BAM, its `.bai`, and samtools' own `.sort.tmp.NNNN.bam` sort temps.
+        #
+        # `\d+` rather than `\d{4}`: minimap2 formats the chunk index with %04d,
+        # which is four digits only until a run exceeds 9999 index parts.
+        # ncodeunits, not length: `startswith` guarantees the first ncodeunits
+        # BYTES match, and length() counts characters, which would slice at the
+        # wrong offset for a non-ASCII path.
+        startswith(name, base) || continue
+        rest = name[(ncodeunits(base) + 1):end]
+        occursin(r"^\.\d+\.tmp$", rest) || continue
         Base.isfile(path) || continue
         sz = try
             filesize(path)

--- a/src/alignments-and-mapping.jl
+++ b/src/alignments-and-mapping.jl
@@ -1403,21 +1403,27 @@ function cleanup_minimap_split_temps(
     base = basename(split_prefix)
     removed = 0
     bytes = 0
-    Base.isdir(dir) || return (; removed, bytes)
     # This function is called from `finally` blocks, where a raised exception
     # REPLACES the one that got us there -- so a cleanup failure would swap a
-    # diagnosable mapping error for a confusing cleanup error. `isdir` above
-    # only rules out nonexistence, not EACCES, nor an EIO on a Lustre/GPFS
-    # mount that has gone away -- which is exactly the condition most likely to
-    # have caused the mapping failure in the first place. Guarding here rather
-    # than at each call site means the function cannot throw at all, so no
-    # caller has to remember to wrap it. Reclaiming disk is never worth losing
-    # the reason the run failed.
+    # diagnosable mapping error for a confusing cleanup error. Guarding here
+    # rather than at each call site means no caller has to remember to wrap it.
+    # Reclaiming disk is never worth losing the reason the run failed.
+    #
+    # `isdir` is INSIDE the try. Julia's `stat` re-raises for every errno except
+    # ENOENT/ENOTDIR/EINVAL, so `isdir` throws an IOError on EACCES, EIO, ELOOP
+    # and ENAMETOOLONG -- measured on 1.10.10 against a chmod-000 parent. An
+    # earlier version put it one line above the try while the comment named
+    # EACCES as the case it was guarding, which left the no-throw contract
+    # false in exactly the Lustre/GPFS-went-away scenario most likely to have
+    # caused the mapping failure in the first place. The same call is made from
+    # the atexit hook, where an escaping IOError makes Julia print
+    # `error during exit hooks` and exit nonzero -- turning a successful SLURM
+    # job into a failed one on the shutdown path the hook exists to serve.
     entries = try
-        readdir(dir; join = true)
+        Base.isdir(dir) ? readdir(dir; join = true) : String[]
     catch err
         @warn "could not list directory for minimap2 split-temp cleanup" dir exception = err
-        return (; removed, bytes)
+        String[]
     end
     for path in entries
         name = basename(path)

--- a/src/alignments-and-mapping.jl
+++ b/src/alignments-and-mapping.jl
@@ -1316,6 +1316,81 @@ temps (`X.sorted.bam.sort.tmp.NNNN.bam`) do not either.
 - `split_prefix`: the `--split-prefix` value used for the run.
 - `verbose::Bool=true`: emit an `@info` summarising what was reclaimed.
 """
+# Split prefixes with a minimap2 run currently in flight, plus the one-time exit
+# hook that sweeps them.
+#
+# Why a registry rather than an `atexit` per call: `Base.atexit` pushes onto a
+# global vector with NO removal API, so a per-call hook accumulates without
+# bound. `benchmarking/15_round_trip_benchmark.jl` calls the mapping entry point
+# from a five-deep loop nest in one long-lived process, which would register
+# hundreds of hooks -- each doing an `isdir` + `readdir` of scratch at exit,
+# every one after the first a guaranteed no-op because the `finally` already
+# swept that prefix. That cost lands inside the very KillWait window the hook
+# exists to exploit, which is self-defeating at exactly the scale the 2026-07
+# incident happened at.
+const MINIMAP_ACTIVE_SPLIT_PREFIXES = Set{String}()
+const MINIMAP_SPLIT_PREFIX_LOCK = ReentrantLock()
+const MINIMAP_ATEXIT_REGISTERED = Ref(false)
+
+"""
+$(DocStringExtensions.TYPEDSIGNATURES)
+
+Register the process-wide exit hook that reclaims minimap2 split-index chunks
+for any run still in flight at shutdown. Idempotent; safe to call per mapping.
+
+Julia runs `atexit` hooks on SIGTERM but not on SIGKILL, and SLURM waits
+`KillWait` (30s by default) between the two, so this reclaims in-job during
+that grace window. Without it the only remaining cover is the next attempt --
+which never comes for a one-shot benchmark.
+"""
+function register_minimap_split_temp_atexit()
+    MINIMAP_ATEXIT_REGISTERED[] && return nothing
+    # `atexit` THROWS if the process is already exiting (Base initdefs.jl:
+    # "cannot register new atexit hook; already exiting."). That race is
+    # reachable here precisely because this is the shutdown path the feature
+    # targets, and this call sits outside the caller's try -- so an unguarded
+    # failure would replace the real shutdown cause with a registration error.
+    try
+        atexit() do
+            for prefix in lock(MINIMAP_SPLIT_PREFIX_LOCK) do
+                collect(MINIMAP_ACTIVE_SPLIT_PREFIXES)
+            end
+                cleanup_minimap_split_temps(prefix)
+            end
+        end
+        MINIMAP_ATEXIT_REGISTERED[] = true
+    catch err
+        @warn "could not register minimap2 split-temp exit hook; " *
+              "relying on the pre-run sweep at the next attempt" exception = err
+    end
+    return nothing
+end
+
+"""
+$(DocStringExtensions.TYPEDSIGNATURES)
+
+Mark `split_prefix` as having a minimap2 run in flight, so the exit hook
+reclaims it if the process is terminated.
+"""
+function track_minimap_split_prefix(split_prefix::AbstractString)
+    lock(MINIMAP_SPLIT_PREFIX_LOCK) do
+        push!(MINIMAP_ACTIVE_SPLIT_PREFIXES, String(split_prefix))
+    end
+    return nothing
+end
+
+"""
+$(DocStringExtensions.TYPEDSIGNATURES)
+
+Drop `split_prefix` from the in-flight registry once its run has finished.
+"""
+function untrack_minimap_split_prefix(split_prefix::AbstractString)
+    lock(MINIMAP_SPLIT_PREFIX_LOCK) do
+        delete!(MINIMAP_ACTIVE_SPLIT_PREFIXES, String(split_prefix))
+    end
+    return nothing
+end
+
 function cleanup_minimap_split_temps(
         split_prefix::AbstractString; verbose::Bool = true)
     dir = dirname(split_prefix)
@@ -2285,12 +2360,19 @@ function minimap_merge_map_and_split(;
         if nonempty_file(merged_bam) && !force
             # resume/caching: keep existing merged BAM
         else
-            # Registered before the run so a SIGTERM at walltime reclaims
-            # in-job, inside SLURM's KillWait grace window, instead of
-            # deferring to a next attempt that may never happen. Idempotent
-            # with the pre-run sweep and the `finally` below: a second call on
-            # an already-swept prefix removes nothing.
-            atexit(() -> cleanup_minimap_split_temps(split_prefix; verbose = false))
+            # Tracked before the run so a SIGTERM at walltime reclaims in-job,
+            # inside SLURM's KillWait grace window, instead of deferring to a
+            # next attempt that may never happen. The hook is registered once
+            # per process and sweeps whatever is in flight; see the registry
+            # above for why this is not an `atexit` per call.
+            #
+            # Not silenced: on the pre-run and `finally` paths `removed` is
+            # normally 0, because minimap2 unlinks its own chunks on a clean
+            # exit, so those log nothing in practice. The exit hook is the only
+            # one that reclaims on the SIGTERM path -- the case that frees
+            # hundreds of GiB -- and an operator needs a record that it fired.
+            register_minimap_split_temp_atexit()
+            track_minimap_split_prefix(split_prefix)
             try
                 run(minimap_cmd)
             catch err
@@ -2332,6 +2414,7 @@ function minimap_merge_map_and_split(;
                 # throw. Wrapping it at one of three call sites would imply the
                 # opposite and invite someone to weaken those internal guards.
                 cleanup_minimap_split_temps(split_prefix)
+                untrack_minimap_split_prefix(split_prefix)
             end
         end
     end

--- a/src/alignments-and-mapping.jl
+++ b/src/alignments-and-mapping.jl
@@ -1324,7 +1324,22 @@ function cleanup_minimap_split_temps(
     removed = 0
     bytes = 0
     Base.isdir(dir) || return (; removed, bytes)
-    for path in readdir(dir; join = true)
+    # This function is called from `finally` blocks, where a raised exception
+    # REPLACES the one that got us there -- so a cleanup failure would swap a
+    # diagnosable mapping error for a confusing cleanup error. `isdir` above
+    # only rules out nonexistence, not EACCES, nor an EIO on a Lustre/GPFS
+    # mount that has gone away -- which is exactly the condition most likely to
+    # have caused the mapping failure in the first place. Guarding here rather
+    # than at each call site means the function cannot throw at all, so no
+    # caller has to remember to wrap it. Reclaiming disk is never worth losing
+    # the reason the run failed.
+    entries = try
+        readdir(dir; join = true)
+    catch err
+        @warn "could not list directory for minimap2 split-temp cleanup" dir exception = err
+        return (; removed, bytes)
+    end
+    for path in entries
         name = basename(path)
         # Anchored on BOTH ends: the split prefix on the left, minimap2's own
         # `.<n>.tmp` chunk naming on the right. The right-hand anchor is what
@@ -1334,14 +1349,19 @@ function cleanup_minimap_split_temps(
         # chunks. It also spares the artifacts that share the stem: the output
         # BAM, its `.bai`, and samtools' own `.sort.tmp.NNNN.bam` sort temps.
         #
-        # `\d+` rather than `\d{4}`: minimap2 formats the chunk index with %04d,
-        # which is four digits only until a run exceeds 9999 index parts.
+        # `[0-9]+` rather than `\d{4}` on two counts. Not `{4}`: minimap2
+        # formats the chunk index with %04d, which is four digits only until a
+        # run exceeds 9999 index parts. And `[0-9]` rather than `\d`, because
+        # Julia compiles regexes with PCRE's UCP flag set by default, so `\d`
+        # matches any Unicode decimal digit -- Arabic-Indic `٠٠٠٠` would pass.
+        # Nothing here produces such names, but the predicate should say what
+        # it means.
         # ncodeunits, not length: `startswith` guarantees the first ncodeunits
         # BYTES match, and length() counts characters, which would slice at the
         # wrong offset for a non-ASCII path.
         startswith(name, base) || continue
         rest = name[(ncodeunits(base) + 1):end]
-        occursin(r"^\.\d+\.tmp$", rest) || continue
+        occursin(r"^\.[0-9]+\.tmp$", rest) || continue
         Base.isfile(path) || continue
         sz = try
             filesize(path)
@@ -2224,9 +2244,32 @@ function minimap_merge_map_and_split(;
         )
     end
     minimap_cmd = minimap_result.cmd
-    split_prefix = minimap_split_prefix(merged_bam)
+    # Consume the builder's own value rather than re-deriving from merged_bam.
+    # The two agree today, but re-deriving reintroduces exactly the drift seam
+    # `minimap_split_prefix` exists to close: if a builder ever normalizes its
+    # outfile (appends an extension, resolves to an absolute path), the sweep
+    # would target a prefix minimap2 was never given and orphan every chunk --
+    # the original bug, re-created. It is also interpolated into the E2BIG
+    # error text below, which would then print a `--split-prefix` that was not
+    # the one used.
+    split_prefix = minimap_result.split_prefix
 
     if run_mapping
+        # Swept BEFORE the run, not only after. A `finally` cannot cover the
+        # abort that actually caused the 2026-07 incident: SLURM sends the job
+        # step SIGTERM then SIGKILL at walltime, and Julia runs no `finally` on
+        # either (verified on 1.10.10) -- it dies in the signal handler. The
+        # next attempt is therefore the only moment a live Julia process exists
+        # after a job-level kill, which makes this the load-bearing half of the
+        # fix. Safe to do unconditionally: minimap2 cannot resume from these
+        # chunks, so any that exist now are orphans from a previous attempt.
+        #
+        # This also covers the resume branch below, which returns the cached
+        # BAM without ever entering the try/finally -- so a run killed after
+        # writing a nonempty merged_bam would otherwise strand its chunks
+        # permanently, with no code path left that would ever reclaim them.
+        cleanup_minimap_split_temps(split_prefix)
+
         if nonempty_file(merged_bam) && !force
             # resume/caching: keep existing merged BAM
         else

--- a/src/alignments-and-mapping.jl
+++ b/src/alignments-and-mapping.jl
@@ -1280,6 +1280,83 @@ end
 """
 $(DocStringExtensions.TYPEDSIGNATURES)
 
+Build the `--split-prefix` value minimap2 is given for a multi-part index run.
+
+minimap2 writes one intermediate file per index chunk, named `PREFIX.NNNN.tmp`,
+and unlinks them itself on clean exit. They survive only when the process dies
+first (walltime, OOM, cancelled job), at which point they are pure orphans:
+minimap2 cannot resume from them, so nothing can consume them afterwards.
+
+Keeping the derivation in one place means [`cleanup_minimap_split_temps`](@ref)
+and the command builders cannot drift apart in what they consider a temp file.
+"""
+function minimap_split_prefix(outfile::AbstractString)
+    return outfile * ".tmp"
+end
+
+"""
+$(DocStringExtensions.TYPEDSIGNATURES)
+
+Remove the `PREFIX.NNNN.tmp` chunk files minimap2 leaves behind when a
+multi-part-index run is interrupted.
+
+`split_prefix` is the exact value passed to minimap2's `--split-prefix` (see
+[`minimap_split_prefix`](@ref)). Only files in `dirname(split_prefix)` whose
+names begin with `basename(split_prefix)` are considered; the search is not
+recursive, so it cannot escape the output directory.
+
+Returns `(; removed, bytes)` — the number of files removed and the total bytes
+reclaimed — so callers can log the reclaim rather than deleting silently.
+
+Safe against the sibling artifacts that share a stem: the output BAM
+`X.sorted.bam` does not start with `X.sorted.bam.tmp`, and samtools' own sort
+temps (`X.sorted.bam.sort.tmp.NNNN.bam`) do not either.
+
+# Arguments
+- `split_prefix`: the `--split-prefix` value used for the run.
+- `verbose::Bool=true`: emit an `@info` summarising what was reclaimed.
+"""
+function cleanup_minimap_split_temps(
+        split_prefix::AbstractString; verbose::Bool = true)
+    dir = dirname(split_prefix)
+    isempty(dir) && (dir = ".")
+    base = basename(split_prefix)
+    removed = 0
+    bytes = 0
+    Base.isdir(dir) || return (; removed, bytes)
+    for path in readdir(dir; join = true)
+        name = basename(path)
+        # TODO(human): decide which files this cleanup is willing to delete.
+        # `name` is a candidate basename in the output directory; `base` is
+        # basename(split_prefix). Set `should_remove::Bool`. See the note in the
+        # PR description for the trade-off between an exact `PREFIX.NNNN.tmp`
+        # match and a looser `startswith(name, base)` sweep.
+        should_remove = false
+        should_remove || continue
+        Base.isfile(path) || continue
+        sz = try
+            filesize(path)
+        catch
+            0
+        end
+        try
+            rm(path; force = true)
+            removed += 1
+            bytes += sz
+        catch err
+            @warn "could not remove minimap2 split temp" path exception = err
+        end
+    end
+    if verbose && removed > 0
+        @info "reclaimed minimap2 split-index temps" split_prefix removed gib=round(
+            bytes / 1024^3; digits = 2)
+    end
+    return (; removed, bytes)
+end
+
+"""
+$(DocStringExtensions.TYPEDSIGNATURES)
+
 Map reads using an existing minimap2 index file.
 
 # Arguments
@@ -1295,7 +1372,20 @@ Map reads using an existing minimap2 index file.
 - `require_index::Bool=true`: Validate index exists (set false to build commands without files on disk).
 
 # Returns
-Named tuple `(cmd, outfile)` producing a BAM file from the mapping.
+Named tuple `(cmd, outfile, split_prefix)` producing a BAM file from the mapping.
+
+This function only *builds* the command; the caller runs it. Because minimap2
+leaves `split_prefix.NNNN.tmp` chunks behind when it is killed mid-run, a caller
+that runs `cmd` itself should wrap it so the temps are reclaimed on failure:
+
+```julia
+res = Mycelia.minimap_map_with_index(; index_file, fastq, outfile)
+try
+    run(res.cmd)
+finally
+    Mycelia.cleanup_minimap_split_temps(res.split_prefix)
+end
+```
 """
 function minimap_map_with_index(;
         fasta::Union{Nothing, AbstractString} = nothing,
@@ -1343,6 +1433,7 @@ function minimap_map_with_index(;
         outfile = output_prefix * "." * basename(index_file) * ".minimap2" *
                   (sorted ? ".sorted" : "") * ".bam"
     end
+    split_prefix = minimap_split_prefix(outfile)
     Mycelia.add_bioconda_env("minimap2")
     Mycelia.add_bioconda_env("samtools")
     if as_string
@@ -1351,12 +1442,12 @@ function minimap_map_with_index(;
         if sorted
             if keep_header
                 cmd = """
-                      $(Mycelia.CONDA_RUNNER) run --live-stream -n minimap2 minimap2 -t $(threads) -x $(mapping_type) -I$(index_size) -a$(extra_args_str) $(index_file) $(fastq_str) --split-prefix=$(outfile).tmp \\
+                      $(Mycelia.CONDA_RUNNER) run --live-stream -n minimap2 minimap2 -t $(threads) -x $(mapping_type) -I$(index_size) -a$(extra_args_str) $(index_file) $(fastq_str) --split-prefix=$(split_prefix) \\
                       | $(Mycelia.CONDA_RUNNER) run --live-stream -n samtools samtools sort -@ $(threads) -T $(outfile).sort.tmp -o $(outfile) -
                       """
             else
                 cmd = """
-                      $(Mycelia.CONDA_RUNNER) run --live-stream -n minimap2 minimap2 -t $(threads) -x $(mapping_type) -I$(index_size) -a$(extra_args_str) $(index_file) $(fastq_str) --split-prefix=$(outfile).tmp \\
+                      $(Mycelia.CONDA_RUNNER) run --live-stream -n minimap2 minimap2 -t $(threads) -x $(mapping_type) -I$(index_size) -a$(extra_args_str) $(index_file) $(fastq_str) --split-prefix=$(split_prefix) \\
                       | $(Mycelia.CONDA_RUNNER) run --live-stream -n samtools samtools sort -@ $(threads) -T $(outfile).sort.tmp - \\
                       | $(Mycelia.CONDA_RUNNER) run --live-stream -n samtools samtools view -@ $(threads) -bS --no-header -o $(outfile) -
                       """
@@ -1364,12 +1455,12 @@ function minimap_map_with_index(;
         else
             if keep_header
                 cmd = """
-                      $(Mycelia.CONDA_RUNNER) run --live-stream -n minimap2 minimap2 -t $(threads) -x $(mapping_type) -I$(index_size) -a$(extra_args_str) $(index_file) $(fastq_str) --split-prefix=$(outfile).tmp \\
+                      $(Mycelia.CONDA_RUNNER) run --live-stream -n minimap2 minimap2 -t $(threads) -x $(mapping_type) -I$(index_size) -a$(extra_args_str) $(index_file) $(fastq_str) --split-prefix=$(split_prefix) \\
                       | $(Mycelia.CONDA_RUNNER) run --live-stream -n samtools samtools view -@ $(threads) -bS -o $(outfile) -
                       """
             else
                 cmd = """
-                      $(Mycelia.CONDA_RUNNER) run --live-stream -n minimap2 minimap2 -t $(threads) -x $(mapping_type) -I$(index_size) -a$(extra_args_str) $(index_file) $(fastq_str) --split-prefix=$(outfile).tmp \\
+                      $(Mycelia.CONDA_RUNNER) run --live-stream -n minimap2 minimap2 -t $(threads) -x $(mapping_type) -I$(index_size) -a$(extra_args_str) $(index_file) $(fastq_str) --split-prefix=$(split_prefix) \\
                       | $(Mycelia.CONDA_RUNNER) run --live-stream -n samtools samtools view -@ $(threads) -bS --no-header -o $(outfile) -
                       """
             end
@@ -1385,7 +1476,7 @@ function minimap_map_with_index(;
         append!(map_args, minimap_extra_args)
         push!(map_args, index_file)
         append!(map_args, fastq_inputs)
-        push!(map_args, "--split-prefix=$(outfile).tmp")
+        push!(map_args, "--split-prefix=$(split_prefix)")
         map_cmd = Cmd(map_args)
         if sorted
             if keep_header
@@ -1405,7 +1496,7 @@ function minimap_map_with_index(;
             cmd = pipeline(map_cmd, compress)
         end
     end
-    return (; cmd, outfile)
+    return (; cmd, outfile, split_prefix)
 end
 
 """
@@ -1436,6 +1527,8 @@ followed by SAM compression with pigz. Handles resource allocation and conda env
 Named tuple containing:
 - `cmd`: Shell command (as string or array)
 - `outfile`: Path to compressed output SAM file
+- `split_prefix`: minimap2 `--split-prefix` value; pass to
+  [`cleanup_minimap_split_temps`](@ref) in a `finally` after running `cmd`.
 """
 function minimap_map(;
         fasta,
@@ -1474,6 +1567,7 @@ function minimap_map(;
         end
         outfile = base_name * "." * output_format
     end
+    split_prefix = minimap_split_prefix(outfile)
 
     Mycelia.add_bioconda_env("minimap2")
     Mycelia.add_bioconda_env("samtools")
@@ -1486,17 +1580,17 @@ function minimap_map(;
                              " " * join(minimap_extra_args, " ")
             if sorted
                 cmd = """
-                $(Mycelia.CONDA_RUNNER) run --live-stream -n minimap2 minimap2 -t $(threads) -x $(mapping_type) -I$(index_size) -a$(extra_args_str) $(fasta) $(fastq_str) --split-prefix=$(outfile).tmp \\
+                $(Mycelia.CONDA_RUNNER) run --live-stream -n minimap2 minimap2 -t $(threads) -x $(mapping_type) -I$(index_size) -a$(extra_args_str) $(fasta) $(fastq_str) --split-prefix=$(split_prefix) \\
                 | $(Mycelia.CONDA_RUNNER) run --live-stream -n samtools samtools sort -@ $(threads) -T $(outfile).sort.tmp -o $(outfile) -
                 """
             else
                 cmd = """
-                $(Mycelia.CONDA_RUNNER) run --live-stream -n minimap2 minimap2 -t $(threads) -x $(mapping_type) -I$(index_size) -a$(extra_args_str) $(fasta) $(fastq_str) --split-prefix=$(outfile).tmp -o $(outfile)
+                $(Mycelia.CONDA_RUNNER) run --live-stream -n minimap2 minimap2 -t $(threads) -x $(mapping_type) -I$(index_size) -a$(extra_args_str) $(fasta) $(fastq_str) --split-prefix=$(split_prefix) -o $(outfile)
                 """
             end
         else
             if sorted
-                map_cmd = `$(Mycelia.CONDA_RUNNER) run --live-stream -n minimap2 minimap2 -t $(threads) -x $(mapping_type) -I$(index_size) -a $(minimap_extra_args...) $(fasta) $(fastq_inputs...) --split-prefix=$(outfile).tmp`
+                map_cmd = `$(Mycelia.CONDA_RUNNER) run --live-stream -n minimap2 minimap2 -t $(threads) -x $(mapping_type) -I$(index_size) -a $(minimap_extra_args...) $(fasta) $(fastq_inputs...) --split-prefix=$(split_prefix)`
                 sort_cmd = `$(Mycelia.CONDA_RUNNER) run --live-stream -n samtools samtools sort -@ $(threads) -T $(outfile).sort.tmp -o $(outfile) -`
                 cmd = pipeline(map_cmd, sort_cmd)
                 if quiet
@@ -1505,11 +1599,11 @@ function minimap_map(;
             else
                 if quiet
                     cmd = pipeline(
-                        `$(Mycelia.CONDA_RUNNER) run --live-stream -n minimap2 minimap2 -t $(threads) -x $(mapping_type) -I$(index_size) -a $(minimap_extra_args...) $(fasta) $(fastq_inputs...) --split-prefix=$(outfile).tmp -o $(outfile)`,
+                        `$(Mycelia.CONDA_RUNNER) run --live-stream -n minimap2 minimap2 -t $(threads) -x $(mapping_type) -I$(index_size) -a $(minimap_extra_args...) $(fasta) $(fastq_inputs...) --split-prefix=$(split_prefix) -o $(outfile)`,
                         stdout = devnull,
                         stderr = devnull)
                 else
-                    cmd = `$(Mycelia.CONDA_RUNNER) run --live-stream -n minimap2 minimap2 -t $(threads) -x $(mapping_type) -I$(index_size) -a $(minimap_extra_args...) $(fasta) $(fastq_inputs...) --split-prefix=$(outfile).tmp -o $(outfile)`
+                    cmd = `$(Mycelia.CONDA_RUNNER) run --live-stream -n minimap2 minimap2 -t $(threads) -x $(mapping_type) -I$(index_size) -a $(minimap_extra_args...) $(fasta) $(fastq_inputs...) --split-prefix=$(split_prefix) -o $(outfile)`
                 end
             end
         end
@@ -1521,25 +1615,25 @@ function minimap_map(;
                              " " * join(minimap_extra_args, " ")
             if sorted
                 cmd = """
-                $(Mycelia.CONDA_RUNNER) run --live-stream -n minimap2 minimap2 -t $(threads) -x $(mapping_type) -I$(index_size) -a$(extra_args_str) $(fasta) $(fastq_str) --split-prefix=$(outfile).tmp \\
+                $(Mycelia.CONDA_RUNNER) run --live-stream -n minimap2 minimap2 -t $(threads) -x $(mapping_type) -I$(index_size) -a$(extra_args_str) $(fasta) $(fastq_str) --split-prefix=$(split_prefix) \\
                 | $(Mycelia.CONDA_RUNNER) run --live-stream -n samtools samtools sort -@ $(threads) -T $(outfile).sort.tmp -O sam,level=6 -o $(outfile) -
                 """
             else
                 cmd = """
-                $(Mycelia.CONDA_RUNNER) run --live-stream -n minimap2 minimap2 -t $(threads) -x $(mapping_type) -I$(index_size) -a$(extra_args_str) $(fasta) $(fastq_str) --split-prefix=$(outfile).tmp \\
+                $(Mycelia.CONDA_RUNNER) run --live-stream -n minimap2 minimap2 -t $(threads) -x $(mapping_type) -I$(index_size) -a$(extra_args_str) $(fasta) $(fastq_str) --split-prefix=$(split_prefix) \\
                 | $(Mycelia.CONDA_RUNNER) run --live-stream -n samtools samtools view -@ $(threads) -O sam,level=6 -o $(outfile) -
                 """
             end
         else
             if sorted
-                map_cmd = `$(Mycelia.CONDA_RUNNER) run --live-stream -n minimap2 minimap2 -t $(threads) -x $(mapping_type) -I$(index_size) -a $(minimap_extra_args...) $(fasta) $(fastq_inputs...) --split-prefix=$(outfile).tmp`
+                map_cmd = `$(Mycelia.CONDA_RUNNER) run --live-stream -n minimap2 minimap2 -t $(threads) -x $(mapping_type) -I$(index_size) -a $(minimap_extra_args...) $(fasta) $(fastq_inputs...) --split-prefix=$(split_prefix)`
                 sort_cmd = `$(Mycelia.CONDA_RUNNER) run --live-stream -n samtools samtools sort -@ $(threads) -T $(outfile).sort.tmp -O sam,level=6 -o $(outfile) -`
                 cmd = pipeline(map_cmd, sort_cmd)
                 if quiet
                     cmd = pipeline(cmd, stderr = devnull)
                 end
             else
-                map_cmd = `$(Mycelia.CONDA_RUNNER) run --live-stream -n minimap2 minimap2 -t $(threads) -x $(mapping_type) -I$(index_size) -a $(minimap_extra_args...) $(fasta) $(fastq_inputs...) --split-prefix=$(outfile).tmp`
+                map_cmd = `$(Mycelia.CONDA_RUNNER) run --live-stream -n minimap2 minimap2 -t $(threads) -x $(mapping_type) -I$(index_size) -a $(minimap_extra_args...) $(fasta) $(fastq_inputs...) --split-prefix=$(split_prefix)`
                 view_cmd = `$(Mycelia.CONDA_RUNNER) run --live-stream -n samtools samtools view -@ $(threads) -O sam,level=6 -o $(outfile) -`
                 cmd = pipeline(map_cmd, view_cmd)
                 if quiet
@@ -1556,12 +1650,12 @@ function minimap_map(;
             if sorted
                 if keep_header
                     cmd = """
-                    $(Mycelia.CONDA_RUNNER) run --live-stream -n minimap2 minimap2 -t $(threads) -x $(mapping_type) -I$(index_size) -a$(extra_args_str) $(fasta) $(fastq_str) --split-prefix=$(outfile).tmp \\
+                    $(Mycelia.CONDA_RUNNER) run --live-stream -n minimap2 minimap2 -t $(threads) -x $(mapping_type) -I$(index_size) -a$(extra_args_str) $(fasta) $(fastq_str) --split-prefix=$(split_prefix) \\
                     | $(Mycelia.CONDA_RUNNER) run --live-stream -n samtools samtools sort -@ $(threads) -T $(outfile).sort.tmp -o $(outfile) -
                     """
                 else
                     cmd = """
-                    $(Mycelia.CONDA_RUNNER) run --live-stream -n minimap2 minimap2 -t $(threads) -x $(mapping_type) -I$(index_size) -a$(extra_args_str) $(fasta) $(fastq_str) --split-prefix=$(outfile).tmp \\
+                    $(Mycelia.CONDA_RUNNER) run --live-stream -n minimap2 minimap2 -t $(threads) -x $(mapping_type) -I$(index_size) -a$(extra_args_str) $(fasta) $(fastq_str) --split-prefix=$(split_prefix) \\
                     | $(Mycelia.CONDA_RUNNER) run --live-stream -n samtools samtools sort -@ $(threads) -T $(outfile).sort.tmp - \\
                     | $(Mycelia.CONDA_RUNNER) run --live-stream -n samtools samtools view -@ $(threads) -bS --no-header -o $(outfile) -
                     """
@@ -1569,19 +1663,19 @@ function minimap_map(;
             else
                 if keep_header
                     cmd = """
-                    $(Mycelia.CONDA_RUNNER) run --live-stream -n minimap2 minimap2 -t $(threads) -x $(mapping_type) -I$(index_size) -a$(extra_args_str) $(fasta) $(fastq_str) --split-prefix=$(outfile).tmp \\
+                    $(Mycelia.CONDA_RUNNER) run --live-stream -n minimap2 minimap2 -t $(threads) -x $(mapping_type) -I$(index_size) -a$(extra_args_str) $(fasta) $(fastq_str) --split-prefix=$(split_prefix) \\
                     | $(Mycelia.CONDA_RUNNER) run --live-stream -n samtools samtools view -@ $(threads) -bS -o $(outfile) -
                     """
                 else
                     cmd = """
-                    $(Mycelia.CONDA_RUNNER) run --live-stream -n minimap2 minimap2 -t $(threads) -x $(mapping_type) -I$(index_size) -a$(extra_args_str) $(fasta) $(fastq_str) --split-prefix=$(outfile).tmp \\
+                    $(Mycelia.CONDA_RUNNER) run --live-stream -n minimap2 minimap2 -t $(threads) -x $(mapping_type) -I$(index_size) -a$(extra_args_str) $(fasta) $(fastq_str) --split-prefix=$(split_prefix) \\
                     | $(Mycelia.CONDA_RUNNER) run --live-stream -n samtools samtools view -@ $(threads) -bS --no-header -o $(outfile) -
                     """
                 end
             end
         else
             if sorted
-                map_cmd = `$(Mycelia.CONDA_RUNNER) run --live-stream -n minimap2 minimap2 -t $(threads) -x $(mapping_type) -I$(index_size) -a $(minimap_extra_args...) $(fasta) $(fastq_inputs...) --split-prefix=$(outfile).tmp`
+                map_cmd = `$(Mycelia.CONDA_RUNNER) run --live-stream -n minimap2 minimap2 -t $(threads) -x $(mapping_type) -I$(index_size) -a $(minimap_extra_args...) $(fasta) $(fastq_inputs...) --split-prefix=$(split_prefix)`
                 if keep_header
                     sort_cmd = `$(Mycelia.CONDA_RUNNER) run --live-stream -n samtools samtools sort -@ $(threads) -T $(outfile).sort.tmp -o $(outfile) -`
                     cmd = pipeline(map_cmd, sort_cmd)
@@ -1594,7 +1688,7 @@ function minimap_map(;
                     cmd = pipeline(cmd, stderr = devnull)
                 end
             else
-                map_cmd = `$(Mycelia.CONDA_RUNNER) run --live-stream -n minimap2 minimap2 -t $(threads) -x $(mapping_type) -I$(index_size) -a $(minimap_extra_args...) $(fasta) $(fastq_inputs...) --split-prefix=$(outfile).tmp`
+                map_cmd = `$(Mycelia.CONDA_RUNNER) run --live-stream -n minimap2 minimap2 -t $(threads) -x $(mapping_type) -I$(index_size) -a $(minimap_extra_args...) $(fasta) $(fastq_inputs...) --split-prefix=$(split_prefix)`
                 if keep_header
                     view_cmd = `$(Mycelia.CONDA_RUNNER) run --live-stream -n samtools samtools view -@ $(threads) -bS -o $(outfile) -`
                 else
@@ -1608,7 +1702,7 @@ function minimap_map(;
         end
     end
 
-    return (; cmd, outfile)
+    return (; cmd, outfile, split_prefix)
 end
 
 """
@@ -1633,6 +1727,8 @@ Map paired-end reads to a reference sequence using minimap2.
 Named tuple containing:
 - `cmd`: Command(s) to execute (String or Pipeline)
 - `outfile`: Path to output BAM file
+- `split_prefix`: minimap2 `--split-prefix` value; pass to
+  [`cleanup_minimap_split_temps`](@ref) in a `finally` after running `cmd`.
 
 # Notes
 - Requires minimap2, and samtools conda environments
@@ -1680,13 +1776,14 @@ function minimap_map_paired_end_with_index(;
         outfile *= ".sorted"
     end
     outfile *= ".bam"
+    split_prefix = minimap_split_prefix(outfile)
     # only run if we will need to do work
     if !isfile(outfile)
         Mycelia.add_bioconda_env("minimap2")
         Mycelia.add_bioconda_env("samtools")
     end
     if as_string
-        map_str = "$(Mycelia.CONDA_RUNNER) run --live-stream -n minimap2 minimap2 -t $(threads) -x $(mapping_preset) -I$(index_size) -a $(index_file) $(forward) $(reverse) --split-prefix=$(outfile).tmp"
+        map_str = "$(Mycelia.CONDA_RUNNER) run --live-stream -n minimap2 minimap2 -t $(threads) -x $(mapping_preset) -I$(index_size) -a $(index_file) $(forward) $(reverse) --split-prefix=$(split_prefix)"
         if sorted
             if keep_header
                 cmd = """
@@ -1714,7 +1811,7 @@ function minimap_map_paired_end_with_index(;
             end
         end
     else
-        map = `$(Mycelia.CONDA_RUNNER) run --live-stream -n minimap2 minimap2 -t $(threads) -x $(mapping_preset) -I$(index_size) -a $(index_file) $(forward) $(reverse) --split-prefix=$(outfile).tmp`
+        map = `$(Mycelia.CONDA_RUNNER) run --live-stream -n minimap2 minimap2 -t $(threads) -x $(mapping_preset) -I$(index_size) -a $(index_file) $(forward) $(reverse) --split-prefix=$(split_prefix)`
         if sorted
             if keep_header
                 sort_cmd = `$(Mycelia.CONDA_RUNNER) run --live-stream -n samtools samtools sort -@ $(threads) -T $(outfile).sort.tmp -o $(outfile) -`
@@ -1734,7 +1831,7 @@ function minimap_map_paired_end_with_index(;
         end
     end
 
-    return (; cmd, outfile)
+    return (; cmd, outfile, split_prefix)
 end
 
 """
@@ -2118,7 +2215,7 @@ function minimap_merge_map_and_split(;
         )
     end
     minimap_cmd = minimap_result.cmd
-    split_prefix = merged_bam * ".tmp"
+    split_prefix = minimap_split_prefix(merged_bam)
 
     if run_mapping
         if nonempty_file(merged_bam) && !force
@@ -2126,14 +2223,6 @@ function minimap_merge_map_and_split(;
         else
             try
                 run(minimap_cmd)
-                # Best-effort cleanup of minimap2 split-prefix temp files.
-                try
-                    split_base = basename(split_prefix)
-                    for path in readdir(tmpdir; join = true)
-                        startswith(basename(path), split_base) && rm(path; force = true)
-                    end
-                catch
-                end
             catch err
                 msg = sprint(showerror, err)
                 if occursin("E2BIG", msg) ||
@@ -2160,6 +2249,19 @@ function minimap_merge_map_and_split(;
                     )
                 end
                 rethrow()
+            finally
+                # Reclaim minimap2's split-index chunks on EVERY exit path.
+                # minimap2 already unlinks them when it exits cleanly, so the
+                # only path this actually recovers is the interrupted one
+                # (walltime, OOM, scancel) — which is exactly where they used
+                # to survive. Previously this ran inside the `try` after a
+                # successful `run`, i.e. only on the path that needed no help;
+                # a 2026-07 CAMI_I_LOW abort stranded 783 GiB as a result.
+                try
+                    cleanup_minimap_split_temps(split_prefix)
+                catch cleanup_err
+                    @warn "minimap2 split-temp cleanup failed" split_prefix exception = cleanup_err
+                end
             end
         end
     end
@@ -2276,6 +2378,8 @@ Map paired-end reads directly to a reference FASTA using minimap2 (indexes on-th
 Named tuple containing:
 - `cmd`: Command(s) to execute (String or Pipeline)
 - `outfile`: Path to output BAM file
+- `split_prefix`: minimap2 `--split-prefix` value; pass to
+  [`cleanup_minimap_split_temps`](@ref) in a `finally` after running `cmd`.
 
 # Notes
 - Requires minimap2 and samtools conda environments.
@@ -2306,6 +2410,7 @@ function minimap_map_paired_end(;
         outfile *= ".sorted"
     end
     outfile *= ".bam"
+    split_prefix = minimap_split_prefix(outfile)
 
     if !isfile(outfile)
         Mycelia.add_bioconda_env("minimap2")
@@ -2313,7 +2418,7 @@ function minimap_map_paired_end(;
     end
 
     if as_string
-        map_str = "$(Mycelia.CONDA_RUNNER) run --live-stream -n minimap2 minimap2 -t $(threads) -x $(mapping_type) -I$(index_size) -a $(fasta) $(forward) $(reverse) --split-prefix=$(outfile).tmp"
+        map_str = "$(Mycelia.CONDA_RUNNER) run --live-stream -n minimap2 minimap2 -t $(threads) -x $(mapping_type) -I$(index_size) -a $(fasta) $(forward) $(reverse) --split-prefix=$(split_prefix)"
         if sorted
             if keep_header
                 cmd = """
@@ -2341,7 +2446,7 @@ function minimap_map_paired_end(;
             end
         end
     else
-        map_cmd = `$(Mycelia.CONDA_RUNNER) run --live-stream -n minimap2 minimap2 -t $(threads) -x $(mapping_type) -I$(index_size) -a $(fasta) $(forward) $(reverse) --split-prefix=$(outfile).tmp`
+        map_cmd = `$(Mycelia.CONDA_RUNNER) run --live-stream -n minimap2 minimap2 -t $(threads) -x $(mapping_type) -I$(index_size) -a $(fasta) $(forward) $(reverse) --split-prefix=$(split_prefix)`
         if sorted
             if keep_header
                 sort_cmd = `$(Mycelia.CONDA_RUNNER) run --live-stream -n samtools samtools sort -@ $(threads) -T $(outfile).sort.tmp -o $(outfile) -`
@@ -2361,7 +2466,7 @@ function minimap_map_paired_end(;
         end
     end
 
-    return (; cmd, outfile)
+    return (; cmd, outfile, split_prefix)
 end
 
 """

--- a/src/sequence-comparison.jl
+++ b/src/sequence-comparison.jl
@@ -730,6 +730,13 @@ function merge_and_map_single_end_samples(;
         fastq = fastq_out,
         index_file = minimap_index
     )
+    # Swept BEFORE the branch, not only inside it. A `finally` covers an
+    # ordinary exception but never a SIGTERM/SIGKILL -- Julia runs no `finally`
+    # on either -- and when the output file already exists this branch is
+    # skipped entirely, so a previous killed run's chunks would have no
+    # remaining code path that could ever reclaim them. Unconditional is safe:
+    # minimap2 cannot resume from these chunks, so any present now are orphans.
+    Mycelia.cleanup_minimap_split_temps(minimap_result.split_prefix)
     if !isfile(minimap_result.outfile)
         # `finally`, because minimap2 leaves its --split-prefix chunks behind
         # only when it is killed mid-run; on a clean exit it removes them itself.

--- a/src/sequence-comparison.jl
+++ b/src/sequence-comparison.jl
@@ -731,7 +731,13 @@ function merge_and_map_single_end_samples(;
         index_file = minimap_index
     )
     if !isfile(minimap_result.outfile)
-        @time run(minimap_result.cmd)
+        # `finally`, because minimap2 leaves its --split-prefix chunks behind
+        # only when it is killed mid-run; on a clean exit it removes them itself.
+        try
+            @time run(minimap_result.cmd)
+        finally
+            Mycelia.cleanup_minimap_split_temps(minimap_result.split_prefix)
+        end
     end
     results_table_outfiles = [outbase * fmt for fmt in outformats]
     # Determine file paths for .tsv.gz and .jld2

--- a/src/sequence-comparison.jl
+++ b/src/sequence-comparison.jl
@@ -730,14 +730,28 @@ function merge_and_map_single_end_samples(;
         fastq = fastq_out,
         index_file = minimap_index
     )
-    # Swept BEFORE the branch, not only inside it. A `finally` covers an
-    # ordinary exception but never a SIGTERM/SIGKILL -- Julia runs no `finally`
-    # on either -- and when the output file already exists this branch is
-    # skipped entirely, so a previous killed run's chunks would have no
-    # remaining code path that could ever reclaim them. Unconditional is safe:
-    # minimap2 cannot resume from these chunks, so any present now are orphans.
-    Mycelia.cleanup_minimap_split_temps(minimap_result.split_prefix)
+    # NOT swept unconditionally here, unlike minimap_merge_map_and_split.
+    #
+    # `outbase` defaults to `normalized_current_date() * "..."`, which is
+    # DATE-ONLY. Every call on a given day from a given working directory
+    # therefore derives the SAME split prefix regardless of `fastq_list`, and
+    # the default `dirname` is "" -> the process CWD. Two concurrent runs under
+    # that default share a prefix, so an unconditional sweep at function entry
+    # would delete a peer's IN-FLIGHT chunks -- turning a disk-space bug into a
+    # truncated-output bug. The shape anchor cannot help: the peer's chunks
+    # match the left anchor too, because the prefix is genuinely the same.
+    #
+    # Sweeping only when we are about to map keeps the peer's no-op path a
+    # no-op. It does leave one hole: a run killed AFTER writing `outfile` keeps
+    # its chunks, since this branch is then skipped forever. That is a leak,
+    # and a leak is strictly better than deleting a file another process is
+    # still writing.
+    #
+    # The real defect is the colliding default; fixing it is a behaviour change
+    # beyond this PR's scope (same-day reuse of `fastq_out`/`tsv_out` is also
+    # wrong under it) and is tracked separately.
     if !isfile(minimap_result.outfile)
+        Mycelia.cleanup_minimap_split_temps(minimap_result.split_prefix)
         # `finally`, because minimap2 leaves its --split-prefix chunks behind
         # only when it is killed mid-run; on a clean exit it removes them itself.
         try

--- a/src/testing-utilities.jl
+++ b/src/testing-utilities.jl
@@ -507,13 +507,22 @@ function prepare_binning_test_inputs(;
         threads = threads,
         sorted = true
     )
-    # Swept BEFORE the branch, not only inside it. A `finally` covers an
-    # ordinary exception but never a SIGTERM/SIGKILL -- Julia runs no `finally`
-    # on either -- and when the output file already exists this branch is
-    # skipped entirely, so a previous killed run's chunks would have no
-    # remaining code path that could ever reclaim them. Unconditional is safe:
-    # minimap2 cannot resume from these chunks, so any present now are orphans.
-    Mycelia.cleanup_minimap_split_temps(mapping.split_prefix)
+    # Swept BEFORE the branch, not only inside it: a `finally` covers an
+    # ordinary exception but never a SIGTERM/SIGKILL, and when the output file
+    # already exists this branch is skipped entirely, so a previous killed
+    # run's chunks would have no remaining code path that could reclaim them.
+    #
+    # Gated on the DEFAULT outdir, though. Orphan-ness is not the safety
+    # condition -- a concurrent peer's in-flight chunks are equally unresumable
+    # and equally match the predicate. NON-COLLISION is the condition. The bam
+    # name here is fixed ("contigs.minimap2.sorted.bam"), so two callers
+    # sharing an explicit `outdir` derive one split prefix, and an entry-time
+    # sweep would unlink a live peer's chunks -- the unlink succeeds while
+    # minimap2 holds the fd, so the victim does not error, it silently loses
+    # index parts. Only the `mktempdir()` default rules that out.
+    if outdir === nothing
+        Mycelia.cleanup_minimap_split_temps(mapping.split_prefix)
+    end
     if !isfile(mapping.outfile) || filesize(mapping.outfile) == 0
         # See sequence-comparison.jl: cleanup belongs on every exit path, since
         # minimap2 only strands split chunks when it is killed mid-run.

--- a/src/testing-utilities.jl
+++ b/src/testing-utilities.jl
@@ -508,7 +508,13 @@ function prepare_binning_test_inputs(;
         sorted = true
     )
     if !isfile(mapping.outfile) || filesize(mapping.outfile) == 0
-        run(mapping.cmd)
+        # See sequence-comparison.jl: cleanup belongs on every exit path, since
+        # minimap2 only strands split chunks when it is killed mid-run.
+        try
+            run(mapping.cmd)
+        finally
+            Mycelia.cleanup_minimap_split_temps(mapping.split_prefix)
+        end
     end
 
     depth_file = joinpath(inputs_dir, "jgi_depth.tsv")

--- a/src/testing-utilities.jl
+++ b/src/testing-utilities.jl
@@ -507,6 +507,13 @@ function prepare_binning_test_inputs(;
         threads = threads,
         sorted = true
     )
+    # Swept BEFORE the branch, not only inside it. A `finally` covers an
+    # ordinary exception but never a SIGTERM/SIGKILL -- Julia runs no `finally`
+    # on either -- and when the output file already exists this branch is
+    # skipped entirely, so a previous killed run's chunks would have no
+    # remaining code path that could ever reclaim them. Unconditional is safe:
+    # minimap2 cannot resume from these chunks, so any present now are orphans.
+    Mycelia.cleanup_minimap_split_temps(mapping.split_prefix)
     if !isfile(mapping.outfile) || filesize(mapping.outfile) == 0
         # See sequence-comparison.jl: cleanup belongs on every exit path, since
         # minimap2 only strands split chunks when it is killed mid-run.

--- a/test/8_tool_integration/minimap_split_temp_cleanup.jl
+++ b/test/8_tool_integration/minimap_split_temp_cleanup.jl
@@ -1,0 +1,93 @@
+# From the Mycelia base directory, run the tests with:
+#
+# ```bash
+# julia --project=. -e 'include("test/8_tool_integration/minimap_split_temp_cleanup.jl")'
+# ```
+#
+# minimap2 writes one `PREFIX.NNNN.tmp` chunk per index part when run against a
+# multi-part index, and unlinks them itself on clean exit. They survive only when
+# the process is killed first (walltime, OOM, scancel) -- and nothing can consume
+# them afterwards, since minimap2 cannot resume from them. A 2026-07 CAMI_I_LOW
+# run aborted this way and stranded 783 GiB on NERSC scratch.
+#
+# These tests need no external tools: they exercise the prefix derivation and the
+# reclaim helper against synthetic files, and check that the command builders
+# hand the caller a prefix to clean up with (run_mapping is never invoked).
+
+import Test
+import Mycelia
+
+Test.@testset "minimap2 split-index temp cleanup" begin
+    Test.@testset "split prefix derives from the output path" begin
+        Test.@test Mycelia.minimap_split_prefix("/x/y.sorted.bam") ==
+                   "/x/y.sorted.bam.tmp"
+    end
+
+    Test.@testset "reclaims chunks, spares siblings" begin
+        mktempdir() do dir
+            outfile = joinpath(dir, "sample.ref.mmi.minimap2.sorted.bam")
+            split_prefix = Mycelia.minimap_split_prefix(outfile)
+
+            # Three minimap2 split chunks, 1 KiB each.
+            chunks = [string(split_prefix, ".", lpad(i, 4, '0'), ".tmp") for i in 0:2]
+            for c in chunks
+                write(c, rand(UInt8, 1024))
+            end
+
+            # Siblings that share a stem and MUST survive: the real output BAM,
+            # its index, and samtools' own sort temps (a different infix).
+            survivors = [
+                outfile,
+                outfile * ".bai",
+                string(outfile, ".sort.tmp.0000.bam"),
+                joinpath(dir, "unrelated.sorted.bam")
+            ]
+            for s in survivors
+                write(s, "keep")
+            end
+
+            result = Mycelia.cleanup_minimap_split_temps(split_prefix; verbose = false)
+
+            Test.@test result.removed == 3
+            Test.@test result.bytes == 3 * 1024
+            for c in chunks
+                Test.@test !isfile(c)
+            end
+            for s in survivors
+                Test.@test isfile(s)
+            end
+        end
+    end
+
+    Test.@testset "is idempotent and safe on a missing directory" begin
+        mktempdir() do dir
+            prefix = joinpath(dir, "nothing-here.bam.tmp")
+            r = Mycelia.cleanup_minimap_split_temps(prefix; verbose = false)
+            Test.@test r.removed == 0
+            Test.@test r.bytes == 0
+        end
+        r = Mycelia.cleanup_minimap_split_temps(
+            joinpath("/nonexistent-dir-for-mycelia-test", "x.bam.tmp"); verbose = false)
+        Test.@test r.removed == 0
+    end
+
+    Test.@testset "builders return a split_prefix the caller can clean up" begin
+        mktempdir() do dir
+            ref = joinpath(dir, "ref.fa")
+            write(ref, ">ref\n" * "ACGT"^100 * "\n")
+            fq = joinpath(dir, "reads.fq")
+            write(fq, "@r1\nACGT\n+\nIIII\n")
+            outfile = joinpath(dir, "out.sorted.bam")
+
+            res = Mycelia.minimap_map(;
+                fasta = ref, fastq = fq, mapping_type = "sr",
+                outfile = outfile, as_string = true)
+
+            Test.@test haskey(res, :split_prefix)
+            Test.@test res.split_prefix == Mycelia.minimap_split_prefix(res.outfile)
+            # The prefix handed back must be the one minimap2 is actually told
+            # to use -- otherwise cleanup would target the wrong files.
+            Test.@test occursin("--split-prefix=$(res.split_prefix)", res.cmd)
+        end
+    end
+end

--- a/test/8_tool_integration/minimap_split_temp_cleanup.jl
+++ b/test/8_tool_integration/minimap_split_temp_cleanup.jl
@@ -28,19 +28,39 @@ Test.@testset "minimap2 split-index temp cleanup" begin
             outfile = joinpath(dir, "sample.ref.mmi.minimap2.sorted.bam")
             split_prefix = Mycelia.minimap_split_prefix(outfile)
 
-            # Three minimap2 split chunks, 1 KiB each.
+            # Four minimap2 split chunks, 1 KiB each. The last one carries a
+            # FIVE-digit index on purpose: minimap2 formats the chunk number
+            # with %04d, which stops being four digits once a run exceeds 9999
+            # index parts. Without this fixture a literal `\d{4}` predicate
+            # passes the whole testset, and the choice of `\d+` is untested.
             chunks = [string(split_prefix, ".", lpad(i, 4, '0'), ".tmp") for i in 0:2]
+            push!(chunks, string(split_prefix, ".10000.tmp"))
             for c in chunks
                 write(c, rand(UInt8, 1024))
             end
 
-            # Siblings that share a stem and MUST survive: the real output BAM,
-            # its index, and samtools' own sort temps (a different infix).
+            # Siblings that MUST survive. Two groups, and the second is the one
+            # that gives this test teeth:
+            #
+            #   (a) files that share the OUTPUT stem -- the BAM, its index, and
+            #       samtools' own sort temps. A loose `startswith(name, base)`
+            #       predicate already spares these, so on their own they prove
+            #       nothing about the shape anchor.
+            #
+            #   (b) files that DO start with `split_prefix` but are not chunks.
+            #       These are the discriminating cases: a loose prefix sweep
+            #       deletes them, the shape-anchored predicate does not. Without
+            #       them this testset passes under either implementation and so
+            #       tests nothing about the choice between them.
             survivors = [
                 outfile,
                 outfile * ".bai",
                 string(outfile, ".sort.tmp.0000.bam"),
-                joinpath(dir, "unrelated.sorted.bam")
+                joinpath(dir, "unrelated.sorted.bam"),
+                split_prefix,                                # bare prefix, no chunk index
+                split_prefix * ".log",                        # non-numeric segment
+                string(split_prefix, ".0000.tmp.bak"),        # trailing suffix past .tmp
+                string(split_prefix, ".notanumber.tmp")       # right shape, wrong segment
             ]
             for s in survivors
                 write(s, "keep")
@@ -48,8 +68,8 @@ Test.@testset "minimap2 split-index temp cleanup" begin
 
             result = Mycelia.cleanup_minimap_split_temps(split_prefix; verbose = false)
 
-            Test.@test result.removed == 3
-            Test.@test result.bytes == 3 * 1024
+            Test.@test result.removed == length(chunks)
+            Test.@test result.bytes == length(chunks) * 1024
             for c in chunks
                 Test.@test !isfile(c)
             end

--- a/test/8_tool_integration/minimap_split_temp_cleanup.jl
+++ b/test/8_tool_integration/minimap_split_temp_cleanup.jl
@@ -147,6 +147,122 @@ Test.@testset "minimap2 split-index temp cleanup" begin
         Test.@test r.removed == 0
     end
 
+    # ------------------------------------------------------------------
+    # The PRE-RUN sweep at each call site.
+    #
+    # This is the half of the fix that actually covers the incident: a
+    # `finally` never runs on SIGTERM or SIGKILL, so the reclaim has to happen
+    # either in an `atexit` hook (SIGTERM only, inside SLURM's KillWait window)
+    # or at the START of the next attempt. Until these tests existed, deleting
+    # all three pre-run sweep calls left the entire suite green -- the primary
+    # fix was reverted and nothing noticed.
+    #
+    # Structural rather than behavioural, and deliberately so: reaching the
+    # sweep through any of the three entry points requires a command builder,
+    # and every builder calls `add_bioconda_env` before it assembles a string.
+    # A behavioural version lives below behind the external gate. These run on
+    # the default CI path so that DELETING a sweep call cannot pass unnoticed,
+    # which is the specific regression worth guarding.
+    Test.@testset "pre-run sweep is wired at every call site" begin
+        srcdir = joinpath(dirname(dirname(@__DIR__)), "src")
+
+        function body_of(path, marker)
+            text = read(joinpath(srcdir, path), String)
+            idx = findfirst(marker, text)
+            Test.@test idx !== nothing
+            return text[first(idx):end]
+        end
+
+        # minimap_merge_map_and_split: swept unconditionally, BEFORE the
+        # resume/caching branch. Order is the whole point -- after the branch
+        # it would never run on the cached path, which is where a run killed
+        # post-output strands its chunks.
+        merge_body = body_of("alignments-and-mapping.jl", "    if run_mapping")
+        sweep = findfirst("cleanup_minimap_split_temps(split_prefix)", merge_body)
+        branch = findfirst("if nonempty_file(merged_bam)", merge_body)
+        Test.@test sweep !== nothing
+        Test.@test branch !== nothing
+        Test.@test first(sweep) < first(branch)
+
+        # merge_and_map_single_end_samples is the deliberate ASYMMETRY: its
+        # sweep sits INSIDE the branch, not before it. `outbase` defaults to a
+        # date-only string, so two same-day runs in one CWD share a split
+        # prefix, and an entry-time sweep would delete a live peer's chunks --
+        # trading a recoverable leak for unrecoverable truncated output. If
+        # someone "fixes the inconsistency" by hoisting this call, that is a
+        # correctness regression, and this assertion is what catches it.
+        seq_body = body_of("sequence-comparison.jl",
+            "    if !isfile(minimap_result.outfile)")
+        seq_sweep = findfirst(
+            "Mycelia.cleanup_minimap_split_temps(minimap_result.split_prefix)", seq_body)
+        Test.@test seq_sweep !== nothing
+        Test.@test first(seq_sweep) < first(findfirst("run(minimap_result.cmd)", seq_body))
+
+        # prepare_binning_test_inputs: unconditional, like the merge path --
+        # its inputs_dir comes from mktempdir(), so it cannot collide.
+        util = read(joinpath(srcdir, "testing-utilities.jl"), String)
+        u_sweep = findfirst(
+            "Mycelia.cleanup_minimap_split_temps(mapping.split_prefix)", util)
+        u_branch = findfirst("if !isfile(mapping.outfile)", util)
+        Test.@test u_sweep !== nothing
+        Test.@test u_branch !== nothing
+        Test.@test first(u_sweep) < first(u_branch)
+    end
+
+
+    # Behavioural counterpart to the structural testset above. Gated for the
+    # same reason the builder testset is: the entry point needs a command
+    # builder, and every builder calls `add_bioconda_env` first.
+    #
+    # `run_mapping = true` is what reaches the sweep; a pre-existing nonempty
+    # `merged_bam` then sends execution down the resume branch, which never
+    # invokes minimap2. So this observes the real sweep, at the real call site,
+    # without needing minimap2 to run.
+    if get(ENV, "MYCELIA_RUN_EXTERNAL", "false") == "true"
+        Test.@testset "pre-run sweep reclaims on the resume path" begin
+            mktempdir() do dir
+                ref = joinpath(dir, "ref.fa")
+                write(ref, ">ref\n" * "ACGT"^500 * "\n")
+                fq = joinpath(dir, "reads.fq")
+                write(fq, join(["@r$i\nACGT\n+\nIIII\n" for i in 1:100]))
+
+                merged = joinpath(dir, "merged.sorted.bam")
+                write(merged, "nonempty, so the resume branch is taken")
+
+                prefix = Mycelia.minimap_split_prefix(merged)
+                chunks = [string(prefix, ".", lpad(i, 4, '0'), ".tmp") for i in 0:1]
+                for c in chunks
+                    write(c, rand(UInt8, 2048))
+                end
+                # Must survive: right stem, wrong shape.
+                survivor = string(prefix, ".notanumber.tmp")
+                write(survivor, "keep")
+
+                Mycelia.minimap_merge_map_and_split(
+                    reference_fasta = ref,
+                    mapping_type = "sr",
+                    single_end_fastqs = [fq],
+                    outdir = dir,
+                    tmpdir = dir,
+                    merged_bam = merged,
+                    run_mapping = true,
+                    run_splitting = false,
+                    gzip_prefixed_fastqs = false
+                )
+
+                for c in chunks
+                    Test.@test !isfile(c)
+                end
+                Test.@test isfile(survivor)
+                # The cached BAM must be left exactly as found -- the sweep
+                # reclaims orphans, it does not invalidate the resume.
+                Test.@test isfile(merged)
+                Test.@test read(merged, String) ==
+                          "nonempty, so the resume branch is taken"
+            end
+        end
+    end
+
     # Gated, because `minimap_map` calls `add_bioconda_env("minimap2")` and
     # `add_bioconda_env("samtools")` unconditionally BEFORE it builds any
     # command string -- so merely asking for a command needs a working conda.

--- a/test/8_tool_integration/minimap_split_temp_cleanup.jl
+++ b/test/8_tool_integration/minimap_split_temp_cleanup.jl
@@ -163,6 +163,37 @@ Test.@testset "minimap2 split-index temp cleanup" begin
     # A behavioural version lives below behind the external gate. These run on
     # the default CI path so that DELETING a sweep call cannot pass unnoticed,
     # which is the specific regression worth guarding.
+
+    Test.@testset "the delete contract is documented and the gate is real" begin
+        # Julia binds a docstring to the NEXT expression and does NOT skip
+        # comments. Twelve comment lines and three consts once sat between this
+        # docstring and its function, so it was dropped with no warning and
+        # `?cleanup_minimap_split_temps` printed "No documentation found" --
+        # leaving the function that decides which files get DELETED with no
+        # written contract at all. `checkdocs = :none` means the docs build
+        # cannot catch it either.
+        doc = string(Base.Docs.doc(Mycelia.cleanup_minimap_split_temps))
+        Test.@test !occursin("No documentation found", doc)
+        Test.@test occursin("does not throw", doc)
+        Test.@test occursin("split_prefix", doc)
+
+        # The pre-run sweep in minimap_merge_map_and_split must stay gated on
+        # owning the output paths. The SHA1 in the default merged_bam is a
+        # CONTENT hash, so identical arguments give an identical split prefix;
+        # only the mktempdir() default separates concurrent runs, and a caller
+        # can override tmpdir -- benchmarking/15_round_trip_benchmark.jl does.
+        # Ungating this would make a run that was previously a total no-op
+        # unlink a live peer's chunks.
+        src = read(joinpath(dirname(dirname(@__DIR__)), "src",
+                "alignments-and-mapping.jl"), String)
+        Test.@test occursin("owns_output_paths = isnothing(tmpdir) && isnothing(merged_bam)",
+            src)
+        gate = findfirst(
+            "if owns_output_paths\n            cleanup_minimap_split_temps(split_prefix)",
+            src)
+        Test.@test gate !== nothing
+    end
+
     Test.@testset "pre-run sweep is wired at every call site" begin
         srcdir = joinpath(dirname(dirname(@__DIR__)), "src")
 

--- a/test/8_tool_integration/minimap_split_temp_cleanup.jl
+++ b/test/8_tool_integration/minimap_split_temp_cleanup.jl
@@ -164,6 +164,33 @@ Test.@testset "minimap2 split-index temp cleanup" begin
     # the default CI path so that DELETING a sweep call cannot pass unnoticed,
     # which is the specific regression worth guarding.
 
+    Test.@testset "cleanup cannot throw, including on an unreadable parent" begin
+        # The no-throw contract is what lets all three call sites invoke this
+        # from a `finally` with no wrapper. It was false until now: `isdir` sat
+        # ABOVE the try, and Julia's `stat` re-raises on every errno except
+        # ENOENT/ENOTDIR/EINVAL, so an unreadable parent threw an IOError that
+        # would REPLACE the mapping exception -- and, from the atexit hook,
+        # would fail an otherwise successful job at shutdown.
+        mktempdir() do root
+            locked = joinpath(root, "locked")
+            mkpath(locked)
+            chmod(locked, 0o000)
+            try
+                # NB: calling `Base.isdir` on a path under `locked` would itself
+                # throw here -- that IS the defect under test, so it must not
+                # appear in the test's own setup.
+                r = Mycelia.cleanup_minimap_split_temps(
+                    joinpath(locked, "sub", "out.bam.tmp"); verbose = false)
+                Test.@test r.removed == 0
+                Test.@test r.bytes == 0
+            catch err
+                Test.@test false  # any throw at all violates the contract
+            finally
+                chmod(locked, 0o755)
+            end
+        end
+    end
+
     Test.@testset "the delete contract is documented and the gate is real" begin
         # Julia binds a docstring to the NEXT expression and does NOT skip
         # comments. Twelve comment lines and three consts once sat between this

--- a/test/8_tool_integration/minimap_split_temp_cleanup.jl
+++ b/test/8_tool_integration/minimap_split_temp_cleanup.jl
@@ -113,6 +113,29 @@ Test.@testset "minimap2 split-index temp cleanup" begin
     end
 
     Test.@testset "is idempotent and safe on a missing directory" begin
+        # Idempotence needs a SECOND call after a real sweep. Both cases below
+        # start with zero matching chunks, so on their own they hold for a
+        # function that does nothing at all -- they test the empty case, not
+        # the repeat case. The pre-run sweep added to every caller means a
+        # second call on an already-swept directory is now the common path.
+        mktempdir() do dir
+            outfile = joinpath(dir, "idem.ref.mmi.minimap2.sorted.bam")
+            prefix = Mycelia.minimap_split_prefix(outfile)
+            for i in 0:1
+                write(string(prefix, ".", lpad(i, 4, '0'), ".tmp"), rand(UInt8, 512))
+            end
+            keep = string(prefix, ".notanumber.tmp")
+            write(keep, "keep")
+
+            first_pass = Mycelia.cleanup_minimap_split_temps(prefix; verbose = false)
+            Test.@test first_pass.removed == 2
+            Test.@test first_pass.bytes == 2 * 512
+
+            second_pass = Mycelia.cleanup_minimap_split_temps(prefix; verbose = false)
+            Test.@test second_pass.removed == 0
+            Test.@test second_pass.bytes == 0
+            Test.@test isfile(keep)
+        end
         mktempdir() do dir
             prefix = joinpath(dir, "nothing-here.bam.tmp")
             r = Mycelia.cleanup_minimap_split_temps(prefix; verbose = false)

--- a/test/8_tool_integration/minimap_split_temp_cleanup.jl
+++ b/test/8_tool_integration/minimap_split_temp_cleanup.jl
@@ -10,9 +10,17 @@
 # them afterwards, since minimap2 cannot resume from them. A 2026-07 CAMI_I_LOW
 # run aborted this way and stranded 783 GiB on NERSC scratch.
 #
-# These tests need no external tools: they exercise the prefix derivation and the
-# reclaim helper against synthetic files, and check that the command builders
-# hand the caller a prefix to clean up with (run_mapping is never invoked).
+# The first three testsets need no external tools -- they exercise the prefix
+# derivation and the reclaim helper against synthetic files -- so they run on the
+# default CI path. The fourth calls `minimap_map`, which invokes
+# `add_bioconda_env` before it builds any command string, and so self-gates
+# behind MYCELIA_RUN_EXTERNAL=true.
+#
+# Note what a `finally` alone CANNOT cover: SLURM sends SIGTERM then SIGKILL at
+# walltime, and Julia runs no `finally` on either -- it dies in the signal
+# handler (verified on 1.10.10). That is why `minimap_merge_map_and_split`
+# sweeps BEFORE the run as well as after; the next attempt is the only moment a
+# live Julia process exists after a job-level kill.
 
 import Test
 import Mycelia
@@ -52,6 +60,30 @@ Test.@testset "minimap2 split-index temp cleanup" begin
             #       deletes them, the shape-anchored predicate does not. Without
             #       them this testset passes under either implementation and so
             #       tests nothing about the choice between them.
+            #
+            #   (c) a chunk belonging to a DIFFERENT job, correctly shaped. Every
+            #       fixture in (a) and (b) fails the right-hand regex on its own
+            #       merits, so deleting the `startswith(name, base)` guard
+            #       entirely leaves them all untouched and the testset green.
+            #       This one is the only fixture that pins the LEFT anchor --
+            #       the guard that scopes the sweep to this run's output rather
+            #       than everything in a shared SLURM-array output directory.
+            #
+            #       Its stem must be the SAME BYTE LENGTH as this run's, which
+            #       is why it is derived rather than written out. Without the
+            #       guard the predicate slices at `ncodeunits(base) + 1`
+            #       regardless of what the name is, so a sibling of any OTHER
+            #       length lands mid-name and fails the regex for the wrong
+            #       reason -- sparing the file by accident and letting the
+            #       mutant survive. Equal length forces the slice to land
+            #       exactly on `.0000.tmp`, so only the left anchor can reject
+            #       it. (A hand-written `othersample....` fixture was tried
+            #       first and did NOT kill the mutant, for exactly this reason.)
+            sibling_base = replace(basename(split_prefix), "sample." => "s4mple.")
+            Test.@test ncodeunits(sibling_base) ==
+                       ncodeunits(basename(split_prefix))
+            Test.@test sibling_base != basename(split_prefix)
+            sibling_chunk = joinpath(dir, sibling_base * ".0000.tmp")
             survivors = [
                 outfile,
                 outfile * ".bai",
@@ -60,7 +92,8 @@ Test.@testset "minimap2 split-index temp cleanup" begin
                 split_prefix,                                # bare prefix, no chunk index
                 split_prefix * ".log",                        # non-numeric segment
                 string(split_prefix, ".0000.tmp.bak"),        # trailing suffix past .tmp
-                string(split_prefix, ".notanumber.tmp")       # right shape, wrong segment
+                string(split_prefix, ".notanumber.tmp"),      # right shape, wrong segment
+                sibling_chunk                                 # another job's LIVE chunk
             ]
             for s in survivors
                 write(s, "keep")
@@ -91,23 +124,31 @@ Test.@testset "minimap2 split-index temp cleanup" begin
         Test.@test r.removed == 0
     end
 
-    Test.@testset "builders return a split_prefix the caller can clean up" begin
-        mktempdir() do dir
-            ref = joinpath(dir, "ref.fa")
-            write(ref, ">ref\n" * "ACGT"^100 * "\n")
-            fq = joinpath(dir, "reads.fq")
-            write(fq, "@r1\nACGT\n+\nIIII\n")
-            outfile = joinpath(dir, "out.sorted.bam")
+    # Gated, because `minimap_map` calls `add_bioconda_env("minimap2")` and
+    # `add_bioconda_env("samtools")` unconditionally BEFORE it builds any
+    # command string -- so merely asking for a command needs a working conda.
+    # The three testsets above genuinely need no external tools, which is what
+    # lets this file run on the default (MYCELIA_RUN_EXTERNAL=false) CI path
+    # where the cleanup predicate is the part that actually matters.
+    if get(ENV, "MYCELIA_RUN_EXTERNAL", "false") == "true"
+        Test.@testset "builders return a split_prefix the caller can clean up" begin
+            mktempdir() do dir
+                ref = joinpath(dir, "ref.fa")
+                write(ref, ">ref\n" * "ACGT"^100 * "\n")
+                fq = joinpath(dir, "reads.fq")
+                write(fq, "@r1\nACGT\n+\nIIII\n")
+                outfile = joinpath(dir, "out.sorted.bam")
 
-            res = Mycelia.minimap_map(;
-                fasta = ref, fastq = fq, mapping_type = "sr",
-                outfile = outfile, as_string = true)
+                res = Mycelia.minimap_map(;
+                    fasta = ref, fastq = fq, mapping_type = "sr",
+                    outfile = outfile, as_string = true)
 
-            Test.@test haskey(res, :split_prefix)
-            Test.@test res.split_prefix == Mycelia.minimap_split_prefix(res.outfile)
-            # The prefix handed back must be the one minimap2 is actually told
-            # to use -- otherwise cleanup would target the wrong files.
-            Test.@test occursin("--split-prefix=$(res.split_prefix)", res.cmd)
+                Test.@test haskey(res, :split_prefix)
+                Test.@test res.split_prefix == Mycelia.minimap_split_prefix(res.outfile)
+                # The prefix handed back must be the one minimap2 is actually told
+                # to use -- otherwise cleanup would target the wrong files.
+                Test.@test occursin("--split-prefix=$(res.split_prefix)", res.cmd)
+            end
         end
     end
 end

--- a/test/8_tool_integration/minimap_split_temp_cleanup.jl
+++ b/test/8_tool_integration/minimap_split_temp_cleanup.jl
@@ -10,11 +10,11 @@
 # them afterwards, since minimap2 cannot resume from them. A 2026-07 CAMI_I_LOW
 # run aborted this way and stranded 783 GiB on NERSC scratch.
 #
-# The first three testsets need no external tools -- they exercise the prefix
-# derivation and the reclaim helper against synthetic files -- so they run on the
-# default CI path. The fourth calls `minimap_map`, which invokes
-# `add_bioconda_env` before it builds any command string, and so self-gates
-# behind MYCELIA_RUN_EXTERNAL=true.
+# Four testsets run on the default CI path: they exercise the prefix
+# derivation, the reclaim helper against synthetic files, its idempotence, and
+# the structural wiring of the pre-run sweep at each call site. Two self-gate
+# behind MYCELIA_RUN_EXTERNAL=true, because both reach a command builder and
+# every builder calls `add_bioconda_env` before it assembles a string.
 #
 # Note what a `finally` alone CANNOT cover: SLURM sends SIGTERM then SIGKILL at
 # walltime, and Julia runs no `finally` on either -- it dies in the signal
@@ -166,10 +166,38 @@ Test.@testset "minimap2 split-index temp cleanup" begin
     Test.@testset "pre-run sweep is wired at every call site" begin
         srcdir = joinpath(dirname(dirname(@__DIR__)), "src")
 
+        # Line-anchored AND asserted unique. A bare substring marker is not
+        # enough: "    if run_mapping" also occurs inside
+        # "            if run_mapping && !isfile(index_file)" 180 lines earlier,
+        # so `findfirst` sliced from the wrong block and a sweep hoisted ABOVE
+        # `if run_mapping` still satisfied `sweep < branch`. That mutant --
+        # which would make the sweep fire on the command-generation-only path
+        # and unlink chunks belonging to a process running that same command --
+        # survived the whole suite until this was fixed.
+        # Plain substring counting, NOT a regex: `escape_string` escapes for a
+        # Julia string literal, so `Regex(escape_string("\n    if x\n"))` looks
+        # for a literal backslash-n and matches nothing. That mistake made this
+        # very assertion vacuous on its first run.
+        function count_occurrences(needle, haystack)
+            n = 0
+            i = firstindex(haystack)
+            while true
+                r = findnext(needle, haystack, i)
+                r === nothing && break
+                n += 1
+                i = first(r) + 1
+            end
+            return n
+        end
+
         function body_of(path, marker)
             text = read(joinpath(srcdir, path), String)
+            Test.@test count_occurrences(marker, text) == 1
             idx = findfirst(marker, text)
-            Test.@test idx !== nothing
+            if idx === nothing
+                Test.@test false  # clean failure, not a MethodError on first(nothing)
+                return ""
+            end
             return text[first(idx):end]
         end
 
@@ -177,7 +205,7 @@ Test.@testset "minimap2 split-index temp cleanup" begin
         # resume/caching branch. Order is the whole point -- after the branch
         # it would never run on the cached path, which is where a run killed
         # post-output strands its chunks.
-        merge_body = body_of("alignments-and-mapping.jl", "    if run_mapping")
+        merge_body = body_of("alignments-and-mapping.jl", "\n    if run_mapping\n")
         sweep = findfirst("cleanup_minimap_split_temps(split_prefix)", merge_body)
         branch = findfirst("if nonempty_file(merged_bam)", merge_body)
         Test.@test sweep !== nothing
@@ -198,8 +226,13 @@ Test.@testset "minimap2 split-index temp cleanup" begin
         Test.@test seq_sweep !== nothing
         Test.@test first(seq_sweep) < first(findfirst("run(minimap_result.cmd)", seq_body))
 
-        # prepare_binning_test_inputs: unconditional, like the merge path --
-        # its inputs_dir comes from mktempdir(), so it cannot collide.
+        # prepare_binning_test_inputs: swept only when `outdir` was NOT
+        # supplied. Its bam name is fixed ("contigs.minimap2.sorted.bam"), so
+        # two concurrent calls sharing an explicit outdir derive one split
+        # prefix and an entry-time sweep would unlink a live peer's chunks.
+        # Orphan-ness is NOT the safety condition -- a peer's in-flight chunks
+        # are equally unresumable and equally match the predicate. Non-collision
+        # is the condition, and only the mktempdir() default guarantees it.
         util = read(joinpath(srcdir, "testing-utilities.jl"), String)
         u_sweep = findfirst(
             "Mycelia.cleanup_minimap_split_temps(mapping.split_prefix)", util)
@@ -207,6 +240,12 @@ Test.@testset "minimap2 split-index temp cleanup" begin
         Test.@test u_sweep !== nothing
         Test.@test u_branch !== nothing
         Test.@test first(u_sweep) < first(u_branch)
+        # ...and that it is GATED on the default outdir. Ordering alone would
+        # still hold if someone removed the gate, which is the change that
+        # would let a shared explicit outdir delete a live peer's chunks.
+        u_gate = findfirst("if outdir === nothing\n        Mycelia.cleanup_minimap_split_temps",
+            util)
+        Test.@test u_gate !== nothing
     end
 
 
@@ -266,7 +305,7 @@ Test.@testset "minimap2 split-index temp cleanup" begin
     # Gated, because `minimap_map` calls `add_bioconda_env("minimap2")` and
     # `add_bioconda_env("samtools")` unconditionally BEFORE it builds any
     # command string -- so merely asking for a command needs a working conda.
-    # The three testsets above genuinely need no external tools, which is what
+    # The four ungated testsets above need no external tools, which is what
     # lets this file run on the default (MYCELIA_RUN_EXTERNAL=false) CI path
     # where the cleanup predicate is the part that actually matters.
     if get(ENV, "MYCELIA_RUN_EXTERNAL", "false") == "true"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -346,6 +346,10 @@ else
     # These suites are pure-Julia/fake-runner coverage and need no external tools.
     include(joinpath(@__DIR__, "8_tool_integration", "execution_backends_test.jl"))
     include(joinpath(@__DIR__, "8_tool_integration", "autocycler.jl"))
+    # The split-temp cleanup predicate decides which files get DELETED, so it
+    # must be covered on the default CI path rather than only under
+    # MYCELIA_RUN_EXTERNAL. Its one conda-dependent testset self-gates.
+    include(joinpath(@__DIR__, "8_tool_integration", "minimap_split_temp_cleanup.jl"))
     @info "Skipping remaining tool integration tests; set MYCELIA_RUN_EXTERNAL=true to enable."
 end
 # for file in (

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -348,7 +348,7 @@ else
     include(joinpath(@__DIR__, "8_tool_integration", "autocycler.jl"))
     # The split-temp cleanup predicate decides which files get DELETED, so it
     # must be covered on the default CI path rather than only under
-    # MYCELIA_RUN_EXTERNAL. Its one conda-dependent testset self-gates.
+    # MYCELIA_RUN_EXTERNAL. Its two conda-dependent testsets self-gate.
     include(joinpath(@__DIR__, "8_tool_integration", "minimap_split_temp_cleanup.jl"))
     @info "Skipping remaining tool integration tests; set MYCELIA_RUN_EXTERNAL=true to enable."
 end


### PR DESCRIPTION
## Summary

- `minimap_merge_map_and_split` cleaned up minimap2's `--split-prefix` chunks **inside the `try`, after a successful `run`** — the one path that never needed help, since minimap2 unlinks its own chunks on clean exit. Every failure path fell through to `catch` and reclaimed nothing. Moved to `finally`.
- Added `cleanup_minimap_split_temps` and `minimap_split_prefix`, so the 24 `--split-prefix` sites and the cleanup can no longer drift on what counts as a temp file.
- The four `minimap_map*` functions only **build** a command; the caller runs it. They now return `split_prefix` alongside `(cmd, outfile)` — without it a caller has no way to know what to clean up. Additive field, existing destructuring unaffected.
- `sequence-comparison.jl` and `testing-utilities.jl` both ran a built command with a bare `run(...)` and no cleanup. Both now use `finally`.

## Why

A 2026-07 CAMI_I_LOW run on NERSC was killed mid-mapping and stranded **68 chunks / 783 GiB** on scratch — 94% of that sample directory, unnoticed for four weeks. minimap2 cannot resume from split chunks, so a survivor is pure orphan.

The residue was first triaged as samtools sort temps and as post-success leftovers. Both were wrong, and the filenames show it: the chunks carry minimap2's `PREFIX.NNNN.tmp` shape (samtools' would be `<outfile>.sort.tmp.NNNN.bam`), and they are prefixed `core_nt.2025-02-18.fna…` while every surviving product is `core_nt.2025-02-18.**dedup**.fna…` — a different reference index entirely. CAMI_I_MEDIUM ran the same code path to completion and left **zero** temps, which is the positive control confirming the success path already cleans itself.

## The delete predicate

A file is removed only when its name starts with the split prefix **and** the remainder matches `.<digits>.tmp`.

Anchoring both ends is what makes the helper safe under concurrency: the CAMI2 driver runs samples as a **SLURM array sharing one output directory**, so a bare prefix sweep could delete another task's *live* chunks — trading a disk-space bug for a corruption bug.

- `\d+` not `\d{4}`: minimap2 formats the index with `%04d`, which stops being four digits past 9999 parts.
- `ncodeunits` not `length`: `startswith` guarantees a **byte** prefix; `length` counts characters and would slice at the wrong offset for a non-ASCII path.

## Test Plan

```bash
julia --project=. -e 'include("test/8_tool_integration/minimap_split_temp_cleanup.jl")'
```

- [x] 21/21 pass
- [x] Mutation-checked against **both** rejected alternatives, 2/2 killed, no survivors:

  | variant | result |
  |---|---|
  | baseline (shape-anchored) | 21/21 pass |
  | mutant: loose `startswith` only | 15/21 — 6 failures |
  | mutant: literal `\d{4}` | 18/21 — 3 failures |

- [x] All three modified sources parse; module loads; both new functions defined.

The testset **as first written passed under the loose mutant** — it asserted the behaviour without testing the choice between implementations. It now includes files that start with the split prefix but are not chunks (bare prefix, `.log`, a trailing suffix past `.tmp`, a non-numeric segment) and a five-digit chunk index. Those fixtures are what kill the mutants.

## Related

Companion change in `hvp-exposome-virome` (`cp/cami-split-temp-cleanup`) wraps the CAMI driver's `run(mapres.cmd)` and adds a job-start sweep. That branch feature-detects these functions, so the two repos have no merge-ordering constraint.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup of temporary minimap2 files created during split-index mapping.
  * Stale files are removed before and after mapping, including interrupted, failed, resumed, and cached runs.
  * Cleanup preserves unrelated files, supports repeated use, and handles missing directories safely.
  * Improved mapping error handling.

* **Documentation**
  * Added guidance for the temporary-file cleanup workflow.

* **Tests**
  * Added integration coverage for cleanup behavior, file preservation, repeated runs, resume scenarios, and generated mapping commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->