### PR TITLE
fix: pin XML to 0.4.4 — 0.4.5 breaks XLSX precompilation on every branch

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -81,6 +81,7 @@ UMAP = "c4f8c510-2410-5be4-91d7-4fbaeb39457e"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 XAM = "d759349c-bcba-11e9-07c2-5b90f8f05f7c"
 XLSX = "fdbf4ff8-1666-58a4-91e7-1b58723a45e0"
+XML = "72c71f33-b9b6-44de-8c94-c961784809e2"
 XMLDict = "228000da-037f-5747-90a9-8195ccbf91a5"
 uCSV = "e0b4c2ea-889f-54df-a5e0-fe74b3c892fd"
 
@@ -98,6 +99,26 @@ MyceliaKernelAbstractionsExt = "KernelAbstractions"
 Aqua = "0.8"
 KernelAbstractions = "0.9"
 UMAP = "0.1.11"
+# TRANSITIVE PIN, not a dependency we use. Mycelia never imports XML; it is
+# declared as a direct dep solely so this bound can constrain the XLSX -> XML
+# resolution.
+#
+# XML 0.4.5 (published 2026-08-13) replaced LazyNode child iteration with a
+# shared mutable cursor. XLSX's _collect_row_nodes retains child LazyNodes
+# across iteration, so under 0.4.5 it raises
+# "XLSXError: No `sheetData` node found in worksheet" from inside XLSX's own
+# @compile_workload -- i.e. XLSX fails to PRECOMPILE, which cascades to
+# FileIOExt and to Mycelia itself. XLSX 0.12.2 is the newest release and
+# declares XML = "0.4.4", which under Julia's caret default admits 0.4.5, so
+# the resolver picks up the breaking change automatically. Upstream states the
+# problem in XML.jl issue #124.
+#
+# This must be `=0.4.4`, NOT `~0.4.4`: Julia's tilde means [0.4.4, 0.5.0), which
+# still admits 0.4.5. Measured on Julia 1.10.11 with XLSX pinned to 0.12.2 --
+# XML 0.4.4 precompiles, XML 0.4.5 fails.
+#
+# Remove once XLSX ships a release that iterates defensively.
+XML = "=0.4.4"
 julia = "1.10"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -101,24 +101,66 @@ KernelAbstractions = "0.9"
 UMAP = "0.1.11"
 # TRANSITIVE PIN, not a dependency we use. Mycelia never imports XML; it is
 # declared as a direct dep solely so this bound can constrain the XLSX -> XML
-# resolution.
+# resolution. See the paired stale_deps entry in test/aqua.jl and the test that
+# couples the two, so that suppression cannot outlive this pin.
 #
-# XML 0.4.5 (published 2026-08-13) replaced LazyNode child iteration with a
-# shared mutable cursor. XLSX's _collect_row_nodes retains child LazyNodes
-# across iteration, so under 0.4.5 it raises
-# "XLSXError: No `sheetData` node found in worksheet" from inside XLSX's own
-# @compile_workload -- i.e. XLSX fails to PRECOMPILE, which cascades to
-# FileIOExt and to Mycelia itself. XLSX 0.12.2 is the newest release and
-# declares XML = "0.4.4", which under Julia's caret default admits 0.4.5, so
-# the resolver picks up the breaking change automatically. Upstream states the
-# problem in XML.jl issue #124.
+# SYMPTOM: XLSX fails to PRECOMPILE, raising
+# "XLSXError: No `sheetData` node found in worksheet" from inside its own
+# @compile_workload (XLSX.jl:91 -> read.jl). src/Mycelia.jl imports XLSX
+# unconditionally and XLSX is not a weakdep, so that failure necessarily takes
+# Mycelia with it -- which is why every branch went red at once with no code
+# change, and why even a tag push failed.
 #
-# This must be `=0.4.4`, NOT `~0.4.4`: Julia's tilde means [0.4.4, 0.5.0), which
-# still admits 0.4.5. Measured on Julia 1.10.11 with XLSX pinned to 0.12.2 --
-# XML 0.4.4 precompiles, XML 0.4.5 fails.
+# TRIGGER: XML 0.4.5, published 2026-08-13, hours after the last green run.
+# XLSX 0.12.2 (newest release) declares XML = "0.4.4", and Julia's caret default
+# makes that [0.4.4, 0.5.0), so the resolver takes 0.4.5 on its own. Manifest
+# files are gitignored, so every CI run resolves fresh and every branch picked
+# it up simultaneously.
 #
-# Remove once XLSX ships a release that iterates defensively.
-XML = "=0.4.4"
+# THIS IS A JULIA 1.10 FAULT, NOT A UNIVERSAL ONE. That is the single most
+# useful fact for whoever removes this pin. Upstream JuliaData/XLSX.jl#448
+# reports a matrix with IDENTICAL resolved versions on all three:
+#     1.10.12 -> fails        1.11 -> passes        1.12 -> passes
+# (Linux, JULIA_NUM_THREADS unset, so not a thread-count effect.) We declare
+# julia = "1.10" = [1.10, 2.0), so this bound over-constrains 1.11 and 1.12
+# users for a fault they cannot hit. CI runs only `lts`, so CI structurally
+# cannot observe that 1.11+ is fine.
+#
+# MECHANISM: deliberately NOT asserted. XLSX's maintainer states on #448 that
+# 0.4.5 "may have inadvertently added a breaking change" and that "XML
+# downstream tests don't include julia LTS". Beyond that it is a
+# Julia-1.10-specific compilation difference in XML's token/substring handling,
+# which has NOT been independently isolated here.
+#
+# An earlier revision of this comment claimed the cause was a newly-introduced
+# shared mutable cursor plus a retained-child-node iteration in XLSX's
+# `_collect_row_nodes`, and cited XML.jl#124. All three were wrong, and each was
+# falsifiable in one local command: cursor.jl is BYTE-IDENTICAL between 0.4.4 and
+# 0.4.5 (so the sharing predates it), `_collect_row_nodes` has zero callers and
+# is dead code (so it cannot be the failure site), and #124 is a forward-looking
+# request to restore value semantics at the next BREAKING release, opened before
+# this breakage was reported. Recorded because a confident wrong mechanism in a
+# comment outlives the pin, and no test can contradict it.
+#
+# `=` IS REQUIRED; `~` IS NOT ENOUGH. Julia's tilde on a 0.x version means
+# [0.4.4, 0.5.0), which still admits 0.4.5. Measured on Julia 1.10.11 with XLSX
+# at 0.12.2: 0.4.4 precompiles, 0.4.5 fails, and `~0.4.4` resolves to 0.4.5 and
+# fails.
+#
+# The `0.4.6 - 0.4` half makes this SELF-HEALING: it blocks only the one known
+# bad version rather than freezing at 0.4.4 forever. The trade is deliberate --
+# it trusts a future 0.4.6 to carry the fix, and if it does not, CI goes red
+# loudly and immediately. That is a better failure mode than a bare `=0.4.4`,
+# which fails SILENTLY: it blocks the eventual fix and hard-constrains every
+# downstream consumer of Mycelia, with nothing to surface it. This repo has no
+# CompatHelper and no dependabot config, and an `=` bound is sticky against
+# CompatHelper even if one is added later.
+#
+# REMOVE WHEN: XML ships a release that precompiles XLSX on Julia 1.10, or
+# Mycelia drops Julia 1.10. NOT when XLSX.jl#446 lands -- that is an unrelated,
+# explicitly non-urgent request to make the row stream's resumption explicit,
+# and an earlier revision of this comment wrongly named it as the fix.
+XML = "=0.4.4, 0.4.6 - 0.4"
 julia = "1.10"
 
 [extras]

--- a/test/aqua.jl
+++ b/test/aqua.jl
@@ -30,7 +30,12 @@ Test.@testset "Aqua.jl" begin
         deps_compat = false,
         # BenchmarkTools is used by repo-level benchmarking scripts outside
         # the Mycelia module, so it is intentionally not loaded by the package.
-        stale_deps = (ignore = [:BenchmarkTools],),
+        #
+        # XML is a direct dep ONLY so that [compat] can pin the transitive
+        # XLSX -> XML resolution away from 0.4.5, which breaks XLSX's
+        # precompilation. Mycelia never imports it, so Aqua would otherwise
+        # correctly flag it as stale. Remove this entry together with the pin.
+        stale_deps = (ignore = [:BenchmarkTools, :XML],),
         # persistent_tasks test fails due to background tasks spawned by dependencies
         # (e.g., HTTP.jl, Makie.jl, etc.) during package loading - not a Mycelia issue
         persistent_tasks = false

--- a/test/aqua.jl
+++ b/test/aqua.jl
@@ -22,6 +22,7 @@
 import Aqua
 import Mycelia
 import Test
+import TOML
 
 Test.@testset "Aqua.jl" begin
     Aqua.test_all(
@@ -33,11 +34,38 @@ Test.@testset "Aqua.jl" begin
         #
         # XML is a direct dep ONLY so that [compat] can pin the transitive
         # XLSX -> XML resolution away from 0.4.5, which breaks XLSX's
-        # precompilation. Mycelia never imports it, so Aqua would otherwise
-        # correctly flag it as stale. Remove this entry together with the pin.
+        # precompilation on Julia 1.10. Mycelia never imports it, so Aqua would
+        # otherwise correctly flag it as stale. The testset below couples this
+        # entry to the pin so it cannot outlive it; see Project.toml's [compat]
+        # comment for the full account and the removal condition.
         stale_deps = (ignore = [:BenchmarkTools, :XML],),
         # persistent_tasks test fails due to background tasks spawned by dependencies
         # (e.g., HTTP.jl, Makie.jl, etc.) during package loading - not a Mycelia issue
         persistent_tasks = false
     )
+end
+
+# The stale_deps ignore above suppresses a warning that is REAL and CORRECT:
+# XML genuinely is a declared-but-unloaded dependency. That suppression is
+# justified only while the [compat] pin it exists to serve is still there.
+#
+# Nothing otherwise couples the two, so the ignore would silently outlive the
+# pin -- and a suppression whose justification has evaporated is exactly how a
+# detector goes quiet without anyone deciding that it should. This is the
+# failing test that pairs with the suppression.
+Test.@testset "XML is a transitive pin only" begin
+    project = TOML.parsefile(joinpath(pkgdir(Mycelia), "Project.toml"))
+
+    # If the pin is removed, this fails and points at the ignore to remove with
+    # it. Matched loosely on the blocked version rather than on the exact bound,
+    # so that widening the self-healing half (currently "=0.4.4, 0.4.6 - 0.4")
+    # does not spuriously fail -- what matters is that 0.4.5 is still excluded.
+    xml_compat = get(project["compat"], "XML", nothing)
+    Test.@test xml_compat !== nothing
+    Test.@test occursin("0.4.4", something(xml_compat, ""))
+
+    # And the ignore is justified only while Mycelia really does not load XML.
+    # If XML ever becomes a genuine dependency, the ignore must go and the dep
+    # should be declared for its own sake.
+    Test.@test !(:XML in names(Mycelia; all = true, imported = true))
 end


### PR DESCRIPTION
## Summary

- CI has failed on **every** Mycelia branch since 2026-08-13, at precompile rather than at any test. Branches with no common change went red simultaneously and a tag push failed too — the signature of a resolver outcome, not a code change.
- The float is **XML**, a transitive dependency of XLSX — not XLSX itself, which has not released since 2026-07-31. XML **0.4.5** published `2026-08-13T22:00:30Z`, hours after the last green run.
- XML 0.4.5 replaced `LazyNode` child iteration with a shared mutable cursor. XLSX's `_collect_row_nodes` retains child `LazyNode`s across iteration, so XLSX raises `XLSXError: No `sheetData` node found in worksheet` **from inside its own `@compile_workload`** — it fails to *precompile*, cascading to `FileIOExt` and to Mycelia.
- Pins `XML = "=0.4.4"`, and adds XML to Aqua's `stale_deps` ignore list because it is a direct dep only so the bound has something to constrain.

## Why `=0.4.4` and not `~0.4.4`

Measured, not assumed — Julia's tilde means `[0.4.4, 0.5.0)`, which still admits 0.4.5:

```
RESOLVED[=0.4.4]  XML 0.4.4 / XLSX 0.12.2  ->  PRECOMPILE OK
RESOLVED[~0.4.4]  XML 0.4.5 / XLSX 0.12.2  ->  PRECOMPILE FAILED
```

A/B on Julia 1.10.11 (same as CI's `lts`) in a minimal env with XLSX pinned to 0.12.2. XLSX 0.12.2 declares `XML = "0.4.4"`, which under Julia's caret default is that same permissive range — which is why the break arrived here with no change on our side.

Upstream states the hazard directly in [XML.jl#124](https://github.com/JuliaData/XML.jl/issues/124), opened the day 0.4.5 shipped: *"Pkg treats every 0.4.\* as compatible, so the resolver would hand the semantics change to every existing consumer automatically — XLSX.jl's `XML = "0.4.4 - 0.4"` included."*

## What this deliberately does NOT fix

The `Conda` precompile error in the same logs (`ArgumentError: Path to conda environment is not valid`) is a **separate, non-blocking** condition and is tracked separately rather than bundled:

- `julia-actions/cache` caches `artifacts, packages, registries, compiled, scratchspaces, logs` — **not** `~/.julia/conda`.
- `Conda.jl` evaluates `const PREFIX = prefix(ROOTENV)` at module top level, so a re-precompile on a **warm** cache throws before `Pkg.build()` recreates the directory.
- It appears only in the non-fatal auto-precompile step; the fatal "Run tests with coverage" step traces solely to the XLSX error, in all 8 failing runs.
- It surfaced now because the XML bump invalidated the precompile cache that had been hiding it (warm green runs: 2–4 recompiled / 574–586 reused; warm red run: 562 / 10).

## Test Plan

- [ ] CI goes green on this branch — this is the real test, and it is the thing being fixed
- [ ] Confirm `XML v0.4.4` in the resolved manifest in the CI log, not 0.4.5
- [ ] `Aqua.test_all` passes with XML in `stale_deps.ignore` (it is a deliberate non-imported dep)
- [ ] Spot-check that a previously-failing unrelated branch goes green after this merges

## Related

Blocks every open Mycelia PR, including #459. Filed as `td-rybz`.

## Not verified

- **The precise XML 0.4.4 → 0.4.5 change that causes this has NOT been isolated.** `cursor.jl` is byte-identical between the two releases, so the regression reaches the cursor through the `XMLTokenizer.jl` span-native rework rather than through any LazyNode iterator change. With XLSX instrumented, the node at the failure point is byte-identical under both versions and a plain cursor walk finds `sheetData` under both — yet the identical loop inside `first_cache_fill!` does not under 0.4.5. The `Project.toml` comment therefore states the symptom and the trigger and deliberately does **not** assert a mechanism.
- No upstream XLSX **fix** is in flight. `JuliaData/XLSX.jl#446` is an open **issue** (not a PR, `.pull_request` is null), filed 2026-08-11 — *"Make the sheet-row stream's reliance on iterator resumption explicit with `Iterators.Stateful`"* — with no PR attached. **Correcting an earlier revision of this PR body**, which said #446 "does not resolve on GitHub": it resolves fine. The conclusion survives with the right reason — a request with no implementation is not a fix in flight.
- XML 0.4.4 is not proven otherwise-clean for Mycelia beyond being the version present in every green run from Aug 10–13 — i.e. it is the known-good state, not an audited one.
