### PR TITLE
add: select k per B8 run so the accuracy arm and its controls cannot diverge

### DIFF
--- a/benchmarking/results/viterbi_accuracy_b8/README.md
+++ b/benchmarking/results/viterbi_accuracy_b8/README.md
@@ -1,0 +1,39 @@
+# Frozen: pre-k-stamping B8 run
+
+This directory holds the B8 Viterbi accuracy run as it existed before `k` became
+a per-run parameter. **No code path writes here any more**, and no invocation of
+`benchmarking/viterbi_accuracy_benchmark.jl` can reproduce it.
+
+| | |
+| --- | --- |
+| `k` | **11** (not recorded in the tables; recoverable only as `editable_positions / (observation_count - 2)`) |
+| `benchmark_run_id` | `b8_viterbi_accuracy_local_20260625` — no `_k` suffix |
+| `benchmark_git_commit` | `806f0748` |
+| `benchmark_k` column | absent |
+| `metadata.k` | absent |
+
+## Why it cannot be reproduced
+
+The generator now stamps `k` into the run id, the metadata, a per-row
+`benchmark_k` column, and the output directory. A run at k=11 therefore emits
+run id `b8_viterbi_accuracy_local_20260625_k11` into
+`benchmarking/results/viterbi_accuracy_b8_k11/`. Nothing produces the unsuffixed
+run id above.
+
+The directory is kept rather than regenerated because it is the artifact several
+external references cite by path and by run id; freezing keeps every one of them
+resolving. It is superseded for all new work.
+
+## The gap this leaves
+
+The `benchmark_k` column exists because provenance sidecars do not survive a
+hand-copy across a repo boundary while a column does. That reasoning does not
+reach these tables: they predate the column, and since no command regenerates
+them, they can never acquire it in place. Any consumer that needs `k` alongside
+these rows must either read it from this file or re-harvest from a k-stamped
+run.
+
+Regenerating into `viterbi_accuracy_b8_k11/` and re-pointing the consumers is
+the real fix. It is a benchmark execution, so it routes to SLURM rather than a
+laptop, and it is deliberately not bundled into the review-fix change that
+created this note.

--- a/benchmarking/results/viterbi_accuracy_b8/README.md
+++ b/benchmarking/results/viterbi_accuracy_b8/README.md
@@ -1,12 +1,16 @@
 # Frozen: pre-k-stamping B8 run
 
 This directory holds the B8 Viterbi accuracy run as it existed before `k` became
-a per-run parameter. **No code path writes here any more**, and no invocation of
-`benchmarking/viterbi_accuracy_benchmark.jl` can reproduce it.
+a per-run parameter. **No default resolution reaches this directory any more** —
+every k, including the default 11, now resolves to a `_k`-stamped sibling. An
+explicit `--output-dir` pointing here still writes, and would overwrite in
+place: the artifact writer has no existence check and no `--force`. And no
+invocation of `benchmarking/viterbi_accuracy_benchmark.jl` can reproduce this
+run, because the run id is unconditionally `_k`-suffixed.
 
 | | |
 | --- | --- |
-| `k` | **11** (not recorded in the tables; recoverable only as `editable_positions / (observation_count - 2)`) |
+| `k` | **11** — recorded in `provenance/run.provenance.json` as `metadata.unit`, and derivable from the accuracy table as `editable_positions / (observation_count - 2)`. Not derivable from the null-control table, which carries neither column. |
 | `benchmark_run_id` | `b8_viterbi_accuracy_local_20260625` — no `_k` suffix |
 | `benchmark_git_commit` | `806f0748` |
 | `benchmark_k` column | absent |
@@ -30,7 +34,8 @@ The `benchmark_k` column exists because provenance sidecars do not survive a
 hand-copy across a repo boundary while a column does. That reasoning does not
 reach these tables: they predate the column, and since no command regenerates
 them, they can never acquire it in place. Any consumer that needs `k` alongside
-these rows must either read it from this file or re-harvest from a k-stamped
+these rows can read it from `provenance/run.provenance.json` (`metadata.unit`)
+or from this file, or re-harvest from a k-stamped
 run.
 
 Regenerating into `viterbi_accuracy_b8_k11/` and re-pointing the consumers is

--- a/benchmarking/viterbi_accuracy_benchmark.jl
+++ b/benchmarking/viterbi_accuracy_benchmark.jl
@@ -194,6 +194,7 @@ function main(args::Vector{String} = ARGS)::Nothing
             "load time. k is a process-launch parameter; run a new process with " *
             "--k $(requested.k) (or VITERBI_ACCURACY_K=$(requested.k)) instead.")
     end
+    _viterbi_accuracy_reject_unknown_args(args)
     output_dir = _viterbi_accuracy_arg_value(
         args, "--output-dir", _viterbi_accuracy_default_output_dir(VITERBI_ACCURACY_K)
     )
@@ -934,6 +935,18 @@ function _viterbi_accuracy_require_flag_value(
         args::Vector{String},
         flag::AbstractString
 )::String
+    # Duplicate detection lives HERE rather than beside any one flag, so it
+    # applies to every value-taking flag by construction. Two earlier rounds
+    # hardened one flag each and left the identical hole on the next one; the
+    # cycle only breaks when the guard is written once, over the parameter.
+    # Measured before this check: ["--output-dir","/a","--output-dir","/b"]
+    # returned "/a", so a wrapper appending its own --output-dir to a command
+    # that already carried one silently discarded the caller's directory and
+    # wrote into whatever the base command named.
+    occurrences = count(==(flag), args)
+    occurrences > 1 && error(
+        "$(flag) was given $(occurrences) times. Refusing to guess which one " *
+        "is authoritative; pass it exactly once.")
     index = findfirst(==(flag), args)
     isnothing(index) && return ""
     index == lastindex(args) && error(
@@ -959,6 +972,54 @@ function _viterbi_accuracy_arg_value(
 )::String
     value = _viterbi_accuracy_require_flag_value(args, flag)
     return isempty(value) ? string(default) : value
+end
+
+# Every flag this script understands. A closing whitelist, NOT another per-flag
+# guard: three consecutive rounds hardened one flag each and each time the same
+# harm reappeared on a spelling nobody had hardened yet. A whitelist over the
+# whole argument vector cannot be incomplete in that way -- an argument either
+# matches something here or it stops the run.
+#
+# What it closes, all measured silently succeeding before it existed:
+#
+#   --output-dir=/tmp/x   the INLINE form this file's own usage header
+#                         documents for --k=, silently ignored, so the run
+#                         landed in the default in-repo tree
+#   --outputdir /tmp/x    likewise
+#   --K 9  --k9  -k 9     every misspelling of --k ran at the default k
+#   --skip-plots=true     plots written anyway (membership test, not a prefix)
+#   --help / garbage      accepted, ran a full benchmark
+#
+# Each of those produced a complete, normal-looking run somewhere the operator
+# did not ask for -- verbatim the harm _viterbi_accuracy_require_flag_value
+# refuses for the one spelling it knows about.
+const VITERBI_ACCURACY_BOOLEAN_FLAGS = ("--skip-plots",)
+const VITERBI_ACCURACY_VALUE_FLAGS = ("--output-dir", "--k")
+
+function _viterbi_accuracy_reject_unknown_args(args::Vector{String})::Nothing
+    consumed = falses(length(args))
+    for (position, argument) in pairs(args)
+        consumed[position] && continue
+        if argument in VITERBI_ACCURACY_BOOLEAN_FLAGS
+            consumed[position] = true
+        elseif argument in VITERBI_ACCURACY_VALUE_FLAGS
+            consumed[position] = true
+            # The value was already validated by require_flag_value; here we
+            # only mark it consumed so it is not itself read as a flag.
+            position < lastindex(args) && (consumed[position + 1] = true)
+        elseif startswith(argument, "--k=")
+            consumed[position] = true
+        end
+    end
+    unknown = [args[position] for position in eachindex(args) if !consumed[position]]
+    isempty(unknown) && return nothing
+    error(
+        "unrecognized argument(s): $(join(map(repr, unknown), ", ")). " *
+        "This script accepts --k <n> / --k=<n>, --output-dir <path>, and " *
+        "--skip-plots. Refusing to run: an unrecognized argument silently " *
+        "produces a complete, normal-looking benchmark at the DEFAULT k in " *
+        "the DEFAULT output tree, which is indistinguishable from a run the " *
+        "operator meant to launch.")
 end
 
 if abspath(PROGRAM_FILE) == @__FILE__

--- a/benchmarking/viterbi_accuracy_benchmark.jl
+++ b/benchmarking/viterbi_accuracy_benchmark.jl
@@ -3,6 +3,22 @@
 # Usage:
 #   julia --project=. benchmarking/viterbi_accuracy_benchmark.jl
 #   julia --project=. benchmarking/viterbi_accuracy_benchmark.jl --output-dir /tmp/b8 --skip-plots
+#   julia --project=. benchmarking/viterbi_accuracy_benchmark.jl --k 9
+#   julia --project=. benchmarking/viterbi_accuracy_benchmark.jl --k=9
+#   VITERBI_ACCURACY_K=9 julia --project=. benchmarking/viterbi_accuracy_benchmark.jl
+#
+# k selection (default 11), in precedence order: `--k <int>`, `--k=<int>`, then the
+# VITERBI_ACCURACY_K environment variable. Every form is validated the same way — a
+# valueless `--k`, a non-integer, or k < 1 is a hard error, never a silent fallback to
+# the default (see `_viterbi_accuracy_k_from_args`).
+#
+# k is a PROCESS-LAUNCH parameter, resolved once at load time from this process's argv
+# and ENV. `main(args)` cannot change it and errors if its `args` request a different k;
+# to run a different k, launch a new process.
+#
+# The resolved k and the source it came from are printed as the first line of output, and
+# stamped into the run id, the default output directory, and a `benchmark_k` column on
+# every emitted table.
 
 import BioSequences
 import CairoMakie
@@ -24,22 +40,25 @@ const VITERBI_ACCURACY_ERROR_RATES = (0.01, 0.05, 0.10)
 # random-rewire null randomizes topology (vertices/edge-count/weight-multiset fixed).
 const VITERBI_NULL_SEED = 20260711
 const VITERBI_ACCURACY_FIXTURE_DIR = joinpath(@__DIR__, "fixtures", "viterbi_accuracy")
-const VITERBI_ACCURACY_DEFAULT_OUTPUT_DIR = joinpath(
+const VITERBI_ACCURACY_K_DEFAULT = 11
+const VITERBI_ACCURACY_K_ENV = "VITERBI_ACCURACY_K"
+# FROZEN. This is the pre-k-stamping historical run (committed k=11 artifacts,
+# run id "b8_viterbi_accuracy_local_20260625", cited by the manuscript repo).
+# No code path writes here any more — it is retained only so the committed
+# artifacts and the references to them keep resolving.
+const VITERBI_ACCURACY_HISTORICAL_OUTPUT_DIR = joinpath(
     @__DIR__, "results", "viterbi_accuracy_b8"
 )
-# k-stamped sibling of the default, used whenever k is not the historical 11 so
-# a k=9 run cannot silently overwrite the committed k=11 artifacts.
+# The default output directory is k-stamped UNCONDITIONALLY, including for
+# k=11. An earlier version special-cased k == 11 back onto the historical
+# directory above, which meant the DEFAULT invocation wrote into a directory of
+# git-tracked artifacts with no --force, no backup and no guard: it prevented
+# silent overwrite in one direction (k=9 could not clobber k=11) and left it
+# wide open in the other. Stamping every k makes each parameterization's
+# artifacts a distinct, non-colliding tree.
 function _viterbi_accuracy_default_output_dir(k::Integer)::String
-    return k == 11 ? VITERBI_ACCURACY_DEFAULT_OUTPUT_DIR :
-           joinpath(@__DIR__, "results", "viterbi_accuracy_b8_k$(k)")
+    return joinpath(@__DIR__, "results", "viterbi_accuracy_b8_k$(k)")
 end
-# PRIME k (was 9 = 3x3, the worst period-3 case). A composite k aliases
-# period-p tandem repeats onto self-overlapping k-mers, which can make single-k
-# correction look either trivially perfect or pathologically wrong; a prime k
-# breaks that periodicity. Matches the prime-only k progression the iterative
-# corrector uses (find_initial_k draws from Primes.primes; build_k_ladder and
-# next_prime_k snap to primes).
-#
 # k is selectable so the accuracy arm and its controls can be produced at the
 # SAME k. They diverged once -- the committed accuracy table was k=9 while the
 # over-correction and null tables were k=11 -- which made the controls describe
@@ -47,22 +66,95 @@ end
 # run, and stamping it into the run id and default output directory, means two
 # parameterizations can no longer overwrite or be mistaken for each other.
 #
-# This stays a `const`: Kmers.RNAKmer{K} / DNAKmer{K} take K as a TYPE
-# parameter, so it must be resolved at load time. Reading argv/ENV here keeps
-# that property while making the value selectable per process.
-function _viterbi_accuracy_k_at_load()::Int
-    index = findfirst(==("--k"), ARGS)
-    if !isnothing(index) && index < length(ARGS)
-        return parse(Int, ARGS[index + 1])
-    end
-    inline = findfirst(argument -> startswith(argument, "--k="), ARGS)
-    if !isnothing(inline)
-        return parse(Int, split(ARGS[inline], "="; limit = 2)[2])
-    end
-    return parse(Int, get(ENV, "VITERBI_ACCURACY_K", "11"))
+# k is a free per-run parameter, NOT constrained to primes. The default 11 is
+# chosen for continuity with the committed historical run; 9 is the manuscript's
+# PRE-REGISTERED PRIMARY and is a first-class value here, not a degraded case.
+# The project's own prime-vs-composite ablation
+# (benchmarking/results/rhizomorph_prime_k_ablation, run
+# prime_k_ablation_denovo_degree_repeatclass_20260712) recorded "no robust
+# prime-k advantage isolated from k-size ... factor-sharing composite k recover
+# within seed noise of size-matched coprime primes"; it bounds any
+# factor-sharing penalty below 0.20 rather than excluding an arbitrarily small
+# one. So primality earns no validation rule here.
+#
+# That ablation's separate odd-k note (an even-length DNA/RNA k-mer can equal
+# its own reverse complement) is also not enforced, for two reasons: these
+# fixtures are built in :singlestrand mode, where reverse complements are not
+# canonicalized, and one of the three fixtures is natural-language text with no
+# reverse complement at all. Both pre-registered values (9, 11) are odd anyway,
+# so an odd-only rule would be an untested constraint that changes nothing.
+#
+# k stays a `const`, but NOT because Kmers requires it: Kmers.DNAKmer{k} is
+# constructed from a runtime `Int` elsewhere in this package (see
+# src/sequence-comparison.jl, src/kmer-saturation-analysis.jl,
+# src/kmer-analysis.jl). The `const` is a TYPE STABILITY choice — a non-const
+# global would force the kmer type to be constructed dynamically at every call
+# site in this file. The consequence of binding it at load time is that k comes
+# from THIS PROCESS's argv/ENV: `--k` is a process-launch parameter, so
+# `main(args)` cannot change it (it errors if `args` disagree — see `main`).
+
+# Parse and validate one k value. Validation is deliberately minimal: has a
+# value, parses as an Int, and is >= 1. No odd-only or prime-only rule (see
+# above). The error names both the flag/variable and the offending value so a
+# misrouted shell expansion is identifiable from the message alone.
+function _viterbi_accuracy_parse_k(raw::AbstractString, source::AbstractString)::Int
+    parsed = tryparse(Int, strip(raw))
+    parsed === nothing && error("$(source) expects an integer, got $(repr(raw))")
+    parsed < 1 && error("$(source) must be >= 1, got $(parsed)")
+    return parsed
 end
 
-const VITERBI_ACCURACY_K = _viterbi_accuracy_k_at_load()
+# Returns `nothing` when the arguments do not select a k; otherwise (k, source).
+#
+# A bare trailing `--k` must ERROR, not fall back to the default. The realistic
+# trigger is shell expansion rather than a typo: unquoted `--k $K` with `K`
+# unset drops the empty word entirely, leaving `--k` as the last argument. A
+# silent fallback would then run k=11, write into the k=11 output tree, AND
+# record a `command_args` provenance line reading `--k 11` — a command line the
+# operator never typed, asserting an explicit request that was never made.
+function _viterbi_accuracy_k_from_args(args)
+    index = findfirst(==("--k"), args)
+    if !isnothing(index)
+        index == lastindex(args) && error(
+            "--k requires a value (got a bare trailing --k). Refusing to default to " *
+            "$(VITERBI_ACCURACY_K_DEFAULT): k selects the fixtures, the run id, the " *
+            "output directory and the recorded command line, so defaulting would " *
+            "publish a k=$(VITERBI_ACCURACY_K_DEFAULT) run whose provenance claims " *
+            "--k was explicitly requested.")
+        return (k = _viterbi_accuracy_parse_k(args[index + 1], "--k"), source = "--k")
+    end
+    inline = findfirst(argument -> startswith(argument, "--k="), args)
+    if !isnothing(inline)
+        value = split(args[inline], "="; limit = 2)[2]
+        return (k = _viterbi_accuracy_parse_k(value, "--k="), source = "--k=")
+    end
+    return nothing
+end
+
+# Full resolution: --k / --k= / VITERBI_ACCURACY_K / default, in that order.
+# `args` and `env` are parameters (not globals) so the resolution rules are
+# unit-testable without launching a process. A SET-BUT-EMPTY environment
+# variable is an explicit selection of "" and errors; it is NOT the default
+# path, which is reached only when the variable is absent.
+function _viterbi_accuracy_resolve_k(args = ARGS, env = ENV)
+    from_args = _viterbi_accuracy_k_from_args(args)
+    isnothing(from_args) || return from_args
+    if haskey(env, VITERBI_ACCURACY_K_ENV)
+        return (
+            k = _viterbi_accuracy_parse_k(env[VITERBI_ACCURACY_K_ENV], VITERBI_ACCURACY_K_ENV),
+            source = VITERBI_ACCURACY_K_ENV
+        )
+    end
+    return (k = VITERBI_ACCURACY_K_DEFAULT, source = "default")
+end
+
+function _viterbi_accuracy_k_at_load(args = ARGS, env = ENV)::Int
+    return _viterbi_accuracy_resolve_k(args, env).k
+end
+
+const _VITERBI_ACCURACY_K_RESOLUTION = _viterbi_accuracy_resolve_k()
+const VITERBI_ACCURACY_K = _VITERBI_ACCURACY_K_RESOLUTION.k
+const VITERBI_ACCURACY_K_SOURCE = _VITERBI_ACCURACY_K_RESOLUTION.source
 
 struct ViterbiAccuracyFixture
     dataset_id::String
@@ -75,10 +167,28 @@ struct ViterbiAccuracyFixture
 end
 
 function main(args::Vector{String} = ARGS)::Nothing
+    # `--k` is a PROCESS-LAUNCH parameter: it was resolved at load time from this
+    # process's global ARGS/ENV, so a `--k` inside a caller-supplied `args` vector
+    # arrives too late to take effect. Without this check `main(["--k", "9"])` would
+    # honour `--output-dir` from the same vector while silently dropping `--k`, and
+    # return k=11 tables to a caller who believes they asked for 9. Error instead.
+    requested = _viterbi_accuracy_k_from_args(args)
+    if !isnothing(requested) && requested.k != VITERBI_ACCURACY_K
+        error(
+            "main() received $(requested.source) $(requested.k) but k was already " *
+            "bound to $(VITERBI_ACCURACY_K) (source: $(VITERBI_ACCURACY_K_SOURCE)) at " *
+            "load time. k is a process-launch parameter; run a new process with " *
+            "--k $(requested.k) (or VITERBI_ACCURACY_K=$(requested.k)) instead.")
+    end
     output_dir = _viterbi_accuracy_arg_value(
         args, "--output-dir", _viterbi_accuracy_default_output_dir(VITERBI_ACCURACY_K)
     )
     write_plots = !("--skip-plots" in args)
+    # Print k FIRST. Without it nothing on stdout distinguishes "asked for 9, got
+    # 11" from "asked for 11" — the four paths below are byte-identical in both
+    # cases once k resolves to the same value.
+    println("B8 Viterbi accuracy benchmark: k = $(VITERBI_ACCURACY_K) " *
+            "(source: $(VITERBI_ACCURACY_K_SOURCE))")
     artifacts = run_viterbi_accuracy_benchmark(output_dir; write_plots = write_plots)
     println("Wrote B8 Viterbi accuracy benchmark artifacts:")
     println("  root: $(artifacts.root)")
@@ -105,7 +215,7 @@ function run_viterbi_accuracy_benchmark(
 
     # Control A (over-correction on un-corrupted input) and Control B (shuffled-
     # edge-weight null) — the two controls the manuscript flags as missing next
-    # to the recall table. Same fixtures, same prime k, same corrector.
+    # to the recall table. Same fixtures, same k, same corrector.
     overcorrection_rows = NamedTuple[]
     null_rows = NamedTuple[]
     for fixture in fixtures
@@ -117,10 +227,12 @@ function run_viterbi_accuracy_benchmark(
     overcorrection = DataFrames.DataFrame(overcorrection_rows)
     null_control = DataFrames.DataFrame(null_rows)
 
-    # Stamp k into every row. The sidecar provenance JSON already records it,
-    # but three independent readers reconstructed k by dividing position counts
-    # by observation counts because they read the .csv and never opened the
-    # sidecar beside it. A column costs nothing and removes the inference.
+    # Stamp k into every row. The sidecar provenance JSON already records it, but
+    # provenance is exactly what gets dropped when a table is hand-copied across a
+    # repo boundary — and this table is: the manuscript repo keeps its own copy
+    # under manuscript/figure-data/ and renders figures from that copy, not from
+    # this tree. A COLUMN survives a manual copy of the .csv; a SIDECAR beside it
+    # does not. The column costs nothing and makes k travel with the numbers.
     for table in (summary, overcorrection, null_control)
         table[!, :benchmark_k] = fill(VITERBI_ACCURACY_K, DataFrames.nrow(table))
     end
@@ -138,9 +250,7 @@ function run_viterbi_accuracy_benchmark(
         run_id = "b8_viterbi_accuracy_local_20260625_k$(VITERBI_ACCURACY_K)",
         scale = "local-smoke",
         dataset_ids = [fixture.dataset_id for fixture in fixtures],
-        command_args = [
-            "julia", "--project=.", "benchmarking/viterbi_accuracy_benchmark.jl",
-            "--k", string(VITERBI_ACCURACY_K)],
+        command_args = _viterbi_accuracy_command_args(),
         metadata = Dict(
             "bead" => "td-he0z.9",
             "benchmark" => "generalized_viterbi_accuracy_vs_error_rate",
@@ -150,6 +260,9 @@ function run_viterbi_accuracy_benchmark(
             "unit" => "fixed-length $(VITERBI_ACCURACY_K)-mers/ngrams",
             # k as a first-class field, not only embedded in the unit string.
             "k" => VITERBI_ACCURACY_K,
+            # How k was selected: "--k", "--k=", "VITERBI_ACCURACY_K", or
+            # "default". Distinguishes an explicit request from an inherited one.
+            "k_source" => VITERBI_ACCURACY_K_SOURCE,
             "controls" => Dict(
                 "over_correction_uncorrupted" => "corrector run on uncorrupted truth; any edit is a false positive",
                 "shuffled_weight_null" => "edge weights permuted (seed $(VITERBI_NULL_SEED)); topology/emission held fixed",
@@ -766,6 +879,22 @@ function _write_viterbi_control_figure(
     CairoMakie.save(png_path, fig)
     CairoMakie.save(svg_path, fig)
     return (png = png_path, svg = svg_path)
+end
+
+# The recorded command line must reflect how k was ACTUALLY selected. Emitting
+# `--k <k>` unconditionally asserted an explicit flag even when k came from the
+# environment or from the default — a command line the operator never typed.
+# k itself is recorded unambiguously in the `k` metadata field either way.
+function _viterbi_accuracy_command_args()::Vector{String}
+    base = ["julia", "--project=.", "benchmarking/viterbi_accuracy_benchmark.jl"]
+    if VITERBI_ACCURACY_K_SOURCE == "--k"
+        return vcat(base, ["--k", string(VITERBI_ACCURACY_K)])
+    elseif VITERBI_ACCURACY_K_SOURCE == "--k="
+        return vcat(base, ["--k=$(VITERBI_ACCURACY_K)"])
+    elseif VITERBI_ACCURACY_K_SOURCE == VITERBI_ACCURACY_K_ENV
+        return vcat(["$(VITERBI_ACCURACY_K_ENV)=$(VITERBI_ACCURACY_K)"], base)
+    end
+    return base
 end
 
 function _viterbi_accuracy_arg_value(

--- a/benchmarking/viterbi_accuracy_benchmark.jl
+++ b/benchmarking/viterbi_accuracy_benchmark.jl
@@ -27,13 +27,42 @@ const VITERBI_ACCURACY_FIXTURE_DIR = joinpath(@__DIR__, "fixtures", "viterbi_acc
 const VITERBI_ACCURACY_DEFAULT_OUTPUT_DIR = joinpath(
     @__DIR__, "results", "viterbi_accuracy_b8"
 )
+# k-stamped sibling of the default, used whenever k is not the historical 11 so
+# a k=9 run cannot silently overwrite the committed k=11 artifacts.
+function _viterbi_accuracy_default_output_dir(k::Integer)::String
+    return k == 11 ? VITERBI_ACCURACY_DEFAULT_OUTPUT_DIR :
+           joinpath(@__DIR__, "results", "viterbi_accuracy_b8_k$(k)")
+end
 # PRIME k (was 9 = 3x3, the worst period-3 case). A composite k aliases
 # period-p tandem repeats onto self-overlapping k-mers, which can make single-k
 # correction look either trivially perfect or pathologically wrong; a prime k
 # breaks that periodicity. Matches the prime-only k progression the iterative
 # corrector uses (find_initial_k draws from Primes.primes; build_k_ladder and
 # next_prime_k snap to primes).
-const VITERBI_ACCURACY_K = 11
+#
+# k is selectable so the accuracy arm and its controls can be produced at the
+# SAME k. They diverged once -- the committed accuracy table was k=9 while the
+# over-correction and null tables were k=11 -- which made the controls describe
+# a different graph from the result they were reported against. Selecting k per
+# run, and stamping it into the run id and default output directory, means two
+# parameterizations can no longer overwrite or be mistaken for each other.
+#
+# This stays a `const`: Kmers.RNAKmer{K} / DNAKmer{K} take K as a TYPE
+# parameter, so it must be resolved at load time. Reading argv/ENV here keeps
+# that property while making the value selectable per process.
+function _viterbi_accuracy_k_at_load()::Int
+    index = findfirst(==("--k"), ARGS)
+    if !isnothing(index) && index < length(ARGS)
+        return parse(Int, ARGS[index + 1])
+    end
+    inline = findfirst(argument -> startswith(argument, "--k="), ARGS)
+    if !isnothing(inline)
+        return parse(Int, split(ARGS[inline], "="; limit = 2)[2])
+    end
+    return parse(Int, get(ENV, "VITERBI_ACCURACY_K", "11"))
+end
+
+const VITERBI_ACCURACY_K = _viterbi_accuracy_k_at_load()
 
 struct ViterbiAccuracyFixture
     dataset_id::String
@@ -46,7 +75,9 @@ struct ViterbiAccuracyFixture
 end
 
 function main(args::Vector{String} = ARGS)::Nothing
-    output_dir = _viterbi_accuracy_arg_value(args, "--output-dir", VITERBI_ACCURACY_DEFAULT_OUTPUT_DIR)
+    output_dir = _viterbi_accuracy_arg_value(
+        args, "--output-dir", _viterbi_accuracy_default_output_dir(VITERBI_ACCURACY_K)
+    )
     write_plots = !("--skip-plots" in args)
     artifacts = run_viterbi_accuracy_benchmark(output_dir; write_plots = write_plots)
     println("Wrote B8 Viterbi accuracy benchmark artifacts:")
@@ -58,7 +89,7 @@ function main(args::Vector{String} = ARGS)::Nothing
 end
 
 function run_viterbi_accuracy_benchmark(
-        output_dir::AbstractString = VITERBI_ACCURACY_DEFAULT_OUTPUT_DIR;
+        output_dir::AbstractString = _viterbi_accuracy_default_output_dir(VITERBI_ACCURACY_K);
         write_plots::Bool = true
 )::NamedTuple
     fixtures = viterbi_accuracy_fixtures()
@@ -86,6 +117,14 @@ function run_viterbi_accuracy_benchmark(
     overcorrection = DataFrames.DataFrame(overcorrection_rows)
     null_control = DataFrames.DataFrame(null_rows)
 
+    # Stamp k into every row. The sidecar provenance JSON already records it,
+    # but three independent readers reconstructed k by dividing position counts
+    # by observation counts because they read the .csv and never opened the
+    # sidecar beside it. A column costs nothing and removes the inference.
+    for table in (summary, overcorrection, null_control)
+        table[!, :benchmark_k] = fill(VITERBI_ACCURACY_K, DataFrames.nrow(table))
+    end
+
     artifacts = write_benchmark_artifacts(
         [
             "viterbi_accuracy_summary" => summary,
@@ -93,11 +132,15 @@ function run_viterbi_accuracy_benchmark(
             "viterbi_null_control_summary" => null_control
         ];
         output_dir = output_dir,
-        run_id = "b8_viterbi_accuracy_local_20260625",
+        # The run id carries k. Both the k=9 and k=11 arms previously shared
+        # "b8_viterbi_accuracy_local_20260625", so the id could not distinguish
+        # two parameterizations that disagree row-for-row.
+        run_id = "b8_viterbi_accuracy_local_20260625_k$(VITERBI_ACCURACY_K)",
         scale = "local-smoke",
         dataset_ids = [fixture.dataset_id for fixture in fixtures],
         command_args = [
-            "julia", "--project=.", "benchmarking/viterbi_accuracy_benchmark.jl"],
+            "julia", "--project=.", "benchmarking/viterbi_accuracy_benchmark.jl",
+            "--k", string(VITERBI_ACCURACY_K)],
         metadata = Dict(
             "bead" => "td-he0z.9",
             "benchmark" => "generalized_viterbi_accuracy_vs_error_rate",
@@ -105,6 +148,8 @@ function run_viterbi_accuracy_benchmark(
             "error_rates" => collect(VITERBI_ACCURACY_ERROR_RATES),
             "fixture_dir" => relpath(VITERBI_ACCURACY_FIXTURE_DIR, @__DIR__),
             "unit" => "fixed-length $(VITERBI_ACCURACY_K)-mers/ngrams",
+            # k as a first-class field, not only embedded in the unit string.
+            "k" => VITERBI_ACCURACY_K,
             "controls" => Dict(
                 "over_correction_uncorrupted" => "corrector run on uncorrupted truth; any edit is a false positive",
                 "shuffled_weight_null" => "edge weights permuted (seed $(VITERBI_NULL_SEED)); topology/emission held fixed",

--- a/benchmarking/viterbi_accuracy_benchmark.jl
+++ b/benchmarking/viterbi_accuracy_benchmark.jl
@@ -113,6 +113,20 @@ end
 # record a `command_args` provenance line reading `--k 11` — a command line the
 # operator never typed, asserting an explicit request that was never made.
 function _viterbi_accuracy_k_from_args(args)
+    # A repeated --k must ERROR rather than resolve. `findfirst` below is
+    # first-wins, which inverts the usual last-wins CLI convention: a wrapper
+    # appending `--k $K` to a base command that already carries `--k 11` would
+    # silently run at 11 and discard the caller's value, then record a
+    # single-flag command line that was never typed. Counting both spellings
+    # also removes the form-dependent precedence (`--k=9 --k 13` and
+    # `--k 13 --k=9` both resolved to 13, because the flag form was consulted
+    # first regardless of position).
+    selections = count(
+        argument -> argument == "--k" || startswith(argument, "--k="), args)
+    selections > 1 && error(
+        "--k was given $(selections) times. Refusing to guess which one is " *
+        "authoritative: k selects the fixtures, the run id, the output " *
+        "directory and the recorded command line. Pass it exactly once.")
     index = findfirst(==("--k"), args)
     if !isnothing(index)
         index == lastindex(args) && error(
@@ -897,16 +911,54 @@ function _viterbi_accuracy_command_args()::Vector{String}
     return base
 end
 
+# Value-taking flags other than --k. This is held to the SAME standard as the
+# k parser above, because the argument for strictness there applies here
+# unchanged and the two live in one file.
+#
+# The previous version returned the default on a bare trailing flag and did no
+# validation at all on the value. Three measured failures, all reachable from
+# ordinary shell quoting accidents:
+#
+#   --output-dir                 -> silently the default directory
+#   --output-dir ""              -> abspath("") is the CWD, so the artifact
+#                                   tree (tables/, plots/, logs/, provenance/,
+#                                   artifact-index.json) was created in the
+#                                   REPO ROOT for the documented invocation
+#   --output-dir --skip-plots    -> the next flag consumed as a path, and
+#                                   --skip-plots silently not applied
+#
+# The empty-value case is the one worth naming: unquoted `--output-dir $DIR`
+# with DIR unset drops the word and gives case 1, quoted `--output-dir "$DIR"`
+# gives case 2. Both look like a normal run.
+function _viterbi_accuracy_require_flag_value(
+        args::Vector{String},
+        flag::AbstractString
+)::String
+    index = findfirst(==(flag), args)
+    isnothing(index) && return ""
+    index == lastindex(args) && error(
+        "$(flag) requires a value (got a bare trailing $(flag)). Refusing to " *
+        "fall back to the default: a silent fallback writes a complete, " *
+        "normal-looking run somewhere the operator did not ask for.")
+    value = args[index + 1]
+    isempty(strip(value)) && error(
+        "$(flag) was given an empty value. Refusing to continue: an empty " *
+        "path resolves to the current working directory, which for the " *
+        "documented invocation is the repository root.")
+    startswith(value, "--") && error(
+        "$(flag) was given $(repr(value)), which is another flag. Refusing to " *
+        "treat a flag as this flag's value; that would also drop " *
+        "$(repr(value)) silently.")
+    return value
+end
+
 function _viterbi_accuracy_arg_value(
         args::Vector{String},
         flag::AbstractString,
         default::AbstractString
 )::String
-    index = findfirst(==(flag), args)
-    if isnothing(index) || index == length(args)
-        return string(default)
-    end
-    return args[index + 1]
+    value = _viterbi_accuracy_require_flag_value(args, flag)
+    return isempty(value) ? string(default) : value
 end
 
 if abspath(PROGRAM_FILE) == @__FILE__

--- a/test/4_assembly/viterbi_accuracy_benchmark_test.jl
+++ b/test/4_assembly/viterbi_accuracy_benchmark_test.jl
@@ -14,6 +14,14 @@ import Test
 include(joinpath(@__DIR__, "..", "..", "benchmarking", "viterbi_accuracy_benchmark.jl"))
 
 Test.@testset "B8 Viterbi accuracy benchmark artifacts" begin
+    # AMBIENT-ENVIRONMENT GUARD. k is bound at load time from this process's
+    # argv/ENV, so an exported VITERBI_ACCURACY_K (or a stray --k on the test
+    # runner's command line) would silently change WHICH parameterization this
+    # suite measures while every assertion below still passed. Pin it: this
+    # testset asserts the k=11 numbers, so it must be running at k=11.
+    Test.@test VITERBI_ACCURACY_K == 11
+    Test.@test VITERBI_ACCURACY_K_SOURCE == "default"
+
     output_dir = mktempdir(prefix = "viterbi_accuracy_b8_test_")
     artifacts = run_viterbi_accuracy_benchmark(output_dir; write_plots = false)
     summary = CSV.read(artifacts.summary_csv, DataFrames.DataFrame)
@@ -31,6 +39,16 @@ Test.@testset "B8 Viterbi accuracy benchmark artifacts" begin
     Test.@test isfile(artifacts.index)
     Test.@test isfile(artifacts.provenance)
 
+    # k is stamped into the emitted rows and into the run id, so a reader of the
+    # .csv alone (the manuscript repo reads a hand-copied .csv, not the sidecar)
+    # can tell which parameterization produced it. Asserted against the LITERAL
+    # 11, never against VITERBI_ACCURACY_K — comparing the column to the constant
+    # that filled it is self-referential and would pass at any k, including a k
+    # inherited from an ambient environment variable.
+    Test.@test "benchmark_k" in DataFrames.names(summary)
+    Test.@test all(summary.benchmark_k .== 11)
+    Test.@test all(endswith.(summary.benchmark_run_id, "_k11"))
+
     # Control A — over-correction on un-corrupted input.
     overcorrection = CSV.read(artifacts.overcorrection_csv, DataFrames.DataFrame)
     Test.@test artifacts.overcorrection_rows == 9
@@ -38,6 +56,8 @@ Test.@testset "B8 Viterbi accuracy benchmark artifacts" begin
     Test.@test all(overcorrection.injected_error_count .== 0)
     Test.@test all(overcorrection.over_correction_edit_distance .>= 0)
     Test.@test all(0.0 .<= overcorrection.over_correction_rate .<= 1.0)
+    Test.@test "benchmark_k" in DataFrames.names(overcorrection)
+    Test.@test all(overcorrection.benchmark_k .== 11)
     # Cross-field accounting invariant: a row has zero changed observations iff it
     # has zero over-correction edit distance. Exercises the numerator logic even
     # though every observed row is the (expected) zero case — a mis-indexed or
@@ -55,6 +75,8 @@ Test.@testset "B8 Viterbi accuracy benchmark artifacts" begin
     Test.@test artifacts.null_control_rows == 9
     Test.@test DataFrames.nrow(null_control) == 9
     Test.@test all(null_control.null_seed .== 20260711)
+    Test.@test "benchmark_k" in DataFrames.names(null_control)
+    Test.@test all(null_control.benchmark_k .== 11)
     for col in (:real_injected_error_recall, :weight_null_injected_error_recall,
         :rewire_null_injected_error_recall)
         Test.@test all(0.0 .<= null_control[!, col] .<= 1.0)
@@ -78,6 +100,96 @@ Test.@testset "B8 Viterbi accuracy benchmark artifacts" begin
     # the portable "null <= real" invariant above carries over unchanged.
     Test.@test Statistics.mean(null_control.rewire_null_injected_error_recall) == 0.0
     Test.@test all(.!null_control.rewire_null_decoded)
+end
+
+Test.@testset "k selection is validated, never silently defaulted" begin
+    # The parser takes `args`/`env` as parameters precisely so these rules can be
+    # exercised without launching a process. Every case below is a wrong-answer
+    # path, not a usability nicety: k selects the fixtures, the run id, the output
+    # directory and the recorded command line, so a silent fallback publishes one
+    # parameterization's numbers under another's identity.
+    no_env = Dict{String, String}()
+
+    # Value forms resolve, and report which form won.
+    Test.@test _viterbi_accuracy_k_at_load(["--k", "13"], no_env) == 13
+    Test.@test _viterbi_accuracy_k_at_load(["--k=13"], no_env) == 13
+    Test.@test _viterbi_accuracy_resolve_k(["--k", "13"], no_env).source == "--k"
+    Test.@test _viterbi_accuracy_resolve_k(["--k=13"], no_env).source == "--k="
+
+    # A bare trailing `--k` must ERROR. The realistic trigger is an unquoted
+    # `--k $K` with K unset: the empty word disappears and `--k` lands last.
+    Test.@test_throws ErrorException _viterbi_accuracy_k_at_load(["--k"], no_env)
+    Test.@test_throws ErrorException _viterbi_accuracy_k_at_load(
+        ["--output-dir", "/tmp/b8", "--skip-plots", "--k"], no_env)
+
+    # Non-integer and out-of-range values error rather than defaulting.
+    Test.@test_throws ErrorException _viterbi_accuracy_k_at_load(["--k", "abc"], no_env)
+    Test.@test_throws ErrorException _viterbi_accuracy_k_at_load(["--k", "0"], no_env)
+    Test.@test_throws ErrorException _viterbi_accuracy_k_at_load(["--k", "-3"], no_env)
+    Test.@test_throws ErrorException _viterbi_accuracy_k_at_load(["--k=abc"], no_env)
+    Test.@test_throws ErrorException _viterbi_accuracy_k_at_load(["--k=0"], no_env)
+    # `--k` followed by the NEXT flag is a missing value, not a value of "--skip-plots".
+    Test.@test_throws ErrorException _viterbi_accuracy_k_at_load(["--k", "--skip-plots"], no_env)
+
+    # No selection at all is the only path to the default.
+    Test.@test _viterbi_accuracy_k_at_load(String[], no_env) == 11
+    Test.@test _viterbi_accuracy_resolve_k(String[], no_env).source == "default"
+    Test.@test _viterbi_accuracy_k_at_load(["--skip-plots"], no_env) == 11
+
+    # Environment variable: honoured, validated, and outranked by the flag.
+    Test.@test _viterbi_accuracy_k_at_load(String[], Dict("VITERBI_ACCURACY_K" => "9")) == 9
+    Test.@test _viterbi_accuracy_resolve_k(
+        String[], Dict("VITERBI_ACCURACY_K" => "9")).source == "VITERBI_ACCURACY_K"
+    Test.@test _viterbi_accuracy_k_at_load(
+        ["--k", "13"], Dict("VITERBI_ACCURACY_K" => "9")) == 13
+    # SET BUT EMPTY is an explicit selection of "", not the default path — the
+    # form an unset shell variable produces under `VITERBI_ACCURACY_K="$K"`.
+    Test.@test_throws ErrorException _viterbi_accuracy_k_at_load(
+        String[], Dict("VITERBI_ACCURACY_K" => ""))
+    Test.@test_throws ErrorException _viterbi_accuracy_k_at_load(
+        String[], Dict("VITERBI_ACCURACY_K" => "abc"))
+    Test.@test_throws ErrorException _viterbi_accuracy_k_at_load(
+        String[], Dict("VITERBI_ACCURACY_K" => "0"))
+end
+
+Test.@testset "default output directory is k-stamped unconditionally" begin
+    # Every k gets its own tree, INCLUDING the default 11. The earlier k == 11
+    # special case pointed the default invocation at the committed historical
+    # directory, so the most common command overwrote git-tracked artifacts with
+    # no --force and no backup. Expected values are pinned literally: comparing
+    # the function to a re-derivation of itself would pass under that mutation.
+    Test.@test basename(_viterbi_accuracy_default_output_dir(11)) ==
+               "viterbi_accuracy_b8_k11"
+    Test.@test basename(_viterbi_accuracy_default_output_dir(9)) ==
+               "viterbi_accuracy_b8_k9"
+    Test.@test _viterbi_accuracy_default_output_dir(9) !=
+               _viterbi_accuracy_default_output_dir(11)
+    # The historical directory is frozen: no k resolves onto it.
+    Test.@test basename(VITERBI_ACCURACY_HISTORICAL_OUTPUT_DIR) == "viterbi_accuracy_b8"
+    Test.@test _viterbi_accuracy_default_output_dir(11) !=
+               VITERBI_ACCURACY_HISTORICAL_OUTPUT_DIR
+    Test.@test _viterbi_accuracy_default_output_dir(9) !=
+               VITERBI_ACCURACY_HISTORICAL_OUTPUT_DIR
+end
+
+Test.@testset "main() refuses a --k it cannot honour" begin
+    # k is bound at load time from the process's argv/ENV, so a `--k` inside a
+    # caller-supplied args vector arrives too late. Silently dropping it would
+    # return k=11 tables to a caller who asked for 9 while `--output-dir` from
+    # the SAME vector was honoured. The check runs before any benchmark work.
+    Test.@test_throws ErrorException main(["--k", "9", "--skip-plots"])
+    Test.@test_throws ErrorException main(["--k=9", "--skip-plots"])
+    # Same validation as at load time, so a bad value cannot slip through here.
+    Test.@test_throws ErrorException main(["--k"])
+    Test.@test_throws ErrorException main(["--k", "abc"])
+end
+
+Test.@testset "recorded command line reflects how k was selected" begin
+    # The suite runs with no --k and no VITERBI_ACCURACY_K, so the provenance
+    # command line must NOT assert a --k the operator never typed.
+    Test.@test VITERBI_ACCURACY_K_SOURCE == "default"
+    Test.@test !("--k" in _viterbi_accuracy_command_args())
+    Test.@test !any(startswith.(_viterbi_accuracy_command_args(), "--k="))
 end
 
 Test.@testset "shuffled-weight null preserves topology + weight multiset" begin

--- a/test/4_assembly/viterbi_accuracy_benchmark_test.jl
+++ b/test/4_assembly/viterbi_accuracy_benchmark_test.jl
@@ -13,12 +13,29 @@ import Test
 
 include(joinpath(@__DIR__, "..", "..", "benchmarking", "viterbi_accuracy_benchmark.jl"))
 
+# AMBIENT-ENVIRONMENT GUARD -- TERMINAL, and deliberately not a `Test.@test`.
+#
+# k is bound at load time from this process's argv/ENV, so an exported
+# VITERBI_ACCURACY_K (or a stray --k on the test runner's command line) would
+# silently change WHICH parameterization this suite measures while every
+# assertion below still passed. This suite asserts the k=11 numbers.
+#
+# It must ERROR rather than record a failure, because a `Test.@test` is
+# advisory: execution continues past it. The `main()` refusal testset below
+# asserts that `main(["--k", "9", ...])` throws -- which it does only when 9
+# disagrees with the load-time k. Under an exported VITERBI_ACCURACY_K=9 the
+# disagreement vanishes, no error is raised, and `main` falls through to TWO
+# full B8 executions that write into benchmarking/results/ inside the repo. A
+# guard whose downstream consumer depends on it being enforcing cannot be
+# fail-open, so this runs before any testset and stops the file.
+VITERBI_ACCURACY_K == 11 || error(
+    "This suite asserts the k=11 numbers but loaded k=$(VITERBI_ACCURACY_K) " *
+    "(source: $(VITERBI_ACCURACY_K_SOURCE)). Refusing to run: the assertions " *
+    "below would measure a different parameterization, and the main() refusal " *
+    "test would execute the benchmark instead of throwing. Unset " *
+    "VITERBI_ACCURACY_K and remove any --k from the test command line.")
+
 Test.@testset "B8 Viterbi accuracy benchmark artifacts" begin
-    # AMBIENT-ENVIRONMENT GUARD. k is bound at load time from this process's
-    # argv/ENV, so an exported VITERBI_ACCURACY_K (or a stray --k on the test
-    # runner's command line) would silently change WHICH parameterization this
-    # suite measures while every assertion below still passed. Pin it: this
-    # testset asserts the k=11 numbers, so it must be running at k=11.
     Test.@test VITERBI_ACCURACY_K == 11
     Test.@test VITERBI_ACCURACY_K_SOURCE == "default"
 
@@ -150,6 +167,46 @@ Test.@testset "k selection is validated, never silently defaulted" begin
         String[], Dict("VITERBI_ACCURACY_K" => "abc"))
     Test.@test_throws ErrorException _viterbi_accuracy_k_at_load(
         String[], Dict("VITERBI_ACCURACY_K" => "0"))
+    # Empty INLINE form -- what unquoted `--k=$K` produces with K unset.
+    Test.@test_throws ErrorException _viterbi_accuracy_k_at_load(
+        ["--k="], Dict{String, String}())
+    # A REPEATED --k must error rather than resolve. Left unguarded this is
+    # first-wins, so a wrapper appending --k to a command that already carries
+    # one would silently discard the caller's value and then record a
+    # single-flag command line that was never typed. Both spellings count, in
+    # every combination, because precedence was previously form-dependent
+    # rather than positional.
+    for duplicate in (
+        ["--k", "9", "--k", "13"],
+        ["--k=9", "--k=13"],
+        ["--k=9", "--k", "13"],
+        ["--k", "13", "--k=9"])
+        Test.@test_throws ErrorException _viterbi_accuracy_k_at_load(
+            duplicate, Dict{String, String}())
+    end
+end
+
+Test.@testset "value-taking flags are validated, never silently defaulted" begin
+    # --output-dir is held to the same standard as --k. Each case below was
+    # measured against the previous implementation and silently succeeded:
+    # a bare trailing flag fell back to the default directory, an empty value
+    # resolved through abspath("") to the CWD (the repository root for the
+    # documented invocation), and a following flag was consumed as the path
+    # while itself being dropped.
+    Test.@test_throws ErrorException _viterbi_accuracy_arg_value(
+        ["--skip-plots", "--output-dir"], "--output-dir", "/tmp/fallback")
+    Test.@test_throws ErrorException _viterbi_accuracy_arg_value(
+        ["--output-dir", ""], "--output-dir", "/tmp/fallback")
+    Test.@test_throws ErrorException _viterbi_accuracy_arg_value(
+        ["--output-dir", "   "], "--output-dir", "/tmp/fallback")
+    Test.@test_throws ErrorException _viterbi_accuracy_arg_value(
+        ["--output-dir", "--skip-plots"], "--output-dir", "/tmp/fallback")
+    # Absent flag still yields the default; a real value is returned verbatim.
+    Test.@test _viterbi_accuracy_arg_value(
+        ["--skip-plots"], "--output-dir", "/tmp/fallback") == "/tmp/fallback"
+    Test.@test _viterbi_accuracy_arg_value(
+        ["--output-dir", "/tmp/real"], "--output-dir", "/tmp/fallback") ==
+               "/tmp/real"
 end
 
 Test.@testset "default output directory is k-stamped unconditionally" begin

--- a/test/4_assembly/viterbi_accuracy_benchmark_test.jl
+++ b/test/4_assembly/viterbi_accuracy_benchmark_test.jl
@@ -207,6 +207,47 @@ Test.@testset "value-taking flags are validated, never silently defaulted" begin
     Test.@test _viterbi_accuracy_arg_value(
         ["--output-dir", "/tmp/real"], "--output-dir", "/tmp/fallback") ==
                "/tmp/real"
+    # Duplicate detection is defined over the FLAG PARAMETER, so it covers every
+    # value-taking flag rather than the one it was written for. Before this,
+    # a repeated --output-dir was silently first-wins: the wrapper-append shape
+    # below dropped the caller's directory and wrote to the base command's.
+    Test.@test_throws ErrorException _viterbi_accuracy_arg_value(
+        ["--output-dir", "/a", "--output-dir", "/b"], "--output-dir", "/tmp/fb")
+    Test.@test_throws ErrorException _viterbi_accuracy_arg_value(
+        ["--output-dir", "/repo/results", "--k", "9", "--output-dir", "/scratch/mine"],
+        "--output-dir", "/tmp/fb")
+end
+
+Test.@testset "unrecognized arguments stop the run" begin
+    # A closing whitelist, not a fourth per-flag guard. Each case below was
+    # measured silently producing a complete benchmark at the DEFAULT k in the
+    # DEFAULT in-repo tree, which is indistinguishable from an intended run.
+    #
+    # --output-dir=/tmp/x is the sharp one: the usage header documents the
+    # inline form for --k=, so an operator who generalizes it lands here.
+    for bad in (
+        ["--output-dir=/tmp/x"],
+        ["--outputdir", "/tmp/x"],
+        ["--K", "9"],
+        ["--k9"],
+        ["-k", "9"],
+        ["--skip-plots=true"],
+        ["--help"],
+        ["garbage"])
+        Test.@test_throws ErrorException _viterbi_accuracy_reject_unknown_args(bad)
+    end
+    # Everything the script really accepts must pass, including a value that
+    # looks like a flag-ish token but is positionally a consumed value.
+    for good in (
+        String[],
+        ["--skip-plots"],
+        ["--k", "9"],
+        ["--k=9"],
+        ["--output-dir", "/tmp/x"],
+        ["--k", "9", "--output-dir", "/tmp/x", "--skip-plots"],
+        ["--skip-plots", "--k=11", "--output-dir", "/tmp/x"])
+        Test.@test _viterbi_accuracy_reject_unknown_args(good) === nothing
+    end
 end
 
 Test.@testset "default output directory is k-stamped unconditionally" begin


### PR DESCRIPTION
## Summary

- Makes `k` selectable per B8 run via `--k` / `VITERBI_ACCURACY_K`, defaulting to 11 so existing invocations are unchanged.
- Stamps `k` into the run id, the default output directory, and a new `benchmark_k` column on all three tables.
- Motivated by a concrete divergence: the committed accuracy table was **k=9** while the over-correction and null tables were **k=11**, so the controls described a different graph — different observation counts, different injected substitutions — from the result they were reported against.

## Why the column, when the sidecar already recorded it

`provenance/*.provenance.json` already carried `metadata.unit = "fixed-length 11-mers/ngrams"`, and it was still missed. Three independent readers reconstructed k by dividing position counts by observation counts, because they read the `.csv` and never opened the provenance file beside it. Recording a fact is not the same as recording it where it will be read.

The run id is the other half: both arms shared `b8_viterbi_accuracy_local_20260625`, so the id could not distinguish two parameterizations that disagree row-for-row.

## Design note

`VITERBI_ACCURACY_K` stays a `const`. `Kmers.RNAKmer{K}` / `DNAKmer{K}` take `K` as a **type parameter**, so it must resolve at load time; reading argv/ENV at load preserves that while making the value selectable per process. A runtime variable would have forced a `Val{k}` function barrier or cost type stability.

## Test plan

- [x] File parses (`Meta.parse` over the whole source).
- [x] k-selection logic passes 8 cases: `--k 9`, `--k=9`, `--k` after another flag, ENV fallback, argv-beats-ENV, trailing `--k` with no value, unrelated flags ignored, default 11.
- [ ] Full 2×2 run (k=9 and k=11, each producing accuracy + over-correction + null tables) on Lawrencium — this is the workload the change exists to enable.

The benchmark is **not** run on the laptop; `[B]` workloads route to SLURM.

## Related

Unblocks the matched-k reconciliation for the Rhizomorph manuscript, where the k=9/k=11 split surfaced during figure review.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable `k` selection for Viterbi accuracy benchmarks via command-line options or environment settings.
  * Added validation for missing, invalid, nonpositive, or conflicting `k` values.
  * Benchmark outputs, run IDs, tables, metadata, and command provenance now record the selected `k`.

* **Bug Fixes**
  * Ensured benchmark execution consistently uses the resolved `k` value.
  * Prevented unsupported runtime `--k` arguments and ambiguous configurations.

* **Tests**
  * Added coverage for `k` parsing, precedence, validation, output naming, metadata, and provenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->